### PR TITLE
fix: resolve Whisper worker path when bundled by esbuild

### DIFF
--- a/electron/audio/LocalWhisperSTT.ts
+++ b/electron/audio/LocalWhisperSTT.ts
@@ -34,6 +34,7 @@
 import { EventEmitter } from 'events';
 import { Worker } from 'worker_threads';
 import path from 'path';
+import fs from 'fs';
 import { resampleToF32 } from './whisper/audioResampler';
 import { VadProcessor } from './whisper/vadProcessor';
 import { filterHallucination } from './whisper/hallucinationFilter';
@@ -41,6 +42,18 @@ import { configureTransformersCache } from './whisper/modelManager';
 import { modelPreloader } from './whisper/modelPreloader';
 import { buildWorkerInitMessage } from './whisper/inferenceConfig';
 import type { WorkerOutMessage } from './whisper/types';
+
+// esbuild bundles this module into dist-electron/electron/main.js, so
+// __dirname resolves to dist-electron/electron/ rather than this file's
+// own directory. Check both candidate locations to support bundled and
+// unbundled execution.
+function resolveWhisperWorkerPath(): string {
+    const candidates = [
+        path.join(__dirname, 'whisper', 'whisperWorker.js'),
+        path.join(__dirname, 'audio', 'whisper', 'whisperWorker.js'),
+    ];
+    return candidates.find(p => fs.existsSync(p)) ?? candidates[0];
+}
 
 export class LocalWhisperSTT extends EventEmitter {
     private readonly modelId: string;
@@ -568,7 +581,7 @@ export class LocalWhisperSTT extends EventEmitter {
             this.flushPending();
         } else {
             console.log(`[LocalWhisperSTT] Cold-starting worker for ${this.modelId}`);
-            const workerPath = path.join(__dirname, 'whisper', 'whisperWorker.js');
+            const workerPath = resolveWhisperWorkerPath();
             this.worker = new Worker(workerPath);
             this.attachWorkerListeners();
             this.worker.postMessage(buildWorkerInitMessage(this.modelId));

--- a/electron/audio/whisper/modelPreloader.ts
+++ b/electron/audio/whisper/modelPreloader.ts
@@ -17,7 +17,21 @@
 
 import { Worker } from 'worker_threads';
 import path from 'path';
+import fs from 'fs';
 import { buildWorkerInitMessage } from './inferenceConfig';
+
+// esbuild bundles this module into dist-electron/electron/main.js, so
+// __dirname can resolve to dist-electron/electron/ rather than this file's
+// own directory. Check both candidate locations to support bundled and
+// unbundled execution.
+function resolveWhisperWorkerPath(): string {
+    const candidates = [
+        path.join(__dirname, 'whisperWorker.js'),
+        path.join(__dirname, 'whisper', 'whisperWorker.js'),
+        path.join(__dirname, 'audio', 'whisper', 'whisperWorker.js'),
+    ];
+    return candidates.find(p => fs.existsSync(p)) ?? candidates[0];
+}
 
 class ModelPreloader {
     private warmWorker: Worker | null = null;
@@ -53,7 +67,7 @@ class ModelPreloader {
         console.log(`[ModelPreloader] Warming worker for ${modelId}...`);
 
         // __dirname at runtime = dist-electron/electron/audio/whisper/
-        const workerPath = path.join(__dirname, 'whisperWorker.js');
+        const workerPath = resolveWhisperWorkerPath();
         const w = new Worker(workerPath);
         this.loadingWorker = w;
 


### PR DESCRIPTION
## Summary

Local Whisper STT fails on every meeting start in `npm run app:dev` with `MODULE_NOT_FOUND` for `whisperWorker.js`, because esbuild's `bundle: true` inlines `LocalWhisperSTT.ts` and `modelPreloader.ts` into `dist-electron/electron/main.js`. After bundling, `__dirname` in those modules resolves to `dist-electron/electron/` instead of the source file's directory, so `path.join(__dirname, 'whisper', 'whisperWorker.js')` resolves to a path that doesn't exist (`dist-electron/electron/whisper/whisperWorker.js`) instead of the actual location (`dist-electron/electron/audio/whisper/whisperWorker.js`).

Reproduces 100% of the time on a fresh clone with Speech Provider = Local Whisper. Observed error:

```
[Main] STT (interviewer) Error: Error: Cannot find module
  '.../dist-electron/electron/whisper/whisperWorker.js'
```

Fix: replace the literal `path.join` with a small resolver that tries both candidate locations and returns the first that exists on disk. Applied to both `LocalWhisperSTT.spawnWorker()` and `ModelPreloader.spawnWorker()`. No behavior change for builds where `__dirname` is already correct — the first candidate matches and the function returns early.

Fixes #

## Type of Change
- 🐛 Bug Fix

## Testing & Environment
- [x] Manual test performed on: **macOS 15.x (Darwin 25.5.0), Apple Silicon, Node 24.7.0, Electron dev mode (`npm run app:dev`)**

Steps to verify:
1. `npm install --legacy-peer-deps && npm run build:native && npm run app:dev`
2. In the app, Settings → Audio → Speech Provider → **Local Whisper**, install **Moonshine Base**
3. Start a meeting and play audio through the default output device
4. Confirm in the terminal:
   - No `MODULE_NOT_FOUND` for `whisperWorker.js`
   - `[ModelPreloader] Handing off warm worker for onnx-community/moonshine-base-ONNX`
   - `[WhisperWorker] Loading onnx-community/moonshine-base-ONNX | providers=coreml,cpu | dtype=fp32`
   - Transcripts emitted end-to-end (CoreAudio Tap → Whisper → overlay)

## Visuals (Optional)

N/A — terminal-only diagnosis. Reproducer logs are inlined in the Summary.