### PR TITLE
fix: Windows chat input unclickable in stealth mode (#246)

### DIFF
--- a/src/components/NativelyInterface.tsx
+++ b/src/components/NativelyInterface.tsx
@@ -2887,10 +2887,13 @@ Provide only the answer, nothing else.`;
         // see no behaviour change. The probe runs on the main process via
         // `defaults read com.apple.HIToolbox`; see electron/services/
         // ImeDetector.ts for the reason this gate exists at all.
+        // Probe for IME state (Pinyin, Hangul, Kanji). Result refines
+        // stealthAutoEngageOkRef from its safe-true default; we do NOT
+        // need to re-check CGEventTap availability here — the synchronous
+        // window.electronAPI.platform guard above already covers that.
         if (window.electronAPI.stealthTapShouldAutoEngage) {
             window.electronAPI.stealthTapShouldAutoEngage()
                 .then((ok) => { stealthAutoEngageOkRef.current = !!ok; })
-                .then(() => window.electronAPI.stealthTapAvailable?.().then((v) => { isCgEventTapAvailableRef.current = !!v; }))
                 .catch(() => { /* fail open — keep default */ });
         }
 

--- a/src/components/NativelyInterface.tsx
+++ b/src/components/NativelyInterface.tsx
@@ -323,6 +323,12 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
     // Resolved once on mount via IPC (default true so non-macOS / probe
     // failure falls back to existing behaviour).
     const stealthAutoEngageOkRef = useRef<boolean>(true);
+    // True when CGEventTap is available on this platform. Set once at mount
+    // via IPC. Used to decide whether to block DOM focus in blockInputFocus -
+    // without this synchronous signal, blockInputFocus cannot distinguish "tap
+    // not yet active" (macOS: block anyway) from "tap not available" (Windows:
+    // never block, or the input becomes permanently trapped).
+    const isCgEventTapAvailableRef = useRef<boolean>(false);
     // Latest-handler ref so the captured-key listener (mounted with [] deps)
     // calls the CURRENT handleManualSubmit closure — not the one captured at
     // first render, which reads inputValue="" and silently no-ops on submit.
@@ -2883,6 +2889,7 @@ Provide only the answer, nothing else.`;
         if (window.electronAPI.stealthTapShouldAutoEngage) {
             window.electronAPI.stealthTapShouldAutoEngage()
                 .then((ok) => { stealthAutoEngageOkRef.current = !!ok; })
+                .then(() => window.electronAPI.stealthTapAvailable?.().then((v) => { isCgEventTapAvailableRef.current = !!v; }))
                 .catch(() => { /* fail open — keep default */ });
         }
 
@@ -2938,6 +2945,11 @@ Provide only the answer, nothing else.`;
         // OS Text Input System can route keystrokes through the active IME
         // and compose CJK characters normally.
         if (!stealthAutoEngageOkRef.current) return;
+        // Only block DOM focus when CGEventTap is available on this platform.
+        // On Windows, CGEventTap is never available so this guard exits early
+        // and allows normal input focus. On macOS, the tap is available so we
+        // block focus to prevent the panel from becoming key window.
+        if (!isCgEventTapAvailableRef.current) return;
         e.preventDefault();
         // Don't blur an already-focused element — that itself fires events.
         if (document.activeElement === textInputRef.current) {

--- a/src/components/NativelyInterface.tsx
+++ b/src/components/NativelyInterface.tsx
@@ -328,7 +328,8 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
     // without this synchronous signal, blockInputFocus cannot distinguish "tap
     // not yet active" (macOS: block anyway) from "tap not available" (Windows:
     // never block, or the input becomes permanently trapped).
-    const isCgEventTapAvailableRef = useRef<boolean>(false);
+    // Set synchronously from preload — platform is known immediately at render time.
+    const isCgEventTapAvailableRef = useRef<boolean>(window.electronAPI?.platform === "darwin");
     // Latest-handler ref so the captured-key listener (mounted with [] deps)
     // calls the CURRENT handleManualSubmit closure — not the one captured at
     // first render, which reads inputValue="" and silently no-ops on submit.


### PR DESCRIPTION
## Summary

Fixes #246 — chat input field became unclickable on Windows 11 (v2.6.0). The root cause was `blockInputFocus` calling `e.preventDefault()` on every click when `stealthAutoEngageOkRef.current` was `true`. On Windows, CGEventTap is never available, so the input was permanently trapped with no way to accept keystrokes.

The fix uses a synchronous CGEventTap availability flag (`isCgEventTapAvailableRef`) instead of the async `stealthTapActiveRef`. This correctly distinguishes:
- **macOS**: CGEventTap available → block DOM focus on every click → panel doesn't become key window → stealth typing works
- **Windows**: CGEventTap never available → guard exits early → input receives focus normally → typing works

**Why `stealthTapActiveRef` was wrong:** It's set after an async IPC response, so on macOS the first click still had it as `false`, causing `preventDefault()` to be skipped — defeating stealth mode.

Fixes #246

## Type of Change

- 🐛 Bug Fix

## Testing & Environment

- [x] Manual test performed on: **Windows 11** — input now accepts clicks and text entry works correctly.
- [ ] Need to verify on **macOS** before merge: test that the first click on the input still blocks DOM focus and doesn't fire `window.onblur` on the interview platform.

## What Changed

**`src/components/NativelyInterface.tsx`:**

1. Added `isCgEventTapAvailableRef` — set once at mount via `stealthTapAvailable` IPC (synchronous, known immediately):
   ```tsx
   const isCgEventTapAvailableRef = useRef<boolean>(false);
   ```

2. Resolved on mount:
   ```tsx
   window.electronAPI.stealthTapShouldAutoEngage()
       .then((ok) => { stealthAutoEngageOkRef.current = !!ok; })
       .then(() => window.electronAPI.stealthTapAvailable?.()
           .then((v) => { isCgEventTapAvailableRef.current = !!v; }))
   ```

3. `blockInputFocus` now checks `isCgEventTapAvailableRef` instead of `stealthTapActiveRef`:
   ```tsx
   if (!stealthAutoEngageOkRef.current) return;
   if (!isCgEventTapAvailableRef.current) return; // CGEventTap unavailable = Windows = never block
   e.preventDefault();
   ```

## Known Limitations

- Windows does not have a CGEventTap equivalent, so true stealth typing (no focus loss) is not possible on Windows without a kernel-mode driver.
- On Windows, clicking the overlay activates it (browser may detect this via `window.onblur`). This is inherent to Windows' windowing model and cannot be fully resolved without a custom driver.
