### PR TITLE
fix(phone-mirror): bidirectional sync, stealth-safe perf, and Greptile review fixes

### DIFF
--- a/electron/WindowHelper.ts
+++ b/electron/WindowHelper.ts
@@ -1,36 +1,37 @@
+import { app, BrowserWindow, Menu, screen } from 'electron';
+import path from 'node:path';
+import { AppState } from './main';
+import { KeybindManager } from './services/KeybindManager';
 
-import { BrowserWindow, screen, app, Menu } from "electron"
-import { AppState } from "./main"
-import { KeybindManager } from "./services/KeybindManager"
-import path from "node:path"
-
-const isEnvDev = process.env.NODE_ENV === "development"
+const isEnvDev = process.env.NODE_ENV === 'development';
 const isPackaged = app.isPackaged;
 const inAppBundle = process.execPath.includes('.app/') || process.execPath.includes('.app\\');
 
-console.log(`[WindowHelper] isEnvDev: ${isEnvDev}, isPackaged: ${isPackaged}, inAppBundle: ${inAppBundle}`);
+console.log(
+  `[WindowHelper] isEnvDev: ${isEnvDev}, isPackaged: ${isPackaged}, inAppBundle: ${inAppBundle}`,
+);
 
 // Force production mode if running as packaged app or inside app bundle
 const isDev = isEnvDev && !isPackaged;
 
 const startUrl = isDev
-  ? "http://localhost:5180"
-  : `file://${path.join(__dirname, "../../dist/index.html")}`
+  ? 'http://localhost:5180'
+  : `file://${path.join(__dirname, '../../dist/index.html')}`;
 
 export class WindowHelper {
-  private launcherWindow: BrowserWindow | null = null
-  private overlayWindow: BrowserWindow | null = null
-  private isWindowVisible: boolean = false
+  private launcherWindow: BrowserWindow | null = null;
+  private overlayWindow: BrowserWindow | null = null;
+  private isWindowVisible: boolean = false;
   // Position/Size tracking for Launcher
-  private launcherPosition: { x: number; y: number } | null = null
-  private launcherSize: { width: number; height: number } | null = null
-  private overlayBounds: Electron.Rectangle | null = null
+  private launcherPosition: { x: number; y: number } | null = null;
+  private launcherSize: { width: number; height: number } | null = null;
+  private overlayBounds: Electron.Rectangle | null = null;
   // Track current window mode (persists even when overlay is hidden via Cmd+B)
-  private currentWindowMode: 'launcher' | 'overlay' = 'launcher'
+  private currentWindowMode: 'launcher' | 'overlay' = 'launcher';
 
-  private appState: AppState
-  private contentProtection: boolean = false
-  private opacityTimeout: NodeJS.Timeout | null = null
+  private appState: AppState;
+  private contentProtection: boolean = false;
+  private opacityTimeout: NodeJS.Timeout | null = null;
 
   // Constants
   private static readonly OVERLAY_DEFAULT_WIDTH = 600;
@@ -42,33 +43,33 @@ export class WindowHelper {
   private static readonly OVERLAY_DEFAULT_TOP_RATIO = 0.035;
 
   // Movement variables (apply to active window)
-  private step: number = 20
+  private step: number = 20;
 
   constructor(appState: AppState) {
-    this.appState = appState
+    this.appState = appState;
   }
 
   private getDisplayWorkArea(bounds?: Electron.Rectangle): Electron.Rectangle {
     if (bounds) {
-      return screen.getDisplayMatching(bounds).workArea
+      return screen.getDisplayMatching(bounds).workArea;
     }
     if (this.overlayBounds) {
-      return screen.getDisplayMatching(this.overlayBounds).workArea
+      return screen.getDisplayMatching(this.overlayBounds).workArea;
     }
     if (this.overlayWindow && !this.overlayWindow.isDestroyed()) {
-      return screen.getDisplayMatching(this.overlayWindow.getBounds()).workArea
+      return screen.getDisplayMatching(this.overlayWindow.getBounds()).workArea;
     }
-    return screen.getPrimaryDisplay().workArea
+    return screen.getPrimaryDisplay().workArea;
   }
 
   public setContentProtection(enable: boolean): void {
-    this.contentProtection = enable
-    this.applyContentProtection(enable)
+    this.contentProtection = enable;
+    this.applyContentProtection(enable);
   }
 
   private applyContentProtection(enable: boolean): void {
-    const windows = [this.launcherWindow, this.overlayWindow]
-    windows.forEach(win => {
+    const windows = [this.launcherWindow, this.overlayWindow];
+    windows.forEach((win) => {
       if (win && !win.isDestroyed()) {
         win.setContentProtection(enable);
       }
@@ -77,51 +78,60 @@ export class WindowHelper {
 
   public setWindowDimensions(width: number, height: number): void {
     const activeWindow = this.getMainWindow(); // Gets currently focused/relevant window
-    if (!activeWindow || activeWindow.isDestroyed()) return
+    if (!activeWindow || activeWindow.isDestroyed()) return;
 
-    const [currentX, currentY] = activeWindow.getPosition()
-    const primaryDisplay = screen.getPrimaryDisplay()
-    const workArea = primaryDisplay.workAreaSize
-    const maxAllowedWidth = Math.floor(workArea.width * 0.9)
-    const newWidth = Math.min(width, maxAllowedWidth)
-    const newHeight = Math.ceil(height)
-    const maxX = workArea.width - newWidth
-    const newX = Math.min(Math.max(currentX, 0), maxX)
+    const [currentX, currentY] = activeWindow.getPosition();
+    const primaryDisplay = screen.getPrimaryDisplay();
+    const workArea = primaryDisplay.workAreaSize;
+    const maxAllowedWidth = Math.floor(workArea.width * 0.9);
+    const newWidth = Math.min(width, maxAllowedWidth);
+    const newHeight = Math.ceil(height);
+    const maxX = workArea.width - newWidth;
+    const newX = Math.min(Math.max(currentX, 0), maxX);
 
     activeWindow.setBounds({
       x: newX,
       y: currentY,
       width: newWidth,
-      height: newHeight
-    })
+      height: newHeight,
+    });
 
     // Update internal tracking if it's launcher
     if (activeWindow === this.launcherWindow) {
-      this.launcherSize = { width: newWidth, height: newHeight }
-      this.launcherPosition = { x: newX, y: currentY }
+      this.launcherSize = { width: newWidth, height: newHeight };
+      this.launcherPosition = { x: newX, y: currentY };
     }
   }
 
   // Dedicated method for overlay window resizing - decoupled from launcher
   public setOverlayDimensions(width: number, height: number): void {
-    if (!this.overlayWindow || this.overlayWindow.isDestroyed()) return
-    console.log('[WindowHelper] setOverlayDimensions:', width, height);
+    if (!this.overlayWindow || this.overlayWindow.isDestroyed()) return;
 
-    const currentBounds = this.overlayWindow.getBounds()
-    const currentX = currentBounds.x
-    const currentY = currentBounds.y
-    const workArea = this.getDisplayWorkArea(currentBounds)
-    const maxAllowedWidth = Math.floor(workArea.width * 0.9)
-    const maxAllowedHeight = Math.floor(workArea.height * 0.9)
-    const newWidth = Math.min(Math.max(width, 300), maxAllowedWidth) // min 300, max 90%
-    const newHeight = Math.min(Math.max(height, 1), maxAllowedHeight) // min 1, max 90%
-    const maxX = workArea.x + workArea.width - newWidth
-    const maxY = workArea.y + workArea.height - newHeight
-    const newX = Math.min(Math.max(currentX, workArea.x), maxX)
-    const newY = Math.min(Math.max(currentY, workArea.y), maxY)
+    const currentBounds = this.overlayWindow.getBounds();
+    const currentContentSize = this.overlayWindow.getContentSize();
+    const currentX = currentBounds.x;
+    const currentY = currentBounds.y;
+    const workArea = this.getDisplayWorkArea(currentBounds);
+    const maxAllowedWidth = Math.floor(workArea.width * 0.9);
+    const maxAllowedHeight = Math.floor(workArea.height * 0.9);
+    const newWidth = Math.min(Math.max(width, 300), maxAllowedWidth); // min 300, max 90%
+    const newHeight = Math.min(Math.max(height, 1), maxAllowedHeight); // min 1, max 90%
+    const maxX = workArea.x + workArea.width - newWidth;
+    const maxY = workArea.y + workArea.height - newHeight;
+    const newX = Math.min(Math.max(currentX, workArea.x), maxX);
+    const newY = Math.min(Math.max(currentY, workArea.y), maxY);
 
-    this.overlayWindow.setBounds({ x: newX, y: newY, width: newWidth, height: newHeight })
-    this.overlayBounds = this.overlayWindow.getBounds()
+    if (
+      Math.abs(newWidth - currentContentSize[0]) <= 1 &&
+      Math.abs(newHeight - currentContentSize[1]) <= 1 &&
+      newX === currentBounds.x &&
+      newY === currentBounds.y
+    ) {
+      return;
+    }
+
+    this.overlayWindow.setBounds({ x: newX, y: newY, width: newWidth, height: newHeight });
+    this.overlayBounds = this.overlayWindow.getBounds();
   }
 
   // Variant of setOverlayDimensions that keeps the horizontal CENTER of the
@@ -130,37 +140,46 @@ export class WindowHelper {
   // window grows: window grows symmetrically (X shifts -widthDelta/2), and
   // mx-auto compensates by reducing margin equally — net visual movement = 0.
   public setOverlayDimensionsCentered(width: number, height: number): void {
-    if (!this.overlayWindow || this.overlayWindow.isDestroyed()) return
+    if (!this.overlayWindow || this.overlayWindow.isDestroyed()) return;
 
-    const currentBounds = this.overlayWindow.getBounds()
-    const currentContentSize = this.overlayWindow.getContentSize()
-    const workArea = this.getDisplayWorkArea(currentBounds)
-    const maxAllowedWidth = Math.floor(workArea.width * 0.9)
-    const maxAllowedHeight = Math.floor(workArea.height * 0.9)
-    const newWidth = Math.min(Math.max(width, 300), maxAllowedWidth)
-    const newHeight = Math.min(Math.max(height, 1), maxAllowedHeight)
+    const currentBounds = this.overlayWindow.getBounds();
+    const currentContentSize = this.overlayWindow.getContentSize();
+    const workArea = this.getDisplayWorkArea(currentBounds);
+    const maxAllowedWidth = Math.floor(workArea.width * 0.9);
+    const maxAllowedHeight = Math.floor(workArea.height * 0.9);
+    const newWidth = Math.min(Math.max(width, 300), maxAllowedWidth);
+    const newHeight = Math.min(Math.max(height, 1), maxAllowedHeight);
 
     // Compute X so the content's horizontal center stays put across the resize.
-    const widthDelta = newWidth - currentContentSize[0]
-    const desiredX = currentBounds.x - Math.floor(widthDelta / 2)
+    const widthDelta = newWidth - currentContentSize[0];
+    const desiredX = currentBounds.x - Math.floor(widthDelta / 2);
 
-    const maxX = workArea.x + workArea.width - newWidth
-    const newX = Math.min(Math.max(desiredX, workArea.x), maxX)
-    const maxY = workArea.y + workArea.height - newHeight
-    const newY = Math.min(Math.max(currentBounds.y, workArea.y), maxY)
+    const maxX = workArea.x + workArea.width - newWidth;
+    const newX = Math.min(Math.max(desiredX, workArea.x), maxX);
+    const maxY = workArea.y + workArea.height - newHeight;
+    const newY = Math.min(Math.max(currentBounds.y, workArea.y), maxY);
+
+    if (
+      Math.abs(newWidth - currentContentSize[0]) <= 1 &&
+      Math.abs(newHeight - currentContentSize[1]) <= 1 &&
+      newX === currentBounds.x &&
+      newY === currentBounds.y
+    ) {
+      return;
+    }
 
     // Atomic frame change: a single setBounds avoids the 1-frame split where
     // the OS window has the new size but the old origin (or vice versa), which
     // is what causes the shell to visibly slide and snap during code-expansion.
-    this.overlayWindow.setBounds({ x: newX, y: newY, width: newWidth, height: newHeight })
-    this.overlayBounds = this.overlayWindow.getBounds()
+    this.overlayWindow.setBounds({ x: newX, y: newY, width: newWidth, height: newHeight });
+    this.overlayBounds = this.overlayWindow.getBounds();
   }
 
   public createWindow(): void {
-    if (this.launcherWindow !== null) return // Already created
+    if (this.launcherWindow !== null) return; // Already created
 
-    const primaryDisplay = screen.getPrimaryDisplay()
-    const workArea = primaryDisplay.workArea
+    const primaryDisplay = screen.getPrimaryDisplay();
+    const workArea = primaryDisplay.workArea;
 
     // Fixed dimensions per user request
     const width = 1200;
@@ -173,7 +192,7 @@ export class WindowHelper {
     const y = Math.round(workArea.y + topMargin);
 
     // --- 1. Create Launcher Window ---
-    const isMac = process.platform === "darwin";
+    const isMac = process.platform === 'darwin';
 
     const launcherSettings: Electron.BrowserWindowConstructorOptions = {
       width: width,
@@ -185,7 +204,7 @@ export class WindowHelper {
       webPreferences: {
         nodeIntegration: false,
         contextIsolation: true,
-        preload: path.join(__dirname, "preload.js"),
+        preload: path.join(__dirname, 'preload.js'),
         scrollBounce: true,
         webSecurity: !isDev, // DEBUG: Disable web security only in dev
       },
@@ -194,63 +213,68 @@ export class WindowHelper {
       ...(isMac
         ? { titleBarStyle: 'hiddenInset' as const, trafficLightPosition: { x: 14, y: 14 } }
         : { frame: false, titleBarOverlay: false, autoHideMenuBar: true }),
-      ...(isMac ? { vibrancy: 'under-window' as const, visualEffectState: 'followWindow' as const } : {}),
+      ...(isMac
+        ? { vibrancy: 'under-window' as const, visualEffectState: 'followWindow' as const }
+        : {}),
       transparent: isMac,
       hasShadow: true,
-      backgroundColor: isMac ? "#00000000" : "#000000",
+      backgroundColor: isMac ? '#00000000' : '#000000',
       focusable: true,
       resizable: true,
       movable: true,
       center: true,
       icon: (() => {
-        const isMac = process.platform === "darwin";
-        const isWin = process.platform === "win32";
+        const isMac = process.platform === 'darwin';
+        const isWin = process.platform === 'win32';
         const mode = this.appState.getDisguise();
 
         if (mode === 'none') {
           if (isMac) {
             return app.isPackaged
-              ? path.join(process.resourcesPath, "natively.icns")
-              : path.resolve(__dirname, "../../assets/natively.icns");
+              ? path.join(process.resourcesPath, 'natively.icns')
+              : path.resolve(__dirname, '../../assets/natively.icns');
           } else if (isWin) {
             return app.isPackaged
-              ? path.join(process.resourcesPath, "assets/icons/win/icon.ico")
-              : path.resolve(__dirname, "../../assets/icons/win/icon.ico");
+              ? path.join(process.resourcesPath, 'assets/icons/win/icon.ico')
+              : path.resolve(__dirname, '../../assets/icons/win/icon.ico');
           } else {
             return app.isPackaged
-              ? path.join(process.resourcesPath, "icon.png")
-              : path.resolve(__dirname, "../../assets/icon.png");
+              ? path.join(process.resourcesPath, 'icon.png')
+              : path.resolve(__dirname, '../../assets/icon.png');
           }
         }
 
         // Disguise mode icons
-        let iconName = "terminal.png";
-        if (mode === 'settings') iconName = "settings.png";
-        if (mode === 'activity') iconName = "activity.png";
+        let iconName = 'terminal.png';
+        if (mode === 'settings') iconName = 'settings.png';
+        if (mode === 'activity') iconName = 'activity.png';
 
-        const platformDir = isWin ? "win" : "mac";
+        const platformDir = isWin ? 'win' : 'mac';
         return app.isPackaged
           ? path.join(process.resourcesPath, `assets/fakeicon/${platformDir}/${iconName}`)
           : path.resolve(__dirname, `../../assets/fakeicon/${platformDir}/${iconName}`);
-      })()
-    }
+      })(),
+    };
 
     console.log(`[WindowHelper] Icon Path: ${launcherSettings.icon}`);
     console.log(`[WindowHelper] Start URL: ${startUrl}`);
 
     try {
-      this.launcherWindow = new BrowserWindow(launcherSettings)
+      this.launcherWindow = new BrowserWindow(launcherSettings);
       console.log('[WindowHelper] BrowserWindow created successfully');
     } catch (err) {
       console.error('[WindowHelper] Failed to create BrowserWindow:', err);
       return;
     }
 
-    this.launcherWindow.setContentProtection(this.contentProtection)
+    this.launcherWindow.setContentProtection(this.contentProtection);
 
-    this.launcherWindow.loadURL(`${startUrl}?window=launcher`)
+    this.launcherWindow
+      .loadURL(`${startUrl}?window=launcher`)
       .then(() => console.log('[WindowHelper] loadURL success'))
-      .catch((e) => { console.error("[WindowHelper] Failed to load URL:", e) })
+      .catch((e) => {
+        console.error('[WindowHelper] Failed to load URL:', e);
+      });
 
     this.launcherWindow.webContents.on('did-fail-load', (event, errorCode, errorDescription) => {
       console.error(`[WindowHelper] did-fail-load: ${errorCode} ${errorDescription}`);
@@ -266,8 +290,12 @@ export class WindowHelper {
     // The in-memory `overlayBounds` is already null here, so `switchToOverlay()`
     // will also fall back to centered logic — but providing explicit x/y in the
     // constructor is the only reliable guard against OS-level position persistence.
-    const overlayDefaultX = Math.floor(workArea.x + (workArea.width - WindowHelper.OVERLAY_DEFAULT_WIDTH) / 2);
-    const overlayDefaultY = Math.floor(workArea.y + workArea.height * WindowHelper.OVERLAY_DEFAULT_TOP_RATIO);
+    const overlayDefaultX = Math.floor(
+      workArea.x + (workArea.width - WindowHelper.OVERLAY_DEFAULT_WIDTH) / 2,
+    );
+    const overlayDefaultY = Math.floor(
+      workArea.y + workArea.height * WindowHelper.OVERLAY_DEFAULT_TOP_RATIO,
+    );
 
     const overlaySettings: Electron.BrowserWindowConstructorOptions = {
       width: WindowHelper.OVERLAY_DEFAULT_WIDTH,
@@ -279,13 +307,13 @@ export class WindowHelper {
       webPreferences: {
         nodeIntegration: false,
         contextIsolation: true,
-        preload: path.join(__dirname, "preload.js"),
+        preload: path.join(__dirname, 'preload.js'),
         scrollBounce: true,
       },
       show: false,
       frame: false, // Frameless
       transparent: true,
-      backgroundColor: "#00000000",
+      backgroundColor: '#00000000',
       alwaysOnTop: true,
       focusable: true,
       resizable: false, // Enforce automatic resizing only
@@ -298,10 +326,10 @@ export class WindowHelper {
       // stays "in front." Required for the chat:focusInput stealth-typing path.
       // Windows/Linux fall back to a regular focusable window.
       ...(isMac ? { type: 'panel' as const } : {}),
-    }
+    };
 
-    this.overlayWindow = new BrowserWindow(overlaySettings)
-    this.overlayWindow.setContentProtection(this.contentProtection)
+    this.overlayWindow = new BrowserWindow(overlaySettings);
+    this.overlayWindow.setContentProtection(this.contentProtection);
 
     // Register the overlay as the sole recipient of CGEventTap captured-key
     // broadcasts. Without this, captured keystrokes fan out to ALL windows
@@ -316,10 +344,10 @@ export class WindowHelper {
       }
     }
 
-    if (process.platform === "darwin") {
-      this.overlayWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })
-      this.overlayWindow.setHiddenInMissionControl(true)
-      this.overlayWindow.setAlwaysOnTop(true, "floating")
+    if (process.platform === 'darwin') {
+      this.overlayWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+      this.overlayWindow.setHiddenInMissionControl(true);
+      this.overlayWindow.setAlwaysOnTop(true, 'floating');
 
       // Apply Spotlight/Alfred-grade stealth attributes that Electron does not
       // expose: becomesKeyOnlyIfNeeded (clicks on buttons / surfaces don't
@@ -351,36 +379,38 @@ export class WindowHelper {
             native.applyStealthToWindow(this.overlayWindow.getNativeWindowHandle());
             console.log('[WindowHelper] Applied stealth NSPanel attributes to overlay');
           } else {
-            console.warn('[WindowHelper] applyStealthToWindow unavailable — rebuild native module (npm run build:native) for full stealth');
+            console.warn(
+              '[WindowHelper] applyStealthToWindow unavailable — rebuild native module (npm run build:native) for full stealth',
+            );
           }
         } catch (e) {
           console.error('[WindowHelper] Failed to apply stealth attributes:', e);
         }
       });
-    } else if (process.platform === "win32") {
+    } else if (process.platform === 'win32') {
       // 'floating' level (HWND_TOPMOST baseline) is not enough to render above
       // fullscreen browser windows (F11). 'screen-saver' uses a higher TOPMOST
       // priority that wins against window-mode fullscreen apps. macOS uses
       // visibleOnFullScreen above; Windows has no equivalent flag, so the level
       // itself is what controls fullscreen visibility. See issue #167.
-      this.overlayWindow.setAlwaysOnTop(true, "screen-saver")
+      this.overlayWindow.setAlwaysOnTop(true, 'screen-saver');
     }
 
-    this.overlayWindow.loadURL(`${startUrl}?window=overlay`).catch(e => {
-        console.error('[WindowHelper] Failed to load Overlay URL:', e);
-    })
+    this.overlayWindow.loadURL(`${startUrl}?window=overlay`).catch((e) => {
+      console.error('[WindowHelper] Failed to load Overlay URL:', e);
+    });
 
     // --- 3. Startup Sequence ---
     this.launcherWindow.once('ready-to-show', () => {
-      this.switchToLauncher()
-      this.isWindowVisible = true
-    })
+      this.switchToLauncher();
+      this.isWindowVisible = true;
+    });
 
-    this.setupWindowListeners()
+    this.setupWindowListeners();
   }
 
   private setupWindowListeners(): void {
-    if (!this.launcherWindow) return
+    if (!this.launcherWindow) return;
 
     // Suppress Windows system context menu on right-click (title bar)
     this.launcherWindow.on('system-context-menu', (e, point) => {
@@ -390,21 +420,21 @@ export class WindowHelper {
       }
     });
 
-    this.launcherWindow.on("move", () => {
+    this.launcherWindow.on('move', () => {
       if (this.launcherWindow) {
-        const bounds = this.launcherWindow.getBounds()
-        this.launcherPosition = { x: bounds.x, y: bounds.y }
-        this.appState.settingsWindowHelper.reposition(bounds)
+        const bounds = this.launcherWindow.getBounds();
+        this.launcherPosition = { x: bounds.x, y: bounds.y };
+        this.appState.settingsWindowHelper.reposition(bounds);
       }
-    })
+    });
 
-    this.launcherWindow.on("resize", () => {
+    this.launcherWindow.on('resize', () => {
       if (this.launcherWindow) {
-        const bounds = this.launcherWindow.getBounds()
-        this.launcherSize = { width: bounds.width, height: bounds.height }
-        this.appState.settingsWindowHelper.reposition(bounds)
+        const bounds = this.launcherWindow.getBounds();
+        this.launcherSize = { width: bounds.width, height: bounds.height };
+        this.appState.settingsWindowHelper.reposition(bounds);
       }
-    })
+    });
 
     // On Windows/Linux: intercept close and hide to tray instead of quitting,
     // unless the app is actually quitting (e.g. from tray "Quit" menu).
@@ -426,30 +456,30 @@ export class WindowHelper {
       });
     }
 
-    this.launcherWindow.on("closed", () => {
-      this.launcherWindow = null
+    this.launcherWindow.on('closed', () => {
+      this.launcherWindow = null;
       // If launcher closes, we should probably quit app or close overlay
       if (this.overlayWindow && !this.overlayWindow.isDestroyed()) {
-        this.overlayWindow.close()
+        this.overlayWindow.close();
       }
-      this.overlayWindow = null
-      this.isWindowVisible = false
-    })
+      this.overlayWindow = null;
+      this.isWindowVisible = false;
+    });
 
     // Listen for overlay close (e.g. Cmd+W). Never truly destroy it — either
     // hide it (during a meeting) or switch back to launcher (between meetings).
     if (this.overlayWindow) {
-      this.overlayWindow.on("move", () => {
+      this.overlayWindow.on('move', () => {
         if (this.overlayWindow && !this.overlayWindow.isDestroyed()) {
-          this.overlayBounds = this.overlayWindow.getBounds()
+          this.overlayBounds = this.overlayWindow.getBounds();
         }
-      })
+      });
 
-      this.overlayWindow.on("resize", () => {
+      this.overlayWindow.on('resize', () => {
         if (this.overlayWindow && !this.overlayWindow.isDestroyed()) {
-          this.overlayBounds = this.overlayWindow.getBounds()
+          this.overlayBounds = this.overlayWindow.getBounds();
         }
-      })
+      });
 
       this.overlayWindow.on('system-context-menu', (e, point) => {
         e.preventDefault();
@@ -483,7 +513,7 @@ export class WindowHelper {
             this.switchToLauncher();
           }
         }
-      })
+      });
     }
   }
 
@@ -496,9 +526,15 @@ export class WindowHelper {
   }
 
   // Specific getters if needed
-  public getLauncherWindow(): BrowserWindow | null { return this.launcherWindow }
-  public getOverlayWindow(): BrowserWindow | null { return this.overlayWindow }
-  public getCurrentWindowMode(): 'launcher' | 'overlay' { return this.currentWindowMode }
+  public getLauncherWindow(): BrowserWindow | null {
+    return this.launcherWindow;
+  }
+  public getOverlayWindow(): BrowserWindow | null {
+    return this.overlayWindow;
+  }
+  public getCurrentWindowMode(): 'launcher' | 'overlay' {
+    return this.currentWindowMode;
+  }
 
   // Clears the remembered overlay position so the next switchToOverlay() call
   // opens at the default centered position (called on new meeting start).
@@ -520,7 +556,7 @@ export class WindowHelper {
   }
 
   public isVisible(): boolean {
-    return this.isWindowVisible
+    return this.isWindowVisible;
   }
 
   public isMainWindowMaximized(): boolean {
@@ -529,14 +565,17 @@ export class WindowHelper {
   }
 
   public hideMainWindow(): void {
-    // Set opacity to 0 immediately so the window vanishes without triggering
-    // the macOS hide animation (same pattern as switchToLauncher / switchToOverlay).
-    // This prevents the brief black/white frame flash before screenshots.
-    this.launcherWindow?.setOpacity(0);
-    this.overlayWindow?.setOpacity(0);
-    this.launcherWindow?.hide()
-    this.overlayWindow?.hide()
-    this.isWindowVisible = false
+    // Do NOT call setOpacity(0) before hide() on macOS — it causes WindowServer to
+    // re-register the app as a regular window, breaking undetectable/stealth mode
+    // (fixed in v2.0.8, regressed when opacity was re-added for screenshot flash).
+    // Screenshot capture already waits 80ms after hide() for compositor flush.
+    if (process.platform === 'win32') {
+      this.launcherWindow?.setOpacity(0);
+      this.overlayWindow?.setOpacity(0);
+    }
+    this.launcherWindow?.hide();
+    this.overlayWindow?.hide();
+    this.isWindowVisible = false;
   }
 
   // Apply or remove click-through (mouse passthrough) on the overlay window.
@@ -613,12 +652,12 @@ export class WindowHelper {
 
   public toggleMainWindow(): void {
     if (this.isWindowVisible) {
-      this.hideMainWindow()
+      this.hideMainWindow();
     } else {
       // Always show without stealing focus — Natively is a ghost overlay.
       // The user is in another app; show the window on top but leave OS focus alone.
       // They can click the window to focus it if they need to type.
-      this.showMainWindow(true)
+      this.showMainWindow(true);
     }
   }
 
@@ -630,10 +669,12 @@ export class WindowHelper {
     // If a meeting is active (overlay mode), bring the overlay up instead of the
     // launcher — switching to the launcher during a meeting would expose it in the
     // taskbar/dock and break stealth.
+    const stealthShow = this.appState.getUndetectable();
     if (this.currentWindowMode === 'overlay') {
-      this.switchToOverlay(); // explicit user action, so we want to grant focus
+      // In undetectable mode, show without stealing focus from the foreground app.
+      this.switchToOverlay(stealthShow ? true : undefined);
     } else {
-      this.switchToLauncher();
+      this.switchToLauncher(stealthShow ? true : undefined);
       this.launcherWindow?.center();
     }
   }
@@ -654,7 +695,7 @@ export class WindowHelper {
       const savedBounds = this.overlayBounds
         ? {
             ...this.overlayBounds,
-            height: Math.max(this.overlayBounds.height, WindowHelper.OVERLAY_MIN_HEIGHT)
+            height: Math.max(this.overlayBounds.height, WindowHelper.OVERLAY_MIN_HEIGHT),
           }
         : null;
       const workArea = this.getDisplayWorkArea(savedBounds ?? currentBounds);
@@ -662,16 +703,25 @@ export class WindowHelper {
       const maxAllowedHeight = Math.floor(workArea.height * 0.9);
       const targetBounds = savedBounds
         ? {
-            x: Math.min(Math.max(savedBounds.x, workArea.x), workArea.x + workArea.width - Math.min(savedBounds.width, maxAllowedWidth)),
-            y: Math.min(Math.max(savedBounds.y, workArea.y), workArea.y + workArea.height - Math.min(savedBounds.height, maxAllowedHeight)),
+            x: Math.min(
+              Math.max(savedBounds.x, workArea.x),
+              workArea.x + workArea.width - Math.min(savedBounds.width, maxAllowedWidth),
+            ),
+            y: Math.min(
+              Math.max(savedBounds.y, workArea.y),
+              workArea.y + workArea.height - Math.min(savedBounds.height, maxAllowedHeight),
+            ),
             width: Math.min(savedBounds.width, maxAllowedWidth),
-            height: Math.min(savedBounds.height, maxAllowedHeight)
+            height: Math.min(savedBounds.height, maxAllowedHeight),
           }
         : {
             x: Math.floor(workArea.x + (workArea.width - WindowHelper.OVERLAY_DEFAULT_WIDTH) / 2),
             y: Math.floor(workArea.y + workArea.height * WindowHelper.OVERLAY_DEFAULT_TOP_RATIO),
             width: WindowHelper.OVERLAY_DEFAULT_WIDTH,
-            height: Math.max(Math.min(currentBounds.height, maxAllowedHeight), WindowHelper.OVERLAY_MIN_HEIGHT)
+            height: Math.max(
+              Math.min(currentBounds.height, maxAllowedHeight),
+              WindowHelper.OVERLAY_MIN_HEIGHT,
+            ),
           };
 
       this.overlayWindow.setBounds(targetBounds);
@@ -681,7 +731,8 @@ export class WindowHelper {
       if (process.platform === 'win32' && this.contentProtection) {
         // Opacity Shield: Show at 0 opacity first to prevent frame leak
         this.overlayWindow.setOpacity(0);
-        if (inactive) this.overlayWindow.showInactive(); else this.overlayWindow.show();
+        if (inactive) this.overlayWindow.showInactive();
+        else this.overlayWindow.show();
         this.overlayWindow.setContentProtection(true);
         // Small delay to ensure Windows DWM processes the flag before making it opaque
 
@@ -707,7 +758,8 @@ export class WindowHelper {
         if (process.platform === 'win32') {
           this.overlayWindow.setAlwaysOnTop(true, 'screen-saver');
         }
-        if (inactive) this.overlayWindow.showInactive(); else this.overlayWindow.show();
+        if (inactive) this.overlayWindow.showInactive();
+        else this.overlayWindow.show();
         // Only grab focus for explicit user-initiated shows (not shortcut/ghost shows)
         if (!inactive) this.overlayWindow.focus();
       }
@@ -730,7 +782,8 @@ export class WindowHelper {
       if (process.platform === 'win32' && this.contentProtection) {
         // Opacity Shield: Show at 0 opacity first
         this.launcherWindow.setOpacity(0);
-        if (inactive) this.launcherWindow.showInactive(); else this.launcherWindow.show();
+        if (inactive) this.launcherWindow.showInactive();
+        else this.launcherWindow.show();
         this.launcherWindow.setContentProtection(true);
 
         if (this.opacityTimeout) clearTimeout(this.opacityTimeout);
@@ -744,7 +797,8 @@ export class WindowHelper {
         // Restore opacity (may have been zeroed pre-screenshot by hideMainWindow)
         this.launcherWindow.setOpacity(1);
         this.launcherWindow.setContentProtection(this.contentProtection);
-        if (inactive) this.launcherWindow.showInactive(); else this.launcherWindow.show();
+        if (inactive) this.launcherWindow.showInactive();
+        else this.launcherWindow.show();
         if (!inactive) this.launcherWindow.focus();
       }
       this.isWindowVisible = true;
@@ -774,16 +828,26 @@ export class WindowHelper {
     win.setPosition(x + dx, y + dy);
   }
 
-  public moveWindowRight(): void { this.moveActiveWindow(this.step, 0) }
-  public moveWindowLeft(): void { this.moveActiveWindow(-this.step, 0) }
-  public moveWindowDown(): void { this.moveActiveWindow(0, this.step) }
-  public moveWindowUp(): void { this.moveActiveWindow(0, -this.step) }
+  public moveWindowRight(): void {
+    this.moveActiveWindow(this.step, 0);
+  }
+  public moveWindowLeft(): void {
+    this.moveActiveWindow(-this.step, 0);
+  }
+  public moveWindowDown(): void {
+    this.moveActiveWindow(0, this.step);
+  }
+  public moveWindowUp(): void {
+    this.moveActiveWindow(0, -this.step);
+  }
 
   private showContextMenu(win: BrowserWindow, point: { x: number; y: number }): void {
     const template: Electron.MenuItemConstructorOptions[] = [
       {
         label: 'Developer Console',
-        click: () => { win.webContents.toggleDevTools(); }
+        click: () => {
+          win.webContents.toggleDevTools();
+        },
       },
       { type: 'separator' },
       { role: 'reload' },

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -1,25 +1,26 @@
 // ipcHandlers.ts
 
-import { app, ipcMain, shell, dialog, desktopCapturer, systemPreferences, BrowserWindow, screen } from "electron"
-import { AppState } from "./main"
-import { GEMINI_FLASH_MODEL } from "./IntelligenceManager"
-import { DatabaseManager } from "./db/DatabaseManager"; // Import Database Manager
-import * as os from "os";
-import * as path from "path";
-import * as fs from "fs";
-import * as crypto from "crypto";
-import { AudioDevices } from "./audio/AudioDevices";
-import { PhoneMirrorService } from "./services/PhoneMirrorService";
-import { CodexCliService } from "./services/CodexCliService";
-import { SettingsManager } from "./services/SettingsManager";
+import * as crypto from 'crypto';
+import { app, BrowserWindow, dialog, ipcMain, shell, systemPreferences } from 'electron';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { AudioDevices } from './audio/AudioDevices';
+import { DatabaseManager } from './db/DatabaseManager'; // Import Database Manager
+import { AppState } from './main';
+import { CodexCliService } from './services/CodexCliService';
+import { PhoneMirrorService } from './services/PhoneMirrorService';
+import { SettingsManager } from './services/SettingsManager';
 
-
-import { RECOGNITION_LANGUAGES, AI_RESPONSE_LANGUAGES } from "./config/languages"
-import { TRIAL_SENTINEL_KEY } from "./config/constants"
-import { CHAT_MODE_PROMPT } from "./llm/prompts"
+import { TRIAL_SENTINEL_KEY } from './config/constants';
+import { AI_RESPONSE_LANGUAGES, RECOGNITION_LANGUAGES } from './config/languages';
+import { CHAT_MODE_PROMPT } from './llm/prompts';
 
 export function initializeIpcHandlers(appState: AppState): void {
-  const safeHandle = (channel: string, listener: (event: any, ...args: any[]) => Promise<any> | any) => {
+  const safeHandle = (
+    channel: string,
+    listener: (event: any, ...args: any[]) => Promise<any> | any,
+  ) => {
     ipcMain.removeHandler(channel);
     ipcMain.handle(channel, listener);
   };
@@ -33,7 +34,9 @@ export function initializeIpcHandlers(appState: AppState): void {
     try {
       const { LicenseManager } = require('../premium/electron/services/LicenseManager');
       if (LicenseManager.getInstance().isPremium()) return true;
-    } catch { /* premium module not available */ }
+    } catch {
+      /* premium module not available */
+    }
 
     // 2. Active free trial (token present and not expired)
     try {
@@ -58,22 +61,24 @@ export function initializeIpcHandlers(appState: AppState): void {
       db.clearProfilePersona?.();
       const llmHelper = appState.processingHelper?.getLLMHelper?.();
       llmHelper?.setPersonaPrompt?.('');
-      BrowserWindow.getAllWindows().forEach(win => {
+      BrowserWindow.getAllWindows().forEach((win) => {
         if (!win.isDestroyed()) win.webContents.send('modes-active-cleared');
       });
       console.log('[IPC] Premium-only context cleared due to license loss');
-    } catch (e) { /* non-fatal */ }
+    } catch (e) {
+      /* non-fatal */
+    }
   };
 
   // --- NEW Test Helper ---
-  safeHandle("test-release-fetch", async () => {
+  safeHandle('test-release-fetch', async () => {
     try {
-      console.log("[IPC] Manual Test Fetch triggered (forcing refresh)...");
+      console.log('[IPC] Manual Test Fetch triggered (forcing refresh)...');
       const { ReleaseNotesManager } = require('./update/ReleaseNotesManager');
       const notes = await ReleaseNotesManager.getInstance().fetchReleaseNotes('latest', true);
 
       if (notes) {
-        console.log("[IPC] Notes fetched for:", notes.version);
+        console.log('[IPC] Notes fetched for:', notes.version);
         const info = {
           version: notes.version || 'latest',
           files: [] as any[],
@@ -81,26 +86,27 @@ export function initializeIpcHandlers(appState: AppState): void {
           sha512: '',
           releaseName: notes.summary,
           releaseNotes: notes.fullBody,
-          parsedNotes: notes
+          parsedNotes: notes,
         };
         // Send to renderer
-        appState.getMainWindow()?.webContents.send("update-available", info);
+        appState.getMainWindow()?.webContents.send('update-available', info);
         return { success: true };
       }
-      return { success: false, error: "No notes returned" };
+      return { success: false, error: 'No notes returned' };
     } catch (err: any) {
-      console.error("[IPC] test-release-fetch failed:", err);
+      console.error('[IPC] test-release-fetch failed:', err);
       return { success: false, error: err.message };
     }
   });
 
-  safeHandle("license:activate", async (event, key: string) => {
+  safeHandle('license:activate', async (event, key: string) => {
     try {
       const { LicenseManager } = require('../premium/electron/services/LicenseManager');
       const result = await LicenseManager.getInstance().activateLicense(key);
       if (result?.success) {
-        BrowserWindow.getAllWindows().forEach(win => {
-          if (!win.isDestroyed()) win.webContents.send('license-status-changed', { isPremium: true });
+        BrowserWindow.getAllWindows().forEach((win) => {
+          if (!win.isDestroyed())
+            win.webContents.send('license-status-changed', { isPremium: true });
         });
       }
       return result;
@@ -112,7 +118,7 @@ export function initializeIpcHandlers(appState: AppState): void {
       return { success: false, error: 'Premium features not available in this build.' };
     }
   });
-  safeHandle("license:check-premium", async () => {
+  safeHandle('license:check-premium', async () => {
     try {
       const { LicenseManager } = require('../premium/electron/services/LicenseManager');
       return LicenseManager.getInstance().isPremium();
@@ -121,7 +127,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("license:get-details", async () => {
+  safeHandle('license:get-details', async () => {
     try {
       const { LicenseManager } = require('../premium/electron/services/LicenseManager');
       return LicenseManager.getInstance().getLicenseDetails();
@@ -132,7 +138,7 @@ export function initializeIpcHandlers(appState: AppState): void {
   // Async variant: performs Dodo server-side revocation check on startup.
   // Returns false only if the server definitively revokes the key.
   // Network errors fail-open (returns cached sync result).
-  safeHandle("license:check-premium-async", async () => {
+  safeHandle('license:check-premium-async', async () => {
     try {
       const { LicenseManager } = require('../premium/electron/services/LicenseManager');
       return await LicenseManager.getInstance().isPremiumAsync();
@@ -140,7 +146,7 @@ export function initializeIpcHandlers(appState: AppState): void {
       return false;
     }
   });
-  safeHandle("license:deactivate", async () => {
+  safeHandle('license:deactivate', async () => {
     try {
       const { LicenseManager } = require('../premium/electron/services/LicenseManager');
       // deactivate() is async — it calls the Dodo server to free the activation slot
@@ -153,16 +159,21 @@ export function initializeIpcHandlers(appState: AppState): void {
           orchestrator.setKnowledgeMode(false);
           console.log('[IPC] Knowledge mode auto-disabled due to license deactivation');
         }
-      } catch (e) { /* ignore */ }
+      } catch (e) {
+        /* ignore */
+      }
       // Notify all windows so the license UI (ProGate, settings) refreshes immediately
       clearActiveModeOnLicenseLoss();
-      BrowserWindow.getAllWindows().forEach(win => {
-        if (!win.isDestroyed()) win.webContents.send('license-status-changed', { isPremium: false });
+      BrowserWindow.getAllWindows().forEach((win) => {
+        if (!win.isDestroyed())
+          win.webContents.send('license-status-changed', { isPremium: false });
       });
-    } catch { /* LicenseManager not available */ }
+    } catch {
+      /* LicenseManager not available */
+    }
     return { success: true };
   });
-  safeHandle("license:get-hardware-id", async () => {
+  safeHandle('license:get-hardware-id', async () => {
     try {
       const { LicenseManager } = require('../premium/electron/services/LicenseManager');
       return LicenseManager.getInstance().getHardwareId();
@@ -171,15 +182,15 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("get-recognition-languages", async () => {
+  safeHandle('get-recognition-languages', async () => {
     return RECOGNITION_LANGUAGES;
   });
 
-  safeHandle("get-ai-response-languages", async () => {
+  safeHandle('get-ai-response-languages', async () => {
     return AI_RESPONSE_LANGUAGES;
   });
 
-  safeHandle("set-ai-response-language", async (_, language: string) => {
+  safeHandle('set-ai-response-language', async (_, language: string) => {
     // Validate: must be a non-empty string
     if (!language || typeof language !== 'string' || !language.trim()) {
       console.warn('[IPC] set-ai-response-language: invalid or empty language received, ignoring.');
@@ -195,68 +206,83 @@ export function initializeIpcHandlers(appState: AppState): void {
       llmHelper.setAiResponseLanguage(sanitizedLanguage);
       console.log(`[IPC] AI response language updated to: ${sanitizedLanguage}`);
     } else {
-      console.warn('[IPC] set-ai-response-language: processingHelper or LLMHelper not ready, language saved to disk only.');
+      console.warn(
+        '[IPC] set-ai-response-language: processingHelper or LLMHelper not ready, language saved to disk only.',
+      );
     }
     return { success: true };
   });
 
-  safeHandle("get-stt-language", async () => {
+  safeHandle('get-stt-language', async () => {
     const { CredentialsManager } = require('./services/CredentialsManager');
     return CredentialsManager.getInstance().getSttLanguage();
   });
 
-  safeHandle("get-ai-response-language", async () => {
+  safeHandle('get-ai-response-language', async () => {
     const { CredentialsManager } = require('./services/CredentialsManager');
     return CredentialsManager.getInstance().getAiResponseLanguage();
   });
   safeHandle(
-    "update-content-dimensions",
+    'update-content-dimensions',
     async (event, { width, height }: { width: number; height: number }) => {
-      if (!width || !height) return
+      if (!width || !height) return;
 
-      const senderWebContents = event.sender
-      const settingsWin = appState.settingsWindowHelper.getSettingsWindow()
-      const overlayWin = appState.getWindowHelper().getOverlayWindow()
-      const launcherWin = appState.getWindowHelper().getLauncherWindow()
+      const senderWebContents = event.sender;
+      const settingsWin = appState.settingsWindowHelper.getSettingsWindow();
+      const overlayWin = appState.getWindowHelper().getOverlayWindow();
+      const launcherWin = appState.getWindowHelper().getLauncherWindow();
 
-      if (settingsWin && !settingsWin.isDestroyed() && settingsWin.webContents.id === senderWebContents.id) {
-        appState.settingsWindowHelper.setWindowDimensions(settingsWin, width, height)
+      if (
+        settingsWin &&
+        !settingsWin.isDestroyed() &&
+        settingsWin.webContents.id === senderWebContents.id
+      ) {
+        appState.settingsWindowHelper.setWindowDimensions(settingsWin, width, height);
       } else if (
-        overlayWin && !overlayWin.isDestroyed() && overlayWin.webContents.id === senderWebContents.id
+        overlayWin &&
+        !overlayWin.isDestroyed() &&
+        overlayWin.webContents.id === senderWebContents.id
       ) {
         // NativelyInterface logic - Resize ONLY the overlay window using dedicated method
-        appState.getWindowHelper().setOverlayDimensions(width, height)
+        appState.getWindowHelper().setOverlayDimensions(width, height);
       } else if (
-        launcherWin && !launcherWin.isDestroyed() && launcherWin.webContents.id === senderWebContents.id
+        launcherWin &&
+        !launcherWin.isDestroyed() &&
+        launcherWin.webContents.id === senderWebContents.id
       ) {
         // EC-05 fix: launcher window resize events were previously silently ignored.
         // Log them so that if the launcher ever sends this IPC it's visible in logs.
-        console.log(`[IPC] update-content-dimensions: launcher window resize request ${width}x${height} (ignored — launcher has fixed dimensions)`);
+        console.log(
+          `[IPC] update-content-dimensions: launcher window resize request ${width}x${height} (ignored — launcher has fixed dimensions)`,
+        );
       }
-    }
-  )
+    },
+  );
 
   // Centered variant: keeps horizontal center fixed during width changes.
   // Used by code-expansion animations to prevent the top pill from sliding sideways.
   safeHandle(
-    "update-content-dimensions-centered",
+    'update-content-dimensions-centered',
     async (event, { width, height }: { width: number; height: number }) => {
-      if (!width || !height) return
-      const senderWebContents = event.sender
-      const overlayWin = appState.getWindowHelper().getOverlayWindow()
-      if (overlayWin && !overlayWin.isDestroyed() && overlayWin.webContents.id === senderWebContents.id) {
-        appState.getWindowHelper().setOverlayDimensionsCentered(width, height)
+      if (!width || !height) return;
+      const senderWebContents = event.sender;
+      const overlayWin = appState.getWindowHelper().getOverlayWindow();
+      if (
+        overlayWin &&
+        !overlayWin.isDestroyed() &&
+        overlayWin.webContents.id === senderWebContents.id
+      ) {
+        appState.getWindowHelper().setOverlayDimensionsCentered(width, height);
       }
-    }
-  )
+    },
+  );
 
-  safeHandle("set-window-mode", async (event, mode: 'launcher' | 'overlay', inactive?: boolean) => {
+  safeHandle('set-window-mode', async (event, mode: 'launcher' | 'overlay', inactive?: boolean) => {
     appState.getWindowHelper().setWindowMode(mode, inactive);
     return { success: true };
-  })
+  });
 
-
-  safeHandle("delete-screenshot", async (event, filePath: string) => {
+  safeHandle('delete-screenshot', async (event, filePath: string) => {
     // Guard: only allow deletion of files within the app's own userData directory
     const userDataDir = app.getPath('userData');
     const resolved = path.resolve(filePath);
@@ -265,137 +291,138 @@ export function initializeIpcHandlers(appState: AppState): void {
       return { success: false, error: 'Path not allowed' };
     }
     return appState.deleteScreenshot(resolved);
-  })
+  });
 
-  safeHandle("take-screenshot", async () => {
+  safeHandle('take-screenshot', async () => {
     try {
-      const screenshotPath = await appState.takeScreenshot()
-      const preview = await appState.getImagePreview(screenshotPath)
-      return { path: screenshotPath, preview }
+      const screenshotPath = await appState.takeScreenshot();
+      const preview = await appState.getImagePreview(screenshotPath);
+      return { path: screenshotPath, preview };
     } catch (error) {
       // console.error("Error taking screenshot:", error)
-      throw error
+      throw error;
     }
-  })
+  });
 
-  safeHandle("take-selective-screenshot", async () => {
+  safeHandle('take-selective-screenshot', async () => {
     try {
-      const screenshotPath = await appState.takeSelectiveScreenshot()
-      const preview = await appState.getImagePreview(screenshotPath)
-      return { path: screenshotPath, preview }
+      const screenshotPath = await appState.takeSelectiveScreenshot();
+      const preview = await appState.getImagePreview(screenshotPath);
+      return { path: screenshotPath, preview };
     } catch (error) {
       // EC-04 fix: cast unknown error to Error before accessing .message
-      if ((error as Error).message === "Selection cancelled") {
-        return { cancelled: true }
+      if ((error as Error).message === 'Selection cancelled') {
+        return { cancelled: true };
       }
-      throw error
+      throw error;
     }
-  })
+  });
 
-  safeHandle("get-screenshots", async () => {
+  safeHandle('get-screenshots', async () => {
     // console.log({ view: appState.getView() })
     try {
-      let previews = []
-      if (appState.getView() === "queue") {
+      let previews = [];
+      if (appState.getView() === 'queue') {
         previews = await Promise.all(
           appState.getScreenshotQueue().map(async (path) => ({
             path,
-            preview: await appState.getImagePreview(path)
-          }))
-        )
+            preview: await appState.getImagePreview(path),
+          })),
+        );
       } else {
         previews = await Promise.all(
           appState.getExtraScreenshotQueue().map(async (path) => ({
             path,
-            preview: await appState.getImagePreview(path)
-          }))
-        )
+            preview: await appState.getImagePreview(path),
+          })),
+        );
       }
       // previews.forEach((preview: any) => console.log(preview.path))
-      return previews
+      return previews;
     } catch (error) {
       // console.error("Error getting screenshots:", error)
-      throw error
+      throw error;
     }
-  })
+  });
 
-  safeHandle("toggle-window", async () => {
-    appState.toggleMainWindow()
-  })
+  safeHandle('toggle-window', async () => {
+    appState.toggleMainWindow();
+  });
 
-  safeHandle("show-window", async (event, inactive?: boolean) => {
+  safeHandle('show-window', async (event, inactive?: boolean) => {
     // Default show main window (Launcher usually)
-    appState.showMainWindow(inactive)
-  })
+    appState.showMainWindow(inactive);
+  });
 
-  safeHandle("hide-window", async () => {
-    appState.hideMainWindow()
-  })
+  safeHandle('hide-window', async () => {
+    appState.hideMainWindow();
+  });
 
-  safeHandle("show-overlay", async () => {
+  safeHandle('show-overlay', async () => {
     appState.getWindowHelper().showOverlay();
-  })
+  });
 
-  safeHandle("hide-overlay", async () => {
+  safeHandle('hide-overlay', async () => {
     appState.getWindowHelper().hideOverlay();
-  })
+  });
 
-  safeHandle("get-meeting-active", async () => {
+  safeHandle('get-meeting-active', async () => {
     return appState.getIsMeetingActive();
-  })
+  });
 
-  safeHandle("reset-queues", async () => {
+  safeHandle('reset-queues', async () => {
     try {
-      appState.clearQueues()
+      appState.clearQueues();
       // console.log("Screenshot queues have been cleared.")
-      return { success: true }
+      return { success: true };
     } catch (error: any) {
       // console.error("Error resetting queues:", error)
-      return { success: false, error: error.message }
+      return { success: false, error: error.message };
     }
-  })
+  });
 
   // Donation IPC Handlers
-  safeHandle("get-donation-status", async () => {
+  safeHandle('get-donation-status', async () => {
     const { DonationManager } = require('./DonationManager');
     const manager = DonationManager.getInstance();
     return {
       shouldShow: manager.shouldShowToaster(),
       hasDonated: manager.getDonationState().hasDonated,
-      lifetimeShows: manager.getDonationState().lifetimeShows
+      lifetimeShows: manager.getDonationState().lifetimeShows,
     };
   });
 
-  safeHandle("mark-donation-toast-shown", async () => {
+  safeHandle('mark-donation-toast-shown', async () => {
     const { DonationManager } = require('./DonationManager');
     DonationManager.getInstance().markAsShown();
     return { success: true };
   });
 
-  safeHandle("set-donation-complete", async () => {
+  safeHandle('set-donation-complete', async () => {
     const { DonationManager } = require('./DonationManager');
     DonationManager.getInstance().setHasDonated(true);
     return { success: true };
   });
 
-
   // Generate suggestion from transcript - Natively-style text-only reasoning
-  safeHandle("generate-suggestion", async (event, context: string, lastQuestion: string) => {
+  safeHandle('generate-suggestion', async (event, context: string, lastQuestion: string) => {
     try {
-      const suggestion = await appState.processingHelper.getLLMHelper().generateSuggestion(context, lastQuestion)
-      return { suggestion }
+      const suggestion = await appState.processingHelper
+        .getLLMHelper()
+        .generateSuggestion(context, lastQuestion);
+      return { suggestion };
     } catch (error: any) {
       // console.error("Error generating suggestion:", error)
-      throw error
+      throw error;
     }
-  })
+  });
 
-  safeHandle("finalize-mic-stt", async () => {
+  safeHandle('finalize-mic-stt', async () => {
     appState.finalizeMicSTT();
   });
 
   // IPC handler for analyzing image from file path
-  safeHandle("analyze-image-file", async (event, filePath: string) => {
+  safeHandle('analyze-image-file', async (event, filePath: string) => {
     // Guard: only allow reading files within the app's own userData directory
     const userDataDir = app.getPath('userData');
     const resolved = path.resolve(filePath);
@@ -404,52 +431,68 @@ export function initializeIpcHandlers(appState: AppState): void {
       throw new Error('Path not allowed');
     }
     try {
-      const result = await appState.processingHelper.getLLMHelper().analyzeImageFiles([resolved])
-      return result
-    } catch (error: any) {
-      throw error
-    }
-  })
-
-  safeHandle("gemini-chat", async (event, message: string, imagePaths?: string[], context?: string, options?: { skipSystemPrompt?: boolean }) => {
-    try {
-      const result = await appState.processingHelper.getLLMHelper().chatWithGemini(message, imagePaths, context, options?.skipSystemPrompt);
-
-      console.log(`[IPC] gemini - chat response received`, { length: result?.length ?? 0 });
-
-      // Don't process empty responses
-      if (!result || result.trim().length === 0) {
-        console.warn("[IPC] Empty response from LLM, not updating IntelligenceManager");
-        return "I apologize, but I couldn't generate a response. Please try again.";
-      }
-
-      // Sync with IntelligenceManager so Follow-Up/Recap work
-      const intelligenceManager = appState.getIntelligenceManager();
-
-      // 1. Add user question to context (as 'user')
-      // CRITICAL: Skip refinement check to prevent auto-triggering follow-up logic
-      // The user's manual question is a NEW input, not a refinement of previous answer.
-      intelligenceManager.addTranscript({
-        text: message,
-        speaker: 'user',
-        timestamp: Date.now(),
-        final: true
-      }, true);
-
-      // 2. Add assistant response and set as last message
-      console.log(`[IPC] Updating IntelligenceManager with assistant message...`);
-      intelligenceManager.addAssistantMessage(result);
-      console.log(`[IPC] Updated IntelligenceManager.Last message`, { length: intelligenceManager.getLastAssistantMessage()?.length ?? 0 });
-
-      // Log Usage
-      intelligenceManager.logUsage('chat', message, result);
-
+      const result = await appState.processingHelper.getLLMHelper().analyzeImageFiles([resolved]);
       return result;
     } catch (error: any) {
-      // console.error("Error in gemini-chat handler:", error);
       throw error;
     }
   });
+
+  safeHandle(
+    'gemini-chat',
+    async (
+      event,
+      message: string,
+      imagePaths?: string[],
+      context?: string,
+      options?: { skipSystemPrompt?: boolean },
+    ) => {
+      try {
+        const result = await appState.processingHelper
+          .getLLMHelper()
+          .chatWithGemini(message, imagePaths, context, options?.skipSystemPrompt);
+
+        console.log(`[IPC] gemini - chat response received`, { length: result?.length ?? 0 });
+
+        // Don't process empty responses
+        if (!result || result.trim().length === 0) {
+          console.warn('[IPC] Empty response from LLM, not updating IntelligenceManager');
+          return "I apologize, but I couldn't generate a response. Please try again.";
+        }
+
+        // Sync with IntelligenceManager so Follow-Up/Recap work
+        const intelligenceManager = appState.getIntelligenceManager();
+
+        // 1. Add user question to context (as 'user')
+        // CRITICAL: Skip refinement check to prevent auto-triggering follow-up logic
+        // The user's manual question is a NEW input, not a refinement of previous answer.
+        intelligenceManager.addTranscript(
+          {
+            text: message,
+            speaker: 'user',
+            timestamp: Date.now(),
+            final: true,
+          },
+          true,
+        );
+
+        // 2. Add assistant response and set as last message
+        console.log(`[IPC] Updating IntelligenceManager with assistant message...`);
+        intelligenceManager.addAssistantMessage(result);
+        console.log(`[IPC] Updated IntelligenceManager.Last message`, {
+          length: intelligenceManager.getLastAssistantMessage()?.length ?? 0,
+        });
+
+        // Log Usage
+        intelligenceManager.logUsage('chat', message, result);
+
+        return result;
+      } catch (error: any) {
+        // console.error("Error in gemini-chat handler:", error);
+        throw error;
+      }
+    },
+  );
 
   // Streaming IPC Handler
   // SECURITY FIX (P0-1): Monotonic stream ID prevents interleaved tokens from concurrent stream requests.
@@ -460,295 +503,356 @@ export function initializeIpcHandlers(appState: AppState): void {
   // Matches narrow identity/meta probes only. Kept tight so coding/normal asks don't trip it.
   // Prevents the small fast-mode model from over-firing the "I'm Natively" canned reply
   // (which used to escape the prompt's hard rule for any ambiguous input).
-  const IDENTITY_PROBE_RE = /^\s*(who\s+(are|r)\s+(you|u|this|natively)|what\s+(are|r)\s+(you|u)|are\s+you\s+(chatgpt|gpt[-\s]?\d?|claude|gemini|llama|an?\s+(ai|bot|llm|model|assistant))|what('?s|\s+is)\s+your\s+(name|model)|which\s+(ai|model|llm)\s+are\s+you|who\s+(made|built|created|developed|trained)\s+(you|this|natively)|what\s+model\s+(are\s+you|do\s+you\s+use)|introduce\s+yourself)\s*\??\s*$/i;
-  const CREATOR_PROBE_RE = /^\s*(who\s+(made|built|created|developed|trained)\s+(you|this|natively))\s*\??\s*$/i;
+  const IDENTITY_PROBE_RE =
+    /^\s*(who\s+(are|r)\s+(you|u|this|natively)|what\s+(are|r)\s+(you|u)|are\s+you\s+(chatgpt|gpt[-\s]?\d?|claude|gemini|llama|an?\s+(ai|bot|llm|model|assistant))|what('?s|\s+is)\s+your\s+(name|model)|which\s+(ai|model|llm)\s+are\s+you|who\s+(made|built|created|developed|trained)\s+(you|this|natively)|what\s+model\s+(are\s+you|do\s+you\s+use)|introduce\s+yourself)\s*\??\s*$/i;
+  const CREATOR_PROBE_RE =
+    /^\s*(who\s+(made|built|created|developed|trained)\s+(you|this|natively))\s*\??\s*$/i;
 
-  safeHandle("gemini-chat-stream", async (event, message: string, imagePaths?: string[], context?: string, options?: { skipSystemPrompt?: boolean, ignoreKnowledgeMode?: boolean }) => {
-    try {
-      console.log("[IPC] gemini-chat-stream started using LLMHelper.streamChat");
-      const llmHelper = appState.processingHelper.getLLMHelper();
-
-      // Claim a new stream ID — any prior stream will detect this and stop emitting.
-      const myStreamId = ++_chatStreamId;
-
-      const intelligenceManager = appState.getIntelligenceManager();
-
-      // Identity probe short-circuit — bypasses the LLM entirely so small models can't
-      // reframe the canned reply or misfire it on coding asks (the original bug).
-      // Regex is `^...$` anchored, so non-probe questions cannot match.
-      if (!imagePaths?.length && typeof message === 'string') {
-        const identityHit = CREATOR_PROBE_RE.test(message)
-          ? "I was developed by Evin John."
-          : (IDENTITY_PROBE_RE.test(message) ? "I'm Natively, an AI assistant." : null);
-        if (identityHit) {
-          intelligenceManager.addTranscript({ text: message, speaker: 'user', timestamp: Date.now(), final: true }, true);
-          try { PhoneMirrorService.getInstance().publishUserMessage(String(myStreamId), message); } catch (_) { /* noop */ }
-          // Guard against a newer chat stream having taken over while we were computing
-          // the canned reply — matches the protection the LLM path uses around its token
-          // loop. Prevents cross-stream UI bleed.
-          if (_chatStreamId !== myStreamId) {
-            console.log(`[IPC] gemini-chat-stream ${myStreamId} (identity probe) superseded by ${_chatStreamId}, skipping emit.`);
-            return null;
-          }
-          event.sender.send("gemini-stream-token", identityHit);
-          event.sender.send("gemini-stream-done");
-          try { PhoneMirrorService.getInstance().publishToken(String(myStreamId), identityHit); } catch (_) { /* noop */ }
-          try { PhoneMirrorService.getInstance().publishDone(String(myStreamId), identityHit); } catch (_) { /* noop */ }
-          intelligenceManager.addAssistantMessage(identityHit);
-          intelligenceManager.logUsage('chat', message, identityHit);
-          return null;
-        }
-      }
-
-      // Capture rolling context BEFORE adding the new user message — otherwise the
-      // 100s window would echo back the user's just-typed message as both context and
-      // question, confusing small models (the "20-char context" log line was just an echo).
-      let autoContextSnapshot: string | undefined;
-      if (!context) {
-        try {
-          const snap = intelligenceManager.getFormattedContext(100);
-          if (snap && snap.trim().length > 0) autoContextSnapshot = snap;
-        } catch (ctxErr) {
-          console.warn("[IPC] Failed to capture pre-turn context:", ctxErr);
-        }
-      }
-
-      // Now add USER message to IntelligenceManager (after context snapshot)
-      intelligenceManager.addTranscript({
-        text: message,
-        speaker: 'user',
-        timestamp: Date.now(),
-        final: true
-      }, true);
-
-      // Mirror to phone (no-op if PhoneMirrorService isn't running).
-      try { PhoneMirrorService.getInstance().publishUserMessage(String(myStreamId), message); } catch (_) { /* noop */ }
-
-      let fullResponse = "";
-
-      if (!context && autoContextSnapshot) {
-        context = autoContextSnapshot;
-        console.log(`[IPC] Auto-injected 100s context for gemini-chat-stream (${context.length} chars)`);
-      }
-
-      // Use CHAT_MODE_PROMPT for general chat — bypasses the interview-copilot
-      // framing in HARD_SYSTEM_PROMPT/ASSIST_MODE_PROMPT that was causing coding
-      // questions to be answered with "At Aetherbot AI, I was responsible for..."
-      // (resume hijack via CONTEXT_INTELLIGENCE_LAYER's "you ARE the user").
-      const systemPromptOverride: string | undefined = options?.skipSystemPrompt ? "" : CHAT_MODE_PROMPT;
-
+  safeHandle(
+    'gemini-chat-stream',
+    async (
+      event,
+      message: string,
+      imagePaths?: string[],
+      context?: string,
+      options?: { skipSystemPrompt?: boolean; ignoreKnowledgeMode?: boolean },
+    ) => {
       try {
-        // USE streamChat which handles routing
-        const stream = llmHelper.streamChat(message, imagePaths, context, systemPromptOverride, options?.ignoreKnowledgeMode);
+        console.log('[IPC] gemini-chat-stream started using LLMHelper.streamChat');
+        const llmHelper = appState.processingHelper.getLLMHelper();
 
-        for await (const token of stream) {
-          // Bail if a newer stream has taken over (user triggered a new request)
-          if (_chatStreamId !== myStreamId) {
-            console.log(`[IPC] gemini-chat-stream ${myStreamId} superseded by ${_chatStreamId}, stopping.`);
+        // Claim a new stream ID — any prior stream will detect this and stop emitting.
+        const myStreamId = ++_chatStreamId;
+
+        const intelligenceManager = appState.getIntelligenceManager();
+
+        // Identity probe short-circuit — bypasses the LLM entirely so small models can't
+        // reframe the canned reply or misfire it on coding asks (the original bug).
+        // Regex is `^...$` anchored, so non-probe questions cannot match.
+        if (!imagePaths?.length && typeof message === 'string') {
+          const identityHit = CREATOR_PROBE_RE.test(message)
+            ? 'I was developed by Evin John.'
+            : IDENTITY_PROBE_RE.test(message)
+              ? "I'm Natively, an AI assistant."
+              : null;
+          if (identityHit) {
+            intelligenceManager.addTranscript(
+              { text: message, speaker: 'user', timestamp: Date.now(), final: true },
+              true,
+            );
+            try {
+              PhoneMirrorService.getInstance().publishUserMessage(String(myStreamId), message);
+            } catch (_) {
+              /* noop */
+            }
+            // Guard against a newer chat stream having taken over while we were computing
+            // the canned reply — matches the protection the LLM path uses around its token
+            // loop. Prevents cross-stream UI bleed.
+            if (_chatStreamId !== myStreamId) {
+              console.log(
+                `[IPC] gemini-chat-stream ${myStreamId} (identity probe) superseded by ${_chatStreamId}, skipping emit.`,
+              );
+              return null;
+            }
+            event.sender.send('gemini-stream-token', identityHit);
+            event.sender.send('gemini-stream-done');
+            try {
+              PhoneMirrorService.getInstance().publishToken(String(myStreamId), identityHit);
+            } catch (_) {
+              /* noop */
+            }
+            try {
+              PhoneMirrorService.getInstance().publishDone(String(myStreamId), identityHit);
+            } catch (_) {
+              /* noop */
+            }
+            intelligenceManager.addAssistantMessage(identityHit);
+            intelligenceManager.logUsage('chat', message, identityHit);
             return null;
           }
-          event.sender.send("gemini-stream-token", token);
-          try { PhoneMirrorService.getInstance().publishToken(String(myStreamId), token); } catch (_) { /* noop */ }
-          fullResponse += token;
         }
 
-        // Final check: only send done if we are still the active stream
-        if (_chatStreamId === myStreamId) {
-          event.sender.send("gemini-stream-done");
-          try { PhoneMirrorService.getInstance().publishDone(String(myStreamId), fullResponse); } catch (_) { /* noop */ }
-
-          // Update IntelligenceManager with ASSISTANT message after completion
-          if (fullResponse.trim().length > 0) {
-            intelligenceManager.addAssistantMessage(fullResponse);
-            // Log Usage for streaming chat
-            intelligenceManager.logUsage('chat', message, fullResponse);
+        // Capture rolling context BEFORE adding the new user message — otherwise the
+        // 100s window would echo back the user's just-typed message as both context and
+        // question, confusing small models (the "20-char context" log line was just an echo).
+        let autoContextSnapshot: string | undefined;
+        if (!context) {
+          try {
+            const snap = intelligenceManager.getFormattedContext(100);
+            if (snap && snap.trim().length > 0) autoContextSnapshot = snap;
+          } catch (ctxErr) {
+            console.warn('[IPC] Failed to capture pre-turn context:', ctxErr);
           }
         }
 
-      } catch (streamError: any) {
-        console.error("[IPC] Streaming error:", streamError);
-        if (_chatStreamId === myStreamId) {
-          event.sender.send("gemini-stream-error", streamError.message || "Unknown streaming error");
-          try { PhoneMirrorService.getInstance().publishError(String(myStreamId), streamError?.message || "Unknown streaming error"); } catch (_) { /* noop */ }
+        // Now add USER message to IntelligenceManager (after context snapshot)
+        intelligenceManager.addTranscript(
+          {
+            text: message,
+            speaker: 'user',
+            timestamp: Date.now(),
+            final: true,
+          },
+          true,
+        );
+
+        // Mirror to phone (no-op if PhoneMirrorService isn't running).
+        try {
+          PhoneMirrorService.getInstance().publishUserMessage(String(myStreamId), message);
+        } catch (_) {
+          /* noop */
         }
+
+        let fullResponse = '';
+
+        if (!context && autoContextSnapshot) {
+          context = autoContextSnapshot;
+          console.log(
+            `[IPC] Auto-injected 100s context for gemini-chat-stream (${context.length} chars)`,
+          );
+        }
+
+        // Use CHAT_MODE_PROMPT for general chat — bypasses the interview-copilot
+        // framing in HARD_SYSTEM_PROMPT/ASSIST_MODE_PROMPT that was causing coding
+        // questions to be answered with "At Aetherbot AI, I was responsible for..."
+        // (resume hijack via CONTEXT_INTELLIGENCE_LAYER's "you ARE the user").
+        const systemPromptOverride: string | undefined = options?.skipSystemPrompt
+          ? ''
+          : CHAT_MODE_PROMPT;
+
+        try {
+          // USE streamChat which handles routing
+          const stream = llmHelper.streamChat(
+            message,
+            imagePaths,
+            context,
+            systemPromptOverride,
+            options?.ignoreKnowledgeMode,
+          );
+
+          for await (const token of stream) {
+            // Bail if a newer stream has taken over (user triggered a new request)
+            if (_chatStreamId !== myStreamId) {
+              console.log(
+                `[IPC] gemini-chat-stream ${myStreamId} superseded by ${_chatStreamId}, stopping.`,
+              );
+              return null;
+            }
+            event.sender.send('gemini-stream-token', token);
+            try {
+              PhoneMirrorService.getInstance().publishToken(String(myStreamId), token);
+            } catch (_) {
+              /* noop */
+            }
+            fullResponse += token;
+          }
+
+          // Final check: only send done if we are still the active stream
+          if (_chatStreamId === myStreamId) {
+            event.sender.send('gemini-stream-done');
+            try {
+              PhoneMirrorService.getInstance().publishDone(String(myStreamId), fullResponse);
+            } catch (_) {
+              /* noop */
+            }
+
+            // Update IntelligenceManager with ASSISTANT message after completion
+            if (fullResponse.trim().length > 0) {
+              intelligenceManager.addAssistantMessage(fullResponse);
+              // Log Usage for streaming chat
+              intelligenceManager.logUsage('chat', message, fullResponse);
+            }
+          }
+        } catch (streamError: any) {
+          console.error('[IPC] Streaming error:', streamError);
+          if (_chatStreamId === myStreamId) {
+            event.sender.send(
+              'gemini-stream-error',
+              streamError.message || 'Unknown streaming error',
+            );
+            try {
+              PhoneMirrorService.getInstance().publishError(
+                String(myStreamId),
+                streamError?.message || 'Unknown streaming error',
+              );
+            } catch (_) {
+              /* noop */
+            }
+          }
+        }
+
+        return null; // Return null as data is sent via events
+      } catch (error: any) {
+        console.error('[IPC] Error in gemini-chat-stream setup:', error);
+        throw error;
       }
+    },
+  );
 
-      return null; // Return null as data is sent via events
+  safeHandle('quit-app', () => {
+    app.quit();
+  });
 
-    } catch (error: any) {
-      console.error("[IPC] Error in gemini-chat-stream setup:", error);
-      throw error;
+  safeHandle('quit-and-install-update', async () => {
+    try {
+      console.log('[IPC] Quit and install update requested');
+      await appState.quitAndInstallUpdate();
+      return { success: true };
+    } catch (err: any) {
+      console.error('[IPC] quit-and-install-update failed:', err);
+      return { success: false, error: err.message };
     }
   });
 
-
-
-  safeHandle("quit-app", () => {
-    app.quit()
-  })
-
-  safeHandle("quit-and-install-update", async () => {
-    try {
-      console.log('[IPC] Quit and install update requested')
-      await appState.quitAndInstallUpdate()
-      return { success: true }
-    } catch (err: any) {
-      console.error('[IPC] quit-and-install-update failed:', err)
-      return { success: false, error: err.message }
-    }
-  })
-
-  safeHandle("delete-meeting", async (_, id: string) => {
+  safeHandle('delete-meeting', async (_, id: string) => {
     return DatabaseManager.getInstance().deleteMeeting(id);
   });
 
-  safeHandle("check-for-updates", async () => {
+  safeHandle('check-for-updates', async () => {
     try {
-      console.log('[IPC] Manual update check requested')
-      await appState.checkForUpdates()
-      return { success: true }
+      console.log('[IPC] Manual update check requested');
+      await appState.checkForUpdates();
+      return { success: true };
     } catch (err: any) {
-      console.error('[IPC] check-for-updates failed:', err)
-      return { success: false, error: err.message }
+      console.error('[IPC] check-for-updates failed:', err);
+      return { success: false, error: err.message };
     }
-  })
+  });
 
-  safeHandle("download-update", async () => {
+  safeHandle('download-update', async () => {
     try {
-      console.log('[IPC] Download update requested')
-      appState.downloadUpdate()
-      return { success: true }
+      console.log('[IPC] Download update requested');
+      appState.downloadUpdate();
+      return { success: true };
     } catch (err: any) {
-      console.error('[IPC] download-update failed:', err)
-      return { success: false, error: err.message }
+      console.error('[IPC] download-update failed:', err);
+      return { success: false, error: err.message };
     }
-  })
+  });
 
   // Window movement handlers
-  safeHandle("move-window-left", async () => {
-    appState.moveWindowLeft()
-  })
+  safeHandle('move-window-left', async () => {
+    appState.moveWindowLeft();
+  });
 
-  safeHandle("move-window-right", async () => {
-    appState.moveWindowRight()
-  })
+  safeHandle('move-window-right', async () => {
+    appState.moveWindowRight();
+  });
 
-  safeHandle("move-window-up", async () => {
-    appState.moveWindowUp()
-  })
+  safeHandle('move-window-up', async () => {
+    appState.moveWindowUp();
+  });
 
-  safeHandle("move-window-down", async () => {
-    appState.moveWindowDown()
-  })
+  safeHandle('move-window-down', async () => {
+    appState.moveWindowDown();
+  });
 
-  safeHandle("center-and-show-window", async () => {
-    appState.centerAndShowWindow()
-  })
+  safeHandle('center-and-show-window', async () => {
+    appState.centerAndShowWindow();
+  });
 
   // Window Controls
-  safeHandle("window-minimize", async () => {
+  safeHandle('window-minimize', async () => {
     appState.getWindowHelper().minimizeWindow();
   });
 
-  safeHandle("window-maximize", async () => {
+  safeHandle('window-maximize', async () => {
     appState.getWindowHelper().maximizeWindow();
   });
 
-  safeHandle("window-close", async () => {
+  safeHandle('window-close', async () => {
     appState.getWindowHelper().closeWindow();
   });
 
-  safeHandle("window-is-maximized", async () => {
+  safeHandle('window-is-maximized', async () => {
     return appState.getWindowHelper().isMainWindowMaximized();
   });
 
   // Settings Window
-  safeHandle("toggle-settings-window", (event, { x, y } = {}) => {
-    appState.settingsWindowHelper.toggleWindow(x, y)
-  })
+  safeHandle('toggle-settings-window', (event, { x, y } = {}) => {
+    appState.settingsWindowHelper.toggleWindow(x, y);
+  });
 
   // Open the launcher's SettingsOverlay on a specific tab (callable from any window)
-  safeHandle("settings:open-tab", (_, tab: string) => {
+  safeHandle('settings:open-tab', (_, tab: string) => {
     const launcherWin = appState.getWindowHelper().getLauncherWindow();
     if (launcherWin && !launcherWin.isDestroyed()) {
       launcherWin.webContents.send('settings:open-tab', tab);
       launcherWin.show();
       launcherWin.focus();
     }
-  })
+  });
 
-  safeHandle("close-settings-window", () => {
-    appState.settingsWindowHelper.closeWindow()
-  })
+  safeHandle('close-settings-window', () => {
+    appState.settingsWindowHelper.closeWindow();
+  });
 
+  safeHandle('set-undetectable', async (_, state: boolean) => {
+    appState.setUndetectable(state);
+    return { success: true };
+  });
 
+  safeHandle('set-disguise', async (_, mode: 'terminal' | 'settings' | 'activity' | 'none') => {
+    appState.setDisguise(mode);
+    return { success: true };
+  });
 
-  safeHandle("set-undetectable", async (_, state: boolean) => {
-    appState.setUndetectable(state)
-    return { success: true }
-  })
-
-  safeHandle("set-disguise", async (_, mode: 'terminal' | 'settings' | 'activity' | 'none') => {
-    appState.setDisguise(mode)
-    return { success: true }
-  })
-
-  safeHandle("get-undetectable", async () => {
-    return appState.getUndetectable()
-  })
+  safeHandle('get-undetectable', async () => {
+    return appState.getUndetectable();
+  });
 
   // Adapted from public PR #113 — verify premium interaction
-  safeHandle("set-overlay-mouse-passthrough", async (_, enabled: boolean) => {
-    appState.setOverlayMousePassthrough(enabled)
-    return { success: true }
-  })
+  safeHandle('set-overlay-mouse-passthrough', async (_, enabled: boolean) => {
+    appState.setOverlayMousePassthrough(enabled);
+    return { success: true };
+  });
 
-  safeHandle("toggle-overlay-mouse-passthrough", async () => {
-    const enabled = appState.toggleOverlayMousePassthrough()
-    return { success: true, enabled }
-  })
+  safeHandle('toggle-overlay-mouse-passthrough', async () => {
+    const enabled = appState.toggleOverlayMousePassthrough();
+    return { success: true, enabled };
+  });
 
-  safeHandle("get-overlay-mouse-passthrough", async () => {
-    return appState.getOverlayMousePassthrough()
-  })
+  safeHandle('get-overlay-mouse-passthrough', async () => {
+    return appState.getOverlayMousePassthrough();
+  });
 
-  safeHandle("get-disguise", async () => {
-    return appState.getDisguise()
-  })
+  safeHandle('get-disguise', async () => {
+    return appState.getDisguise();
+  });
 
-  safeHandle("set-open-at-login", async (_, openAtLogin: boolean) => {
+  safeHandle('set-open-at-login', async (_, openAtLogin: boolean) => {
     app.setLoginItemSettings({
       openAtLogin,
       openAsHidden: false,
-      path: app.getPath('exe') // Explicitly point to executable for production reliability
+      path: app.getPath('exe'), // Explicitly point to executable for production reliability
     });
     return { success: true };
   });
 
-  safeHandle("get-open-at-login", async () => {
+  safeHandle('get-open-at-login', async () => {
     const settings = app.getLoginItemSettings();
     return settings.openAtLogin;
   });
 
-  safeHandle("get-verbose-logging", async () => {
+  safeHandle('get-verbose-logging', async () => {
     return appState.getVerboseLogging();
   });
 
-  safeHandle("set-verbose-logging", async (_, enabled: boolean) => {
+  safeHandle('set-verbose-logging', async (_, enabled: boolean) => {
     appState.setVerboseLogging(enabled);
     return { success: true };
   });
 
-  safeHandle("get-meeting-retention", async () => {
+  safeHandle('get-meeting-retention', async () => {
     return SettingsManager.getInstance().get('meetingRetention') ?? 'forever';
   });
 
-  safeHandle("set-meeting-retention", async (_, retention: 'forever' | '7d' | '30d' | 'never') => {
+  safeHandle('set-meeting-retention', async (_, retention: 'forever' | '7d' | '30d' | 'never') => {
     if (!['forever', '7d', '30d', 'never'].includes(retention)) {
       return { success: false, error: 'invalid_retention' };
     }
     SettingsManager.getInstance().set('meetingRetention', retention);
-    BrowserWindow.getAllWindows().forEach(win => {
+    BrowserWindow.getAllWindows().forEach((win) => {
       if (!win.isDestroyed()) {
         win.webContents.send('meeting-retention-changed', retention);
       }
@@ -756,15 +860,22 @@ export function initializeIpcHandlers(appState: AppState): void {
     return { success: true };
   });
 
-  safeHandle("get-provider-data-scopes", async () => {
+  safeHandle('get-provider-data-scopes', async () => {
     return SettingsManager.getInstance().get('providerDataScopes') ?? {};
   });
 
-  safeHandle("set-provider-data-scopes", async (_, scopes: Record<string, boolean>) => {
+  safeHandle('set-provider-data-scopes', async (_, scopes: Record<string, boolean>) => {
     if (!scopes || typeof scopes !== 'object') {
       return { success: false, error: 'invalid_scopes' };
     }
-    const allowedKeys = new Set(['transcript', 'screenshots', 'reference_files', 'profile_history', 'embeddings', 'post_call_summary']);
+    const allowedKeys = new Set([
+      'transcript',
+      'screenshots',
+      'reference_files',
+      'profile_history',
+      'embeddings',
+      'post_call_summary',
+    ]);
     const sanitized: Record<string, boolean> = {};
     for (const [key, value] of Object.entries(scopes)) {
       if (allowedKeys.has(key) && typeof value === 'boolean') {
@@ -772,7 +883,7 @@ export function initializeIpcHandlers(appState: AppState): void {
       }
     }
     SettingsManager.getInstance().set('providerDataScopes', sanitized as any);
-    BrowserWindow.getAllWindows().forEach(win => {
+    BrowserWindow.getAllWindows().forEach((win) => {
       if (!win.isDestroyed()) {
         win.webContents.send('provider-data-scopes-changed', sanitized);
       }
@@ -780,33 +891,36 @@ export function initializeIpcHandlers(appState: AppState): void {
     return { success: true };
   });
 
-  safeHandle("get-screen-understanding-mode", async () => {
+  safeHandle('get-screen-understanding-mode', async () => {
     return SettingsManager.getInstance().getScreenUnderstandingMode();
   });
 
-  safeHandle("set-screen-understanding-mode", async (_, mode: 'vision_first' | 'vision_only' | 'private_vision') => {
-    if (!['vision_first', 'vision_only', 'private_vision'].includes(mode)) {
-      return { success: false, error: 'invalid_mode' };
-    }
-    SettingsManager.getInstance().setScreenUnderstandingMode(mode);
-    BrowserWindow.getAllWindows().forEach(win => {
-      if (!win.isDestroyed()) {
-        win.webContents.send('screen-understanding-mode-changed', mode);
+  safeHandle(
+    'set-screen-understanding-mode',
+    async (_, mode: 'vision_first' | 'vision_only' | 'private_vision') => {
+      if (!['vision_first', 'vision_only', 'private_vision'].includes(mode)) {
+        return { success: false, error: 'invalid_mode' };
       }
-    });
-    return { success: true };
-  });
+      SettingsManager.getInstance().setScreenUnderstandingMode(mode);
+      BrowserWindow.getAllWindows().forEach((win) => {
+        if (!win.isDestroyed()) {
+          win.webContents.send('screen-understanding-mode-changed', mode);
+        }
+      });
+      return { success: true };
+    },
+  );
 
-  safeHandle("get-technical-interview-vision-first", async () => {
+  safeHandle('get-technical-interview-vision-first', async () => {
     return SettingsManager.getInstance().getTechnicalInterviewVisionFirst();
   });
 
-  safeHandle("set-technical-interview-vision-first", async (_, enabled: boolean) => {
+  safeHandle('set-technical-interview-vision-first', async (_, enabled: boolean) => {
     if (typeof enabled !== 'boolean') {
       return { success: false, error: 'invalid_value' };
     }
     SettingsManager.getInstance().set('technicalInterviewVisionFirst', enabled);
-    BrowserWindow.getAllWindows().forEach(win => {
+    BrowserWindow.getAllWindows().forEach((win) => {
       if (!win.isDestroyed()) {
         win.webContents.send('technical-interview-vision-first-changed', enabled);
       }
@@ -817,15 +931,15 @@ export function initializeIpcHandlers(appState: AppState): void {
   // Legacy alias for renderer builds that still call the old IPC name.
   // Maps the deprecated technicalInterviewDirectVision channel onto the new
   // technicalInterviewVisionFirst getter/setter so old renderer builds keep working.
-  safeHandle("get-technical-interview-direct-vision", async () => {
+  safeHandle('get-technical-interview-direct-vision', async () => {
     return SettingsManager.getInstance().getTechnicalInterviewVisionFirst();
   });
-  safeHandle("set-technical-interview-direct-vision", async (_, enabled: boolean) => {
+  safeHandle('set-technical-interview-direct-vision', async (_, enabled: boolean) => {
     if (typeof enabled !== 'boolean') {
       return { success: false, error: 'invalid_value' };
     }
     SettingsManager.getInstance().set('technicalInterviewVisionFirst', enabled);
-    BrowserWindow.getAllWindows().forEach(win => {
+    BrowserWindow.getAllWindows().forEach((win) => {
       if (!win.isDestroyed()) {
         win.webContents.send('technical-interview-vision-first-changed', enabled);
       }
@@ -833,7 +947,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     return { success: true };
   });
 
-  safeHandle("get-log-file-path", async () => {
+  safeHandle('get-log-file-path', async () => {
     try {
       return path.join(app.getPath('documents'), 'natively_debug.log');
     } catch {
@@ -841,7 +955,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("open-log-file", async () => {
+  safeHandle('open-log-file', async () => {
     try {
       const logPath = path.join(app.getPath('documents'), 'natively_debug.log');
       // Ensure the file exists before opening
@@ -857,26 +971,24 @@ export function initializeIpcHandlers(appState: AppState): void {
 
   // Fire-and-forget: renderer forwards its console output to the main-process log file.
   // Only written when verbose logging is enabled.
-  ipcMain.on("forward-log-to-file", (_event, level: string, msg: string) => {
+  ipcMain.on('forward-log-to-file', (_event, level: string, msg: string) => {
     if (!appState.getVerboseLogging()) return;
-    const tag = level === 'error' ? '[RENDERER-ERROR]' : level === 'warn' ? '[RENDERER-WARN]' : '[RENDERER]';
+    const tag =
+      level === 'error' ? '[RENDERER-ERROR]' : level === 'warn' ? '[RENDERER-WARN]' : '[RENDERER]';
     console.log(`${tag} ${msg}`);
   });
 
-  safeHandle("get-arch", async () => {
+  safeHandle('get-arch', async () => {
     return process.arch;
   });
 
-  safeHandle("get-os-version", async () => {
+  safeHandle('get-os-version', async () => {
     const platform = process.platform;
     if (platform === 'darwin') {
       const darwinMajor = parseInt(os.release().split('.')[0] || '0', 10);
       // Darwin 25+ = macOS 26+ (calendar-year scheme), Darwin 20-24 = macOS 11-15
-      const macosMajor = darwinMajor >= 25
-        ? darwinMajor + 1
-        : darwinMajor >= 20
-          ? darwinMajor - 9
-          : null;
+      const macosMajor =
+        darwinMajor >= 25 ? darwinMajor + 1 : darwinMajor >= 20 ? darwinMajor - 9 : null;
       return macosMajor ? `macOS ${macosMajor}` : `macOS ${os.release()}`;
     }
     if (platform === 'win32') {
@@ -889,13 +1001,13 @@ export function initializeIpcHandlers(appState: AppState): void {
   });
 
   // LLM Model Management Handlers
-  safeHandle("get-current-llm-config", async () => {
+  safeHandle('get-current-llm-config', async () => {
     try {
       const llmHelper = appState.processingHelper.getLLMHelper();
       return {
         provider: llmHelper.getCurrentProvider(),
         model: llmHelper.getCurrentModel(),
-        isOllama: llmHelper.isUsingOllama()
+        isOllama: llmHelper.isUsingOllama(),
       };
     } catch (error: any) {
       // console.error("Error getting current LLM config:", error);
@@ -903,7 +1015,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("get-available-ollama-models", async () => {
+  safeHandle('get-available-ollama-models', async () => {
     try {
       const llmHelper = appState.processingHelper.getLLMHelper();
       const models = await llmHelper.getOllamaModels();
@@ -914,7 +1026,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("switch-to-ollama", async (_, model?: string, url?: string) => {
+  safeHandle('switch-to-ollama', async (_, model?: string, url?: string) => {
     try {
       const llmHelper = appState.processingHelper.getLLMHelper();
       await llmHelper.switchToOllama(model, url);
@@ -925,13 +1037,13 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("force-restart-ollama", async () => {
+  safeHandle('force-restart-ollama', async () => {
     try {
       const llmHelper = appState.processingHelper.getLLMHelper();
       const success = await llmHelper.forceRestartOllama();
       return { success };
     } catch (error: any) {
-      console.error("Error force restarting Ollama:", error);
+      console.error('Error force restarting Ollama:', error);
       return { success: false, error: error.message };
     }
   });
@@ -946,12 +1058,12 @@ export function initializeIpcHandlers(appState: AppState): void {
 
       return true;
     } catch (error: any) {
-      console.error("[IPC restart-ollama] Failed to restart:", error);
+      console.error('[IPC restart-ollama] Failed to restart:', error);
       return false;
     }
   });
 
-  safeHandle("ensure-ollama-running", async () => {
+  safeHandle('ensure-ollama-running', async () => {
     try {
       const { OllamaManager } = require('./services/OllamaManager');
       await OllamaManager.getInstance().init();
@@ -961,7 +1073,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("switch-to-gemini", async (_, apiKey?: string, modelId?: string) => {
+  safeHandle('switch-to-gemini', async (_, apiKey?: string, modelId?: string) => {
     try {
       const llmHelper = appState.processingHelper.getLLMHelper();
       await llmHelper.switchToGemini(apiKey, modelId);
@@ -980,7 +1092,7 @@ export function initializeIpcHandlers(appState: AppState): void {
   });
 
   // Dedicated API key setters (for Settings UI Save buttons)
-  safeHandle("set-gemini-api-key", async (_, apiKey: string) => {
+  safeHandle('set-gemini-api-key', async (_, apiKey: string) => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       CredentialsManager.getInstance().setGeminiApiKey(apiKey);
@@ -998,12 +1110,12 @@ export function initializeIpcHandlers(appState: AppState): void {
 
       return { success: true };
     } catch (error: any) {
-      console.error("Error saving Gemini API key:", error);
+      console.error('Error saving Gemini API key:', error);
       return { success: false, error: error.message };
     }
   });
 
-  safeHandle("set-groq-api-key", async (_, apiKey: string) => {
+  safeHandle('set-groq-api-key', async (_, apiKey: string) => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       CredentialsManager.getInstance().setGroqApiKey(apiKey);
@@ -1019,12 +1131,12 @@ export function initializeIpcHandlers(appState: AppState): void {
 
       return { success: true };
     } catch (error: any) {
-      console.error("Error saving Groq API key:", error);
+      console.error('Error saving Groq API key:', error);
       return { success: false, error: error.message };
     }
   });
 
-  safeHandle("set-openai-api-key", async (_, apiKey: string) => {
+  safeHandle('set-openai-api-key', async (_, apiKey: string) => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       CredentialsManager.getInstance().setOpenaiApiKey(apiKey);
@@ -1040,12 +1152,12 @@ export function initializeIpcHandlers(appState: AppState): void {
 
       return { success: true };
     } catch (error: any) {
-      console.error("Error saving OpenAI API key:", error);
+      console.error('Error saving OpenAI API key:', error);
       return { success: false, error: error.message };
     }
   });
 
-  safeHandle("set-claude-api-key", async (_, apiKey: string) => {
+  safeHandle('set-claude-api-key', async (_, apiKey: string) => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       CredentialsManager.getInstance().setClaudeApiKey(apiKey);
@@ -1061,7 +1173,7 @@ export function initializeIpcHandlers(appState: AppState): void {
 
       return { success: true };
     } catch (error: any) {
-      console.error("Error saving Claude API key:", error);
+      console.error('Error saving Claude API key:', error);
       return { success: false, error: error.message };
     }
   });
@@ -1070,7 +1182,7 @@ export function initializeIpcHandlers(appState: AppState): void {
   const _usageCache = new Map<string, { data: any; ts: number }>();
   const USAGE_CACHE_TTL_MS = 60_000;
 
-  safeHandle("set-natively-api-key", async (_, apiKey: string) => {
+  safeHandle('set-natively-api-key', async (_, apiKey: string) => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       const cm = CredentialsManager.getInstance();
@@ -1085,7 +1197,7 @@ export function initializeIpcHandlers(appState: AppState): void {
       const defaultModel = cm.getDefaultModel();
       const providers = [...(cm.getCurlProviders() || []), ...(cm.getCustomProviders() || [])];
       llmHelper.setModel(defaultModel, providers);
-      BrowserWindow.getAllWindows().forEach(win => {
+      BrowserWindow.getAllWindows().forEach((win) => {
         if (!win.isDestroyed()) win.webContents.send('model-changed', defaultModel);
       });
 
@@ -1094,7 +1206,9 @@ export function initializeIpcHandlers(appState: AppState): void {
       // the old STT provider (e.g. Google) until the app restarts.
       const newSttProvider = cm.getSttProvider();
       if (newSttProvider !== prevSttProvider) {
-        console.log(`[IPC] set-natively-api-key: STT provider changed ${prevSttProvider} → ${newSttProvider}, reconfiguring pipeline`);
+        console.log(
+          `[IPC] set-natively-api-key: STT provider changed ${prevSttProvider} → ${newSttProvider}, reconfiguring pipeline`,
+        );
         await appState.reconfigureSttProvider();
       }
 
@@ -1107,17 +1221,23 @@ export function initializeIpcHandlers(appState: AppState): void {
           if (result.success) {
             console.log('[IPC] set-natively-api-key: Pro auto-activated via API plan.');
             // Notify all windows so the license UI refreshes immediately
-            BrowserWindow.getAllWindows().forEach(win => {
-              if (!win.isDestroyed()) win.webContents.send('license-status-changed', { isPremium: true });
+            BrowserWindow.getAllWindows().forEach((win) => {
+              if (!win.isDestroyed())
+                win.webContents.send('license-status-changed', { isPremium: true });
             });
           } else if (result.skipped) {
-            console.log('[IPC] set-natively-api-key: existing Gumroad/Dodo license preserved — Pro not overwritten.');
+            console.log(
+              '[IPC] set-natively-api-key: existing Gumroad/Dodo license preserved — Pro not overwritten.',
+            );
           } else {
             console.log('[IPC] set-natively-api-key: Pro not activated —', result.error);
           }
         } catch (e: any) {
           // LicenseManager not available in this build — non-fatal
-          console.warn('[IPC] set-natively-api-key: LicenseManager unavailable for Pro auto-activation:', e?.message);
+          console.warn(
+            '[IPC] set-natively-api-key: LicenseManager unavailable for Pro auto-activation:',
+            e?.message,
+          );
         }
       } else {
         // API key was cleared — deactivate any natively_api Pro license so premium is revoked.
@@ -1129,20 +1249,26 @@ export function initializeIpcHandlers(appState: AppState): void {
           const details = lm.getLicenseDetails();
           if (details.isPremium && details.provider === 'natively_api') {
             await lm.deactivate();
-            console.log('[IPC] set-natively-api-key: key cleared — natively_api Pro license deactivated.');
+            console.log(
+              '[IPC] set-natively-api-key: key cleared — natively_api Pro license deactivated.',
+            );
             clearActiveModeOnLicenseLoss();
-            BrowserWindow.getAllWindows().forEach(win => {
-              if (!win.isDestroyed()) win.webContents.send('license-status-changed', { isPremium: false });
+            BrowserWindow.getAllWindows().forEach((win) => {
+              if (!win.isDestroyed())
+                win.webContents.send('license-status-changed', { isPremium: false });
             });
           }
         } catch (e: any) {
-          console.warn('[IPC] set-natively-api-key: LicenseManager unavailable for Pro deactivation on key clear:', e?.message);
+          console.warn(
+            '[IPC] set-natively-api-key: LicenseManager unavailable for Pro deactivation on key clear:',
+            e?.message,
+          );
         }
       }
 
       return { success: true };
     } catch (error: any) {
-      console.error("Error saving Natively API key:", error);
+      console.error('Error saving Natively API key:', error);
       return { success: false, error: error.message };
     } finally {
       // Always bust the cache when the key changes so the next usage fetch is fresh
@@ -1150,8 +1276,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-
-  safeHandle("get-natively-usage", async () => {
+  safeHandle('get-natively-usage', async () => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       const key = CredentialsManager.getInstance().getNativelyApiKey();
@@ -1168,10 +1293,10 @@ export function initializeIpcHandlers(appState: AppState): void {
         signal: AbortSignal.timeout(8000),
       });
       if (!res.ok) {
-        const body = await res.json().catch(() => ({})) as any;
+        const body = (await res.json().catch(() => ({}))) as any;
         return { ok: false, error: body.error || 'request_failed', status: res.status };
       }
-      const data = await res.json() as any;
+      const data = (await res.json()) as any;
       const result = { ok: true, ...data };
 
       // Cache the successful response
@@ -1183,7 +1308,7 @@ export function initializeIpcHandlers(appState: AppState): void {
   });
 
   // Allow other handlers to force-invalidate the usage cache (e.g. after key change)
-  safeHandle("invalidate-natively-usage-cache", () => {
+  safeHandle('invalidate-natively-usage-cache', () => {
     _usageCache.clear();
     return { ok: true };
   });
@@ -1191,7 +1316,7 @@ export function initializeIpcHandlers(appState: AppState): void {
   // ── Free Trial IPC ───────────────────────────────────────────────────────────
 
   // Start or resume a free trial. Fetches HWID, calls server, persists token locally.
-  safeHandle("trial:start", async () => {
+  safeHandle('trial:start', async () => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       const cm = CredentialsManager.getInstance();
@@ -1201,7 +1326,9 @@ export function initializeIpcHandlers(appState: AppState): void {
       try {
         const { LicenseManager } = require('../premium/electron/services/LicenseManager');
         hwid = LicenseManager.getInstance().getHardwareId() || 'unavailable';
-      } catch { /* LicenseManager not available — fall back */ }
+      } catch {
+        /* LicenseManager not available — fall back */
+      }
 
       const res = await fetch('https://api.natively.software/v1/trial/start', {
         method: 'POST',
@@ -1211,18 +1338,18 @@ export function initializeIpcHandlers(appState: AppState): void {
       });
 
       if (!res.ok) {
-        const body = await res.json().catch(() => ({})) as any;
+        const body = (await res.json().catch(() => ({}))) as any;
         return { ok: false, error: body.error || 'request_failed', status: res.status };
       }
 
-      const data = await res.json() as any;
+      const data = (await res.json()) as any;
 
       if (data.ok && data.trial_token && !data.expired) {
         cm.setTrialToken(data.trial_token, data.expires_at, data.started_at);
 
         // Auto-configure natively as the model + STT provider during trial
         const prevSttProvider = cm.getSttProvider();
-        cm.setNativelyApiKey(TRIAL_SENTINEL_KEY);   // sentinel — activates natively model routing
+        cm.setNativelyApiKey(TRIAL_SENTINEL_KEY); // sentinel — activates natively model routing
         const newSttProvider = cm.getSttProvider();
         if (newSttProvider !== prevSttProvider) {
           await appState.reconfigureSttProvider();
@@ -1240,7 +1367,7 @@ export function initializeIpcHandlers(appState: AppState): void {
   });
 
   // Poll the server for live trial status (remaining time + usage counters).
-  safeHandle("trial:status", async () => {
+  safeHandle('trial:status', async () => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       const token = CredentialsManager.getInstance().getTrialToken();
@@ -1252,7 +1379,7 @@ export function initializeIpcHandlers(appState: AppState): void {
       });
 
       if (!res.ok) {
-        const body = await res.json().catch(() => ({})) as any;
+        const body = (await res.json().catch(() => ({}))) as any;
         return { ok: false, error: body.error || 'request_failed', status: res.status };
       }
 
@@ -1263,7 +1390,7 @@ export function initializeIpcHandlers(appState: AppState): void {
   });
 
   // Return local trial state from credentials (no network call — safe for startup check).
-  safeHandle("trial:get-local", async () => {
+  safeHandle('trial:get-local', async () => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       const cm = CredentialsManager.getInstance();
@@ -1284,18 +1411,18 @@ export function initializeIpcHandlers(appState: AppState): void {
   });
 
   // Record the user's post-trial choice in analytics and clean up local state.
-  safeHandle("trial:convert", async (_, choice: string) => {
+  safeHandle('trial:convert', async (_, choice: string) => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       const token = CredentialsManager.getInstance().getTrialToken();
-      if (!token) return { ok: true };  // no token to report
+      if (!token) return { ok: true }; // no token to report
 
       await fetch('https://api.natively.software/v1/trial/convert', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'x-trial-token': token },
         body: JSON.stringify({ choice }),
         signal: AbortSignal.timeout(5_000),
-      }).catch(() => { });  // fire-and-forget — don't block local cleanup on network failure
+      }).catch(() => {}); // fire-and-forget — don't block local cleanup on network failure
 
       return { ok: true };
     } catch {
@@ -1304,7 +1431,7 @@ export function initializeIpcHandlers(appState: AppState): void {
   });
 
   // End trial via BYOK path: wipe Pro-ingested data, clear trial token + natively key.
-  safeHandle("trial:end-byok", async () => {
+  safeHandle('trial:end-byok', async () => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       const cm = CredentialsManager.getInstance();
@@ -1317,7 +1444,7 @@ export function initializeIpcHandlers(appState: AppState): void {
           headers: { 'Content-Type': 'application/json', 'x-trial-token': token },
           body: JSON.stringify({ choice: 'byok' }),
           signal: AbortSignal.timeout(4_000),
-        }).catch(() => { });
+        }).catch(() => {});
       }
 
       // 2. Clear trial token
@@ -1333,7 +1460,9 @@ export function initializeIpcHandlers(appState: AppState): void {
       try {
         const { LicenseManager } = require('../premium/electron/services/LicenseManager');
         await LicenseManager.getInstance().deactivate();
-      } catch { /* LicenseManager not available in this build */ }
+      } catch {
+        /* LicenseManager not available in this build */
+      }
 
       // 5. Disable knowledge mode + wipe orchestrator in-memory caches for resume/JD
       try {
@@ -1344,7 +1473,9 @@ export function initializeIpcHandlers(appState: AppState): void {
           orchestrator.deleteDocumentsByType(DocType.RESUME);
           orchestrator.deleteDocumentsByType(DocType.JD);
         }
-      } catch { /* ignore */ }
+      } catch {
+        /* ignore */
+      }
 
       // 6. Wipe Pro-specific cached data from local SQLite
       //    Targets: company dossiers, knowledge docs (+ cascades), resume nodes, user profile
@@ -1366,7 +1497,7 @@ export function initializeIpcHandlers(appState: AppState): void {
 
       // 7. Notify all windows to refresh license + model state
       clearActiveModeOnLicenseLoss();
-      BrowserWindow.getAllWindows().forEach(win => {
+      BrowserWindow.getAllWindows().forEach((win) => {
         if (!win.isDestroyed()) {
           win.webContents.send('license-status-changed', { isPremium: false });
           win.webContents.send('trial-ended', { choice: 'byok' });
@@ -1383,7 +1514,7 @@ export function initializeIpcHandlers(appState: AppState): void {
   // Wipe only Pro profile data (resume + JD + company dossiers) without clearing
   // trial token or natively key. Called automatically when trial expires so that
   // profile intelligence data can't linger in SQLite after the trial window closes.
-  safeHandle("trial:wipe-profile-data", async () => {
+  safeHandle('trial:wipe-profile-data', async () => {
     try {
       // 1. Disable knowledge mode + wipe orchestrator in-memory caches
       try {
@@ -1394,7 +1525,9 @@ export function initializeIpcHandlers(appState: AppState): void {
           orchestrator.deleteDocumentsByType(DocType.RESUME);
           orchestrator.deleteDocumentsByType(DocType.JD);
         }
-      } catch { /* ignore — orchestrator may not be initialised */ }
+      } catch {
+        /* ignore — orchestrator may not be initialised */
+      }
 
       // 2. Wipe Pro-specific SQLite tables
       //    NOT wiped: meetings, transcripts, audio chunks (user's own recordings)
@@ -1420,7 +1553,7 @@ export function initializeIpcHandlers(appState: AppState): void {
   });
 
   // Custom Provider Handlers
-  safeHandle("get-custom-providers", async () => {
+  safeHandle('get-custom-providers', async () => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       const cm = CredentialsManager.getInstance();
@@ -1430,17 +1563,18 @@ export function initializeIpcHandlers(appState: AppState): void {
       const legacyProviders = cm.getCustomProviders() || [];
       return [...curlProviders, ...legacyProviders];
     } catch (error: any) {
-      console.error("Error getting custom providers:", error);
+      console.error('Error getting custom providers:', error);
       return [];
     }
   });
 
-  safeHandle("save-custom-provider", async (_, provider: unknown) => {
+  safeHandle('save-custom-provider', async (_, provider: unknown) => {
     try {
       // SECURITY FIX (P1-2): Validate provider payload shape before persisting.
       // Prevents malformed/malicious renderer data from polluting CredentialsManager.
       if (
-        typeof provider !== 'object' || provider === null ||
+        typeof provider !== 'object' ||
+        provider === null ||
         typeof (provider as any).id !== 'string' ||
         typeof (provider as any).name !== 'string' ||
         typeof (provider as any).curlCommand !== 'string'
@@ -1454,7 +1588,10 @@ export function initializeIpcHandlers(appState: AppState): void {
       // We do NOT require the string to start with 'curl' — curlCommand is a template field,
       // not necessarily a raw CLI string, and over-constraining it would break valid providers.
       if (!curlCmd.includes('{{TEXT}}')) {
-        return { success: false, error: 'curlCommand must contain {{TEXT}} placeholder for the prompt' };
+        return {
+          success: false,
+          error: 'curlCommand must contain {{TEXT}} placeholder for the prompt',
+        };
       }
 
       const { CredentialsManager } = require('./services/CredentialsManager');
@@ -1462,12 +1599,12 @@ export function initializeIpcHandlers(appState: AppState): void {
       CredentialsManager.getInstance().saveCurlProvider(provider);
       return { success: true };
     } catch (error: any) {
-      console.error("Error saving custom provider:", error);
+      console.error('Error saving custom provider:', error);
       return { success: false, error: error.message };
     }
   });
 
-  safeHandle("delete-custom-provider", async (_, id: string) => {
+  safeHandle('delete-custom-provider', async (_, id: string) => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       // Try deleting from both storages to be safe
@@ -1475,24 +1612,23 @@ export function initializeIpcHandlers(appState: AppState): void {
       CredentialsManager.getInstance().deleteCustomProvider(id);
       return { success: true };
     } catch (error: any) {
-      console.error("Error deleting custom provider:", error);
+      console.error('Error deleting custom provider:', error);
       return { success: false, error: error.message };
     }
   });
 
-  safeHandle("switch-to-custom-provider", async (_, providerId: string) => {
+  safeHandle('switch-to-custom-provider', async (_, providerId: string) => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       const cm = CredentialsManager.getInstance();
       // BUG-05 fix: providers may be in either the curl or legacy custom store —
       // merge both when looking up by id so neither store is silently ignored.
-      const provider = [
-        ...(cm.getCurlProviders() || []),
-        ...(cm.getCustomProviders() || [])
-      ].find((p: any) => p.id === providerId);
+      const provider = [...(cm.getCurlProviders() || []), ...(cm.getCustomProviders() || [])].find(
+        (p: any) => p.id === providerId,
+      );
 
       if (!provider) {
-        throw new Error("Provider not found");
+        throw new Error('Provider not found');
       }
 
       const llmHelper = appState.processingHelper.getLLMHelper();
@@ -1503,52 +1639,53 @@ export function initializeIpcHandlers(appState: AppState): void {
 
       return { success: true };
     } catch (error: any) {
-      console.error("Error switching to custom provider:", error);
+      console.error('Error switching to custom provider:', error);
       return { success: false, error: error.message };
     }
   });
 
-
   // cURL Provider Handlers
-  safeHandle("get-curl-providers", async () => {
+  safeHandle('get-curl-providers', async () => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       return CredentialsManager.getInstance().getCurlProviders();
     } catch (error: any) {
-      console.error("Error getting curl providers:", error);
+      console.error('Error getting curl providers:', error);
       return [];
     }
   });
 
-  safeHandle("save-curl-provider", async (_, provider: any) => {
+  safeHandle('save-curl-provider', async (_, provider: any) => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       CredentialsManager.getInstance().saveCurlProvider(provider);
       return { success: true };
     } catch (error: any) {
-      console.error("Error saving curl provider:", error);
+      console.error('Error saving curl provider:', error);
       return { success: false, error: error.message };
     }
   });
 
-  safeHandle("delete-curl-provider", async (_, id: string) => {
+  safeHandle('delete-curl-provider', async (_, id: string) => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       CredentialsManager.getInstance().deleteCurlProvider(id);
       return { success: true };
     } catch (error: any) {
-      console.error("Error deleting curl provider:", error);
+      console.error('Error deleting curl provider:', error);
       return { success: false, error: error.message };
     }
   });
 
-  safeHandle("switch-to-curl-provider", async (_, providerId: string) => {
+  safeHandle('switch-to-curl-provider', async (_, providerId: string) => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
-      const provider = CredentialsManager.getInstance().getCurlProviders().find((p: any) => p.id === providerId);
+      const provider = CredentialsManager.getInstance()
+        .getCurlProviders()
+        .find((p: any) => p.id === providerId);
 
       if (!provider) {
-        throw new Error("Provider not found");
+        throw new Error('Provider not found');
       }
 
       const llmHelper = appState.processingHelper.getLLMHelper();
@@ -1559,13 +1696,13 @@ export function initializeIpcHandlers(appState: AppState): void {
 
       return { success: true };
     } catch (error: any) {
-      console.error("Error switching to curl provider:", error);
+      console.error('Error switching to curl provider:', error);
       return { success: false, error: error.message };
     }
   });
 
   // Get stored API keys (masked for UI display)
-  safeHandle("get-stored-credentials", async () => {
+  safeHandle('get-stored-credentials', async () => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       const creds = CredentialsManager.getInstance().getAllCredentials();
@@ -1611,7 +1748,33 @@ export function initializeIpcHandlers(appState: AppState): void {
       };
     } catch (error: any) {
       // SECURITY FIX (P0): Error fallback returns masked keys, not raw strings
-      return { hasGeminiKey: false, hasGroqKey: false, hasOpenaiKey: false, hasClaudeKey: false, hasNativelyKey: false, googleServiceAccountPath: null, sttProvider: 'none', groqSttModel: 'whisper-large-v3-turbo', hasSttGroqKey: false, hasSttOpenaiKey: false, hasDeepgramKey: false, hasElevenLabsKey: false, hasAzureKey: false, azureRegion: 'eastus', hasIbmWatsonKey: false, ibmWatsonRegion: 'us-south', hasSonioxKey: false, hasTavilyKey: false, sttGroqKey: '', sttOpenaiKey: '', sttDeepgramKey: '', sttElevenLabsKey: '', sttAzureKey: '', sttIbmKey: '', sttSonioxKey: '' };
+      return {
+        hasGeminiKey: false,
+        hasGroqKey: false,
+        hasOpenaiKey: false,
+        hasClaudeKey: false,
+        hasNativelyKey: false,
+        googleServiceAccountPath: null,
+        sttProvider: 'none',
+        groqSttModel: 'whisper-large-v3-turbo',
+        hasSttGroqKey: false,
+        hasSttOpenaiKey: false,
+        hasDeepgramKey: false,
+        hasElevenLabsKey: false,
+        hasAzureKey: false,
+        azureRegion: 'eastus',
+        hasIbmWatsonKey: false,
+        ibmWatsonRegion: 'us-south',
+        hasSonioxKey: false,
+        hasTavilyKey: false,
+        sttGroqKey: '',
+        sttOpenaiKey: '',
+        sttDeepgramKey: '',
+        sttElevenLabsKey: '',
+        sttAzureKey: '',
+        sttIbmKey: '',
+        sttSonioxKey: '',
+      };
     }
   });
 
@@ -1619,67 +1782,90 @@ export function initializeIpcHandlers(appState: AppState): void {
   // Dynamic Model Discovery Handlers
   // ==========================================
 
-  safeHandle("fetch-provider-models", async (_, provider: 'gemini' | 'groq' | 'openai' | 'claude', apiKey: string) => {
-    try {
-      // Fall back to stored key if no key was explicitly provided
-      let key = apiKey?.trim();
-      if (!key) {
+  safeHandle(
+    'fetch-provider-models',
+    async (_, provider: 'gemini' | 'groq' | 'openai' | 'claude', apiKey: string) => {
+      try {
+        // Fall back to stored key if no key was explicitly provided
+        let key = apiKey?.trim();
+        if (!key) {
+          const { CredentialsManager } = require('./services/CredentialsManager');
+          const cm = CredentialsManager.getInstance();
+          if (provider === 'gemini') key = cm.getGeminiApiKey();
+          else if (provider === 'groq') key = cm.getGroqApiKey();
+          else if (provider === 'openai') key = cm.getOpenaiApiKey();
+          else if (provider === 'claude') key = cm.getClaudeApiKey();
+        }
+
+        if (!key) {
+          return { success: false, error: 'No API key available. Please save a key first.' };
+        }
+
+        const { fetchProviderModels } = require('./utils/modelFetcher');
+        const models = await fetchProviderModels(provider, key);
+        return { success: true, models };
+      } catch (error: any) {
+        console.error(`[IPC] Failed to fetch ${provider} models:`, error);
+        const msg =
+          error?.response?.data?.error?.message || error.message || 'Failed to fetch models';
+        return { success: false, error: msg };
+      }
+    },
+  );
+
+  safeHandle(
+    'set-provider-preferred-model',
+    async (_, provider: 'gemini' | 'groq' | 'openai' | 'claude', modelId: string) => {
+      try {
         const { CredentialsManager } = require('./services/CredentialsManager');
-        const cm = CredentialsManager.getInstance();
-        if (provider === 'gemini') key = cm.getGeminiApiKey();
-        else if (provider === 'groq') key = cm.getGroqApiKey();
-        else if (provider === 'openai') key = cm.getOpenaiApiKey();
-        else if (provider === 'claude') key = cm.getClaudeApiKey();
+        CredentialsManager.getInstance().setPreferredModel(provider, modelId);
+      } catch (error: any) {
+        console.error(`[IPC] Failed to set preferred model for ${provider}:`, error);
       }
-
-      if (!key) {
-        return { success: false, error: 'No API key available. Please save a key first.' };
-      }
-
-      const { fetchProviderModels } = require('./utils/modelFetcher');
-      const models = await fetchProviderModels(provider, key);
-      return { success: true, models };
-    } catch (error: any) {
-      console.error(`[IPC] Failed to fetch ${provider} models:`, error);
-      const msg = error?.response?.data?.error?.message || error.message || 'Failed to fetch models';
-      return { success: false, error: msg };
-    }
-  });
-
-  safeHandle("set-provider-preferred-model", async (_, provider: 'gemini' | 'groq' | 'openai' | 'claude', modelId: string) => {
-    try {
-      const { CredentialsManager } = require('./services/CredentialsManager');
-      CredentialsManager.getInstance().setPreferredModel(provider, modelId);
-    } catch (error: any) {
-      console.error(`[IPC] Failed to set preferred model for ${provider}:`, error);
-    }
-  });
+    },
+  );
 
   // ==========================================
   // STT Provider Management Handlers
   // ==========================================
 
-  safeHandle("set-stt-provider", async (_, provider: 'none' | 'google' | 'groq' | 'openai' | 'deepgram' | 'elevenlabs' | 'azure' | 'ibmwatson' | 'soniox' | 'natively') => {
-    try {
-      const { CredentialsManager } = require('./services/CredentialsManager');
-      CredentialsManager.getInstance().setSttProvider(provider);
+  safeHandle(
+    'set-stt-provider',
+    async (
+      _,
+      provider:
+        | 'none'
+        | 'google'
+        | 'groq'
+        | 'openai'
+        | 'deepgram'
+        | 'elevenlabs'
+        | 'azure'
+        | 'ibmwatson'
+        | 'soniox'
+        | 'natively',
+    ) => {
+      try {
+        const { CredentialsManager } = require('./services/CredentialsManager');
+        CredentialsManager.getInstance().setSttProvider(provider);
 
-      // Reconfigure the audio pipeline to use the new STT provider
-      await appState.reconfigureSttProvider();
+        // Reconfigure the audio pipeline to use the new STT provider
+        await appState.reconfigureSttProvider();
 
-      // Notify all windows so the settings UI reflects the change immediately
-      BrowserWindow.getAllWindows().forEach(win => {
-        if (!win.isDestroyed()) win.webContents.send('credentials-changed');
-      });
+        // Notify all windows so the settings UI reflects the change immediately
+        BrowserWindow.getAllWindows().forEach((win) => {
+          if (!win.isDestroyed()) win.webContents.send('credentials-changed');
+        });
 
-      return { success: true };
-    } catch (error: any) {
-      console.error("Error setting STT provider:", error);
-      return { success: false, error: error.message };
-    }
-  });
+        return { success: true };
+      } catch (error: any) {
+        console.error('Error setting STT provider:', error);
+        return { success: false, error: error.message };
+      }
+    },
+  );
 
-  safeHandle("get-stt-provider", async () => {
+  safeHandle('get-stt-provider', async () => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       return CredentialsManager.getInstance().getSttProvider();
@@ -1688,66 +1874,66 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("set-groq-stt-api-key", async (_, apiKey: string) => {
+  safeHandle('set-groq-stt-api-key', async (_, apiKey: string) => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       CredentialsManager.getInstance().setGroqSttApiKey(apiKey);
-      BrowserWindow.getAllWindows().forEach(win => {
+      BrowserWindow.getAllWindows().forEach((win) => {
         if (!win.isDestroyed()) win.webContents.send('credentials-changed');
       });
       return { success: true };
     } catch (error: any) {
-      console.error("Error saving Groq STT API key:", error);
+      console.error('Error saving Groq STT API key:', error);
       return { success: false, error: error.message };
     }
   });
 
-  safeHandle("set-openai-stt-api-key", async (_, apiKey: string) => {
+  safeHandle('set-openai-stt-api-key', async (_, apiKey: string) => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       CredentialsManager.getInstance().setOpenAiSttApiKey(apiKey);
-      BrowserWindow.getAllWindows().forEach(win => {
+      BrowserWindow.getAllWindows().forEach((win) => {
         if (!win.isDestroyed()) win.webContents.send('credentials-changed');
       });
       return { success: true };
     } catch (error: any) {
-      console.error("Error saving OpenAI STT API key:", error);
+      console.error('Error saving OpenAI STT API key:', error);
       return { success: false, error: error.message };
     }
   });
 
-  safeHandle("set-openai-stt-base-url", async (_, url: string) => {
+  safeHandle('set-openai-stt-base-url', async (_, url: string) => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       CredentialsManager.getInstance().setOpenAiSttBaseUrl(url);
       // Reconfigure the active pipeline so the new endpoint is used immediately,
       // matching the behavior of azure/ibmwatson region setters.
       await appState.reconfigureSttProvider();
-      BrowserWindow.getAllWindows().forEach(win => {
+      BrowserWindow.getAllWindows().forEach((win) => {
         if (!win.isDestroyed()) win.webContents.send('credentials-changed');
       });
       return { success: true };
     } catch (error: any) {
-      console.error("Error saving OpenAI STT base URL:", error);
+      console.error('Error saving OpenAI STT base URL:', error);
       return { success: false, error: error.message };
     }
   });
 
-  safeHandle("set-deepgram-api-key", async (_, apiKey: string) => {
+  safeHandle('set-deepgram-api-key', async (_, apiKey: string) => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       CredentialsManager.getInstance().setDeepgramApiKey(apiKey);
-      BrowserWindow.getAllWindows().forEach(win => {
+      BrowserWindow.getAllWindows().forEach((win) => {
         if (!win.isDestroyed()) win.webContents.send('credentials-changed');
       });
       return { success: true };
     } catch (error: any) {
-      console.error("Error saving Deepgram API key:", error);
+      console.error('Error saving Deepgram API key:', error);
       return { success: false, error: error.message };
     }
   });
 
-  safeHandle("set-groq-stt-model", async (_, model: string) => {
+  safeHandle('set-groq-stt-model', async (_, model: string) => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       CredentialsManager.getInstance().setGroqSttModel(model);
@@ -1757,37 +1943,37 @@ export function initializeIpcHandlers(appState: AppState): void {
 
       return { success: true };
     } catch (error: any) {
-      console.error("Error setting Groq STT model:", error);
+      console.error('Error setting Groq STT model:', error);
       return { success: false, error: error.message };
     }
   });
 
-  safeHandle("set-elevenlabs-api-key", async (_, apiKey: string) => {
+  safeHandle('set-elevenlabs-api-key', async (_, apiKey: string) => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       CredentialsManager.getInstance().setElevenLabsApiKey(apiKey);
-      BrowserWindow.getAllWindows().forEach(win => {
+      BrowserWindow.getAllWindows().forEach((win) => {
         if (!win.isDestroyed()) win.webContents.send('credentials-changed');
       });
       return { success: true };
     } catch (error: any) {
-      console.error("Error saving ElevenLabs API key:", error);
+      console.error('Error saving ElevenLabs API key:', error);
       return { success: false, error: error.message };
     }
   });
 
-  safeHandle("set-azure-api-key", async (_, apiKey: string) => {
+  safeHandle('set-azure-api-key', async (_, apiKey: string) => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       CredentialsManager.getInstance().setAzureApiKey(apiKey);
       return { success: true };
     } catch (error: any) {
-      console.error("Error saving Azure API key:", error);
+      console.error('Error saving Azure API key:', error);
       return { success: false, error: error.message };
     }
   });
 
-  safeHandle("set-azure-region", async (_, region: string) => {
+  safeHandle('set-azure-region', async (_, region: string) => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       CredentialsManager.getInstance().setAzureRegion(region);
@@ -1797,37 +1983,37 @@ export function initializeIpcHandlers(appState: AppState): void {
 
       return { success: true };
     } catch (error: any) {
-      console.error("Error setting Azure region:", error);
+      console.error('Error setting Azure region:', error);
       return { success: false, error: error.message };
     }
   });
 
-  safeHandle("set-ibmwatson-api-key", async (_, apiKey: string) => {
+  safeHandle('set-ibmwatson-api-key', async (_, apiKey: string) => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       CredentialsManager.getInstance().setIbmWatsonApiKey(apiKey);
       return { success: true };
     } catch (error: any) {
-      console.error("Error saving IBM Watson API key:", error);
+      console.error('Error saving IBM Watson API key:', error);
       return { success: false, error: error.message };
     }
   });
 
-  safeHandle("set-soniox-api-key", async (_, apiKey: string) => {
+  safeHandle('set-soniox-api-key', async (_, apiKey: string) => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       CredentialsManager.getInstance().setSonioxApiKey(apiKey);
-      BrowserWindow.getAllWindows().forEach(win => {
+      BrowserWindow.getAllWindows().forEach((win) => {
         if (!win.isDestroyed()) win.webContents.send('credentials-changed');
       });
       return { success: true };
     } catch (error: any) {
-      console.error("Error saving Soniox API key:", error);
+      console.error('Error saving Soniox API key:', error);
       return { success: false, error: error.message };
     }
   });
 
-  safeHandle("set-ibmwatson-region", async (_, region: string) => {
+  safeHandle('set-ibmwatson-region', async (_, region: string) => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       CredentialsManager.getInstance().setIbmWatsonRegion(region);
@@ -1837,7 +2023,7 @@ export function initializeIpcHandlers(appState: AppState): void {
 
       return { success: true };
     } catch (error: any) {
-      console.error("Error setting IBM Watson region:", error);
+      console.error('Error setting IBM Watson region:', error);
       return { success: false, error: error.message };
     }
   });
@@ -1848,221 +2034,248 @@ export function initializeIpcHandlers(appState: AppState): void {
     return msg.replace(/:\s*[a-zA-Z0-9*]+\*+[a-zA-Z0-9*]+\.?$/g, '').trim();
   };
 
-  safeHandle("test-stt-connection", async (_, provider: 'groq' | 'openai' | 'deepgram' | 'elevenlabs' | 'azure' | 'ibmwatson' | 'soniox', apiKey: string, region?: string) => {
-    console.log(`[IPC] Received test - stt - connection request for provider: ${provider} `);
-    try {
-      if (provider === 'deepgram') {
-        const WebSocket = require('ws');
-        const token = apiKey.trim();
-        return await new Promise<{ success: boolean; error?: string }>((resolve) => {
-          const url = 'wss://api.deepgram.com/v1/listen?model=nova-2&encoding=linear16&sample_rate=16000&channels=1';
-          const ws = new WebSocket(url, {
-            headers: { Authorization: `Token ${token}` },
-          });
+  safeHandle(
+    'test-stt-connection',
+    async (
+      _,
+      provider: 'groq' | 'openai' | 'deepgram' | 'elevenlabs' | 'azure' | 'ibmwatson' | 'soniox',
+      apiKey: string,
+      region?: string,
+    ) => {
+      console.log(`[IPC] Received test - stt - connection request for provider: ${provider} `);
+      try {
+        if (provider === 'deepgram') {
+          const WebSocket = require('ws');
+          const token = apiKey.trim();
+          return await new Promise<{ success: boolean; error?: string }>((resolve) => {
+            const url =
+              'wss://api.deepgram.com/v1/listen?model=nova-2&encoding=linear16&sample_rate=16000&channels=1';
+            const ws = new WebSocket(url, {
+              headers: { Authorization: `Token ${token}` },
+            });
 
-          const timeout = setTimeout(() => {
-            ws.close();
-            console.error('[IPC] Deepgram test failed: Connection timed out');
-            resolve({ success: false, error: 'Connection timed out' });
-          }, 15000);
+            const timeout = setTimeout(() => {
+              ws.close();
+              console.error('[IPC] Deepgram test failed: Connection timed out');
+              resolve({ success: false, error: 'Connection timed out' });
+            }, 15000);
 
-          ws.on('open', () => {
-            clearTimeout(timeout);
-            try { ws.send(JSON.stringify({ type: 'CloseStream' })); } catch { }
-            ws.close();
-            resolve({ success: true });
-          });
+            ws.on('open', () => {
+              clearTimeout(timeout);
+              try {
+                ws.send(JSON.stringify({ type: 'CloseStream' }));
+              } catch {}
+              ws.close();
+              resolve({ success: true });
+            });
 
-          ws.on('unexpected-response', (request: any, response: any) => {
-            clearTimeout(timeout);
-            const status = response.statusCode;
-            let body = '';
-            response.on('data', (chunk: Buffer) => { body += chunk.toString(); });
-            response.on('end', () => {
-              const errMsg = `Unexpected server response: ${status} - ${body}`;
-              console.error(`[IPC] Deepgram test failed: ${errMsg}`);
-              resolve({ success: false, error: errMsg });
+            ws.on('unexpected-response', (request: any, response: any) => {
+              clearTimeout(timeout);
+              const status = response.statusCode;
+              let body = '';
+              response.on('data', (chunk: Buffer) => {
+                body += chunk.toString();
+              });
+              response.on('end', () => {
+                const errMsg = `Unexpected server response: ${status} - ${body}`;
+                console.error(`[IPC] Deepgram test failed: ${errMsg}`);
+                resolve({ success: false, error: errMsg });
+              });
+            });
+
+            ws.on('error', (err: any) => {
+              clearTimeout(timeout);
+              console.error(`[IPC] Deepgram test error: ${err.message}`);
+              resolve({ success: false, error: err.message || 'Connection failed' });
             });
           });
-
-          ws.on('error', (err: any) => {
-            clearTimeout(timeout);
-            console.error(`[IPC] Deepgram test error: ${err.message}`);
-            resolve({ success: false, error: err.message || 'Connection failed' });
-          });
-        });
-      }
-
-      if (provider === 'soniox') {
-        // Test Soniox via WebSocket connection.
-        // With a valid key, Soniox accepts the config and then silently waits for audio —
-        // it never sends a response message. With an invalid key it immediately sends an
-        // error message and closes. So the strategy is:
-        //   • If we receive an error message → fail
-        //   • If the connection errors at the WS level → fail
-        //   • If 2.5 s pass after sending the config with no error → success
-        const WebSocket = require('ws');
-        return await new Promise<{ success: boolean; error?: string }>((resolve) => {
-          let resolved = false;
-          const done = (result: { success: boolean; error?: string }) => {
-            if (resolved) return;
-            resolved = true;
-            try { ws.close(); } catch { }
-            resolve(result);
-          };
-
-          const ws = new WebSocket('wss://stt-rt.soniox.com/transcribe-websocket');
-
-          // Hard connect timeout — server unreachable
-          const connectTimeout = setTimeout(() => {
-            done({ success: false, error: 'Connection timed out' });
-          }, 10000);
-
-          ws.on('open', () => {
-            clearTimeout(connectTimeout);
-            ws.send(JSON.stringify({
-              api_key: apiKey,
-              model: 'stt-rt-v4',
-              audio_format: 'pcm_s16le',
-              sample_rate: 16000,
-              num_channels: 1,
-            }));
-            // Give Soniox 2.5 s to reject the key; silence means the key is valid
-            setTimeout(() => done({ success: true }), 2500);
-          });
-
-          ws.on('message', (msg: any) => {
-            try {
-              const res = JSON.parse(msg.toString());
-              if (res.error_code) {
-                done({ success: false, error: `${res.error_code}: ${res.error_message}` });
-              }
-              // Non-error message is unexpected but treat as success
-            } catch {
-              // Unparseable message — treat as success
-            }
-          });
-
-          ws.on('error', (err: any) => {
-            clearTimeout(connectTimeout);
-            done({ success: false, error: err.message || 'Connection failed' });
-          });
-
-          ws.on('close', (code: number) => {
-            // Abnormal close before we resolved means the server rejected us
-            if (!resolved && code !== 1000) {
-              done({ success: false, error: `Server closed connection (code ${code})` });
-            }
-          });
-        });
-      }
-
-      const axios = require('axios');
-      const FormData = require('form-data');
-
-      // Generate a tiny silent WAV (0.5s of silence at 16kHz mono 16-bit)
-      const numSamples = 8000;
-      const pcmData = Buffer.alloc(numSamples * 2);
-      const wavHeader = Buffer.alloc(44);
-      wavHeader.write('RIFF', 0);
-      wavHeader.writeUInt32LE(36 + pcmData.length, 4);
-      wavHeader.write('WAVE', 8);
-      wavHeader.write('fmt ', 12);
-      wavHeader.writeUInt32LE(16, 16);
-      wavHeader.writeUInt16LE(1, 20);
-      wavHeader.writeUInt16LE(1, 22);
-      wavHeader.writeUInt32LE(16000, 24);
-      wavHeader.writeUInt32LE(32000, 28);
-      wavHeader.writeUInt16LE(2, 32);
-      wavHeader.writeUInt16LE(16, 34);
-      wavHeader.write('data', 36);
-      wavHeader.writeUInt32LE(pcmData.length, 40);
-      const testWav = Buffer.concat([wavHeader, pcmData]);
-
-      if (provider === 'elevenlabs') {
-        // ElevenLabs: Use /v1/voices to validate the API key (minimal scope required).
-        // Scoped keys may lack speech_to_text or user_read but still be usable once permissions are added.
-        try {
-          await axios.get('https://api.elevenlabs.io/v1/voices', {
-            headers: { 'xi-api-key': apiKey },
-            timeout: 10000,
-          });
-        } catch (elErr: any) {
-          const elStatus = elErr?.response?.data?.detail?.status;
-          // If the error is "invalid_api_key", the key itself is wrong — fail.
-          // Any other error (missing permission, etc.) means the key IS valid, just possibly scoped.
-          if (elStatus === 'invalid_api_key') {
-            throw elErr;
-          }
-          // Key is valid but scoped — pass with a warning
-          console.log('[IPC] ElevenLabs key is valid but may have restricted scopes. Saving key.');
         }
-      } else if (provider === 'azure') {
-        // Azure: raw binary with subscription key
-        const azureRegion = region || 'eastus';
-        await axios.post(
-          `https://${azureRegion}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1?language=en-US`,
-          testWav,
-          {
-            headers: { 'Ocp-Apim-Subscription-Key': apiKey, 'Content-Type': 'audio/wav' },
-            timeout: 15000,
+
+        if (provider === 'soniox') {
+          // Test Soniox via WebSocket connection.
+          // With a valid key, Soniox accepts the config and then silently waits for audio —
+          // it never sends a response message. With an invalid key it immediately sends an
+          // error message and closes. So the strategy is:
+          //   • If we receive an error message → fail
+          //   • If the connection errors at the WS level → fail
+          //   • If 2.5 s pass after sending the config with no error → success
+          const WebSocket = require('ws');
+          return await new Promise<{ success: boolean; error?: string }>((resolve) => {
+            let resolved = false;
+            const done = (result: { success: boolean; error?: string }) => {
+              if (resolved) return;
+              resolved = true;
+              try {
+                ws.close();
+              } catch {}
+              resolve(result);
+            };
+
+            const ws = new WebSocket('wss://stt-rt.soniox.com/transcribe-websocket');
+
+            // Hard connect timeout — server unreachable
+            const connectTimeout = setTimeout(() => {
+              done({ success: false, error: 'Connection timed out' });
+            }, 10000);
+
+            ws.on('open', () => {
+              clearTimeout(connectTimeout);
+              ws.send(
+                JSON.stringify({
+                  api_key: apiKey,
+                  model: 'stt-rt-v4',
+                  audio_format: 'pcm_s16le',
+                  sample_rate: 16000,
+                  num_channels: 1,
+                }),
+              );
+              // Give Soniox 2.5 s to reject the key; silence means the key is valid
+              setTimeout(() => done({ success: true }), 2500);
+            });
+
+            ws.on('message', (msg: any) => {
+              try {
+                const res = JSON.parse(msg.toString());
+                if (res.error_code) {
+                  done({ success: false, error: `${res.error_code}: ${res.error_message}` });
+                }
+                // Non-error message is unexpected but treat as success
+              } catch {
+                // Unparseable message — treat as success
+              }
+            });
+
+            ws.on('error', (err: any) => {
+              clearTimeout(connectTimeout);
+              done({ success: false, error: err.message || 'Connection failed' });
+            });
+
+            ws.on('close', (code: number) => {
+              // Abnormal close before we resolved means the server rejected us
+              if (!resolved && code !== 1000) {
+                done({ success: false, error: `Server closed connection (code ${code})` });
+              }
+            });
+          });
+        }
+
+        const axios = require('axios');
+        const FormData = require('form-data');
+
+        // Generate a tiny silent WAV (0.5s of silence at 16kHz mono 16-bit)
+        const numSamples = 8000;
+        const pcmData = Buffer.alloc(numSamples * 2);
+        const wavHeader = Buffer.alloc(44);
+        wavHeader.write('RIFF', 0);
+        wavHeader.writeUInt32LE(36 + pcmData.length, 4);
+        wavHeader.write('WAVE', 8);
+        wavHeader.write('fmt ', 12);
+        wavHeader.writeUInt32LE(16, 16);
+        wavHeader.writeUInt16LE(1, 20);
+        wavHeader.writeUInt16LE(1, 22);
+        wavHeader.writeUInt32LE(16000, 24);
+        wavHeader.writeUInt32LE(32000, 28);
+        wavHeader.writeUInt16LE(2, 32);
+        wavHeader.writeUInt16LE(16, 34);
+        wavHeader.write('data', 36);
+        wavHeader.writeUInt32LE(pcmData.length, 40);
+        const testWav = Buffer.concat([wavHeader, pcmData]);
+
+        if (provider === 'elevenlabs') {
+          // ElevenLabs: Use /v1/voices to validate the API key (minimal scope required).
+          // Scoped keys may lack speech_to_text or user_read but still be usable once permissions are added.
+          try {
+            await axios.get('https://api.elevenlabs.io/v1/voices', {
+              headers: { 'xi-api-key': apiKey },
+              timeout: 10000,
+            });
+          } catch (elErr: any) {
+            const elStatus = elErr?.response?.data?.detail?.status;
+            // If the error is "invalid_api_key", the key itself is wrong — fail.
+            // Any other error (missing permission, etc.) means the key IS valid, just possibly scoped.
+            if (elStatus === 'invalid_api_key') {
+              throw elErr;
+            }
+            // Key is valid but scoped — pass with a warning
+            console.log(
+              '[IPC] ElevenLabs key is valid but may have restricted scopes. Saving key.',
+            );
           }
-        );
-      } else if (provider === 'ibmwatson') {
-        // IBM Watson: raw binary with Basic auth
-        const ibmRegion = region || 'us-south';
-        await axios.post(
-          `https://api.${ibmRegion}.speech-to-text.watson.cloud.ibm.com/v1/recognize`,
-          testWav,
-          {
+        } else if (provider === 'azure') {
+          // Azure: raw binary with subscription key
+          const azureRegion = region || 'eastus';
+          await axios.post(
+            `https://${azureRegion}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1?language=en-US`,
+            testWav,
+            {
+              headers: { 'Ocp-Apim-Subscription-Key': apiKey, 'Content-Type': 'audio/wav' },
+              timeout: 15000,
+            },
+          );
+        } else if (provider === 'ibmwatson') {
+          // IBM Watson: raw binary with Basic auth
+          const ibmRegion = region || 'us-south';
+          await axios.post(
+            `https://api.${ibmRegion}.speech-to-text.watson.cloud.ibm.com/v1/recognize`,
+            testWav,
+            {
+              headers: {
+                Authorization: `Basic ${Buffer.from(`apikey:${apiKey}`).toString('base64')}`,
+                'Content-Type': 'audio/wav',
+              },
+              timeout: 15000,
+            },
+          );
+        } else {
+          // Groq / OpenAI: multipart FormData
+          let openAiEndpoint = 'https://api.openai.com/v1/audio/transcriptions';
+          if (provider === 'openai') {
+            // If a custom OpenAI-compatible base URL is configured, test against it.
+            const { CredentialsManager } = require('./services/CredentialsManager');
+            const customBase = (
+              CredentialsManager.getInstance().getOpenAiSttBaseUrl() || ''
+            ).trim();
+            if (customBase) {
+              const trimmed = customBase.replace(/\/+$/, '');
+              openAiEndpoint = /\/v\d+$/.test(trimmed)
+                ? `${trimmed}/audio/transcriptions`
+                : `${trimmed}/v1/audio/transcriptions`;
+            }
+          }
+          const endpoint =
+            provider === 'groq'
+              ? 'https://api.groq.com/openai/v1/audio/transcriptions'
+              : openAiEndpoint;
+          const model = provider === 'groq' ? 'whisper-large-v3-turbo' : 'whisper-1';
+
+          const form = new FormData();
+          form.append('file', testWav, { filename: 'test.wav', contentType: 'audio/wav' });
+          form.append('model', model);
+
+          await axios.post(endpoint, form, {
             headers: {
-              Authorization: `Basic ${Buffer.from(`apikey:${apiKey}`).toString('base64')}`,
-              'Content-Type': 'audio/wav',
+              Authorization: `Bearer ${apiKey}`,
+              ...form.getHeaders(),
             },
             timeout: 15000,
-          }
-        );
-      } else {
-        // Groq / OpenAI: multipart FormData
-        let openAiEndpoint = 'https://api.openai.com/v1/audio/transcriptions';
-        if (provider === 'openai') {
-          // If a custom OpenAI-compatible base URL is configured, test against it.
-          const { CredentialsManager } = require('./services/CredentialsManager');
-          const customBase = (CredentialsManager.getInstance().getOpenAiSttBaseUrl() || '').trim();
-          if (customBase) {
-            const trimmed = customBase.replace(/\/+$/, '');
-            openAiEndpoint = /\/v\d+$/.test(trimmed)
-              ? `${trimmed}/audio/transcriptions`
-              : `${trimmed}/v1/audio/transcriptions`;
-          }
+          });
         }
-        const endpoint = provider === 'groq'
-          ? 'https://api.groq.com/openai/v1/audio/transcriptions'
-          : openAiEndpoint;
-        const model = provider === 'groq' ? 'whisper-large-v3-turbo' : 'whisper-1';
 
-        const form = new FormData();
-        form.append('file', testWav, { filename: 'test.wav', contentType: 'audio/wav' });
-        form.append('model', model);
-
-        await axios.post(endpoint, form, {
-          headers: {
-            Authorization: `Bearer ${apiKey}`,
-            ...form.getHeaders(),
-          },
-          timeout: 15000,
-        });
+        return { success: true };
+      } catch (error: any) {
+        const respData = error?.response?.data;
+        const rawMsg =
+          respData?.error?.message ||
+          respData?.detail?.message ||
+          respData?.message ||
+          error.message ||
+          'Connection failed';
+        const msg = sanitizeErrorMessage(rawMsg);
+        console.error('STT connection test failed:', msg);
+        return { success: false, error: msg };
       }
-
-      return { success: true };
-    } catch (error: any) {
-      const respData = error?.response?.data;
-      const rawMsg = respData?.error?.message || respData?.detail?.message || respData?.message || error.message || 'Connection failed';
-      const msg = sanitizeErrorMessage(rawMsg);
-      console.error("STT connection test failed:", msg);
-      return { success: false, error: msg };
-    }
-  });
+    },
+  );
 
   // ==========================================
   // Local Whisper STT Handlers
@@ -2070,7 +2283,7 @@ export function initializeIpcHandlers(appState: AppState): void {
 
   const activeWhisperDownloads = new Set<string>();
 
-  safeHandle("local-whisper-get-models", async () => {
+  safeHandle('local-whisper-get-models', async () => {
     try {
       const { getAvailableModels } = require('./audio/whisper/modelManager');
       const models = getAvailableModels();
@@ -2082,7 +2295,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("local-whisper-set-model", async (_, modelId: string) => {
+  safeHandle('local-whisper-set-model', async (_, modelId: string) => {
     try {
       SettingsManager.getInstance().set('localWhisperModel', modelId);
       return { success: true };
@@ -2094,7 +2307,7 @@ export function initializeIpcHandlers(appState: AppState): void {
   // Per-channel model overrides (mic / system audio). When enabled, the two
   // STT instances pick their own model via these slots. When disabled, both
   // fall back to localWhisperModel (the existing global setting).
-  safeHandle("local-whisper-get-channel-config", async () => {
+  safeHandle('local-whisper-get-channel-config', async () => {
     const sm = SettingsManager.getInstance();
     return {
       enabled: !!sm.get('localWhisperPerChannelEnabled'),
@@ -2104,19 +2317,23 @@ export function initializeIpcHandlers(appState: AppState): void {
     };
   });
 
-  safeHandle("local-whisper-set-channel-config", async (_, cfg: { enabled?: boolean; micModelId?: string; systemModelId?: string }) => {
-    try {
-      const sm = SettingsManager.getInstance();
-      if (typeof cfg?.enabled === 'boolean') sm.set('localWhisperPerChannelEnabled', cfg.enabled);
-      if (typeof cfg?.micModelId === 'string') sm.set('localWhisperModelMic', cfg.micModelId);
-      if (typeof cfg?.systemModelId === 'string') sm.set('localWhisperModelSystem', cfg.systemModelId);
-      return { success: true };
-    } catch (e: any) {
-      return { success: false, error: e.message };
-    }
-  });
+  safeHandle(
+    'local-whisper-set-channel-config',
+    async (_, cfg: { enabled?: boolean; micModelId?: string; systemModelId?: string }) => {
+      try {
+        const sm = SettingsManager.getInstance();
+        if (typeof cfg?.enabled === 'boolean') sm.set('localWhisperPerChannelEnabled', cfg.enabled);
+        if (typeof cfg?.micModelId === 'string') sm.set('localWhisperModelMic', cfg.micModelId);
+        if (typeof cfg?.systemModelId === 'string')
+          sm.set('localWhisperModelSystem', cfg.systemModelId);
+        return { success: true };
+      } catch (e: any) {
+        return { success: false, error: e.message };
+      }
+    },
+  );
 
-  safeHandle("local-whisper-delete-model", async (_, modelId: string) => {
+  safeHandle('local-whisper-delete-model', async (_, modelId: string) => {
     try {
       const { deleteModel } = require('./audio/whisper/modelManager');
       deleteModel(modelId);
@@ -2126,7 +2343,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("local-whisper-start-download", async (event, modelId: string) => {
+  safeHandle('local-whisper-start-download', async (event, modelId: string) => {
     if (activeWhisperDownloads.has(modelId)) {
       return { success: false, error: 'already-downloading' };
     }
@@ -2166,13 +2383,16 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("local-whisper-preload", async (_, modelId: string) => {
+  safeHandle('local-whisper-preload', async (_, modelId: string) => {
     try {
       const { modelPreloader } = require('./audio/whisper/modelPreloader');
       const { isModelCached } = require('./audio/whisper/modelManager');
       const { resolveInferenceConfig } = require('./audio/whisper/inferenceConfig');
       const { SettingsManager } = require('./services/SettingsManager');
-      const id = modelId || SettingsManager.getInstance().get('localWhisperModel') || 'Xenova/whisper-tiny.en';
+      const id =
+        modelId ||
+        SettingsManager.getInstance().get('localWhisperModel') ||
+        'Xenova/whisper-tiny.en';
       // Pass active dtype so the cache check verifies the SPECIFIC ONNX
       // files (e.g. encoder_model.onnx for fp32) are present — not just
       // "directory non-empty". Otherwise a v2-cached _quantized.onnx-only
@@ -2189,95 +2409,119 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("local-whisper-get-hardware", () => {
+  safeHandle('local-whisper-get-hardware', () => {
     const { detectHardware } = require('./audio/whisper/hardwareDetect');
     return detectHardware();
   });
 
-  safeHandle("test-llm-connection", async (_, provider: 'gemini' | 'groq' | 'openai' | 'claude', apiKey?: string) => {
-    console.log(`[IPC] Received test-llm-connection request for provider: ${provider}`);
-    try {
-      if (!apiKey || !apiKey.trim()) {
-        const { CredentialsManager } = require('./services/CredentialsManager');
-        const creds = CredentialsManager.getInstance();
-        if (provider === 'gemini') apiKey = creds.getGeminiApiKey();
-        else if (provider === 'groq') apiKey = creds.getGroqApiKey();
-        else if (provider === 'openai') apiKey = creds.getOpenaiApiKey();
-        else if (provider === 'claude') apiKey = creds.getClaudeApiKey();
+  safeHandle(
+    'test-llm-connection',
+    async (_, provider: 'gemini' | 'groq' | 'openai' | 'claude', apiKey?: string) => {
+      console.log(`[IPC] Received test-llm-connection request for provider: ${provider}`);
+      try {
+        if (!apiKey || !apiKey.trim()) {
+          const { CredentialsManager } = require('./services/CredentialsManager');
+          const creds = CredentialsManager.getInstance();
+          if (provider === 'gemini') apiKey = creds.getGeminiApiKey();
+          else if (provider === 'groq') apiKey = creds.getGroqApiKey();
+          else if (provider === 'openai') apiKey = creds.getOpenaiApiKey();
+          else if (provider === 'claude') apiKey = creds.getClaudeApiKey();
+        }
+
+        if (!apiKey || !apiKey.trim()) {
+          return { success: false, error: 'No API key provided' };
+        }
+
+        const axios = require('axios');
+        let response;
+
+        if (provider === 'gemini') {
+          const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-lite-preview:generateContent`;
+          response = await axios.post(
+            url,
+            {
+              contents: [{ parts: [{ text: 'Hello' }] }],
+            },
+            {
+              headers: { 'x-goog-api-key': apiKey },
+              timeout: 15000,
+            },
+          );
+        } else if (provider === 'groq') {
+          response = await axios.post(
+            'https://api.groq.com/openai/v1/chat/completions',
+            {
+              model: 'llama-3.3-70b-versatile',
+              messages: [{ role: 'user', content: 'Hello' }],
+            },
+            {
+              headers: { Authorization: `Bearer ${apiKey}` },
+              timeout: 15000,
+            },
+          );
+        } else if (provider === 'openai') {
+          response = await axios.post(
+            'https://api.openai.com/v1/chat/completions',
+            {
+              model: 'gpt-4o-mini',
+              messages: [{ role: 'user', content: 'Hello' }],
+            },
+            {
+              headers: { Authorization: `Bearer ${apiKey}` },
+              timeout: 15000,
+            },
+          );
+        } else if (provider === 'claude') {
+          response = await axios.post(
+            'https://api.anthropic.com/v1/messages',
+            {
+              model: 'claude-sonnet-4-6',
+              max_tokens: 10,
+              messages: [{ role: 'user', content: 'Hello' }],
+            },
+            {
+              headers: {
+                'x-api-key': apiKey,
+                'anthropic-version': '2023-06-01',
+                'content-type': 'application/json',
+              },
+              timeout: 15000,
+            },
+          );
+        }
+
+        if (response && (response.status === 200 || response.status === 201)) {
+          return { success: true };
+        } else {
+          return { success: false, error: 'Request failed with status ' + response?.status };
+        }
+      } catch (error: any) {
+        // CRITICAL: do NOT log the raw axios error — it includes the request config
+        // with the Authorization header (full API key) and is dumped verbatim by
+        // Node's util.inspect. Strip to a safe shape before logging.
+        const safeInfo = {
+          provider,
+          status: error?.response?.status,
+          statusText: error?.response?.statusText,
+          code: error?.code,
+          message: error?.message,
+          responseError: error?.response?.data?.error?.message || error?.response?.data?.message,
+        };
+        console.error('LLM connection test failed:', safeInfo);
+        const rawMsg =
+          error?.response?.data?.error?.message ||
+          error?.response?.data?.message ||
+          (error.response?.data?.error?.type
+            ? `${error.response.data.error.type}: ${error.response.data.error.message}`
+            : error.message) ||
+          'Connection failed';
+        const msg = sanitizeErrorMessage(rawMsg);
+        return { success: false, error: msg };
       }
+    },
+  );
 
-      if (!apiKey || !apiKey.trim()) {
-        return { success: false, error: 'No API key provided' };
-      }
-
-      const axios = require('axios');
-      let response;
-
-      if (provider === 'gemini') {
-        const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-lite-preview:generateContent`;
-        response = await axios.post(url, {
-          contents: [{ parts: [{ text: "Hello" }] }]
-        }, {
-          headers: { 'x-goog-api-key': apiKey },
-          timeout: 15000
-        });
-      } else if (provider === 'groq') {
-        response = await axios.post('https://api.groq.com/openai/v1/chat/completions', {
-          model: "llama-3.3-70b-versatile",
-          messages: [{ role: "user", content: "Hello" }]
-        }, {
-          headers: { Authorization: `Bearer ${apiKey}` },
-          timeout: 15000
-        });
-      } else if (provider === 'openai') {
-        response = await axios.post('https://api.openai.com/v1/chat/completions', {
-          model: "gpt-4o-mini",
-          messages: [{ role: "user", content: "Hello" }]
-        }, {
-          headers: { Authorization: `Bearer ${apiKey}` },
-          timeout: 15000
-        });
-      } else if (provider === 'claude') {
-        response = await axios.post('https://api.anthropic.com/v1/messages', {
-          model: "claude-sonnet-4-6",
-          max_tokens: 10,
-          messages: [{ role: "user", content: "Hello" }]
-        }, {
-          headers: {
-            'x-api-key': apiKey,
-            'anthropic-version': '2023-06-01',
-            'content-type': 'application/json'
-          },
-          timeout: 15000
-        });
-      }
-
-      if (response && (response.status === 200 || response.status === 201)) {
-        return { success: true };
-      } else {
-        return { success: false, error: 'Request failed with status ' + response?.status };
-      }
-
-    } catch (error: any) {
-      // CRITICAL: do NOT log the raw axios error — it includes the request config
-      // with the Authorization header (full API key) and is dumped verbatim by
-      // Node's util.inspect. Strip to a safe shape before logging.
-      const safeInfo = {
-        provider,
-        status: error?.response?.status,
-        statusText: error?.response?.statusText,
-        code: error?.code,
-        message: error?.message,
-        responseError: error?.response?.data?.error?.message || error?.response?.data?.message,
-      };
-      console.error("LLM connection test failed:", safeInfo);
-      const rawMsg = error?.response?.data?.error?.message || error?.response?.data?.message || (error.response?.data?.error?.type ? `${error.response.data.error.type}: ${error.response.data.error.message}` : error.message) || 'Connection failed';
-      const msg = sanitizeErrorMessage(rawMsg);
-      return { success: false, error: msg };
-    }
-  });
-
-  safeHandle("get-groq-fast-text-mode", () => {
+  safeHandle('get-groq-fast-text-mode', () => {
     try {
       const llmHelper = appState.processingHelper.getLLMHelper();
       return { enabled: llmHelper.getGroqFastTextMode() };
@@ -2287,7 +2531,7 @@ export function initializeIpcHandlers(appState: AppState): void {
   });
 
   // Set Groq Fast Text Mode
-  safeHandle("set-groq-fast-text-mode", (_, enabled: boolean) => {
+  safeHandle('set-groq-fast-text-mode', (_, enabled: boolean) => {
     try {
       const llmHelper = appState.processingHelper.getLLMHelper();
       llmHelper.setGroqFastTextMode(enabled);
@@ -2296,7 +2540,7 @@ export function initializeIpcHandlers(appState: AppState): void {
       SettingsManager.getInstance().set('groqFastTextMode', enabled);
 
       // Broadcast to all windows
-      BrowserWindow.getAllWindows().forEach(win => {
+      BrowserWindow.getAllWindows().forEach((win) => {
         win.webContents.send('groq-fast-text-changed', enabled);
       });
 
@@ -2306,7 +2550,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("get-codex-cli-config", () => {
+  safeHandle('get-codex-cli-config', () => {
     try {
       const llmHelper = appState.processingHelper.getLLMHelper();
       return llmHelper.getCodexCliConfig();
@@ -2315,7 +2559,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("set-codex-cli-config", (_, config: any) => {
+  safeHandle('set-codex-cli-config', (_, config: any) => {
     try {
       const normalized = CodexCliService.normalizeConfig(config || {});
       const sm = SettingsManager.getInstance();
@@ -2332,7 +2576,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("test-codex-cli", async (_, config?: any) => {
+  safeHandle('test-codex-cli', async (_, config?: any) => {
     try {
       const current = appState.processingHelper.getLLMHelper().getCodexCliConfig();
       const normalized = CodexCliService.normalizeConfig({ ...current, ...(config || {}) });
@@ -2340,7 +2584,10 @@ export function initializeIpcHandlers(appState: AppState): void {
       // If auto-detection found a different working path, persist it so
       // subsequent chat calls don't re-ENOENT.
       if (result.success && result.resolvedPath && result.resolvedPath !== normalized.path) {
-        const updated = CodexCliService.normalizeConfig({ ...normalized, path: result.resolvedPath });
+        const updated = CodexCliService.normalizeConfig({
+          ...normalized,
+          path: result.resolvedPath,
+        });
         const sm = SettingsManager.getInstance();
         sm.set('codexCliPath', updated.path);
         appState.processingHelper.getLLMHelper().setCodexCliConfig(updated);
@@ -2352,7 +2599,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("set-model", async (_, modelId: string) => {
+  safeHandle('set-model', async (_, modelId: string) => {
     try {
       const llmHelper = appState.processingHelper.getLLMHelper();
       const { CredentialsManager } = require('./services/CredentialsManager');
@@ -2369,7 +2616,7 @@ export function initializeIpcHandlers(appState: AppState): void {
       appState.modelSelectorWindowHelper.hideWindow();
 
       // Broadcast to all windows so NativelyInterface can update its selector (session-only update)
-      BrowserWindow.getAllWindows().forEach(win => {
+      BrowserWindow.getAllWindows().forEach((win) => {
         if (!win.isDestroyed()) {
           win.webContents.send('model-changed', modelId);
         }
@@ -2377,13 +2624,13 @@ export function initializeIpcHandlers(appState: AppState): void {
 
       return { success: true };
     } catch (error: any) {
-      console.error("Error setting model:", error);
+      console.error('Error setting model:', error);
       return { success: false, error: error.message };
     }
   });
 
   // Persist default model (from Settings) + update runtime + broadcast to all windows
-  safeHandle("set-default-model", async (_, modelId: string) => {
+  safeHandle('set-default-model', async (_, modelId: string) => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       const cm = CredentialsManager.getInstance();
@@ -2400,7 +2647,7 @@ export function initializeIpcHandlers(appState: AppState): void {
       appState.modelSelectorWindowHelper.hideWindow();
 
       // Broadcast to all windows so NativelyInterface can update its selector
-      BrowserWindow.getAllWindows().forEach(win => {
+      BrowserWindow.getAllWindows().forEach((win) => {
         if (!win.isDestroyed()) {
           win.webContents.send('model-changed', modelId);
         }
@@ -2408,34 +2655,34 @@ export function initializeIpcHandlers(appState: AppState): void {
 
       return { success: true };
     } catch (error: any) {
-      console.error("Error setting default model:", error);
+      console.error('Error setting default model:', error);
       return { success: false, error: error.message };
     }
   });
 
   // Read the persisted default model
-  safeHandle("get-default-model", async () => {
+  safeHandle('get-default-model', async () => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       const cm = CredentialsManager.getInstance();
       return { model: cm.getDefaultModel() };
     } catch (error: any) {
-      console.error("Error getting default model:", error);
+      console.error('Error getting default model:', error);
       return { model: 'gemini-3.1-flash-lite-preview' };
     }
   });
 
   // --- Model Selector Window IPC ---
 
-  safeHandle("show-model-selector", (_, coords: { x: number; y: number }) => {
+  safeHandle('show-model-selector', (_, coords: { x: number; y: number }) => {
     appState.modelSelectorWindowHelper.showWindow(coords.x, coords.y);
   });
 
-  safeHandle("hide-model-selector", () => {
+  safeHandle('hide-model-selector', () => {
     appState.modelSelectorWindowHelper.hideWindow();
   });
 
-  safeHandle("toggle-model-selector", (_, coords: { x: number; y: number }) => {
+  safeHandle('toggle-model-selector', (_, coords: { x: number; y: number }) => {
     appState.modelSelectorWindowHelper.toggleWindow(coords.x, coords.y);
   });
 
@@ -2445,41 +2692,39 @@ export function initializeIpcHandlers(appState: AppState): void {
   // → never receives blur). The overlay's renderer fires this IPC on every
   // mousedown that isn't on the toggle button itself; if the model selector
   // is open, we close it. No-op when closed (toggleWindow handled the open).
-  safeHandle("model-selector:close-if-open", () => {
+  safeHandle('model-selector:close-if-open', () => {
     const win = appState.modelSelectorWindowHelper.getWindow();
     if (win && !win.isDestroyed() && win.isVisible()) {
       appState.modelSelectorWindowHelper.hideWindow();
     }
   });
 
-
-
   // Native Audio Service Handlers
   // Native Audio handlers removed as part of migration to driverless architecture
-  safeHandle("native-audio-status", async () => {
+  safeHandle('native-audio-status', async () => {
     // Always return true or pseudo-status since it's "driverless"
     return { connected: true };
   });
 
-  safeHandle("get-input-devices", async () => {
+  safeHandle('get-input-devices', async () => {
     return AudioDevices.getInputDevices();
   });
 
-  safeHandle("get-output-devices", async () => {
+  safeHandle('get-output-devices', async () => {
     return AudioDevices.getOutputDevices();
   });
 
-  safeHandle("start-audio-test", async (event, deviceId?: string) => {
+  safeHandle('start-audio-test', async (event, deviceId?: string) => {
     await appState.startAudioTest(deviceId);
     return { success: true };
   });
 
-  safeHandle("stop-audio-test", async () => {
+  safeHandle('stop-audio-test', async () => {
     appState.stopAudioTest();
     return { success: true };
   });
 
-  safeHandle("set-recognition-language", async (_, key: string) => {
+  safeHandle('set-recognition-language', async (_, key: string) => {
     appState.setRecognitionLanguage(key);
     return { success: true };
   });
@@ -2488,45 +2733,45 @@ export function initializeIpcHandlers(appState: AppState): void {
   // Meeting Lifecycle Handlers
   // ==========================================
 
-  safeHandle("start-meeting", async (event, metadata?: any) => {
+  safeHandle('start-meeting', async (event, metadata?: any) => {
     try {
       await appState.startMeeting(metadata);
       return { success: true };
     } catch (error: any) {
-      console.error("Error starting meeting:", error);
+      console.error('Error starting meeting:', error);
       return { success: false, error: error.message };
     }
   });
 
-  safeHandle("end-meeting", async () => {
+  safeHandle('end-meeting', async () => {
     try {
       await appState.endMeeting();
       return { success: true };
     } catch (error: any) {
-      console.error("Error ending meeting:", error);
+      console.error('Error ending meeting:', error);
       return { success: false, error: error.message };
     }
   });
 
-  safeHandle("get-recent-meetings", async () => {
+  safeHandle('get-recent-meetings', async () => {
     // Fetch from SQLite (limit 50)
     return DatabaseManager.getInstance().getRecentMeetings(50);
   });
 
-  safeHandle("get-meeting-details", async (event, id) => {
+  safeHandle('get-meeting-details', async (event, id) => {
     // Helper to fetch full details
     return DatabaseManager.getInstance().getMeetingDetails(id);
   });
 
-  safeHandle("update-meeting-title", async (_, { id, title }: { id: string; title: string }) => {
+  safeHandle('update-meeting-title', async (_, { id, title }: { id: string; title: string }) => {
     return DatabaseManager.getInstance().updateMeetingTitle(id, title);
   });
 
-  safeHandle("update-meeting-summary", async (_, { id, updates }: { id: string; updates: any }) => {
+  safeHandle('update-meeting-summary', async (_, { id, updates }: { id: string; updates: any }) => {
     return DatabaseManager.getInstance().updateMeetingSummary(id, updates);
   });
 
-  safeHandle("seed-demo", async () => {
+  safeHandle('seed-demo', async () => {
     DatabaseManager.getInstance().seedDemoMeeting();
 
     // Ensure RAG embeddings exist for the demo meeting.
@@ -2540,12 +2785,12 @@ export function initializeIpcHandlers(appState: AppState): void {
     return { success: true };
   });
 
-  safeHandle("flush-database", async () => {
+  safeHandle('flush-database', async () => {
     const result = DatabaseManager.getInstance().clearAllData();
     return { success: result };
   });
 
-  safeHandle("open-external", async (event, url: string) => {
+  safeHandle('open-external', async (event, url: string) => {
     try {
       if (typeof url !== 'string') {
         console.warn('[IPC] Blocked invalid open-external request', { reason: 'non-string' });
@@ -2553,17 +2798,24 @@ export function initializeIpcHandlers(appState: AppState): void {
       }
 
       const parsed = new URL(url);
-      const allowedWebUrl = parsed.protocol === 'https:' && parsed.hostname === 'mail.google.com' && parsed.pathname === '/mail/';
+      const allowedWebUrl =
+        parsed.protocol === 'https:' &&
+        parsed.hostname === 'mail.google.com' &&
+        parsed.pathname === '/mail/';
       // x-apple.systempreferences is a macOS-only URI scheme. Allowing it on
       // Windows let renderer regressions hand Windows shell an unknown
       // protocol → Microsoft Store popup (issue #252). Gate the allowlist on
       // the actual platform so the IPC layer is the last line of defense.
-      const allowedSystemSettingsUrl = parsed.protocol === 'x-apple.systempreferences:' && process.platform === 'darwin';
+      const allowedSystemSettingsUrl =
+        parsed.protocol === 'x-apple.systempreferences:' && process.platform === 'darwin';
 
       if (allowedWebUrl || allowedSystemSettingsUrl) {
         await shell.openExternal(url);
       } else {
-        console.warn('[IPC] Blocked open-external request', { protocol: parsed.protocol, hostname: parsed.hostname });
+        console.warn('[IPC] Blocked open-external request', {
+          protocol: parsed.protocol,
+          hostname: parsed.hostname,
+        });
       }
     } catch {
       console.warn('[IPC] Invalid URL in open-external');
@@ -2575,12 +2827,18 @@ export function initializeIpcHandlers(appState: AppState): void {
   // ==========================================
 
   // MODE 1: Assist (Passive observation)
-  safeHandle("generate-assist", async () => {
+  safeHandle('generate-assist', async () => {
     try {
       const intelligenceManager = appState.getIntelligenceManager();
       const insight = await intelligenceManager.runAssistMode();
       if (insight) {
-        try { PhoneMirrorService.getInstance().publishAssistantMessage(crypto.randomUUID(), insight, 'Assist'); } catch (_) {}
+        try {
+          PhoneMirrorService.getInstance().publishAssistantMessage(
+            crypto.randomUUID(),
+            insight,
+            'Assist',
+          );
+        } catch (_) {}
       }
       return { insight };
     } catch (error: any) {
@@ -2596,120 +2854,157 @@ export function initializeIpcHandlers(appState: AppState): void {
   // here to run Tesseract OCR before answering. That path is now removed from the runtime —
   // Natively answers from the image directly via a vision-capable provider. Do not re-introduce
   // OCR here unless a future explicit OCR-only mode is reintroduced.
-  safeHandle("generate-what-to-say", async (_, question?: string, imagePaths?: string[], options?: { promptInstruction?: string }) => {
-    try {
-      let screenContext: any;
-      let screenContextStatus: 'not_available' | 'available' | 'failed' = 'not_available';
-      let visionProviderUsed: string | undefined;
-      let visionModelUsed: string | undefined;
-      let visionAttempts: number | undefined;
-      let visionFailureReason: string | undefined;
+  safeHandle(
+    'generate-what-to-say',
+    async (
+      _,
+      question?: string,
+      imagePaths?: string[],
+      options?: { promptInstruction?: string },
+    ) => {
+      try {
+        let screenContext: any;
+        let screenContextStatus: 'not_available' | 'available' | 'failed' = 'not_available';
+        let visionProviderUsed: string | undefined;
+        let visionModelUsed: string | undefined;
+        let visionAttempts: number | undefined;
+        let visionFailureReason: string | undefined;
 
-      const validatedImagePaths: string[] | undefined = imagePaths?.length ? [] : undefined;
+        const validatedImagePaths: string[] | undefined = imagePaths?.length ? [] : undefined;
 
-      // SECURITY (P0): Validate image paths if provided from renderer
-      if (imagePaths && imagePaths.length > 0) {
-        if (!Array.isArray(imagePaths) || imagePaths.length > 5 || imagePaths.some(imagePath => typeof imagePath !== 'string' || imagePath.trim().length === 0)) {
-          console.warn('[IPC] generate-what-to-say: malformed image path payload rejected');
-          return {
-            answer: null,
-            question: question || 'unknown',
-            screenContextStatus,
-            error: 'Invalid image path payload'
-          };
-        }
-
-        const { app } = require('electron');
-        const { validateImagePath } = require('./utils/curlUtils');
-        const userDataDir = app.getPath('userData');
-
-        for (const imagePath of imagePaths) {
-          const validation = validateImagePath(imagePath, userDataDir);
-          if (!validation.isValid) {
-            console.warn(`[IPC] generate-what-to-say: invalid image path rejected: ${validation.reason}`);
+        // SECURITY (P0): Validate image paths if provided from renderer
+        if (imagePaths && imagePaths.length > 0) {
+          if (
+            !Array.isArray(imagePaths) ||
+            imagePaths.length > 5 ||
+            imagePaths.some(
+              (imagePath) => typeof imagePath !== 'string' || imagePath.trim().length === 0,
+            )
+          ) {
+            console.warn('[IPC] generate-what-to-say: malformed image path payload rejected');
             return {
               answer: null,
               question: question || 'unknown',
               screenContextStatus,
-              error: `Invalid image path: ${validation.reason}`
+              error: 'Invalid image path payload',
             };
           }
-          validatedImagePaths!.push(imagePath);
+
+          const { app } = require('electron');
+          const { validateImagePath } = require('./utils/curlUtils');
+          const userDataDir = app.getPath('userData');
+
+          for (const imagePath of imagePaths) {
+            const validation = validateImagePath(imagePath, userDataDir);
+            if (!validation.isValid) {
+              console.warn(
+                `[IPC] generate-what-to-say: invalid image path rejected: ${validation.reason}`,
+              );
+              return {
+                answer: null,
+                question: question || 'unknown',
+                screenContextStatus,
+                error: `Invalid image path: ${validation.reason}`,
+              };
+            }
+            validatedImagePaths!.push(imagePath);
+          }
+
+          // Vision-first: run the ScreenUnderstandingService so the image is hashed, optimized,
+          // and routed through the vision provider fallback chain. The structured result becomes
+          // the screenContext that PromptAssembler consumes.
+          try {
+            const {
+              getScreenUnderstandingService,
+            } = require('./services/screen/ScreenUnderstandingService');
+            const { CredentialsManager } = require('./services/CredentialsManager');
+            const sus = getScreenUnderstandingService();
+            const settings = SettingsManager.getInstance();
+            const credentials = CredentialsManager.getInstance();
+            const providerScopes = settings.get('providerDataScopes') || {};
+
+            const sur = await sus.understand({
+              modeId: 'what-to-say',
+              transcript: question,
+              userAction: 'what_to_say',
+              qualityMode: 'balanced',
+              imagePaths: validatedImagePaths,
+              screenUnderstandingMode: settings.getScreenUnderstandingMode(),
+              technicalInterviewVisionFirst: settings.getTechnicalInterviewVisionFirst(),
+              providerPolicy: {
+                localOnly: settings.getScreenUnderstandingMode() === 'private_vision',
+                allowScreenshots: providerScopes.screenshots !== false,
+                visionAvailable: credentials.anyVisionProviderConfigured?.() ?? true,
+                localVisionAvailable: credentials.anyLocalVisionProviderConfigured?.() ?? false,
+              },
+            });
+
+            screenContext = sur.status === 'available' ? sur : undefined;
+            screenContextStatus =
+              sur.status === 'available'
+                ? 'available'
+                : sur.status === 'failed'
+                  ? 'failed'
+                  : 'not_available';
+            visionProviderUsed = sur.providerUsed;
+            visionModelUsed = sur.modelUsed;
+            visionAttempts = Array.isArray(sur.attempts) ? sur.attempts.length : undefined;
+            visionFailureReason = sur.failureReason;
+          } catch (sErr: any) {
+            screenContextStatus = 'failed';
+            console.warn('[IPC] generate-what-to-say: ScreenUnderstandingService failed', {
+              errorClass: sErr?.name || 'Error',
+            });
+          }
         }
 
-        // Vision-first: run the ScreenUnderstandingService so the image is hashed, optimized,
-        // and routed through the vision provider fallback chain. The structured result becomes
-        // the screenContext that PromptAssembler consumes.
-        try {
-          const { getScreenUnderstandingService } = require('./services/screen/ScreenUnderstandingService');
-          const { CredentialsManager } = require('./services/CredentialsManager');
-          const sus = getScreenUnderstandingService();
-          const settings = SettingsManager.getInstance();
-          const credentials = CredentialsManager.getInstance();
-          const providerScopes = settings.get('providerDataScopes') || {};
-
-          const sur = await sus.understand({
-            modeId: 'what-to-say',
-            transcript: question,
-            userAction: 'what_to_say',
-            qualityMode: 'balanced',
-            imagePaths: validatedImagePaths,
-            screenUnderstandingMode: settings.getScreenUnderstandingMode(),
-            technicalInterviewVisionFirst: settings.getTechnicalInterviewVisionFirst(),
-            providerPolicy: {
-              localOnly: settings.getScreenUnderstandingMode() === 'private_vision',
-              allowScreenshots: providerScopes.screenshots !== false,
-              visionAvailable: credentials.anyVisionProviderConfigured?.() ?? true,
-              localVisionAvailable: credentials.anyLocalVisionProviderConfigured?.() ?? false,
-            },
-          });
-
-          screenContext = sur.status === 'available' ? sur : undefined;
-          screenContextStatus = sur.status === 'available' ? 'available' : (sur.status === 'failed' ? 'failed' : 'not_available');
-          visionProviderUsed = sur.providerUsed;
-          visionModelUsed = sur.modelUsed;
-          visionAttempts = Array.isArray(sur.attempts) ? sur.attempts.length : undefined;
-          visionFailureReason = sur.failureReason;
-        } catch (sErr: any) {
-          screenContextStatus = 'failed';
-          console.warn('[IPC] generate-what-to-say: ScreenUnderstandingService failed', {
-            errorClass: sErr?.name || 'Error',
-          });
+        const intelligenceManager = appState.getIntelligenceManager();
+        // Question and imagePaths are now optional - IntelligenceManager infers from transcript
+        const answer = await intelligenceManager.runWhatShouldISay(
+          question,
+          0.8,
+          validatedImagePaths,
+          {
+            skipCooldown: process.env.NODE_ENV === 'test',
+            screenContext,
+            promptInstruction:
+              typeof options?.promptInstruction === 'string'
+                ? options.promptInstruction
+                : undefined,
+          },
+        );
+        if (answer) {
+          try {
+            PhoneMirrorService.getInstance().publishAssistantMessage(
+              crypto.randomUUID(),
+              answer,
+              'What to Answer',
+            );
+          } catch (_) {}
         }
+        return {
+          answer,
+          question: question || 'inferred from context',
+          screenContextStatus,
+          visionProviderUsed,
+          visionModelUsed,
+          visionAttempts,
+          visionFailureReason,
+          imageCount: validatedImagePaths?.length || 0,
+          usedImageInput: Boolean(validatedImagePaths?.length),
+        };
+      } catch (error: any) {
+        console.error('[IPC] generate-what-to-say error:', error);
+        return {
+          answer: null,
+          question: question || 'unknown',
+          error: error?.message || 'unknown_error',
+        };
       }
+    },
+  );
 
-      const intelligenceManager = appState.getIntelligenceManager();
-      // Question and imagePaths are now optional - IntelligenceManager infers from transcript
-      const answer = await intelligenceManager.runWhatShouldISay(question, 0.8, validatedImagePaths, {
-        skipCooldown: process.env.NODE_ENV === 'test',
-        screenContext,
-        promptInstruction: typeof options?.promptInstruction === 'string' ? options.promptInstruction : undefined,
-      });
-      if (answer) {
-        try { PhoneMirrorService.getInstance().publishAssistantMessage(crypto.randomUUID(), answer, 'What to Answer'); } catch (_) {}
-      }
-      return {
-        answer,
-        question: question || 'inferred from context',
-        screenContextStatus,
-        visionProviderUsed,
-        visionModelUsed,
-        visionAttempts,
-        visionFailureReason,
-        imageCount: validatedImagePaths?.length || 0,
-        usedImageInput: Boolean(validatedImagePaths?.length),
-      };
-    } catch (error: any) {
-      console.error('[IPC] generate-what-to-say error:', error);
-      return {
-        answer: null,
-        question: question || 'unknown',
-        error: error?.message || 'unknown_error'
-      };
-    }
-  });
-
-  safeHandle("generate-clarify", async () => {
+  safeHandle('generate-clarify', async () => {
     try {
       const intelligenceManager = appState.getIntelligenceManager();
       const clarification = await intelligenceManager.runClarify();
@@ -2717,9 +3012,19 @@ export function initializeIpcHandlers(appState: AppState): void {
       // We must still ensure the frontend un-sticks — emit an error so onIntelligenceError fires.
       if (clarification === null) {
         const win = appState.getMainWindow();
-        win?.webContents.send('intelligence-error', { error: 'Could not generate a clarifying question. Try again after some audio context is available.', mode: 'clarify' });
+        win?.webContents.send('intelligence-error', {
+          error:
+            'Could not generate a clarifying question. Try again after some audio context is available.',
+          mode: 'clarify',
+        });
       } else {
-        try { PhoneMirrorService.getInstance().publishAssistantMessage(crypto.randomUUID(), clarification, 'Clarify'); } catch (_) {}
+        try {
+          PhoneMirrorService.getInstance().publishAssistantMessage(
+            crypto.randomUUID(),
+            clarification,
+            'Clarify',
+          );
+        } catch (_) {}
       }
       return { clarification };
     } catch (error: any) {
@@ -2746,7 +3051,10 @@ export function initializeIpcHandlers(appState: AppState): void {
           const out = await optimizer.optimize(p, { profile, provider: 'openai', cacheKey: p });
           optimized.push(out.path);
         } catch (err: any) {
-          console.warn(`[IPC] ${handlerLabel}: image optimization failed for ${p}, using original`, { errorClass: err?.name });
+          console.warn(
+            `[IPC] ${handlerLabel}: image optimization failed for ${p}, using original`,
+            { errorClass: err?.name },
+          );
           optimized.push(p);
         }
       }
@@ -2756,15 +3064,13 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   }
 
-  safeHandle("generate-code-hint", async (_, imagePaths?: string[], problemStatement?: string) => {
+  safeHandle('generate-code-hint', async (_, imagePaths?: string[], problemStatement?: string) => {
     try {
       // If no explicit images were passed from the frontend, fall back to the
       // screenshot queue so the AI can always "see" the user's screen.
       const screenshotQueue = appState.getScreenshotQueue();
       const resolvedImagePaths: string[] =
-        imagePaths && imagePaths.length > 0
-          ? imagePaths
-          : screenshotQueue;
+        imagePaths && imagePaths.length > 0 ? imagePaths : screenshotQueue;
 
       // SECURITY (P0): Validate image paths if provided from renderer
       if (imagePaths && imagePaths.length > 0) {
@@ -2775,25 +3081,39 @@ export function initializeIpcHandlers(appState: AppState): void {
         for (const imagePath of imagePaths) {
           const validation = validateImagePath(imagePath, userDataDir);
           if (!validation.isValid) {
-            console.warn(`[IPC] generate-code-hint: invalid image path rejected: ${validation.reason}`);
+            console.warn(
+              `[IPC] generate-code-hint: invalid image path rejected: ${validation.reason}`,
+            );
             return { error: `Invalid image path: ${validation.reason}`, hint: null };
           }
         }
       }
 
-      console.log(`[IPC] generate-code-hint: using ${resolvedImagePaths.length} image(s) (${imagePaths?.length ? 'explicit' : 'queue fallback'})`);
+      console.log(
+        `[IPC] generate-code-hint: using ${resolvedImagePaths.length} image(s) (${imagePaths?.length ? 'explicit' : 'queue fallback'})`,
+      );
 
       // VISION-FIRST: optimize the screenshot(s) with Sharp before they reach the LLM,
       // using the 'technical' profile so code text stays sharp at 1536px.
-      const optimizedPaths = await optimizeImagesForVision(resolvedImagePaths, 'generate-code-hint', 'technical');
+      const optimizedPaths = await optimizeImagesForVision(
+        resolvedImagePaths,
+        'generate-code-hint',
+        'technical',
+      );
 
       const intelligenceManager = appState.getIntelligenceManager();
       const hint = await intelligenceManager.runCodeHint(
         optimizedPaths.length > 0 ? optimizedPaths : undefined,
-        problemStatement
+        problemStatement,
       );
       if (hint) {
-        try { PhoneMirrorService.getInstance().publishAssistantMessage(crypto.randomUUID(), hint, 'Code Hint'); } catch (_) {}
+        try {
+          PhoneMirrorService.getInstance().publishAssistantMessage(
+            crypto.randomUUID(),
+            hint,
+            'Code Hint',
+          );
+        } catch (_) {}
       }
       return { hint };
     } catch (error: any) {
@@ -2801,15 +3121,13 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("generate-brainstorm", async (_, imagePaths?: string[], problemStatement?: string) => {
+  safeHandle('generate-brainstorm', async (_, imagePaths?: string[], problemStatement?: string) => {
     try {
       // If no explicit images were passed from the frontend, fall back to the
       // screenshot queue so the AI can always "see" the user's screen.
       const screenshotQueue = appState.getScreenshotQueue();
       const resolvedImagePaths: string[] =
-        imagePaths && imagePaths.length > 0
-          ? imagePaths
-          : screenshotQueue;
+        imagePaths && imagePaths.length > 0 ? imagePaths : screenshotQueue;
 
       // SECURITY (P0): Validate image paths if provided from renderer
       if (imagePaths && imagePaths.length > 0) {
@@ -2820,24 +3138,38 @@ export function initializeIpcHandlers(appState: AppState): void {
         for (const imagePath of imagePaths) {
           const validation = validateImagePath(imagePath, userDataDir);
           if (!validation.isValid) {
-            console.warn(`[IPC] generate-brainstorm: invalid image path rejected: ${validation.reason}`);
+            console.warn(
+              `[IPC] generate-brainstorm: invalid image path rejected: ${validation.reason}`,
+            );
             return { error: `Invalid image path: ${validation.reason}`, script: null };
           }
         }
       }
 
-      console.log(`[IPC] generate-brainstorm: using ${resolvedImagePaths.length} image(s) (${imagePaths?.length ? 'explicit' : 'queue fallback'})`);
+      console.log(
+        `[IPC] generate-brainstorm: using ${resolvedImagePaths.length} image(s) (${imagePaths?.length ? 'explicit' : 'queue fallback'})`,
+      );
 
       // VISION-FIRST: balanced profile (1280px) — brainstorm doesn't need code-sharp text.
-      const optimizedPaths = await optimizeImagesForVision(resolvedImagePaths, 'generate-brainstorm', 'balanced');
+      const optimizedPaths = await optimizeImagesForVision(
+        resolvedImagePaths,
+        'generate-brainstorm',
+        'balanced',
+      );
 
       const intelligenceManager = appState.getIntelligenceManager();
       const script = await intelligenceManager.runBrainstorm(
         optimizedPaths.length > 0 ? optimizedPaths : undefined,
-        problemStatement
+        problemStatement,
       );
       if (script) {
-        try { PhoneMirrorService.getInstance().publishAssistantMessage(crypto.randomUUID(), script, 'Brainstorm'); } catch (_) {}
+        try {
+          PhoneMirrorService.getInstance().publishAssistantMessage(
+            crypto.randomUUID(),
+            script,
+            'Brainstorm',
+          );
+        } catch (_) {}
       }
       return { script };
     } catch (error: any) {
@@ -2846,18 +3178,18 @@ export function initializeIpcHandlers(appState: AppState): void {
   });
 
   // Dynamic Action Button Mode (Recap vs Brainstorm)
-  safeHandle("get-action-button-mode", () => {
+  safeHandle('get-action-button-mode', () => {
     const { SettingsManager } = require('./services/SettingsManager');
     const sm = SettingsManager.getInstance();
     return sm.get('actionButtonMode') ?? 'recap';
   });
 
-  safeHandle("set-action-button-mode", (_, mode: 'recap' | 'brainstorm') => {
+  safeHandle('set-action-button-mode', (_, mode: 'recap' | 'brainstorm') => {
     const { SettingsManager } = require('./services/SettingsManager');
     const sm = SettingsManager.getInstance();
     sm.set('actionButtonMode', mode);
 
-    BrowserWindow.getAllWindows().forEach(win => {
+    BrowserWindow.getAllWindows().forEach((win) => {
       if (!win.isDestroyed()) {
         win.webContents.send('action-button-mode-changed', mode);
       }
@@ -2867,12 +3199,18 @@ export function initializeIpcHandlers(appState: AppState): void {
   });
 
   // MODE 3: Follow-Up (Refinement)
-  safeHandle("generate-follow-up", async (_, intent: string, userRequest?: string) => {
+  safeHandle('generate-follow-up', async (_, intent: string, userRequest?: string) => {
     try {
       const intelligenceManager = appState.getIntelligenceManager();
       const refined = await intelligenceManager.runFollowUp(intent, userRequest);
       if (refined) {
-        try { PhoneMirrorService.getInstance().publishAssistantMessage(crypto.randomUUID(), refined, 'Follow Up'); } catch (_) {}
+        try {
+          PhoneMirrorService.getInstance().publishAssistantMessage(
+            crypto.randomUUID(),
+            refined,
+            'Follow Up',
+          );
+        } catch (_) {}
       }
       return { refined, intent };
     } catch (error: any) {
@@ -2881,12 +3219,18 @@ export function initializeIpcHandlers(appState: AppState): void {
   });
 
   // MODE 4: Recap (Summary)
-  safeHandle("generate-recap", async () => {
+  safeHandle('generate-recap', async () => {
     try {
       const intelligenceManager = appState.getIntelligenceManager();
       const summary = await intelligenceManager.runRecap();
       if (summary) {
-        try { PhoneMirrorService.getInstance().publishAssistantMessage(crypto.randomUUID(), summary, 'Recap'); } catch (_) {}
+        try {
+          PhoneMirrorService.getInstance().publishAssistantMessage(
+            crypto.randomUUID(),
+            summary,
+            'Recap',
+          );
+        } catch (_) {}
       }
       return { summary };
     } catch (error: any) {
@@ -2895,12 +3239,18 @@ export function initializeIpcHandlers(appState: AppState): void {
   });
 
   // MODE 6: Follow-Up Questions
-  safeHandle("generate-follow-up-questions", async () => {
+  safeHandle('generate-follow-up-questions', async () => {
     try {
       const intelligenceManager = appState.getIntelligenceManager();
       const questions = await intelligenceManager.runFollowUpQuestions();
       if (questions) {
-        try { PhoneMirrorService.getInstance().publishAssistantMessage(crypto.randomUUID(), questions, 'Follow-Up Questions'); } catch (_) {}
+        try {
+          PhoneMirrorService.getInstance().publishAssistantMessage(
+            crypto.randomUUID(),
+            questions,
+            'Follow-Up Questions',
+          );
+        } catch (_) {}
       }
       return { questions };
     } catch (error: any) {
@@ -2909,14 +3259,18 @@ export function initializeIpcHandlers(appState: AppState): void {
   });
 
   // MODE 5: Manual Answer (Fallback)
-  safeHandle("submit-manual-question", async (_, question: string) => {
+  safeHandle('submit-manual-question', async (_, question: string) => {
     try {
       const intelligenceManager = appState.getIntelligenceManager();
       const answer = await intelligenceManager.runManualAnswer(question);
       if (answer) {
         try {
           PhoneMirrorService.getInstance().publishUserMessage(crypto.randomUUID(), question);
-          PhoneMirrorService.getInstance().publishAssistantMessage(crypto.randomUUID(), answer, 'Answer');
+          PhoneMirrorService.getInstance().publishAssistantMessage(
+            crypto.randomUUID(),
+            answer,
+            'Answer',
+          );
         } catch (_) {}
       }
       return { answer, question };
@@ -2926,13 +3280,13 @@ export function initializeIpcHandlers(appState: AppState): void {
   });
 
   // Get current intelligence context
-  safeHandle("get-intelligence-context", async () => {
+  safeHandle('get-intelligence-context', async () => {
     try {
       const intelligenceManager = appState.getIntelligenceManager();
       return {
         context: intelligenceManager.getFormattedContext(),
         lastAssistantMessage: intelligenceManager.getLastAssistantMessage(),
-        activeMode: intelligenceManager.getActiveMode()
+        activeMode: intelligenceManager.getActiveMode(),
       };
     } catch (error: any) {
       throw error;
@@ -2940,7 +3294,7 @@ export function initializeIpcHandlers(appState: AppState): void {
   });
 
   // Reset intelligence state
-  safeHandle("reset-intelligence", async () => {
+  safeHandle('reset-intelligence', async () => {
     try {
       const intelligenceManager = appState.getIntelligenceManager();
       intelligenceManager.reset();
@@ -2953,7 +3307,7 @@ export function initializeIpcHandlers(appState: AppState): void {
   // Phase 3 — Dynamic Actions IPC. Accept/dismiss/list. The action emission
   // direction is push-only (intelligence-dynamic-action channel from main →
   // renderer); these handlers are the renderer → main control plane.
-  safeHandle("dynamic-action:accept", async (_, actionId: string) => {
+  safeHandle('dynamic-action:accept', async (_, actionId: string) => {
     try {
       if (typeof actionId !== 'string' || !actionId) {
         return { success: false, error: 'invalid_action_id' };
@@ -2968,9 +3322,15 @@ export function initializeIpcHandlers(appState: AppState): void {
           name: 'dynamic_action_accepted',
           sessionId: action.sessionId,
           modeId: action.modeId,
-          properties: { actionId: action.id, actionType: action.type, modeTemplateType: action.modeTemplateType },
+          properties: {
+            actionId: action.id,
+            actionType: action.type,
+            modeTemplateType: action.modeTemplateType,
+          },
         });
-      } catch { /* non-fatal */ }
+      } catch {
+        /* non-fatal */
+      }
       // Caller (renderer) is expected to follow up with a normal Ask-AI call
       // using action.promptInstruction. We return the action so the renderer
       // can populate the answer prompt without a second round-trip.
@@ -2980,7 +3340,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("dynamic-action:dismiss", async (_, actionId: string) => {
+  safeHandle('dynamic-action:dismiss', async (_, actionId: string) => {
     try {
       if (typeof actionId !== 'string' || !actionId) {
         return { success: false, error: 'invalid_action_id' };
@@ -2991,14 +3351,16 @@ export function initializeIpcHandlers(appState: AppState): void {
       try {
         const { telemetryService } = require('./services/telemetry/TelemetryService');
         telemetryService.track({ name: 'dynamic_action_dismissed', properties: { actionId } });
-      } catch { /* non-fatal */ }
+      } catch {
+        /* non-fatal */
+      }
       return { success: true };
     } catch (error: any) {
       return { success: false, error: error?.message ?? 'internal_error' };
     }
   });
 
-  safeHandle("dynamic-action:list", async () => {
+  safeHandle('dynamic-action:list', async () => {
     try {
       const intelligenceManager = appState.getIntelligenceManager();
       return { success: true, actions: intelligenceManager.getActiveDynamicActions() };
@@ -3007,23 +3369,29 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("test-inject-transcript", async (_, segment: { speaker: string; text: string; timestamp?: number; final?: boolean }) => {
-    try {
-      if (process.env.NODE_ENV !== 'test') return { success: false, error: 'test_only' };
-      const intelligenceManager = appState.getIntelligenceManager();
-      intelligenceManager.addTranscript({
-        speaker: segment.speaker,
-        text: segment.text,
-        timestamp: segment.timestamp ?? Date.now(),
-        final: segment.final ?? true,
-      }, true);
-      return { success: true };
-    } catch (error: any) {
-      return { success: false, error: error.message };
-    }
-  });
+  safeHandle(
+    'test-inject-transcript',
+    async (_, segment: { speaker: string; text: string; timestamp?: number; final?: boolean }) => {
+      try {
+        if (process.env.NODE_ENV !== 'test') return { success: false, error: 'test_only' };
+        const intelligenceManager = appState.getIntelligenceManager();
+        intelligenceManager.addTranscript(
+          {
+            speaker: segment.speaker,
+            text: segment.text,
+            timestamp: segment.timestamp ?? Date.now(),
+            final: segment.final ?? true,
+          },
+          true,
+        );
+        return { success: true };
+      } catch (error: any) {
+        return { success: false, error: error.message };
+      }
+    },
+  );
 
-  safeHandle("test-get-mode-context", async () => {
+  safeHandle('test-get-mode-context', async () => {
     try {
       if (process.env.NODE_ENV !== 'test') return { success: false, error: 'test_only' };
       const { ModesManager } = require('./services/ModesManager');
@@ -3038,13 +3406,12 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-
   // Service Account Selection
-  safeHandle("select-service-account", async () => {
+  safeHandle('select-service-account', async () => {
     try {
       const result: any = await dialog.showOpenDialog({
         properties: ['openFile'],
-        filters: [{ name: 'JSON', extensions: ['json'] }]
+        filters: [{ name: 'JSON', extensions: ['json'] }],
       });
 
       if (result.canceled || result.filePaths.length === 0) {
@@ -3062,7 +3429,7 @@ export function initializeIpcHandlers(appState: AppState): void {
 
       return { success: true, path: filePath };
     } catch (error: any) {
-      console.error("Error selecting service account:", error);
+      console.error('Error selecting service account:', error);
       return { success: false, error: error.message };
     }
   });
@@ -3071,15 +3438,15 @@ export function initializeIpcHandlers(appState: AppState): void {
   // Theme System Handlers
   // ==========================================
 
-  safeHandle("theme:get-mode", () => {
+  safeHandle('theme:get-mode', () => {
     const tm = appState.getThemeManager();
     return {
       mode: tm.getMode(),
-      resolved: tm.getResolvedTheme()
+      resolved: tm.getResolvedTheme(),
     };
   });
 
-  safeHandle("theme:set-mode", (_, mode: 'system' | 'light' | 'dark') => {
+  safeHandle('theme:set-mode', (_, mode: 'system' | 'light' | 'dark') => {
     appState.getThemeManager().setMode(mode);
     return { success: true };
   });
@@ -3088,34 +3455,34 @@ export function initializeIpcHandlers(appState: AppState): void {
   // Calendar Integration Handlers
   // ==========================================
 
-  safeHandle("calendar-connect", async () => {
+  safeHandle('calendar-connect', async () => {
     try {
       const { CalendarManager } = require('./services/CalendarManager');
       await CalendarManager.getInstance().startAuthFlow();
       return { success: true };
     } catch (error: any) {
-      console.error("Calendar auth error:", error);
+      console.error('Calendar auth error:', error);
       return { success: false, error: error.message };
     }
   });
 
-  safeHandle("calendar-disconnect", async () => {
+  safeHandle('calendar-disconnect', async () => {
     const { CalendarManager } = require('./services/CalendarManager');
     await CalendarManager.getInstance().disconnect();
     return { success: true };
   });
 
-  safeHandle("get-calendar-status", async () => {
+  safeHandle('get-calendar-status', async () => {
     const { CalendarManager } = require('./services/CalendarManager');
     return CalendarManager.getInstance().getConnectionStatus();
   });
 
-  safeHandle("get-upcoming-events", async () => {
+  safeHandle('get-upcoming-events', async () => {
     const { CalendarManager } = require('./services/CalendarManager');
     return CalendarManager.getInstance().getUpcomingEvents();
   });
 
-  safeHandle("calendar-refresh", async () => {
+  safeHandle('calendar-refresh', async () => {
     const { CalendarManager } = require('./services/CalendarManager');
     await CalendarManager.getInstance().refreshState();
     return { success: true };
@@ -3125,7 +3492,7 @@ export function initializeIpcHandlers(appState: AppState): void {
   // Follow-up Email Handlers
   // ==========================================
 
-  safeHandle("generate-followup-email", async (_, input: any) => {
+  safeHandle('generate-followup-email', async (_, input: any) => {
     try {
       const { FOLLOWUP_EMAIL_PROMPT, GROQ_FOLLOWUP_EMAIL_PROMPT } = require('./llm/prompts');
       const { buildFollowUpEmailPromptInput } = require('./utils/emailUtils');
@@ -3140,26 +3507,32 @@ export function initializeIpcHandlers(appState: AppState): void {
       const groqPrompt = `${GROQ_FOLLOWUP_EMAIL_PROMPT}\n\nMEETING DETAILS:\n${contextString}`;
 
       // Use chatWithGemini with alternateGroqMessage for fallback
-      const emailBody = await llmHelper.chatWithGemini(geminiPrompt, undefined, undefined, true, groqPrompt);
+      const emailBody = await llmHelper.chatWithGemini(
+        geminiPrompt,
+        undefined,
+        undefined,
+        true,
+        groqPrompt,
+      );
 
       return emailBody;
     } catch (error: any) {
-      console.error("Error generating follow-up email:", error);
+      console.error('Error generating follow-up email:', error);
       throw error;
     }
   });
 
-  safeHandle("extract-emails-from-transcript", async (_, transcript: Array<{ text: string }>) => {
+  safeHandle('extract-emails-from-transcript', async (_, transcript: Array<{ text: string }>) => {
     try {
       const { extractEmailsFromTranscript } = require('./utils/emailUtils');
       return extractEmailsFromTranscript(transcript);
     } catch (error: any) {
-      console.error("Error extracting emails:", error);
+      console.error('Error extracting emails:', error);
       return [];
     }
   });
 
-  safeHandle("get-calendar-attendees", async (_, eventId: string) => {
+  safeHandle('get-calendar-attendees', async (_, eventId: string) => {
     try {
       const { CalendarManager } = require('./services/CalendarManager');
       const cm = CalendarManager.getInstance();
@@ -3169,30 +3542,35 @@ export function initializeIpcHandlers(appState: AppState): void {
       const event = events?.find((e: any) => e.id === eventId);
 
       if (event && event.attendees) {
-        return event.attendees.map((a: any) => ({
-          email: a.email,
-          name: a.displayName || a.email?.split('@')[0] || ''
-        })).filter((a: any) => a.email);
+        return event.attendees
+          .map((a: any) => ({
+            email: a.email,
+            name: a.displayName || a.email?.split('@')[0] || '',
+          }))
+          .filter((a: any) => a.email);
       }
 
       return [];
     } catch (error: any) {
-      console.error("Error getting calendar attendees:", error);
+      console.error('Error getting calendar attendees:', error);
       return [];
     }
   });
 
-  safeHandle("open-mailto", async (_, { to, subject, body }: { to: string; subject: string; body: string }) => {
-    try {
-      const { buildMailtoLink } = require('./utils/emailUtils');
-      const mailtoUrl = buildMailtoLink(to, subject, body);
-      await shell.openExternal(mailtoUrl);
-      return { success: true };
-    } catch (error: any) {
-      console.error("Error opening mailto:", error);
-      return { success: false, error: error.message };
-    }
-  });
+  safeHandle(
+    'open-mailto',
+    async (_, { to, subject, body }: { to: string; subject: string; body: string }) => {
+      try {
+        const { buildMailtoLink } = require('./utils/emailUtils');
+        const mailtoUrl = buildMailtoLink(to, subject, body);
+        await shell.openExternal(mailtoUrl);
+        return { success: true };
+      } catch (error: any) {
+        console.error('Error opening mailto:', error);
+        return { success: false, error: error.message };
+      }
+    },
+  );
 
   // ==========================================
   // RAG (Retrieval-Augmented Generation) Handlers
@@ -3202,57 +3580,64 @@ export function initializeIpcHandlers(appState: AppState): void {
   const activeRAGQueries = new Map<string, AbortController>();
 
   // Query meeting with RAG (meeting-scoped)
-  safeHandle("rag:query-meeting", async (event, { meetingId, query }: { meetingId: string; query: string }) => {
-    const ragManager = appState.getRAGManager();
+  safeHandle(
+    'rag:query-meeting',
+    async (event, { meetingId, query }: { meetingId: string; query: string }) => {
+      const ragManager = appState.getRAGManager();
 
-    if (!ragManager || !ragManager.isReady()) {
-      // Fallback to regular chat if RAG not available
-      console.log("[RAG] Not ready, falling back to regular chat");
-      return { fallback: true };
-    }
-
-    // For completed meetings, check if post-meeting RAG is processed.
-    // For live meetings with JIT indexing, let RAGManager.queryMeeting() decide.
-    if (!ragManager.isMeetingProcessed(meetingId) && !ragManager.isLiveIndexingActive(meetingId)) {
-      console.log(`[RAG] Meeting ${meetingId} not processed and no JIT indexing, falling back to regular chat`);
-      return { fallback: true };
-    }
-
-    const abortController = new AbortController();
-    const queryKey = `meeting-${meetingId}`;
-    activeRAGQueries.set(queryKey, abortController);
-
-    try {
-      const stream = ragManager.queryMeeting(meetingId, query, abortController.signal);
-
-      for await (const chunk of stream) {
-        if (abortController.signal.aborted) break;
-        event.sender.send("rag:stream-chunk", { meetingId, chunk });
+      if (!ragManager || !ragManager.isReady()) {
+        // Fallback to regular chat if RAG not available
+        console.log('[RAG] Not ready, falling back to regular chat');
+        return { fallback: true };
       }
 
-      event.sender.send("rag:stream-complete", { meetingId });
-      return { success: true };
+      // For completed meetings, check if post-meeting RAG is processed.
+      // For live meetings with JIT indexing, let RAGManager.queryMeeting() decide.
+      if (
+        !ragManager.isMeetingProcessed(meetingId) &&
+        !ragManager.isLiveIndexingActive(meetingId)
+      ) {
+        console.log(
+          `[RAG] Meeting ${meetingId} not processed and no JIT indexing, falling back to regular chat`,
+        );
+        return { fallback: true };
+      }
 
-    } catch (error: any) {
-      if (error.name !== 'AbortError') {
-        const msg = error.message || "";
-        // If specific RAG failures, return fallback to use transcript window
-        if (msg.includes('NO_RELEVANT_CONTEXT') || msg.includes('NO_MEETING_EMBEDDINGS')) {
-          console.log(`[RAG] Query failed with '${msg}', falling back to regular chat`);
-          return { fallback: true };
+      const abortController = new AbortController();
+      const queryKey = `meeting-${meetingId}`;
+      activeRAGQueries.set(queryKey, abortController);
+
+      try {
+        const stream = ragManager.queryMeeting(meetingId, query, abortController.signal);
+
+        for await (const chunk of stream) {
+          if (abortController.signal.aborted) break;
+          event.sender.send('rag:stream-chunk', { meetingId, chunk });
         }
 
-        console.error("[RAG] Query error:", error);
-        event.sender.send("rag:stream-error", { meetingId, error: msg });
+        event.sender.send('rag:stream-complete', { meetingId });
+        return { success: true };
+      } catch (error: any) {
+        if (error.name !== 'AbortError') {
+          const msg = error.message || '';
+          // If specific RAG failures, return fallback to use transcript window
+          if (msg.includes('NO_RELEVANT_CONTEXT') || msg.includes('NO_MEETING_EMBEDDINGS')) {
+            console.log(`[RAG] Query failed with '${msg}', falling back to regular chat`);
+            return { fallback: true };
+          }
+
+          console.error('[RAG] Query error:', error);
+          event.sender.send('rag:stream-error', { meetingId, error: msg });
+        }
+        return { success: false, error: error.message };
+      } finally {
+        activeRAGQueries.delete(queryKey);
       }
-      return { success: false, error: error.message };
-    } finally {
-      activeRAGQueries.delete(queryKey);
-    }
-  });
+    },
+  );
 
   // Query live meeting with JIT RAG
-  safeHandle("rag:query-live", async (event, { query }: { query: string }) => {
+  safeHandle('rag:query-live', async (event, { query }: { query: string }) => {
     const ragManager = appState.getRAGManager();
 
     if (!ragManager || !ragManager.isReady()) {
@@ -3277,22 +3662,21 @@ export function initializeIpcHandlers(appState: AppState): void {
 
       for await (const chunk of stream) {
         if (abortController.signal.aborted) break;
-        event.sender.send("rag:stream-chunk", { live: true, chunk });
+        event.sender.send('rag:stream-chunk', { live: true, chunk });
       }
 
-      event.sender.send("rag:stream-complete", { live: true });
+      event.sender.send('rag:stream-complete', { live: true });
       return { success: true };
-
     } catch (error: any) {
       if (error.name !== 'AbortError') {
-        const msg = error.message || "";
+        const msg = error.message || '';
         // If JIT RAG failed (no embeddings yet, no relevant context), fallback to regular chat
         if (msg.includes('NO_RELEVANT_CONTEXT') || msg.includes('NO_MEETING_EMBEDDINGS')) {
           console.log(`[RAG] JIT query failed with '${msg}', falling back to regular live chat`);
           return { fallback: true };
         }
-        console.error("[RAG] Live query error:", error);
-        event.sender.send("rag:stream-error", { live: true, error: msg });
+        console.error('[RAG] Live query error:', error);
+        event.sender.send('rag:stream-error', { live: true, error: msg });
       }
       return { success: false, error: error.message };
     } finally {
@@ -3301,7 +3685,7 @@ export function initializeIpcHandlers(appState: AppState): void {
   });
 
   // Query global (cross-meeting search)
-  safeHandle("rag:query-global", async (event, { query }: { query: string }) => {
+  safeHandle('rag:query-global', async (event, { query }: { query: string }) => {
     const ragManager = appState.getRAGManager();
 
     if (!ragManager || !ragManager.isReady()) {
@@ -3317,15 +3701,14 @@ export function initializeIpcHandlers(appState: AppState): void {
 
       for await (const chunk of stream) {
         if (abortController.signal.aborted) break;
-        event.sender.send("rag:stream-chunk", { global: true, chunk });
+        event.sender.send('rag:stream-chunk', { global: true, chunk });
       }
 
-      event.sender.send("rag:stream-complete", { global: true });
+      event.sender.send('rag:stream-complete', { global: true });
       return { success: true };
-
     } catch (error: any) {
       if (error.name !== 'AbortError') {
-        event.sender.send("rag:stream-error", { global: true, error: error.message });
+        event.sender.send('rag:stream-error', { global: true, error: error.message });
       }
       return { success: false, error: error.message };
     } finally {
@@ -3334,19 +3717,22 @@ export function initializeIpcHandlers(appState: AppState): void {
   });
 
   // Cancel active RAG query
-  safeHandle("rag:cancel-query", async (_, { meetingId, global }: { meetingId?: string; global?: boolean }) => {
-    const queryKey = global ? 'global' : `meeting-${meetingId}`;
+  safeHandle(
+    'rag:cancel-query',
+    async (_, { meetingId, global }: { meetingId?: string; global?: boolean }) => {
+      const queryKey = global ? 'global' : `meeting-${meetingId}`;
 
-    // Cancel any matching key
-    for (const [key, controller] of activeRAGQueries) {
-      if (key.startsWith(queryKey) || (global && key.startsWith('global'))) {
-        controller.abort();
-        activeRAGQueries.delete(key);
+      // Cancel any matching key
+      for (const [key, controller] of activeRAGQueries) {
+        if (key.startsWith(queryKey) || (global && key.startsWith('global'))) {
+          controller.abort();
+          activeRAGQueries.delete(key);
+        }
       }
-    }
 
-    return { success: true };
-  });
+      return { success: true };
+    },
+  );
 
   // Check if meeting has RAG embeddings
   safeHandle('rag:is-meeting-processed', async (_, meetingId: string) => {
@@ -3373,14 +3759,14 @@ export function initializeIpcHandlers(appState: AppState): void {
   });
 
   // Get RAG queue status
-  safeHandle("rag:get-queue-status", async () => {
+  safeHandle('rag:get-queue-status', async () => {
     const ragManager = appState.getRAGManager();
     if (!ragManager) return { pending: 0, processing: 0, completed: 0, failed: 0 };
     return ragManager.getQueueStatus();
   });
 
   // Retry pending embeddings
-  safeHandle("rag:retry-embeddings", async () => {
+  safeHandle('rag:retry-embeddings', async () => {
     const ragManager = appState.getRAGManager();
     if (!ragManager) return { success: false };
     await ragManager.retryPendingEmbeddings();
@@ -3391,16 +3777,23 @@ export function initializeIpcHandlers(appState: AppState): void {
   // Profile Engine IPC Handlers
   // ==========================================
 
-  safeHandle("profile:upload-resume", async (_, filePath: string) => {
+  safeHandle('profile:upload-resume', async (_, filePath: string) => {
     try {
       // Premium gate: require active license or free trial for profile features
       if (!isProOrTrialActive()) {
-        return { success: false, error: 'Pro license required. Please activate a license key to use Profile Intelligence features.' };
+        return {
+          success: false,
+          error:
+            'Pro license required. Please activate a license key to use Profile Intelligence features.',
+        };
       }
       console.log(`[IPC] profile:upload-resume called with: ${filePath}`);
       const orchestrator = appState.getKnowledgeOrchestrator();
       if (!orchestrator) {
-        return { success: false, error: 'Knowledge engine not initialized. Please ensure API keys are configured.' };
+        return {
+          success: false,
+          error: 'Knowledge engine not initialized. Please ensure API keys are configured.',
+        };
       }
       const { DocType } = require('../premium/electron/knowledge/types');
       const result = await orchestrator.ingestDocument(filePath, DocType.RESUME);
@@ -3411,7 +3804,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("profile:get-status", async () => {
+  safeHandle('profile:get-status', async () => {
     try {
       const orchestrator = appState.getKnowledgeOrchestrator();
       if (!orchestrator) {
@@ -3424,18 +3817,22 @@ export function initializeIpcHandlers(appState: AppState): void {
         profileMode: status.activeMode,
         name: status.resumeSummary?.name,
         role: status.resumeSummary?.role,
-        totalExperienceYears: status.resumeSummary?.totalExperienceYears
+        totalExperienceYears: status.resumeSummary?.totalExperienceYears,
       };
     } catch (error: any) {
       return { hasProfile: false, profileMode: false };
     }
   });
 
-  safeHandle("profile:set-mode", async (_, enabled: boolean) => {
+  safeHandle('profile:set-mode', async (_, enabled: boolean) => {
     try {
       // Premium gate: only allow enabling profile mode with active license or free trial
       if (enabled && !isProOrTrialActive()) {
-        return { success: false, error: 'Pro license required. Please activate a license key to use Profile Intelligence features.' };
+        return {
+          success: false,
+          error:
+            'Pro license required. Please activate a license key to use Profile Intelligence features.',
+        };
       }
       const orchestrator = appState.getKnowledgeOrchestrator();
       if (!orchestrator) {
@@ -3452,7 +3849,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("profile:delete", async () => {
+  safeHandle('profile:delete', async () => {
     try {
       const orchestrator = appState.getKnowledgeOrchestrator();
       if (!orchestrator) {
@@ -3466,7 +3863,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("profile:get-profile", async () => {
+  safeHandle('profile:get-profile', async () => {
     try {
       const orchestrator = appState.getKnowledgeOrchestrator();
       if (!orchestrator) return null;
@@ -3476,13 +3873,11 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("profile:select-file", async () => {
+  safeHandle('profile:select-file', async () => {
     try {
       const result: any = await dialog.showOpenDialog({
         properties: ['openFile'],
-        filters: [
-          { name: 'Resume Files', extensions: ['pdf', 'docx', 'txt'] }
-        ]
+        filters: [{ name: 'Resume Files', extensions: ['pdf', 'docx', 'txt'] }],
       });
 
       if (result.canceled || result.filePaths.length === 0) {
@@ -3499,16 +3894,23 @@ export function initializeIpcHandlers(appState: AppState): void {
   // JD & Research IPC Handlers
   // ==========================================
 
-  safeHandle("profile:upload-jd", async (_, filePath: string) => {
+  safeHandle('profile:upload-jd', async (_, filePath: string) => {
     try {
       // Premium gate
       if (!isProOrTrialActive()) {
-        return { success: false, error: 'Pro license required. Please activate a license key to use Profile Intelligence features.' };
+        return {
+          success: false,
+          error:
+            'Pro license required. Please activate a license key to use Profile Intelligence features.',
+        };
       }
       console.log(`[IPC] profile:upload-jd called with: ${filePath}`);
       const orchestrator = appState.getKnowledgeOrchestrator();
       if (!orchestrator) {
-        return { success: false, error: 'Knowledge engine not initialized. Please ensure API keys are configured.' };
+        return {
+          success: false,
+          error: 'Knowledge engine not initialized. Please ensure API keys are configured.',
+        };
       }
       const { DocType } = require('../premium/electron/knowledge/types');
       const result = await orchestrator.ingestDocument(filePath, DocType.JD);
@@ -3519,7 +3921,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("profile:delete-jd", async () => {
+  safeHandle('profile:delete-jd', async () => {
     try {
       const orchestrator = appState.getKnowledgeOrchestrator();
       if (!orchestrator) {
@@ -3533,11 +3935,15 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("profile:research-company", async (_, companyName: string) => {
+  safeHandle('profile:research-company', async (_, companyName: string) => {
     try {
       // Premium gate
       if (!isProOrTrialActive()) {
-        return { success: false, error: 'Pro license required. Please activate a license key to use Profile Intelligence features.' };
+        return {
+          success: false,
+          error:
+            'Pro license required. Please activate a license key to use Profile Intelligence features.',
+        };
       }
       const orchestrator = appState.getKnowledgeOrchestrator();
       if (!orchestrator) {
@@ -3550,33 +3956,43 @@ export function initializeIpcHandlers(appState: AppState): void {
       const cm = CredentialsManager.getInstance();
       const tavilyApiKey = cm.getTavilyApiKey();
       if (tavilyApiKey) {
-        const { TavilySearchProvider } = require('../premium/electron/knowledge/TavilySearchProvider');
+        const {
+          TavilySearchProvider,
+        } = require('../premium/electron/knowledge/TavilySearchProvider');
         engine.setSearchProvider(new TavilySearchProvider(tavilyApiKey));
       } else {
         const nativelyKey = cm.getNativelyApiKey();
         if (nativelyKey) {
-          const { NativelySearchProvider } = require('../premium/electron/knowledge/NativelySearchProvider');
+          const {
+            NativelySearchProvider,
+          } = require('../premium/electron/knowledge/NativelySearchProvider');
           // Pass the real trial token when key is the __trial__ sentinel so the
           // server can authenticate via x-trial-token instead of the invalid key.
           const trialToken = nativelyKey === TRIAL_SENTINEL_KEY ? cm.getTrialToken() : undefined;
-          engine.setSearchProvider(new NativelySearchProvider(nativelyKey, trialToken ?? undefined));
-          console.log('[IPC] Company research: using Natively API search (no Tavily key configured)');
+          engine.setSearchProvider(
+            new NativelySearchProvider(nativelyKey, trialToken ?? undefined),
+          );
+          console.log(
+            '[IPC] Company research: using Natively API search (no Tavily key configured)',
+          );
         }
       }
 
       // Build full JD context so the dossier is tailored to the exact role
       const profileData = orchestrator.getProfileData();
       const activeJD = profileData?.activeJD;
-      const jdCtx = activeJD ? {
-        title: activeJD.title,
-        location: activeJD.location,
-        level: activeJD.level,
-        technologies: activeJD.technologies,
-        requirements: activeJD.requirements,
-        keywords: activeJD.keywords,
-        compensation_hint: activeJD.compensation_hint,
-        min_years_experience: activeJD.min_years_experience,
-      } : {};
+      const jdCtx = activeJD
+        ? {
+            title: activeJD.title,
+            location: activeJD.location,
+            level: activeJD.level,
+            technologies: activeJD.technologies,
+            requirements: activeJD.requirements,
+            keywords: activeJD.keywords,
+            compensation_hint: activeJD.compensation_hint,
+            min_years_experience: activeJD.min_years_experience,
+          }
+        : {};
       const dossier = await engine.researchCompany(companyName, jdCtx, true);
       const searchQuotaExhausted = (engine.searchProvider as any)?.quotaExhausted === true;
       return { success: true, dossier, searchQuotaExhausted };
@@ -3586,11 +4002,15 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("profile:generate-negotiation", async (_, force: boolean = false) => {
+  safeHandle('profile:generate-negotiation', async (_, force: boolean = false) => {
     try {
       // Premium gate
       if (!isProOrTrialActive()) {
-        return { success: false, error: 'Pro license required. Please activate a license key to use Profile Intelligence features.' };
+        return {
+          success: false,
+          error:
+            'Pro license required. Please activate a license key to use Profile Intelligence features.',
+        };
       }
       const orchestrator = appState.getKnowledgeOrchestrator();
       if (!orchestrator) {
@@ -3607,7 +4027,11 @@ export function initializeIpcHandlers(appState: AppState): void {
         script = await orchestrator.generateNegotiationScriptOnDemand();
       }
       if (!script) {
-        return { success: false, error: 'Could not generate negotiation script. Ensure a resume and job description are uploaded.' };
+        return {
+          success: false,
+          error:
+            'Could not generate negotiation script. Ensure a resume and job description are uploaded.',
+        };
       }
       return { success: true, script };
     } catch (error: any) {
@@ -3616,7 +4040,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("profile:get-negotiation-state", async () => {
+  safeHandle('profile:get-negotiation-state', async () => {
     try {
       const orchestrator = appState.getKnowledgeOrchestrator();
       if (!orchestrator) return { success: false, error: 'Engine not ready' };
@@ -3631,7 +4055,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("profile:reset-negotiation", async () => {
+  safeHandle('profile:reset-negotiation', async () => {
     try {
       const orchestrator = appState.getKnowledgeOrchestrator();
       if (!orchestrator) return { success: false };
@@ -3646,7 +4070,7 @@ export function initializeIpcHandlers(appState: AppState): void {
   // Profile Custom Notes
   // ==========================================
 
-  safeHandle("profile:get-notes", async () => {
+  safeHandle('profile:get-notes', async () => {
     try {
       const content = DatabaseManager.getInstance().getCustomNotes();
       return { success: true, content };
@@ -3655,7 +4079,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("profile:save-notes", async (_, content: string) => {
+  safeHandle('profile:save-notes', async (_, content: string) => {
     try {
       // Enforce a max length of 4000 chars to prevent prompt bloat
       const trimmed = typeof content === 'string' ? content.slice(0, 4000) : '';
@@ -3674,7 +4098,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("profile:get-persona", async () => {
+  safeHandle('profile:get-persona', async () => {
     try {
       if (!isProOrTrialActive()) return { success: false, content: '', error: 'pro_required' };
       const content = DatabaseManager.getInstance().getPersona();
@@ -3686,7 +4110,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("profile:save-persona", async (_, content: string) => {
+  safeHandle('profile:save-persona', async (_, content: string) => {
     try {
       if (!isProOrTrialActive()) return { success: false, error: 'pro_required' };
       if (typeof content !== 'string') return { success: false, error: 'invalid_persona' };
@@ -3706,7 +4130,7 @@ export function initializeIpcHandlers(appState: AppState): void {
   // Tavily Search API Credentials
   // ==========================================
 
-  safeHandle("set-tavily-api-key", async (_, apiKey: string) => {
+  safeHandle('set-tavily-api-key', async (_, apiKey: string) => {
     try {
       if (apiKey && !apiKey.startsWith('tvly-')) {
         return { success: false, error: 'Invalid Tavily API key. Keys must start with "tvly-".' };
@@ -3723,11 +4147,11 @@ export function initializeIpcHandlers(appState: AppState): void {
   // Overlay Opacity (Stealth Mode)
   // ==========================================
 
-  safeHandle("set-overlay-opacity", async (_, opacity: number) => {
+  safeHandle('set-overlay-opacity', async (_, opacity: number) => {
     // Clamp to valid range
     const clamped = Math.min(1.0, Math.max(0.35, opacity));
     // Broadcast to all renderer windows so the overlay picks it up in real-time
-    BrowserWindow.getAllWindows().forEach(win => {
+    BrowserWindow.getAllWindows().forEach((win) => {
       if (!win.isDestroyed()) {
         win.webContents.send('overlay-opacity-changed', clamped);
       }
@@ -3736,30 +4160,30 @@ export function initializeIpcHandlers(appState: AppState): void {
   });
 
   // ── Permissions ──────────────────────────────────────────────
-  safeHandle("permissions:check", async () => {
+  safeHandle('permissions:check', async () => {
     if (process.platform === 'darwin') {
-      const mic = systemPreferences.getMediaAccessStatus('microphone')
-      const screen = systemPreferences.getMediaAccessStatus('screen')
-      return { microphone: mic, screen, platform: 'darwin' }
+      const mic = systemPreferences.getMediaAccessStatus('microphone');
+      const screen = systemPreferences.getMediaAccessStatus('screen');
+      return { microphone: mic, screen, platform: 'darwin' };
     }
     // Windows/Linux: no TCC — permissions handled by OS at install/first-use time
-    return { microphone: 'granted', screen: 'granted', platform: process.platform }
-  })
+    return { microphone: 'granted', screen: 'granted', platform: process.platform };
+  });
 
-  safeHandle("permissions:request-mic", async () => {
-    if (process.platform !== 'darwin') return true
+  safeHandle('permissions:request-mic', async () => {
+    if (process.platform !== 'darwin') return true;
     try {
-      return await systemPreferences.askForMediaAccess('microphone')
+      return await systemPreferences.askForMediaAccess('microphone');
     } catch {
-      return false
+      return false;
     }
-  })
+  });
 
   // ==========================================
   // Modes IPC Handlers
   // ==========================================
 
-  safeHandle("modes:get-all", async () => {
+  safeHandle('modes:get-all', async () => {
     try {
       const { ModesManager } = require('./services/ModesManager');
       const mgr = ModesManager.getInstance();
@@ -3775,7 +4199,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("modes:get-active", async () => {
+  safeHandle('modes:get-active', async () => {
     try {
       const { ModesManager } = require('./services/ModesManager');
       return ModesManager.getInstance().getActiveMode();
@@ -3785,7 +4209,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("modes:create", async (_, params: { name: string; templateType: string }) => {
+  safeHandle('modes:create', async (_, params: { name: string; templateType: string }) => {
     try {
       if (!isProOrTrialActive()) return { success: false, error: 'pro_required' };
       const { ModesManager } = require('./services/ModesManager');
@@ -3800,30 +4224,37 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("modes:update", async (_, id: string, updates: { name?: string; templateType?: string; customContext?: string }) => {
-    try {
-      const { ModesManager } = require('./services/ModesManager');
-      const mgr = ModesManager.getInstance();
-      // Gate: changing templateType to a non-general template requires pro.
-      // Also gate if the existing mode is already non-general (editing a pro mode requires pro).
-      if (!isProOrTrialActive()) {
-        if (updates.templateType && updates.templateType !== 'general') {
-          return { success: false, error: 'pro_required' };
+  safeHandle(
+    'modes:update',
+    async (
+      _,
+      id: string,
+      updates: { name?: string; templateType?: string; customContext?: string },
+    ) => {
+      try {
+        const { ModesManager } = require('./services/ModesManager');
+        const mgr = ModesManager.getInstance();
+        // Gate: changing templateType to a non-general template requires pro.
+        // Also gate if the existing mode is already non-general (editing a pro mode requires pro).
+        if (!isProOrTrialActive()) {
+          if (updates.templateType && updates.templateType !== 'general') {
+            return { success: false, error: 'pro_required' };
+          }
+          const existing = mgr.getModes().find((m: any) => m.id === id);
+          if (existing && existing.templateType !== 'general') {
+            return { success: false, error: 'pro_required' };
+          }
         }
-        const existing = mgr.getModes().find((m: any) => m.id === id);
-        if (existing && existing.templateType !== 'general') {
-          return { success: false, error: 'pro_required' };
-        }
+        mgr.updateMode(id, updates);
+        return { success: true };
+      } catch (e: any) {
+        console.error('[IPC] modes:update error:', e);
+        return { success: false, error: e.message };
       }
-      mgr.updateMode(id, updates);
-      return { success: true };
-    } catch (e: any) {
-      console.error('[IPC] modes:update error:', e);
-      return { success: false, error: e.message };
-    }
-  });
+    },
+  );
 
-  safeHandle("modes:delete", async (_, id: string) => {
+  safeHandle('modes:delete', async (_, id: string) => {
     try {
       if (!isProOrTrialActive()) return { success: false, error: 'pro_required' };
       const { ModesManager } = require('./services/ModesManager');
@@ -3835,12 +4266,14 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("modes:set-active", async (_, id: string | null) => {
+  safeHandle('modes:set-active', async (_, id: string | null) => {
     try {
       // Allow clearing (null) or setting general mode without pro; all other modes require pro
       if (id !== null) {
         const { ModesManager } = require('./services/ModesManager');
-        const targetMode = ModesManager.getInstance().getModes().find((m: any) => m.id === id);
+        const targetMode = ModesManager.getInstance()
+          .getModes()
+          .find((m: any) => m.id === id);
         if (targetMode && targetMode.templateType !== 'general' && !isProOrTrialActive()) {
           return { success: false, error: 'pro_required' };
         }
@@ -3851,13 +4284,15 @@ export function initializeIpcHandlers(appState: AppState): void {
       try {
         const appStateIntMgr = appState.getIntelligenceManager();
         if (appStateIntMgr) appStateIntMgr.clearSessionContext();
-      } catch { /* non-fatal — session may not exist during startup */ }
+      } catch {
+        /* non-fatal — session may not exist during startup */
+      }
 
       ModesManager.getInstance().setActiveMode(id);
       // Broadcast mode change to all windows so indicators update immediately
       const activeMode = id ? ModesManager.getInstance().getActiveMode() : null;
       const activeName = activeMode?.name ?? null;
-      BrowserWindow.getAllWindows().forEach(win => {
+      BrowserWindow.getAllWindows().forEach((win) => {
         if (!win.isDestroyed()) win.webContents.send('mode-changed', { id, name: activeName });
       });
       // Phase 3 — re-bind dynamic action engine so the new mode's trigger pack
@@ -3874,7 +4309,9 @@ export function initializeIpcHandlers(appState: AppState): void {
         } else if (appStateIntMgr && !id) {
           appStateIntMgr.clearDynamicActionContext();
         }
-      } catch { /* non-fatal */ }
+      } catch {
+        /* non-fatal */
+      }
       // Phase 6 — mode_switched telemetry (no PII).
       try {
         const { telemetryService } = require('./services/telemetry/TelemetryService');
@@ -3883,7 +4320,9 @@ export function initializeIpcHandlers(appState: AppState): void {
           modeId: activeMode?.id,
           properties: { modeTemplateType: activeMode?.templateType, cleared: !id },
         });
-      } catch { /* non-fatal */ }
+      } catch {
+        /* non-fatal */
+      }
       return { success: true };
     } catch (e: any) {
       console.error('[IPC] modes:set-active error:', e);
@@ -3891,7 +4330,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("modes:get-reference-files", async (_, modeId: string) => {
+  safeHandle('modes:get-reference-files', async (_, modeId: string) => {
     try {
       const { ModesManager } = require('./services/ModesManager');
       return ModesManager.getInstance().getReferenceFiles(modeId);
@@ -3901,7 +4340,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("modes:upload-reference-file", async (_, modeId: string) => {
+  safeHandle('modes:upload-reference-file', async (_, modeId: string) => {
     try {
       if (!isProOrTrialActive()) return { success: false, error: 'pro_required' };
       // Server-side allow-list. The dialog filter is a hint to users — never
@@ -3910,8 +4349,19 @@ export function initializeIpcHandlers(appState: AppState): void {
       // Plain-text formats parse trivially; PDF and DOCX go through their
       // dedicated parsers below.
       const ALLOWED_EXTENSIONS = new Set([
-        '.txt', '.md', '.markdown', '.json', '.csv', '.tsv', '.xml', '.html', '.htm', '.log',
-        '.pdf', '.docx', '.doc',
+        '.txt',
+        '.md',
+        '.markdown',
+        '.json',
+        '.csv',
+        '.tsv',
+        '.xml',
+        '.html',
+        '.htm',
+        '.log',
+        '.pdf',
+        '.docx',
+        '.doc',
       ]);
       // 10 MiB per file. Anything larger is almost always a database dump,
       // a media file, or a misclicked archive; the modes layer would just
@@ -3921,7 +4371,10 @@ export function initializeIpcHandlers(appState: AppState): void {
       const result: any = await dialog.showOpenDialog({
         properties: ['openFile'],
         filters: [
-          { name: 'Text & Documents', extensions: ['txt', 'md', 'json', 'csv', 'xml', 'html', 'pdf', 'docx', 'doc'] },
+          {
+            name: 'Text & Documents',
+            extensions: ['txt', 'md', 'json', 'csv', 'xml', 'html', 'pdf', 'docx', 'doc'],
+          },
           { name: 'All Files', extensions: ['*'] },
         ],
       });
@@ -3947,12 +4400,16 @@ export function initializeIpcHandlers(appState: AppState): void {
       try {
         stats = fs.lstatSync(filePath);
       } catch {
-        return { success: false, error: 'Could not read the selected file. It may have moved or been deleted.' };
+        return {
+          success: false,
+          error: 'Could not read the selected file. It may have moved or been deleted.',
+        };
       }
       if (!stats.isFile()) {
         return {
           success: false,
-          error: 'Selected path is not a regular file (it may be a symlink, device, or directory). Pick a real document file.',
+          error:
+            'Selected path is not a regular file (it may be a symlink, device, or directory). Pick a real document file.',
         };
       }
       if (stats.size > MAX_FILE_BYTES) {
@@ -3970,7 +4427,9 @@ export function initializeIpcHandlers(appState: AppState): void {
       function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
         return Promise.race([
           p,
-          new Promise<T>((_, reject) => setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)),
+          new Promise<T>((_, reject) =>
+            setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms),
+          ),
         ]);
       }
 
@@ -3984,7 +4443,11 @@ export function initializeIpcHandlers(appState: AppState): void {
           content = data.text;
         } else if (ext === '.docx' || ext === '.doc') {
           const mammoth = require('mammoth');
-          const result2: any = await withTimeout<any>(mammoth.extractRawText({ path: filePath }), PARSE_TIMEOUT_MS, 'DOCX parse');
+          const result2: any = await withTimeout<any>(
+            mammoth.extractRawText({ path: filePath }),
+            PARSE_TIMEOUT_MS,
+            'DOCX parse',
+          );
           content = result2.value;
         } else {
           // Plain-text family. Read raw bytes first so we can detect text
@@ -3996,9 +4459,9 @@ export function initializeIpcHandlers(appState: AppState): void {
           }
           // BOM-aware decode. UTF-16 files have many embedded null bytes; we
           // must NOT treat those as a binary-rename signal.
-          if (probe.length >= 2 && probe[0] === 0xFF && probe[1] === 0xFE) {
+          if (probe.length >= 2 && probe[0] === 0xff && probe[1] === 0xfe) {
             content = probe.subarray(2).toString('utf16le');
-          } else if (probe.length >= 2 && probe[0] === 0xFE && probe[1] === 0xFF) {
+          } else if (probe.length >= 2 && probe[0] === 0xfe && probe[1] === 0xff) {
             // UTF-16 BE → swap pairs then decode as utf16le.
             const swapped = Buffer.allocUnsafe(probe.length - 2);
             for (let i = 2; i + 1 < probe.length; i += 2) {
@@ -4006,7 +4469,12 @@ export function initializeIpcHandlers(appState: AppState): void {
               swapped[i - 1] = probe[i];
             }
             content = swapped.toString('utf16le');
-          } else if (probe.length >= 3 && probe[0] === 0xEF && probe[1] === 0xBB && probe[2] === 0xBF) {
+          } else if (
+            probe.length >= 3 &&
+            probe[0] === 0xef &&
+            probe[1] === 0xbb &&
+            probe[2] === 0xbf
+          ) {
             content = probe.subarray(3).toString('utf8');
           } else {
             // No BOM. Sniff the first 2 KiB for a null byte — that's the
@@ -4024,7 +4492,10 @@ export function initializeIpcHandlers(appState: AppState): void {
       } catch (parseErr: any) {
         // Parser-specific failures (timeout, malformed PDF, zip-bomb DOCX).
         // Log detail to main-process; return a generic message.
-        console.error('[IPC] modes:upload-reference-file parser error:', parseErr?.message ?? parseErr);
+        console.error(
+          '[IPC] modes:upload-reference-file parser error:',
+          parseErr?.message ?? parseErr,
+        );
         return {
           success: false,
           error: `Could not parse "${fileName}". The file may be corrupt, password-protected, or in an unsupported variant of ${ext}.`,
@@ -4046,11 +4517,14 @@ export function initializeIpcHandlers(appState: AppState): void {
       // Do not leak raw error.message to the renderer (may contain absolute
       // paths or library internals). Return a generic message; the detail is
       // already in the main-process log above.
-      return { success: false, error: 'Could not read the selected file. Please try a different file or contact support.' };
+      return {
+        success: false,
+        error: 'Could not read the selected file. Please try a different file or contact support.',
+      };
     }
   });
 
-  safeHandle("modes:delete-reference-file", async (_, id: string) => {
+  safeHandle('modes:delete-reference-file', async (_, id: string) => {
     try {
       if (!isProOrTrialActive()) return { success: false, error: 'pro_required' };
       const { ModesManager } = require('./services/ModesManager');
@@ -4064,7 +4538,7 @@ export function initializeIpcHandlers(appState: AppState): void {
 
   // ── Note Sections ──────────────────────────────────────────────
 
-  safeHandle("modes:get-note-sections", async (_, modeId: string) => {
+  safeHandle('modes:get-note-sections', async (_, modeId: string) => {
     try {
       const { ModesManager } = require('./services/ModesManager');
       return ModesManager.getInstance().getNoteSections(modeId);
@@ -4074,31 +4548,37 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("modes:add-note-section", async (_, modeId: string, title: string, description: string) => {
-    try {
-      if (!isProOrTrialActive()) return { success: false, error: 'pro_required' };
-      const { ModesManager } = require('./services/ModesManager');
-      const section = ModesManager.getInstance().addNoteSection({ modeId, title, description });
-      return { success: true, section };
-    } catch (e: any) {
-      console.error('[IPC] modes:add-note-section error:', e);
-      return { success: false, error: e.message };
-    }
-  });
+  safeHandle(
+    'modes:add-note-section',
+    async (_, modeId: string, title: string, description: string) => {
+      try {
+        if (!isProOrTrialActive()) return { success: false, error: 'pro_required' };
+        const { ModesManager } = require('./services/ModesManager');
+        const section = ModesManager.getInstance().addNoteSection({ modeId, title, description });
+        return { success: true, section };
+      } catch (e: any) {
+        console.error('[IPC] modes:add-note-section error:', e);
+        return { success: false, error: e.message };
+      }
+    },
+  );
 
-  safeHandle("modes:update-note-section", async (_, id: string, updates: { title?: string; description?: string }) => {
-    try {
-      if (!isProOrTrialActive()) return { success: false, error: 'pro_required' };
-      const { ModesManager } = require('./services/ModesManager');
-      ModesManager.getInstance().updateNoteSection(id, updates);
-      return { success: true };
-    } catch (e: any) {
-      console.error('[IPC] modes:update-note-section error:', e);
-      return { success: false, error: e.message };
-    }
-  });
+  safeHandle(
+    'modes:update-note-section',
+    async (_, id: string, updates: { title?: string; description?: string }) => {
+      try {
+        if (!isProOrTrialActive()) return { success: false, error: 'pro_required' };
+        const { ModesManager } = require('./services/ModesManager');
+        ModesManager.getInstance().updateNoteSection(id, updates);
+        return { success: true };
+      } catch (e: any) {
+        console.error('[IPC] modes:update-note-section error:', e);
+        return { success: false, error: e.message };
+      }
+    },
+  );
 
-  safeHandle("modes:delete-note-section", async (_, id: string) => {
+  safeHandle('modes:delete-note-section', async (_, id: string) => {
     try {
       if (!isProOrTrialActive()) return { success: false, error: 'pro_required' };
       const { ModesManager } = require('./services/ModesManager');
@@ -4110,7 +4590,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("modes:remove-all-note-sections", async (_, modeId: string) => {
+  safeHandle('modes:remove-all-note-sections', async (_, modeId: string) => {
     try {
       if (!isProOrTrialActive()) return { success: false, error: 'pro_required' };
       const { ModesManager } = require('./services/ModesManager');
@@ -4134,28 +4614,33 @@ export function initializeIpcHandlers(appState: AppState): void {
     try {
       const settingsWin = (appState as any).settingsWindowHelper?.getWindow?.();
       settingsWin?.webContents?.send('phone-mirror:status', info);
-    } catch (_) { /* settings window may not exist yet */ }
+    } catch (_) {
+      /* settings window may not exist yet */
+    }
   });
 
-  safeHandle("phone-mirror:get-info", async () => {
+  safeHandle('phone-mirror:get-info', async () => {
     return PhoneMirrorService.getInstance().snapshot();
   });
 
-  safeHandle("phone-mirror:enable", async (_, exposeOnLan?: boolean) => {
+  safeHandle('phone-mirror:enable', async (_, exposeOnLan?: boolean) => {
     try {
-      return await PhoneMirrorService.getInstance().start({ exposeOnLan: !!exposeOnLan, persist: true });
+      return await PhoneMirrorService.getInstance().start({
+        exposeOnLan: !!exposeOnLan,
+        persist: true,
+      });
     } catch (e: any) {
       console.error('[IPC] phone-mirror:enable error:', e);
       return { error: e?.message || 'failed to start phone mirror' };
     }
   });
 
-  safeHandle("phone-mirror:disable", async () => {
+  safeHandle('phone-mirror:disable', async () => {
     await PhoneMirrorService.getInstance().stop({ persist: true });
     return { success: true };
   });
 
-  safeHandle("phone-mirror:set-lan", async (_, exposeOnLan: boolean) => {
+  safeHandle('phone-mirror:set-lan', async (_, exposeOnLan: boolean) => {
     try {
       return await PhoneMirrorService.getInstance().setExposeOnLan(!!exposeOnLan);
     } catch (e: any) {
@@ -4164,7 +4649,7 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  safeHandle("phone-mirror:rotate-token", async () => {
+  safeHandle('phone-mirror:rotate-token', async () => {
     try {
       return await PhoneMirrorService.getInstance().rotateToken();
     } catch (e: any) {
@@ -4173,28 +4658,22 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
-  // Push a desktop screenshot thumbnail to connected phones.
-  // The caller can optionally pass a pre-captured path; if absent, a fresh
-  // screenshot is taken.  The image is resized to 800 px wide and compressed
-  // to JPEG so the WebSocket payload stays well under 200 KB.
-  safeHandle("phone-mirror:push-screenshot", async (_, screenshotPath?: string) => {
+  // Stealth screenshot capture triggered from the phone UI.
+  // Takes a screenshot on the PC (adding it to the screenshot queue so it can
+  // be used in the next AI prompt), then broadcasts an ack so the phone shows
+  // a confirmation toast.  The image is NOT sent to the phone — the phone is
+  // just a remote shutter; the screenshot stays on the desktop for AI use.
+  safeHandle('phone-mirror:push-screenshot', async (_, screenshotPath?: string) => {
     try {
-      let imgPath = screenshotPath;
-      if (!imgPath) {
-        imgPath = await appState.takeScreenshot(false);
-      }
-      const buf = await fs.promises.readFile(imgPath);
-      const sharp = require('sharp') as typeof import('sharp');
-      const compressed = await sharp(buf)
-        .resize({ width: 800, withoutEnlargement: true })
-        .jpeg({ quality: 70 })
-        .toBuffer();
-      const dataUrl = 'data:image/jpeg;base64,' + compressed.toString('base64');
-      PhoneMirrorService.getInstance().publishScreenshot(crypto.randomUUID(), dataUrl);
-      return { success: true };
+      const imgPath = screenshotPath || (await appState.takeScreenshot(false));
+      PhoneMirrorService.getInstance().publishAck(
+        'screenshot',
+        'Screenshot captured — queued for AI',
+      );
+      return { success: true, path: imgPath };
     } catch (e: any) {
       console.error('[IPC] phone-mirror:push-screenshot error:', e);
-      return { error: e?.message || 'failed to push screenshot' };
+      return { error: e?.message || 'failed to capture screenshot' };
     }
   });
 
@@ -4208,10 +4687,9 @@ export function initializeIpcHandlers(appState: AppState): void {
       // Re-use the same global-shortcut dispatch path the keyboard uses.
       // This keeps phone actions identical to key-triggered stealth actions.
       const allWindows = BrowserWindow.getAllWindows();
-      allWindows.forEach(w => {
+      allWindows.forEach((w) => {
         if (!w.isDestroyed()) w.webContents.send('global-shortcut', { action: cmd.action });
       });
-
     } else if (cmd.type === 'chat') {
       // Stream a phone-initiated chat through the LLM exactly like gemini-chat-stream
       // but without requiring a renderer event sender. Tokens are pushed directly to
@@ -4219,9 +4697,10 @@ export function initializeIpcHandlers(appState: AppState): void {
       // stay in sync.
       const myStreamId = crypto.randomUUID();
       const message = cmd.message;
+      const phoneMirror = PhoneMirrorService.getInstance();
 
-      try { PhoneMirrorService.getInstance().publishUserMessage(myStreamId, message); } catch (_) {}
-      // Notify renderer so it can display the incoming phone message too
+      try { phoneMirror.publishUserMessage(myStreamId, message); } catch (_) {}
+      // Notify renderer so it can display the incoming phone message too.
       win?.webContents.send('phone-mirror:incoming-chat', { message, streamId: myStreamId });
 
       try {
@@ -4229,32 +4708,35 @@ export function initializeIpcHandlers(appState: AppState): void {
         const stream = llmHelper.streamChat(message);
         let full = '';
         for await (const token of stream) {
-          try { PhoneMirrorService.getInstance().publishToken(myStreamId, token); } catch (_) {}
+          // Cancel early if all phones have disconnected — no point burning LLM
+          // tokens when nobody is receiving them and we have no desktop renderer
+          // context to show the result in either.
+          if (!phoneMirror.hasClients() && win?.isDestroyed()) break;
+          try { phoneMirror.publishToken(myStreamId, token); } catch (_) {}
           win?.webContents.send('gemini-stream-token', token);
           full += token;
         }
-        try { PhoneMirrorService.getInstance().publishDone(myStreamId, full); } catch (_) {}
+        try { phoneMirror.publishDone(myStreamId, full); } catch (_) {}
         win?.webContents.send('gemini-stream-done');
       } catch (err: any) {
         console.error('[PhoneMirror] phone-chat stream error:', err);
-        try { PhoneMirrorService.getInstance().publishError(myStreamId, err?.message || 'stream error'); } catch (_) {}
+        try { phoneMirror.publishError(myStreamId, err?.message || 'stream error'); } catch (_) {}
         win?.webContents.send('gemini-stream-error', err?.message || 'stream error');
       }
 
     } else if (cmd.type === 'screenshot') {
-      // Capture a fresh screenshot and push it back to the phone.
+      // Stealth screenshot: capture on PC → add to screenshot queue → ack to phone.
+      // The image is NOT sent to the phone — it stays on the desktop for AI use.
+      // The phone simply acts as a remote shutter button.
       try {
-        const imgPath = await appState.takeScreenshot(false);
-        const buf = await fs.promises.readFile(imgPath);
-        const sharp = require('sharp') as typeof import('sharp');
-        const compressed = await sharp(buf)
-          .resize({ width: 800, withoutEnlargement: true })
-          .jpeg({ quality: 70 })
-          .toBuffer();
-        const dataUrl = 'data:image/jpeg;base64,' + compressed.toString('base64');
-        PhoneMirrorService.getInstance().publishScreenshot(crypto.randomUUID(), dataUrl);
+        await appState.takeScreenshot(false);
+        PhoneMirrorService.getInstance().publishAck(
+          'screenshot',
+          'Screenshot captured — queued for AI',
+        );
       } catch (e: any) {
         console.error('[PhoneMirror] phone screenshot request failed:', e);
+        PhoneMirrorService.getInstance().publishAck('screenshot', 'Screenshot failed');
       }
     }
   });

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -7,6 +7,7 @@ import { DatabaseManager } from "./db/DatabaseManager"; // Import Database Manag
 import * as os from "os";
 import * as path from "path";
 import * as fs from "fs";
+import * as crypto from "crypto";
 import { AudioDevices } from "./audio/AudioDevices";
 import { PhoneMirrorService } from "./services/PhoneMirrorService";
 import { CodexCliService } from "./services/CodexCliService";
@@ -2578,6 +2579,9 @@ export function initializeIpcHandlers(appState: AppState): void {
     try {
       const intelligenceManager = appState.getIntelligenceManager();
       const insight = await intelligenceManager.runAssistMode();
+      if (insight) {
+        try { PhoneMirrorService.getInstance().publishAssistantMessage(crypto.randomUUID(), insight, 'Assist'); } catch (_) {}
+      }
       return { insight };
     } catch (error: any) {
       throw error;
@@ -2681,6 +2685,9 @@ export function initializeIpcHandlers(appState: AppState): void {
         screenContext,
         promptInstruction: typeof options?.promptInstruction === 'string' ? options.promptInstruction : undefined,
       });
+      if (answer) {
+        try { PhoneMirrorService.getInstance().publishAssistantMessage(crypto.randomUUID(), answer, 'What to Answer'); } catch (_) {}
+      }
       return {
         answer,
         question: question || 'inferred from context',
@@ -2711,6 +2718,8 @@ export function initializeIpcHandlers(appState: AppState): void {
       if (clarification === null) {
         const win = appState.getMainWindow();
         win?.webContents.send('intelligence-error', { error: 'Could not generate a clarifying question. Try again after some audio context is available.', mode: 'clarify' });
+      } else {
+        try { PhoneMirrorService.getInstance().publishAssistantMessage(crypto.randomUUID(), clarification, 'Clarify'); } catch (_) {}
       }
       return { clarification };
     } catch (error: any) {
@@ -2783,6 +2792,9 @@ export function initializeIpcHandlers(appState: AppState): void {
         optimizedPaths.length > 0 ? optimizedPaths : undefined,
         problemStatement
       );
+      if (hint) {
+        try { PhoneMirrorService.getInstance().publishAssistantMessage(crypto.randomUUID(), hint, 'Code Hint'); } catch (_) {}
+      }
       return { hint };
     } catch (error: any) {
       throw error;
@@ -2824,6 +2836,9 @@ export function initializeIpcHandlers(appState: AppState): void {
         optimizedPaths.length > 0 ? optimizedPaths : undefined,
         problemStatement
       );
+      if (script) {
+        try { PhoneMirrorService.getInstance().publishAssistantMessage(crypto.randomUUID(), script, 'Brainstorm'); } catch (_) {}
+      }
       return { script };
     } catch (error: any) {
       throw error;
@@ -2856,6 +2871,9 @@ export function initializeIpcHandlers(appState: AppState): void {
     try {
       const intelligenceManager = appState.getIntelligenceManager();
       const refined = await intelligenceManager.runFollowUp(intent, userRequest);
+      if (refined) {
+        try { PhoneMirrorService.getInstance().publishAssistantMessage(crypto.randomUUID(), refined, 'Follow Up'); } catch (_) {}
+      }
       return { refined, intent };
     } catch (error: any) {
       throw error;
@@ -2867,6 +2885,9 @@ export function initializeIpcHandlers(appState: AppState): void {
     try {
       const intelligenceManager = appState.getIntelligenceManager();
       const summary = await intelligenceManager.runRecap();
+      if (summary) {
+        try { PhoneMirrorService.getInstance().publishAssistantMessage(crypto.randomUUID(), summary, 'Recap'); } catch (_) {}
+      }
       return { summary };
     } catch (error: any) {
       throw error;
@@ -2878,6 +2899,9 @@ export function initializeIpcHandlers(appState: AppState): void {
     try {
       const intelligenceManager = appState.getIntelligenceManager();
       const questions = await intelligenceManager.runFollowUpQuestions();
+      if (questions) {
+        try { PhoneMirrorService.getInstance().publishAssistantMessage(crypto.randomUUID(), questions, 'Follow-Up Questions'); } catch (_) {}
+      }
       return { questions };
     } catch (error: any) {
       throw error;
@@ -2889,6 +2913,12 @@ export function initializeIpcHandlers(appState: AppState): void {
     try {
       const intelligenceManager = appState.getIntelligenceManager();
       const answer = await intelligenceManager.runManualAnswer(question);
+      if (answer) {
+        try {
+          PhoneMirrorService.getInstance().publishUserMessage(crypto.randomUUID(), question);
+          PhoneMirrorService.getInstance().publishAssistantMessage(crypto.randomUUID(), answer, 'Answer');
+        } catch (_) {}
+      }
       return { answer, question };
     } catch (error: any) {
       throw error;
@@ -4140,6 +4170,92 @@ export function initializeIpcHandlers(appState: AppState): void {
     } catch (e: any) {
       console.error('[IPC] phone-mirror:rotate-token error:', e);
       return { error: e?.message || 'failed to rotate token' };
+    }
+  });
+
+  // Push a desktop screenshot thumbnail to connected phones.
+  // The caller can optionally pass a pre-captured path; if absent, a fresh
+  // screenshot is taken.  The image is resized to 800 px wide and compressed
+  // to JPEG so the WebSocket payload stays well under 200 KB.
+  safeHandle("phone-mirror:push-screenshot", async (_, screenshotPath?: string) => {
+    try {
+      let imgPath = screenshotPath;
+      if (!imgPath) {
+        imgPath = await appState.takeScreenshot(false);
+      }
+      const buf = await fs.promises.readFile(imgPath);
+      const sharp = require('sharp') as typeof import('sharp');
+      const compressed = await sharp(buf)
+        .resize({ width: 800, withoutEnlargement: true })
+        .jpeg({ quality: 70 })
+        .toBuffer();
+      const dataUrl = 'data:image/jpeg;base64,' + compressed.toString('base64');
+      PhoneMirrorService.getInstance().publishScreenshot(crypto.randomUUID(), dataUrl);
+      return { success: true };
+    } catch (e: any) {
+      console.error('[IPC] phone-mirror:push-screenshot error:', e);
+      return { error: e?.message || 'failed to push screenshot' };
+    }
+  });
+
+  // Route commands sent by the phone browser back to the Electron renderer so
+  // the existing action system (global-shortcut events, chat stream) handles
+  // them without duplicating logic.
+  PhoneMirrorService.getInstance().onPhoneCommand(async (cmd) => {
+    const win = appState.getMainWindow();
+
+    if (cmd.type === 'action') {
+      // Re-use the same global-shortcut dispatch path the keyboard uses.
+      // This keeps phone actions identical to key-triggered stealth actions.
+      const allWindows = BrowserWindow.getAllWindows();
+      allWindows.forEach(w => {
+        if (!w.isDestroyed()) w.webContents.send('global-shortcut', { action: cmd.action });
+      });
+
+    } else if (cmd.type === 'chat') {
+      // Stream a phone-initiated chat through the LLM exactly like gemini-chat-stream
+      // but without requiring a renderer event sender. Tokens are pushed directly to
+      // the phone over WebSocket; desktop renderer also receives them so both views
+      // stay in sync.
+      const myStreamId = crypto.randomUUID();
+      const message = cmd.message;
+
+      try { PhoneMirrorService.getInstance().publishUserMessage(myStreamId, message); } catch (_) {}
+      // Notify renderer so it can display the incoming phone message too
+      win?.webContents.send('phone-mirror:incoming-chat', { message, streamId: myStreamId });
+
+      try {
+        const llmHelper = appState.processingHelper.getLLMHelper();
+        const stream = llmHelper.streamChat(message);
+        let full = '';
+        for await (const token of stream) {
+          try { PhoneMirrorService.getInstance().publishToken(myStreamId, token); } catch (_) {}
+          win?.webContents.send('gemini-stream-token', token);
+          full += token;
+        }
+        try { PhoneMirrorService.getInstance().publishDone(myStreamId, full); } catch (_) {}
+        win?.webContents.send('gemini-stream-done');
+      } catch (err: any) {
+        console.error('[PhoneMirror] phone-chat stream error:', err);
+        try { PhoneMirrorService.getInstance().publishError(myStreamId, err?.message || 'stream error'); } catch (_) {}
+        win?.webContents.send('gemini-stream-error', err?.message || 'stream error');
+      }
+
+    } else if (cmd.type === 'screenshot') {
+      // Capture a fresh screenshot and push it back to the phone.
+      try {
+        const imgPath = await appState.takeScreenshot(false);
+        const buf = await fs.promises.readFile(imgPath);
+        const sharp = require('sharp') as typeof import('sharp');
+        const compressed = await sharp(buf)
+          .resize({ width: 800, withoutEnlargement: true })
+          .jpeg({ quality: 70 })
+          .toBuffer();
+        const dataUrl = 'data:image/jpeg;base64,' + compressed.toString('base64');
+        PhoneMirrorService.getInstance().publishScreenshot(crypto.randomUUID(), dataUrl);
+      } catch (e: any) {
+        console.error('[PhoneMirror] phone screenshot request failed:', e);
+      }
     }
   });
 }

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -778,8 +778,12 @@ export function initializeIpcHandlers(appState: AppState): void {
     const launcherWin = appState.getWindowHelper().getLauncherWindow();
     if (launcherWin && !launcherWin.isDestroyed()) {
       launcherWin.webContents.send('settings:open-tab', tab);
-      launcherWin.show();
-      launcherWin.focus();
+      if (appState.getUndetectable()) {
+        launcherWin.showInactive();
+      } else {
+        launcherWin.show();
+        launcherWin.focus();
+      }
     }
   });
 
@@ -4695,35 +4699,76 @@ export function initializeIpcHandlers(appState: AppState): void {
       // but without requiring a renderer event sender. Tokens are pushed directly to
       // the phone over WebSocket; desktop renderer also receives them so both views
       // stay in sync.
-      const myStreamId = crypto.randomUUID();
+      const myStreamId = ++_chatStreamId;
       const message = cmd.message;
       const phoneMirror = PhoneMirrorService.getInstance();
+      const intelligenceManager = appState.getIntelligenceManager();
 
-      try { phoneMirror.publishUserMessage(myStreamId, message); } catch (_) {}
+      // Capture rolling context BEFORE adding the new user message — same ordering
+      // as gemini-chat-stream so Recap / Follow Up / What to Answer see phone turns.
+      let context: string | undefined;
+      try {
+        const snap = intelligenceManager.getFormattedContext(100);
+        if (snap && snap.trim().length > 0) context = snap;
+      } catch (ctxErr) {
+        console.warn('[PhoneMirror] Failed to capture pre-turn context:', ctxErr);
+      }
+
+      intelligenceManager.addTranscript(
+        { text: message, speaker: 'user', timestamp: Date.now(), final: true },
+        true,
+      );
+
+      try {
+        phoneMirror.publishUserMessage(String(myStreamId), message);
+      } catch (_) {}
       // Notify renderer so it can display the incoming phone message too.
-      win?.webContents.send('phone-mirror:incoming-chat', { message, streamId: myStreamId });
+      win?.webContents.send('phone-mirror:incoming-chat', {
+        message,
+        streamId: String(myStreamId),
+      });
 
       try {
         const llmHelper = appState.processingHelper.getLLMHelper();
-        const stream = llmHelper.streamChat(message);
+        const stream = llmHelper.streamChat(message, undefined, context, CHAT_MODE_PROMPT);
         let full = '';
         for await (const token of stream) {
+          // Bail if a newer stream has taken over (phone or desktop chat).
+          if (_chatStreamId !== myStreamId) {
+            console.log(
+              `[PhoneMirror] phone-chat ${myStreamId} superseded by ${_chatStreamId}, stopping.`,
+            );
+            return;
+          }
           // Cancel early if all phones have disconnected — no point burning LLM
           // tokens when nobody is receiving them and we have no desktop renderer
           // context to show the result in either.
           if (!phoneMirror.hasClients() && win?.isDestroyed()) break;
-          try { phoneMirror.publishToken(myStreamId, token); } catch (_) {}
+          try {
+            phoneMirror.publishToken(String(myStreamId), token);
+          } catch (_) {}
           win?.webContents.send('gemini-stream-token', token);
           full += token;
         }
-        try { phoneMirror.publishDone(myStreamId, full); } catch (_) {}
-        win?.webContents.send('gemini-stream-done');
+        if (_chatStreamId === myStreamId) {
+          try {
+            phoneMirror.publishDone(String(myStreamId), full);
+          } catch (_) {}
+          win?.webContents.send('gemini-stream-done');
+          if (full.trim().length > 0) {
+            intelligenceManager.addAssistantMessage(full);
+            intelligenceManager.logUsage('chat', message, full);
+          }
+        }
       } catch (err: any) {
         console.error('[PhoneMirror] phone-chat stream error:', err);
-        try { phoneMirror.publishError(myStreamId, err?.message || 'stream error'); } catch (_) {}
-        win?.webContents.send('gemini-stream-error', err?.message || 'stream error');
+        if (_chatStreamId === myStreamId) {
+          try {
+            phoneMirror.publishError(String(myStreamId), err?.message || 'stream error');
+          } catch (_) {}
+          win?.webContents.send('gemini-stream-error', err?.message || 'stream error');
+        }
       }
-
     } else if (cmd.type === 'screenshot') {
       // Stealth screenshot: capture on PC → add to screenshot queue → ack to phone.
       // The image is NOT sent to the phone — it stays on the desktop for AI use.

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,325 +1,627 @@
-import { contextBridge, ipcRenderer } from "electron"
+import { contextBridge, ipcRenderer } from 'electron';
 
 // Types for the exposed Electron API
 interface ElectronAPI {
-  updateContentDimensions: (dimensions: {
-    width: number
-    height: number
-  }) => Promise<void>
-  updateContentDimensionsCentered: (dimensions: {
-    width: number
-    height: number
-  }) => Promise<void>
-  getRecognitionLanguages: () => Promise<Record<string, any>>
-  getScreenshots: () => Promise<Array<{ path: string; preview: string }>>
-  deleteScreenshot: (
-    path: string
-  ) => Promise<{ success: boolean; error?: string }>
-  onScreenshotTaken: (
-    callback: (data: { path: string; preview: string }) => void
-  ) => () => void
-  onScreenshotAttached: (
-    callback: (data: { path: string; preview: string }) => void
-  ) => () => void
-  onCaptureAndProcess: (
-    callback: (data: { path: string; preview: string }) => void
-  ) => () => void
-  onSolutionsReady: (callback: (solutions: string) => void) => () => void
-  onResetView: (callback: () => void) => () => void
-  onSolutionStart: (callback: () => void) => () => void
-  onDebugStart: (callback: () => void) => () => void
-  onDebugSuccess: (callback: (data: any) => void) => () => void
-  onSolutionError: (callback: (error: string) => void) => () => void
-  onProcessingNoScreenshots: (callback: () => void) => () => void
-  onProblemExtracted: (callback: (data: any) => void) => () => void
-  onSolutionSuccess: (callback: (data: any) => void) => () => void
+  updateContentDimensions: (dimensions: { width: number; height: number }) => Promise<void>;
+  updateContentDimensionsCentered: (dimensions: { width: number; height: number }) => Promise<void>;
+  getRecognitionLanguages: () => Promise<Record<string, any>>;
+  getScreenshots: () => Promise<Array<{ path: string; preview: string }>>;
+  deleteScreenshot: (path: string) => Promise<{ success: boolean; error?: string }>;
+  onScreenshotTaken: (callback: (data: { path: string; preview: string }) => void) => () => void;
+  onScreenshotAttached: (callback: (data: { path: string; preview: string }) => void) => () => void;
+  onCaptureAndProcess: (callback: (data: { path: string; preview: string }) => void) => () => void;
+  onSolutionsReady: (callback: (solutions: string) => void) => () => void;
+  onResetView: (callback: () => void) => () => void;
+  onSolutionStart: (callback: () => void) => () => void;
+  onDebugStart: (callback: () => void) => () => void;
+  onDebugSuccess: (callback: (data: any) => void) => () => void;
+  onSolutionError: (callback: (error: string) => void) => () => void;
+  onProcessingNoScreenshots: (callback: () => void) => () => void;
+  onProblemExtracted: (callback: (data: any) => void) => () => void;
+  onSolutionSuccess: (callback: (data: any) => void) => () => void;
 
-  onUnauthorized: (callback: () => void) => () => void
-  onDebugError: (callback: (error: string) => void) => () => void
-  takeScreenshot: () => Promise<void>
-  takeSelectiveScreenshot: () => Promise<{ path: string; preview: string; cancelled?: boolean }>
-  moveWindowLeft: () => Promise<void>
-  moveWindowRight: () => Promise<void>
-  moveWindowUp: () => Promise<void>
-  moveWindowDown: () => Promise<void>
-  windowMinimize: () => Promise<void>
-  windowMaximize: () => Promise<void>
-  windowClose: () => Promise<void>
-  windowIsMaximized: () => Promise<boolean>
+  onUnauthorized: (callback: () => void) => () => void;
+  onDebugError: (callback: (error: string) => void) => () => void;
+  takeScreenshot: () => Promise<void>;
+  takeSelectiveScreenshot: () => Promise<{ path: string; preview: string; cancelled?: boolean }>;
+  moveWindowLeft: () => Promise<void>;
+  moveWindowRight: () => Promise<void>;
+  moveWindowUp: () => Promise<void>;
+  moveWindowDown: () => Promise<void>;
+  windowMinimize: () => Promise<void>;
+  windowMaximize: () => Promise<void>;
+  windowClose: () => Promise<void>;
+  windowIsMaximized: () => Promise<boolean>;
 
-  analyzeImageFile: (path: string) => Promise<void>
-  quitApp: () => Promise<void>
+  analyzeImageFile: (path: string) => Promise<void>;
+  quitApp: () => Promise<void>;
 
   // LLM Model Management
-  getCurrentLlmConfig: () => Promise<{ provider: "ollama" | "gemini"; model: string; isOllama: boolean }>
-  getAvailableOllamaModels: () => Promise<string[]>
-  switchToOllama: (model?: string, url?: string) => Promise<{ success: boolean; error?: string }>
-  switchToGemini: (apiKey?: string, modelId?: string) => Promise<{ success: boolean; error?: string }>
-  testLlmConnection: (provider: 'gemini' | 'groq' | 'openai' | 'claude', apiKey?: string) => Promise<{ success: boolean; error?: string }>
-  selectServiceAccount: () => Promise<{ success: boolean; path?: string; cancelled?: boolean; error?: string }>
+  getCurrentLlmConfig: () => Promise<{
+    provider: 'ollama' | 'gemini';
+    model: string;
+    isOllama: boolean;
+  }>;
+  getAvailableOllamaModels: () => Promise<string[]>;
+  switchToOllama: (model?: string, url?: string) => Promise<{ success: boolean; error?: string }>;
+  switchToGemini: (
+    apiKey?: string,
+    modelId?: string,
+  ) => Promise<{ success: boolean; error?: string }>;
+  testLlmConnection: (
+    provider: 'gemini' | 'groq' | 'openai' | 'claude',
+    apiKey?: string,
+  ) => Promise<{ success: boolean; error?: string }>;
+  selectServiceAccount: () => Promise<{
+    success: boolean;
+    path?: string;
+    cancelled?: boolean;
+    error?: string;
+  }>;
 
   // API Key Management
-  setGeminiApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>
-  setGroqApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>
-  setOpenaiApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>
-  setClaudeApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>
-  setNativelyApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>
-  getNativelyUsage: () => Promise<{ ok: boolean; plan?: string; quota?: { transcription: { used: number; limit: number; remaining: number }; ai: { used: number; limit: number; remaining: number }; search: { used: number; limit: number; remaining: number }; resets_at: string }; member_since?: string; error?: string; status?: number }>
-  getStoredCredentials: () => Promise<{ hasGeminiKey: boolean; hasGroqKey: boolean; hasOpenaiKey: boolean; hasClaudeKey: boolean; hasNativelyKey: boolean; googleServiceAccountPath: string | null; sttProvider: string; hasSttGroqKey: boolean; hasSttOpenaiKey: boolean; hasDeepgramKey: boolean; hasElevenLabsKey: boolean; hasAzureKey: boolean; azureRegion: string; hasIbmWatsonKey: boolean; ibmWatsonRegion: string; hasSonioxKey: boolean }>
+  setGeminiApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>;
+  setGroqApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>;
+  setOpenaiApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>;
+  setClaudeApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>;
+  setNativelyApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>;
+  getNativelyUsage: () => Promise<{
+    ok: boolean;
+    plan?: string;
+    quota?: {
+      transcription: { used: number; limit: number; remaining: number };
+      ai: { used: number; limit: number; remaining: number };
+      search: { used: number; limit: number; remaining: number };
+      resets_at: string;
+    };
+    member_since?: string;
+    error?: string;
+    status?: number;
+  }>;
+  getStoredCredentials: () => Promise<{
+    hasGeminiKey: boolean;
+    hasGroqKey: boolean;
+    hasOpenaiKey: boolean;
+    hasClaudeKey: boolean;
+    hasNativelyKey: boolean;
+    googleServiceAccountPath: string | null;
+    sttProvider: string;
+    hasSttGroqKey: boolean;
+    hasSttOpenaiKey: boolean;
+    hasDeepgramKey: boolean;
+    hasElevenLabsKey: boolean;
+    hasAzureKey: boolean;
+    azureRegion: string;
+    hasIbmWatsonKey: boolean;
+    ibmWatsonRegion: string;
+    hasSonioxKey: boolean;
+  }>;
   // Free Trial
-  startTrial:     () => Promise<{ ok: boolean; hasToken?: boolean; started_at?: string; expires_at?: string; expired?: boolean; already_used?: boolean; converted_to?: string | null; usage?: { ai: number; stt_seconds: number; search: number }; limits?: { duration_ms: number; ai_requests: number; stt_minutes: number; search_requests: number }; error?: string; status?: number }>
-  getTrialStatus: () => Promise<{ ok: boolean; expired?: boolean; remaining_ms?: number; started_at?: string; expires_at?: string; converted_to?: string | null; usage?: { ai: number; stt_seconds: number; search: number }; limits?: object; error?: string }>
-  getLocalTrial:  () => Promise<{ hasToken: boolean; trialClaimed?: boolean; expiresAt?: string; startedAt?: string; expired?: boolean }>
-  convertTrial:   (choice: string) => Promise<{ ok: boolean }>
-  endTrialByok:   () => Promise<{ success: boolean; error?: string }>
-  onTrialEnded:   (cb: (data: { choice: string }) => void) => () => void
-  onModesActiveCleared: (cb: () => void) => () => void
+  startTrial: () => Promise<{
+    ok: boolean;
+    hasToken?: boolean;
+    started_at?: string;
+    expires_at?: string;
+    expired?: boolean;
+    already_used?: boolean;
+    converted_to?: string | null;
+    usage?: { ai: number; stt_seconds: number; search: number };
+    limits?: {
+      duration_ms: number;
+      ai_requests: number;
+      stt_minutes: number;
+      search_requests: number;
+    };
+    error?: string;
+    status?: number;
+  }>;
+  getTrialStatus: () => Promise<{
+    ok: boolean;
+    expired?: boolean;
+    remaining_ms?: number;
+    started_at?: string;
+    expires_at?: string;
+    converted_to?: string | null;
+    usage?: { ai: number; stt_seconds: number; search: number };
+    limits?: object;
+    error?: string;
+  }>;
+  getLocalTrial: () => Promise<{
+    hasToken: boolean;
+    trialClaimed?: boolean;
+    expiresAt?: string;
+    startedAt?: string;
+    expired?: boolean;
+  }>;
+  convertTrial: (choice: string) => Promise<{ ok: boolean }>;
+  endTrialByok: () => Promise<{ success: boolean; error?: string }>;
+  onTrialEnded: (cb: (data: { choice: string }) => void) => () => void;
+  onModesActiveCleared: (cb: () => void) => () => void;
 
   // STT Provider Management
-  setSttProvider: (provider: 'none' | 'google' | 'groq' | 'openai' | 'deepgram' | 'elevenlabs' | 'azure' | 'ibmwatson' | 'soniox' | 'natively' | 'local-whisper') => Promise<{ success: boolean; error?: string }>
-  localWhisperGetModels: () => Promise<{ models: any[]; activeModelId: string }>
-  localWhisperSetModel: (modelId: string) => Promise<{ success: boolean }>
-  localWhisperDeleteModel: (modelId: string) => Promise<{ success: boolean; error?: string }>
-  localWhisperStartDownload: (modelId: string) => Promise<{ success: boolean; error?: string }>
-  onLocalWhisperDownloadProgress: (callback: (data: { modelId: string; progress: number }) => void) => () => void
-  onLocalWhisperDownloadComplete: (callback: (data: { modelId: string }) => void) => () => void
-  onLocalWhisperDownloadError: (callback: (data: { modelId: string; error: string }) => void) => () => void
-  localWhisperPreload: (modelId?: string) => Promise<{ success: boolean; reason?: string; error?: string }>
-  localWhisperGetHardware: () => Promise<{ arch: string; platform: string; cpuModel: string; isAppleSilicon: boolean; totalRamGb: number; tier: string; recommendation: string; recommendedModel: string }>
-  getSttProvider: () => Promise<string>
-  setGroqSttApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>
-  setOpenAiSttApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>
-  setOpenAiSttBaseUrl: (url: string) => Promise<{ success: boolean; error?: string }>
-  setDeepgramApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>
-  setElevenLabsApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>
-  setAzureApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>
-  setAzureRegion: (region: string) => Promise<{ success: boolean; error?: string }>
-  setIbmWatsonApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>
-  setGroqSttModel: (model: string) => Promise<{ success: boolean; error?: string }>
-  setSonioxApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>
-  setIbmWatsonRegion: (region: string) => Promise<{ success: boolean; error?: string }>
-  testSttConnection: (provider: 'groq' | 'openai' | 'deepgram' | 'elevenlabs' | 'azure' | 'ibmwatson' | 'soniox', apiKey: string, region?: string) => Promise<{ success: boolean; error?: string }>
+  setSttProvider: (
+    provider:
+      | 'none'
+      | 'google'
+      | 'groq'
+      | 'openai'
+      | 'deepgram'
+      | 'elevenlabs'
+      | 'azure'
+      | 'ibmwatson'
+      | 'soniox'
+      | 'natively'
+      | 'local-whisper',
+  ) => Promise<{ success: boolean; error?: string }>;
+  localWhisperGetModels: () => Promise<{ models: any[]; activeModelId: string }>;
+  localWhisperSetModel: (modelId: string) => Promise<{ success: boolean }>;
+  localWhisperDeleteModel: (modelId: string) => Promise<{ success: boolean; error?: string }>;
+  localWhisperStartDownload: (modelId: string) => Promise<{ success: boolean; error?: string }>;
+  onLocalWhisperDownloadProgress: (
+    callback: (data: { modelId: string; progress: number }) => void,
+  ) => () => void;
+  onLocalWhisperDownloadComplete: (callback: (data: { modelId: string }) => void) => () => void;
+  onLocalWhisperDownloadError: (
+    callback: (data: { modelId: string; error: string }) => void,
+  ) => () => void;
+  localWhisperPreload: (
+    modelId?: string,
+  ) => Promise<{ success: boolean; reason?: string; error?: string }>;
+  localWhisperGetHardware: () => Promise<{
+    arch: string;
+    platform: string;
+    cpuModel: string;
+    isAppleSilicon: boolean;
+    totalRamGb: number;
+    tier: string;
+    recommendation: string;
+    recommendedModel: string;
+  }>;
+  getSttProvider: () => Promise<string>;
+  setGroqSttApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>;
+  setOpenAiSttApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>;
+  setOpenAiSttBaseUrl: (url: string) => Promise<{ success: boolean; error?: string }>;
+  setDeepgramApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>;
+  setElevenLabsApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>;
+  setAzureApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>;
+  setAzureRegion: (region: string) => Promise<{ success: boolean; error?: string }>;
+  setIbmWatsonApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>;
+  setGroqSttModel: (model: string) => Promise<{ success: boolean; error?: string }>;
+  setSonioxApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>;
+  setIbmWatsonRegion: (region: string) => Promise<{ success: boolean; error?: string }>;
+  testSttConnection: (
+    provider: 'groq' | 'openai' | 'deepgram' | 'elevenlabs' | 'azure' | 'ibmwatson' | 'soniox',
+    apiKey: string,
+    region?: string,
+  ) => Promise<{ success: boolean; error?: string }>;
 
   // STT Config Events
-  onSttConfigChanged: (callback: (data: { configured: boolean; provider: string }) => void) => () => void
-  onCredentialsChanged: (callback: () => void) => () => void
+  onSttConfigChanged: (
+    callback: (data: { configured: boolean; provider: string }) => void,
+  ) => () => void;
+  onCredentialsChanged: (callback: () => void) => () => void;
 
   // Native Audio Service Events
-  onNativeAudioTranscript: (callback: (transcript: { speaker: string; text: string; final: boolean }) => void) => () => void
-  onNativeAudioSuggestion: (callback: (suggestion: { context: string; lastQuestion: string; confidence: number }) => void) => () => void
-  onNativeAudioConnected: (callback: () => void) => () => void
-  onNativeAudioDisconnected: (callback: () => void) => () => void
-  onSuggestionGenerated: (callback: (data: { question: string; suggestion: string; confidence: number }) => void) => () => void
-  onSuggestionProcessingStart: (callback: () => void) => () => void
-  onSuggestionError: (callback: (error: { error: string }) => void) => () => void
-  generateSuggestion: (context: string, lastQuestion: string) => Promise<{ suggestion: string }>
-  getInputDevices: () => Promise<Array<{ id: string; name: string }>>
-  getOutputDevices: () => Promise<Array<{ id: string; name: string }>>
-  setRecognitionLanguage: (key: string) => Promise<{ success: boolean; error?: string }>
-  getAiResponseLanguages: () => Promise<Array<{ label: string; code: string }>>
-  setAiResponseLanguage: (language: string) => Promise<{ success: boolean; error?: string }>
-  getSttLanguage: () => Promise<string>
-  getAiResponseLanguage: () => Promise<string>
-  onSttLanguageAutoDetected: (callback: (bcp47: string) => void) => () => void
-  onSystemAudioPermissionDenied: (callback: (message: string) => void) => () => void
-  onDeviceSelectionApplied: (callback: (payload: { kind: 'input' | 'output'; requested: string | null; actual: string | null; fellBack: boolean; reason?: string }) => void) => () => void
-  onAudioCaptureFailed: (callback: (payload: { channel: 'system' | 'mic'; message: string; attempt: number; maxAttempts: number; terminal?: boolean; stuck?: boolean }) => void) => () => void
+  onNativeAudioTranscript: (
+    callback: (transcript: { speaker: string; text: string; final: boolean }) => void,
+  ) => () => void;
+  onNativeAudioSuggestion: (
+    callback: (suggestion: { context: string; lastQuestion: string; confidence: number }) => void,
+  ) => () => void;
+  onNativeAudioConnected: (callback: () => void) => () => void;
+  onNativeAudioDisconnected: (callback: () => void) => () => void;
+  onSuggestionGenerated: (
+    callback: (data: { question: string; suggestion: string; confidence: number }) => void,
+  ) => () => void;
+  onSuggestionProcessingStart: (callback: () => void) => () => void;
+  onSuggestionError: (callback: (error: { error: string }) => void) => () => void;
+  generateSuggestion: (context: string, lastQuestion: string) => Promise<{ suggestion: string }>;
+  getInputDevices: () => Promise<Array<{ id: string; name: string }>>;
+  getOutputDevices: () => Promise<Array<{ id: string; name: string }>>;
+  setRecognitionLanguage: (key: string) => Promise<{ success: boolean; error?: string }>;
+  getAiResponseLanguages: () => Promise<Array<{ label: string; code: string }>>;
+  setAiResponseLanguage: (language: string) => Promise<{ success: boolean; error?: string }>;
+  getSttLanguage: () => Promise<string>;
+  getAiResponseLanguage: () => Promise<string>;
+  onSttLanguageAutoDetected: (callback: (bcp47: string) => void) => () => void;
+  onSystemAudioPermissionDenied: (callback: (message: string) => void) => () => void;
+  onDeviceSelectionApplied: (
+    callback: (payload: {
+      kind: 'input' | 'output';
+      requested: string | null;
+      actual: string | null;
+      fellBack: boolean;
+      reason?: string;
+    }) => void,
+  ) => () => void;
+  onAudioCaptureFailed: (
+    callback: (payload: {
+      channel: 'system' | 'mic';
+      message: string;
+      attempt: number;
+      maxAttempts: number;
+      terminal?: boolean;
+      stuck?: boolean;
+    }) => void,
+  ) => () => void;
 
   // STT Status Events
-  onSttStatusChanged: (callback: (data: { state: 'connected' | 'reconnecting' | 'failed'; provider: string; error?: string; channel: 'user' | 'interviewer'; reconnectAttempts?: number }) => void) => () => void
+  onSttStatusChanged: (
+    callback: (data: {
+      state: 'connected' | 'reconnecting' | 'failed';
+      provider: string;
+      error?: string;
+      channel: 'user' | 'interviewer';
+      reconnectAttempts?: number;
+    }) => void,
+  ) => () => void;
 
   // Intelligence Mode IPC
-  generateAssist: () => Promise<{ insight: string | null }>
-  generateWhatToSay: (question?: string, imagePaths?: string[], options?: { promptInstruction?: string }) => Promise<{ answer: string | null; question?: string; error?: string; screenContextStatus?: 'not_available' | 'available' | 'failed'; ocrTextLength?: number; imageCount?: number; usedImageInput?: boolean }>
-  generateFollowUp: (intent: string, userRequest?: string) => Promise<{ refined: string | null; intent: string }>
-  generateRecap: () => Promise<{ summary: string | null }>
-  submitManualQuestion: (question: string) => Promise<{ answer: string | null; question: string }>
-  getIntelligenceContext: () => Promise<{ context: string; lastAssistantMessage: string | null; activeMode: string }>
-  testInjectTranscript: (segment: { speaker: string; text: string; timestamp?: number; final?: boolean }) => Promise<{ success: boolean; error?: string }>
-  testGetModeContext: () => Promise<{ success: boolean; block?: string; suffix?: string; error?: string }>
-  resetIntelligence: () => Promise<{ success: boolean; error?: string }>
+  generateAssist: () => Promise<{ insight: string | null }>;
+  generateWhatToSay: (
+    question?: string,
+    imagePaths?: string[],
+    options?: { promptInstruction?: string },
+  ) => Promise<{
+    answer: string | null;
+    question?: string;
+    error?: string;
+    screenContextStatus?: 'not_available' | 'available' | 'failed';
+    ocrTextLength?: number;
+    imageCount?: number;
+    usedImageInput?: boolean;
+  }>;
+  generateFollowUp: (
+    intent: string,
+    userRequest?: string,
+  ) => Promise<{ refined: string | null; intent: string }>;
+  generateRecap: () => Promise<{ summary: string | null }>;
+  submitManualQuestion: (question: string) => Promise<{ answer: string | null; question: string }>;
+  getIntelligenceContext: () => Promise<{
+    context: string;
+    lastAssistantMessage: string | null;
+    activeMode: string;
+  }>;
+  testInjectTranscript: (segment: {
+    speaker: string;
+    text: string;
+    timestamp?: number;
+    final?: boolean;
+  }) => Promise<{ success: boolean; error?: string }>;
+  testGetModeContext: () => Promise<{
+    success: boolean;
+    block?: string;
+    suffix?: string;
+    error?: string;
+  }>;
+  resetIntelligence: () => Promise<{ success: boolean; error?: string }>;
 
   // Meeting Lifecycle
-  startMeeting: (metadata?: any) => Promise<{ success: boolean; error?: string }>
-  endMeeting: () => Promise<{ success: boolean; error?: string }>
-  finalizeMicSTT: () => Promise<void>
-  getRecentMeetings: () => Promise<Array<{ id: string; title: string; date: string; duration: string; summary: string }>>
-  getMeetingDetails: (id: string) => Promise<any>
-  updateMeetingTitle: (id: string, title: string) => Promise<boolean>
-  updateMeetingSummary: (id: string, updates: { overview?: string, actionItems?: string[], keyPoints?: string[], actionItemsTitle?: string, keyPointsTitle?: string }) => Promise<boolean>
-  onMeetingsUpdated: (callback: () => void) => () => void
+  startMeeting: (metadata?: any) => Promise<{ success: boolean; error?: string }>;
+  endMeeting: () => Promise<{ success: boolean; error?: string }>;
+  finalizeMicSTT: () => Promise<void>;
+  getRecentMeetings: () => Promise<
+    Array<{ id: string; title: string; date: string; duration: string; summary: string }>
+  >;
+  getMeetingDetails: (id: string) => Promise<any>;
+  updateMeetingTitle: (id: string, title: string) => Promise<boolean>;
+  updateMeetingSummary: (
+    id: string,
+    updates: {
+      overview?: string;
+      actionItems?: string[];
+      keyPoints?: string[];
+      actionItemsTitle?: string;
+      keyPointsTitle?: string;
+    },
+  ) => Promise<boolean>;
+  onMeetingsUpdated: (callback: () => void) => () => void;
 
   // Intelligence Mode Events
-  onIntelligenceAssistUpdate: (callback: (data: { insight: string }) => void) => () => void
-  onIntelligenceSuggestedAnswer: (callback: (data: { answer: string; question: string; confidence: number }) => void) => () => void
-  onIntelligenceRefinedAnswer: (callback: (data: { answer: string; intent: string }) => void) => () => void
-  onIntelligenceRecap: (callback: (data: { summary: string }) => void) => () => void
-  onIntelligenceClarify: (callback: (data: { clarification: string }) => void) => () => void
-  onIntelligenceClarifyToken: (callback: (data: { token: string }) => void) => () => void
-  onIntelligenceManualStarted: (callback: () => void) => () => void
-  onIntelligenceManualResult: (callback: (data: { answer: string; question: string }) => void) => () => void
-  onIntelligenceModeChanged: (callback: (data: { mode: string }) => void) => () => void
-  onIntelligenceError: (callback: (data: { error: string; mode: string }) => void) => () => void
+  onIntelligenceAssistUpdate: (callback: (data: { insight: string }) => void) => () => void;
+  onIntelligenceSuggestedAnswer: (
+    callback: (data: { answer: string; question: string; confidence: number }) => void,
+  ) => () => void;
+  onIntelligenceRefinedAnswer: (
+    callback: (data: { answer: string; intent: string }) => void,
+  ) => () => void;
+  onIntelligenceRecap: (callback: (data: { summary: string }) => void) => () => void;
+  onIntelligenceClarify: (callback: (data: { clarification: string }) => void) => () => void;
+  onIntelligenceClarifyToken: (callback: (data: { token: string }) => void) => () => void;
+  onIntelligenceManualStarted: (callback: () => void) => () => void;
+  onIntelligenceManualResult: (
+    callback: (data: { answer: string; question: string }) => void,
+  ) => () => void;
+  onIntelligenceModeChanged: (callback: (data: { mode: string }) => void) => () => void;
+  onIntelligenceError: (callback: (data: { error: string; mode: string }) => void) => () => void;
   // Sprint 7: dedicated negotiation-coaching channel. Replaces the
   // sentinel-string multiplex through suggested_answer_token / suggested_answer.
-  onIntelligenceNegotiationCoaching: (callback: (data: { payload: any }) => void) => () => void
+  onIntelligenceNegotiationCoaching: (callback: (data: { payload: any }) => void) => () => void;
   // Sprint 9: time-batched IPC token channel. Carries a batch of streaming
   // tokens for ANY of the 5 streaming kinds in one IPC send. Replaces
   // per-token sends to the 5 individual channels (which still exist as
   // unused defense-in-depth bridges).
-  onIntelligenceTokenBatch: (callback: (data: { kind: 'suggested_answer' | 'refined_answer' | 'recap' | 'clarify' | 'follow_up_questions'; items: any[] }) => void) => () => void
+  onIntelligenceTokenBatch: (
+    callback: (data: {
+      kind: 'suggested_answer' | 'refined_answer' | 'recap' | 'clarify' | 'follow_up_questions';
+      items: any[];
+    }) => void,
+  ) => () => void;
 
   // Model Management
-  getDefaultModel: () => Promise<{ model: string }>
-  setModel: (modelId: string) => Promise<{ success: boolean; error?: string }>
-  setDefaultModel: (modelId: string) => Promise<{ success: boolean; error?: string }>
-  toggleModelSelector: (coords: { x: number; y: number }) => Promise<void>
-  modelSelectorCloseIfOpen: () => Promise<void>
-  forceRestartOllama: () => Promise<void>
+  getDefaultModel: () => Promise<{ model: string }>;
+  setModel: (modelId: string) => Promise<{ success: boolean; error?: string }>;
+  setDefaultModel: (modelId: string) => Promise<{ success: boolean; error?: string }>;
+  toggleModelSelector: (coords: { x: number; y: number }) => Promise<void>;
+  modelSelectorCloseIfOpen: () => Promise<void>;
+  forceRestartOllama: () => Promise<void>;
 
   // Settings Window
-  toggleSettingsWindow: (coords?: { x: number; y: number }) => Promise<void>
+  toggleSettingsWindow: (coords?: { x: number; y: number }) => Promise<void>;
 
   // Groq Fast Text Mode
-  getGroqFastTextMode: () => Promise<{ enabled: boolean }>
-  setGroqFastTextMode: (enabled: boolean) => Promise<{ success: boolean; error?: string }>
-  getCodexCliConfig: () => Promise<{ enabled: boolean; path: string; model: string; fastModel: string; timeoutMs: number }>
-  setCodexCliConfig: (config: { enabled: boolean; path: string; model: string; fastModel: string; timeoutMs: number }) => Promise<{ success: boolean; error?: string; config?: { enabled: boolean; path: string; model: string; fastModel: string; timeoutMs: number } }>
-  testCodexCli: (config?: { enabled?: boolean; path?: string; model?: string; fastModel?: string; timeoutMs?: number }) => Promise<{ success: boolean; error?: string; resolvedPath?: string; config?: { enabled: boolean; path: string; model: string; fastModel: string; timeoutMs: number } }>
+  getGroqFastTextMode: () => Promise<{ enabled: boolean }>;
+  setGroqFastTextMode: (enabled: boolean) => Promise<{ success: boolean; error?: string }>;
+  getCodexCliConfig: () => Promise<{
+    enabled: boolean;
+    path: string;
+    model: string;
+    fastModel: string;
+    timeoutMs: number;
+  }>;
+  setCodexCliConfig: (config: {
+    enabled: boolean;
+    path: string;
+    model: string;
+    fastModel: string;
+    timeoutMs: number;
+  }) => Promise<{
+    success: boolean;
+    error?: string;
+    config?: {
+      enabled: boolean;
+      path: string;
+      model: string;
+      fastModel: string;
+      timeoutMs: number;
+    };
+  }>;
+  testCodexCli: (config?: {
+    enabled?: boolean;
+    path?: string;
+    model?: string;
+    fastModel?: string;
+    timeoutMs?: number;
+  }) => Promise<{
+    success: boolean;
+    error?: string;
+    resolvedPath?: string;
+    config?: {
+      enabled: boolean;
+      path: string;
+      model: string;
+      fastModel: string;
+      timeoutMs: number;
+    };
+  }>;
 
   // Demo
-  seedDemo: () => Promise<{ success: boolean }>
+  seedDemo: () => Promise<{ success: boolean }>;
 
   // Custom Providers
-  saveCustomProvider: (provider: any) => Promise<{ success: boolean; id?: string; error?: string }>
-  getCustomProviders: () => Promise<any[]>
-  deleteCustomProvider: (id: string) => Promise<{ success: boolean; error?: string }>
+  saveCustomProvider: (provider: any) => Promise<{ success: boolean; id?: string; error?: string }>;
+  getCustomProviders: () => Promise<any[]>;
+  deleteCustomProvider: (id: string) => Promise<{ success: boolean; error?: string }>;
 
   // Follow-up Email
-  generateFollowupEmail: (input: any) => Promise<string>
-  extractEmailsFromTranscript: (transcript: Array<{ text: string }>) => Promise<string[]>
-  getCalendarAttendees: (eventId: string) => Promise<Array<{ email: string; name: string }>>
-  openMailto: (params: { to: string; subject: string; body: string }) => Promise<{ success: boolean; error?: string }>
+  generateFollowupEmail: (input: any) => Promise<string>;
+  extractEmailsFromTranscript: (transcript: Array<{ text: string }>) => Promise<string[]>;
+  getCalendarAttendees: (eventId: string) => Promise<Array<{ email: string; name: string }>>;
+  openMailto: (params: {
+    to: string;
+    subject: string;
+    body: string;
+  }) => Promise<{ success: boolean; error?: string }>;
 
   // Audio Test
-  startAudioTest: (deviceId?: string) => Promise<{ success: boolean }>
-  stopAudioTest: () => Promise<{ success: boolean }>
-  onAudioTestLevel: (callback: (level: number) => void) => () => void
+  startAudioTest: (deviceId?: string) => Promise<{ success: boolean }>;
+  stopAudioTest: () => Promise<{ success: boolean }>;
+  onAudioTestLevel: (callback: (level: number) => void) => () => void;
 
   // Database
-  flushDatabase: () => Promise<{ success: boolean }>
-  showWindow: () => Promise<void>
-  hideWindow: () => Promise<void>
-  showOverlay: () => Promise<void>
-  hideOverlay: () => Promise<void>
-  getMeetingActive: () => Promise<boolean>
-  onMeetingStateChanged: (callback: (data: { isActive: boolean }) => void) => () => void
-  onWindowMaximizedChanged: (callback: (isMaximized: boolean) => void) => () => void
-  onEnsureExpanded: (callback: () => void) => () => void
-  onToggleExpand: (callback: () => void) => () => void
-  toggleAdvancedSettings: () => Promise<void>
-  openSettingsTab: (tab: string) => Promise<void>
-  onOpenSettingsTab: (callback: (tab: string) => void) => () => void
-  setOverlayMousePassthrough: (enabled: boolean) => Promise<{ success: boolean }>
-  toggleOverlayMousePassthrough: () => Promise<{ success: boolean; enabled: boolean }>
-  getOverlayMousePassthrough: () => Promise<boolean>
-  onOverlayMousePassthroughChanged: (callback: (enabled: boolean) => void) => () => void
+  flushDatabase: () => Promise<{ success: boolean }>;
+  showWindow: () => Promise<void>;
+  hideWindow: () => Promise<void>;
+  showOverlay: () => Promise<void>;
+  hideOverlay: () => Promise<void>;
+  getMeetingActive: () => Promise<boolean>;
+  onMeetingStateChanged: (callback: (data: { isActive: boolean }) => void) => () => void;
+  onWindowMaximizedChanged: (callback: (isMaximized: boolean) => void) => () => void;
+  onEnsureExpanded: (callback: () => void) => () => void;
+  onToggleExpand: (callback: () => void) => () => void;
+  toggleAdvancedSettings: () => Promise<void>;
+  openSettingsTab: (tab: string) => Promise<void>;
+  onOpenSettingsTab: (callback: (tab: string) => void) => () => void;
+  setOverlayMousePassthrough: (enabled: boolean) => Promise<{ success: boolean }>;
+  toggleOverlayMousePassthrough: () => Promise<{ success: boolean; enabled: boolean }>;
+  getOverlayMousePassthrough: () => Promise<boolean>;
+  onOverlayMousePassthroughChanged: (callback: (enabled: boolean) => void) => () => void;
 
   // Streaming listeners
-  streamGeminiChat: (message: string, imagePaths?: string[], context?: string, options?: { skipSystemPrompt?: boolean, ignoreKnowledgeMode?: boolean }) => Promise<void>
-  onGeminiStreamToken: (callback: (token: string) => void) => () => void
-  onGeminiStreamDone: (callback: () => void) => () => void
-  onGeminiStreamError: (callback: (error: string) => void) => () => void
+  streamGeminiChat: (
+    message: string,
+    imagePaths?: string[],
+    context?: string,
+    options?: { skipSystemPrompt?: boolean; ignoreKnowledgeMode?: boolean },
+  ) => Promise<void>;
+  onGeminiStreamToken: (callback: (token: string) => void) => () => void;
+  onGeminiStreamDone: (callback: () => void) => () => void;
+  onGeminiStreamError: (callback: (error: string) => void) => () => void;
 
-
-  onUndetectableChanged: (callback: (state: boolean) => void) => () => void
-  onGroqFastTextChanged: (callback: (enabled: boolean) => void) => () => void
-  onModelChanged: (callback: (modelId: string) => void) => () => void
+  onUndetectableChanged: (callback: (state: boolean) => void) => () => void;
+  onGroqFastTextChanged: (callback: (enabled: boolean) => void) => () => void;
+  onModelChanged: (callback: (modelId: string) => void) => () => void;
 
   // Ollama
-  onOllamaPullProgress: (callback: (data: { status: string; percent: number }) => void) => () => void
-  onOllamaPullComplete: (callback: () => void) => () => void
+  onOllamaPullProgress: (
+    callback: (data: { status: string; percent: number }) => void,
+  ) => () => void;
+  onOllamaPullComplete: (callback: () => void) => () => void;
 
   // Theme API
-  getThemeMode: () => Promise<{ mode: 'system' | 'light' | 'dark', resolved: 'light' | 'dark' }>
-  setThemeMode: (mode: 'system' | 'light' | 'dark') => Promise<void>
-  onThemeChanged: (callback: (data: { mode: 'system' | 'light' | 'dark', resolved: 'light' | 'dark' }) => void) => () => void
+  getThemeMode: () => Promise<{ mode: 'system' | 'light' | 'dark'; resolved: 'light' | 'dark' }>;
+  setThemeMode: (mode: 'system' | 'light' | 'dark') => Promise<void>;
+  onThemeChanged: (
+    callback: (data: { mode: 'system' | 'light' | 'dark'; resolved: 'light' | 'dark' }) => void,
+  ) => () => void;
 
   // Calendar
-  calendarConnect: () => Promise<{ success: boolean; error?: string }>
-  calendarDisconnect: () => Promise<{ success: boolean; error?: string }>
-  getCalendarStatus: () => Promise<{ connected: boolean; email?: string }>
-  getUpcomingEvents: () => Promise<Array<{ id: string; title: string; startTime: string; endTime: string; link?: string; source: 'google' }>>
-  calendarRefresh: () => Promise<{ success: boolean; error?: string }>
+  calendarConnect: () => Promise<{ success: boolean; error?: string }>;
+  calendarDisconnect: () => Promise<{ success: boolean; error?: string }>;
+  getCalendarStatus: () => Promise<{ connected: boolean; email?: string }>;
+  getUpcomingEvents: () => Promise<
+    Array<{
+      id: string;
+      title: string;
+      startTime: string;
+      endTime: string;
+      link?: string;
+      source: 'google';
+    }>
+  >;
+  calendarRefresh: () => Promise<{ success: boolean; error?: string }>;
 
   // Auto-Update
-  onUpdateAvailable: (callback: (info: any) => void) => () => void
-  onUpdateDownloaded: (callback: (info: any) => void) => () => void
-  onUpdateChecking: (callback: () => void) => () => void
-  onUpdateNotAvailable: (callback: (info: any) => void) => () => void
-  onUpdateError: (callback: (err: string) => void) => () => void
-  onDownloadProgress: (callback: (progressObj: any) => void) => () => void
-  restartAndInstall: () => Promise<void>
-  checkForUpdates: () => Promise<void>
-  downloadUpdate: () => Promise<void>
-  testReleaseFetch: () => Promise<{ success: boolean; error?: string }>
+  onUpdateAvailable: (callback: (info: any) => void) => () => void;
+  onUpdateDownloaded: (callback: (info: any) => void) => () => void;
+  onUpdateChecking: (callback: () => void) => () => void;
+  onUpdateNotAvailable: (callback: (info: any) => void) => () => void;
+  onUpdateError: (callback: (err: string) => void) => () => void;
+  onDownloadProgress: (callback: (progressObj: any) => void) => () => void;
+  restartAndInstall: () => Promise<void>;
+  checkForUpdates: () => Promise<void>;
+  downloadUpdate: () => Promise<void>;
+  testReleaseFetch: () => Promise<{ success: boolean; error?: string }>;
 
   // RAG (Retrieval-Augmented Generation) API
-  ragQueryMeeting: (meetingId: string, query: string) => Promise<{ success?: boolean; fallback?: boolean; error?: string }>
-  ragQueryLive: (query: string) => Promise<{ success?: boolean; fallback?: boolean; error?: string }>
-  ragQueryGlobal: (query: string) => Promise<{ success?: boolean; fallback?: boolean; error?: string }>
-  ragCancelQuery: (options: { meetingId?: string; global?: boolean }) => Promise<{ success: boolean }>
-  ragIsMeetingProcessed: (meetingId: string) => Promise<boolean>
-  ragGetQueueStatus: () => Promise<{ pending: number; processing: number; completed: number; failed: number }>
-  ragRetryEmbeddings: () => Promise<{ success: boolean }>
-  onRAGStreamChunk: (callback: (data: { meetingId?: string; global?: boolean; chunk: string }) => void) => () => void
-  onRAGStreamComplete: (callback: (data: { meetingId?: string; global?: boolean }) => void) => () => void
-  onRAGStreamError: (callback: (data: { meetingId?: string; global?: boolean; error: string }) => void) => () => void
+  ragQueryMeeting: (
+    meetingId: string,
+    query: string,
+  ) => Promise<{ success?: boolean; fallback?: boolean; error?: string }>;
+  ragQueryLive: (
+    query: string,
+  ) => Promise<{ success?: boolean; fallback?: boolean; error?: string }>;
+  ragQueryGlobal: (
+    query: string,
+  ) => Promise<{ success?: boolean; fallback?: boolean; error?: string }>;
+  ragCancelQuery: (options: {
+    meetingId?: string;
+    global?: boolean;
+  }) => Promise<{ success: boolean }>;
+  ragIsMeetingProcessed: (meetingId: string) => Promise<boolean>;
+  ragGetQueueStatus: () => Promise<{
+    pending: number;
+    processing: number;
+    completed: number;
+    failed: number;
+  }>;
+  ragRetryEmbeddings: () => Promise<{ success: boolean }>;
+  onRAGStreamChunk: (
+    callback: (data: { meetingId?: string; global?: boolean; chunk: string }) => void,
+  ) => () => void;
+  onRAGStreamComplete: (
+    callback: (data: { meetingId?: string; global?: boolean }) => void,
+  ) => () => void;
+  onRAGStreamError: (
+    callback: (data: { meetingId?: string; global?: boolean; error: string }) => void,
+  ) => () => void;
 
   // Keybind Management
-  getKeybinds: () => Promise<Array<{ id: string; label: string; accelerator: string; isGlobal: boolean; defaultAccelerator: string }>>
-  setKeybind: (id: string, accelerator: string) => Promise<boolean>
-  resetKeybinds: () => Promise<Array<{ id: string; label: string; accelerator: string; isGlobal: boolean; defaultAccelerator: string }>>
-  onKeybindsUpdate: (callback: (keybinds: Array<any>) => void) => () => void
+  getKeybinds: () => Promise<
+    Array<{
+      id: string;
+      label: string;
+      accelerator: string;
+      isGlobal: boolean;
+      defaultAccelerator: string;
+    }>
+  >;
+  setKeybind: (id: string, accelerator: string) => Promise<boolean>;
+  resetKeybinds: () => Promise<
+    Array<{
+      id: string;
+      label: string;
+      accelerator: string;
+      isGlobal: boolean;
+      defaultAccelerator: string;
+    }>
+  >;
+  onKeybindsUpdate: (callback: (keybinds: Array<any>) => void) => () => void;
 
   // Global shortcut events (stealth: fired even when window is not focused)
-  onGlobalShortcut: (callback: (data: { action: string }) => void) => () => void
+  onGlobalShortcut: (callback: (data: { action: string }) => void) => () => void;
 
   // CGEventTap-backed stealth keyboard tap (macOS only). Returns false on
   // non-macOS or when the native module / Accessibility permission is missing.
-  stealthTapAvailable: () => Promise<boolean>
-  stealthTapPermissionGranted: () => Promise<boolean>
-  stealthTapRequestPermission: () => Promise<boolean>
-  stealthTapOpenSettings: () => Promise<void>
-  stealthTapIsActive: () => Promise<boolean>
-  stealthTapStop: () => Promise<void>
-  stealthTapStart: () => Promise<boolean>
+  stealthTapAvailable: () => Promise<boolean>;
+  stealthTapPermissionGranted: () => Promise<boolean>;
+  stealthTapRequestPermission: () => Promise<boolean>;
+  stealthTapOpenSettings: () => Promise<void>;
+  stealthTapIsActive: () => Promise<boolean>;
+  stealthTapStop: () => Promise<void>;
+  stealthTapStart: () => Promise<boolean>;
   /** False on macOS when a composition IME (Pinyin/Hangul/Kanji/…) is
    *  enabled — the tap captures below the IME and breaks composition, so
    *  the renderer falls back to plain DOM focus on click. */
-  stealthTapShouldAutoEngage: () => Promise<boolean>
-  onStealthTapState: (cb: (state: { active: boolean; reason?: string }) => void) => () => void
-  onStealthKeyCaptured: (cb: (ev: { keyCode: number; chars: string; flags: number; isKeyDown: boolean }) => void) => () => void
+  stealthTapShouldAutoEngage: () => Promise<boolean>;
+  onStealthTapState: (cb: (state: { active: boolean; reason?: string }) => void) => () => void;
+  onStealthKeyCaptured: (
+    cb: (ev: { keyCode: number; chars: string; flags: number; isKeyDown: boolean }) => void,
+  ) => () => void;
 
   // Donation API
-  getDonationStatus: () => Promise<{ shouldShow: boolean; hasDonated: boolean; lifetimeShows: number }>;
+  getDonationStatus: () => Promise<{
+    shouldShow: boolean;
+    hasDonated: boolean;
+    lifetimeShows: number;
+  }>;
   markDonationToastShown: () => Promise<{ success: boolean }>;
   setDonationComplete: () => Promise<{ success: boolean }>;
 
   // Profile Engine API
   profileUploadResume: (filePath: string) => Promise<{ success: boolean; error?: string }>;
-  profileGetStatus: () => Promise<{ hasProfile: boolean; profileMode: boolean; name?: string; role?: string; totalExperienceYears?: number }>;
+  profileGetStatus: () => Promise<{
+    hasProfile: boolean;
+    profileMode: boolean;
+    name?: string;
+    role?: string;
+    totalExperienceYears?: number;
+  }>;
   profileSetMode: (enabled: boolean) => Promise<{ success: boolean; error?: string }>;
   profileDelete: () => Promise<{ success: boolean; error?: string }>;
   profileGetProfile: () => Promise<any>;
-  profileSelectFile: () => Promise<{ success?: boolean; cancelled?: boolean; filePath?: string; error?: string }>;
+  profileSelectFile: () => Promise<{
+    success?: boolean;
+    cancelled?: boolean;
+    filePath?: string;
+    error?: string;
+  }>;
 
   // JD & Research API
   profileUploadJD: (filePath: string) => Promise<{ success: boolean; error?: string }>;
   profileDeleteJD: () => Promise<{ success: boolean; error?: string }>;
-  profileResearchCompany: (companyName: string) => Promise<{ success: boolean; dossier?: any; error?: string }>;
-  profileGenerateNegotiation: (force?: boolean) => Promise<{ success: boolean; script?: any; error?: string }>;
-  profileGetNegotiationState: () => Promise<{ success: boolean; state?: any; isActive?: boolean; error?: string }>;
+  profileResearchCompany: (
+    companyName: string,
+  ) => Promise<{ success: boolean; dossier?: any; error?: string }>;
+  profileGenerateNegotiation: (
+    force?: boolean,
+  ) => Promise<{ success: boolean; script?: any; error?: string }>;
+  profileGetNegotiationState: () => Promise<{
+    success: boolean;
+    state?: any;
+    isActive?: boolean;
+    error?: string;
+  }>;
   profileResetNegotiation: () => Promise<{ success: boolean; error?: string }>;
 
   // Tavily Search API
@@ -333,21 +635,56 @@ interface ElectronAPI {
   getVerboseLogging: () => Promise<boolean>;
   setVerboseLogging: (enabled: boolean) => Promise<{ success: boolean }>;
   getMeetingRetention: () => Promise<'forever' | '7d' | '30d' | 'never'>;
-  setMeetingRetention: (retention: 'forever' | '7d' | '30d' | 'never') => Promise<{ success: boolean; error?: string }>;
-  onMeetingRetentionChanged: (callback: (retention: 'forever' | '7d' | '30d' | 'never') => void) => () => void;
-  getProviderDataScopes: () => Promise<{ transcript?: boolean; screenshots?: boolean; reference_files?: boolean; profile_history?: boolean; embeddings?: boolean; post_call_summary?: boolean }>;
-  setProviderDataScopes: (scopes: { transcript?: boolean; screenshots?: boolean; reference_files?: boolean; profile_history?: boolean; embeddings?: boolean; post_call_summary?: boolean }) => Promise<{ success: boolean; error?: string }>;
-  onProviderDataScopesChanged: (callback: (scopes: { transcript?: boolean; screenshots?: boolean; reference_files?: boolean; profile_history?: boolean; embeddings?: boolean; post_call_summary?: boolean }) => void) => () => void;
+  setMeetingRetention: (
+    retention: 'forever' | '7d' | '30d' | 'never',
+  ) => Promise<{ success: boolean; error?: string }>;
+  onMeetingRetentionChanged: (
+    callback: (retention: 'forever' | '7d' | '30d' | 'never') => void,
+  ) => () => void;
+  getProviderDataScopes: () => Promise<{
+    transcript?: boolean;
+    screenshots?: boolean;
+    reference_files?: boolean;
+    profile_history?: boolean;
+    embeddings?: boolean;
+    post_call_summary?: boolean;
+  }>;
+  setProviderDataScopes: (scopes: {
+    transcript?: boolean;
+    screenshots?: boolean;
+    reference_files?: boolean;
+    profile_history?: boolean;
+    embeddings?: boolean;
+    post_call_summary?: boolean;
+  }) => Promise<{ success: boolean; error?: string }>;
+  onProviderDataScopesChanged: (
+    callback: (scopes: {
+      transcript?: boolean;
+      screenshots?: boolean;
+      reference_files?: boolean;
+      profile_history?: boolean;
+      embeddings?: boolean;
+      post_call_summary?: boolean;
+    }) => void,
+  ) => () => void;
   getScreenUnderstandingMode: () => Promise<'vision_first' | 'vision_only' | 'private_vision'>;
-  setScreenUnderstandingMode: (mode: 'vision_first' | 'vision_only' | 'private_vision') => Promise<{ success: boolean; error?: string }>;
-  onScreenUnderstandingModeChanged: (callback: (mode: 'vision_first' | 'vision_only' | 'private_vision') => void) => () => void;
+  setScreenUnderstandingMode: (
+    mode: 'vision_first' | 'vision_only' | 'private_vision',
+  ) => Promise<{ success: boolean; error?: string }>;
+  onScreenUnderstandingModeChanged: (
+    callback: (mode: 'vision_first' | 'vision_only' | 'private_vision') => void,
+  ) => () => void;
   getTechnicalInterviewVisionFirst: () => Promise<boolean>;
-  setTechnicalInterviewVisionFirst: (enabled: boolean) => Promise<{ success: boolean; error?: string }>;
+  setTechnicalInterviewVisionFirst: (
+    enabled: boolean,
+  ) => Promise<{ success: boolean; error?: string }>;
   onTechnicalInterviewVisionFirstChanged: (callback: (enabled: boolean) => void) => () => void;
   /** @deprecated alias for technicalInterviewVisionFirst — retained so older renderer builds keep working. */
   getTechnicalInterviewDirectVision: () => Promise<boolean>;
   /** @deprecated alias for technicalInterviewVisionFirst — retained so older renderer builds keep working. */
-  setTechnicalInterviewDirectVision: (enabled: boolean) => Promise<{ success: boolean; error?: string }>;
+  setTechnicalInterviewDirectVision: (
+    enabled: boolean,
+  ) => Promise<{ success: boolean; error?: string }>;
   /** @deprecated alias for technicalInterviewVisionFirstChanged — retained so older renderer builds keep working. */
   onTechnicalInterviewDirectVisionChanged: (callback: (enabled: boolean) => void) => () => void;
   getLogFilePath: () => Promise<string | null>;
@@ -360,321 +697,388 @@ interface ElectronAPI {
   // Cropper API
   cropperConfirmed: (bounds: Electron.Rectangle) => void;
   cropperCancelled: () => void;
-  onResetCropper: (callback: (data: { hudPosition: { x: number; y: number } }) => void) => () => void;
+  onResetCropper: (
+    callback: (data: { hudPosition: { x: number; y: number } }) => void,
+  ) => () => void;
 
   // Platform
   platform: NodeJS.Platform;
 
   // Modes API
-  modesGetAll: () => Promise<Array<{ id: string; name: string; templateType: string; customContext: string; isActive: boolean; createdAt: string; referenceFileCount: number }>>;
-  modesGetActive: () => Promise<{ id: string; name: string; templateType: string; customContext: string; isActive: boolean; createdAt: string } | null>;
-  modesCreate: (params: { name: string; templateType: string }) => Promise<{ success: boolean; mode?: any; error?: string }>;
-  modesUpdate: (id: string, updates: { name?: string; templateType?: string; customContext?: string }) => Promise<{ success: boolean; error?: string }>;
+  modesGetAll: () => Promise<
+    Array<{
+      id: string;
+      name: string;
+      templateType: string;
+      customContext: string;
+      isActive: boolean;
+      createdAt: string;
+      referenceFileCount: number;
+    }>
+  >;
+  modesGetActive: () => Promise<{
+    id: string;
+    name: string;
+    templateType: string;
+    customContext: string;
+    isActive: boolean;
+    createdAt: string;
+  } | null>;
+  modesCreate: (params: {
+    name: string;
+    templateType: string;
+  }) => Promise<{ success: boolean; mode?: any; error?: string }>;
+  modesUpdate: (
+    id: string,
+    updates: { name?: string; templateType?: string; customContext?: string },
+  ) => Promise<{ success: boolean; error?: string }>;
   modesDelete: (id: string) => Promise<{ success: boolean; error?: string }>;
   modesSetActive: (id: string | null) => Promise<{ success: boolean; error?: string }>;
-  modesGetReferenceFiles: (modeId: string) => Promise<Array<{ id: string; modeId: string; fileName: string; content: string; createdAt: string }>>;
-  modesUploadReferenceFile: (modeId: string) => Promise<{ success: boolean; cancelled?: boolean; file?: any; error?: string }>;
+  modesGetReferenceFiles: (
+    modeId: string,
+  ) => Promise<
+    Array<{ id: string; modeId: string; fileName: string; content: string; createdAt: string }>
+  >;
+  modesUploadReferenceFile: (
+    modeId: string,
+  ) => Promise<{ success: boolean; cancelled?: boolean; file?: any; error?: string }>;
   modesDeleteReferenceFile: (id: string) => Promise<{ success: boolean; error?: string }>;
-  modesGetNoteSections: (modeId: string) => Promise<Array<{ id: string; modeId: string; title: string; description: string; sortOrder: number; createdAt: string }>>;
-  modesAddNoteSection: (modeId: string, title: string, description: string) => Promise<{ success: boolean; section?: any; error?: string }>;
-  modesUpdateNoteSection: (id: string, updates: { title?: string; description?: string }) => Promise<{ success: boolean; error?: string }>;
+  modesGetNoteSections: (modeId: string) => Promise<
+    Array<{
+      id: string;
+      modeId: string;
+      title: string;
+      description: string;
+      sortOrder: number;
+      createdAt: string;
+    }>
+  >;
+  modesAddNoteSection: (
+    modeId: string,
+    title: string,
+    description: string,
+  ) => Promise<{ success: boolean; section?: any; error?: string }>;
+  modesUpdateNoteSection: (
+    id: string,
+    updates: { title?: string; description?: string },
+  ) => Promise<{ success: boolean; error?: string }>;
   modesDeleteNoteSection: (id: string) => Promise<{ success: boolean; error?: string }>;
   modesRemoveAllNoteSections: (modeId: string) => Promise<{ success: boolean; error?: string }>;
 }
 
 export const PROCESSING_EVENTS = {
   //global states
-  UNAUTHORIZED: "procesing-unauthorized",
-  NO_SCREENSHOTS: "processing-no-screenshots",
+  UNAUTHORIZED: 'procesing-unauthorized',
+  NO_SCREENSHOTS: 'processing-no-screenshots',
 
   //states for generating the initial solution
-  INITIAL_START: "initial-start",
-  PROBLEM_EXTRACTED: "problem-extracted",
-  SOLUTION_SUCCESS: "solution-success",
-  INITIAL_SOLUTION_ERROR: "solution-error",
+  INITIAL_START: 'initial-start',
+  PROBLEM_EXTRACTED: 'problem-extracted',
+  SOLUTION_SUCCESS: 'solution-success',
+  INITIAL_SOLUTION_ERROR: 'solution-error',
 
   //states for processing the debugging
-  DEBUG_START: "debug-start",
-  DEBUG_SUCCESS: "debug-success",
-  DEBUG_ERROR: "debug-error"
-} as const
+  DEBUG_START: 'debug-start',
+  DEBUG_SUCCESS: 'debug-success',
+  DEBUG_ERROR: 'debug-error',
+} as const;
 
 // Expose the Electron API to the renderer process
-contextBridge.exposeInMainWorld("electronAPI", {
+contextBridge.exposeInMainWorld('electronAPI', {
   updateContentDimensions: (dimensions: { width: number; height: number }) =>
-    ipcRenderer.invoke("update-content-dimensions", dimensions),
+    ipcRenderer.invoke('update-content-dimensions', dimensions),
   updateContentDimensionsCentered: (dimensions: { width: number; height: number }) =>
-    ipcRenderer.invoke("update-content-dimensions-centered", dimensions),
-  getRecognitionLanguages: () => ipcRenderer.invoke("get-recognition-languages"),
-  takeScreenshot: () => ipcRenderer.invoke("take-screenshot"),
-  takeSelectiveScreenshot: () => ipcRenderer.invoke("take-selective-screenshot"),
-  getScreenshots: () => ipcRenderer.invoke("get-screenshots"),
-  deleteScreenshot: (path: string) =>
-    ipcRenderer.invoke("delete-screenshot", path),
+    ipcRenderer.invoke('update-content-dimensions-centered', dimensions),
+  getRecognitionLanguages: () => ipcRenderer.invoke('get-recognition-languages'),
+  takeScreenshot: () => ipcRenderer.invoke('take-screenshot'),
+  takeSelectiveScreenshot: () => ipcRenderer.invoke('take-selective-screenshot'),
+  getScreenshots: () => ipcRenderer.invoke('get-screenshots'),
+  deleteScreenshot: (path: string) => ipcRenderer.invoke('delete-screenshot', path),
 
   // Event listeners
-  onScreenshotTaken: (
-    callback: (data: { path: string; preview: string }) => void
-  ) => {
-    const subscription = (_: any, data: { path: string; preview: string }) =>
-      callback(data)
-    ipcRenderer.on("screenshot-taken", subscription)
+  onScreenshotTaken: (callback: (data: { path: string; preview: string }) => void) => {
+    const subscription = (_: any, data: { path: string; preview: string }) => callback(data);
+    ipcRenderer.on('screenshot-taken', subscription);
     return () => {
-      ipcRenderer.removeListener("screenshot-taken", subscription)
-    }
+      ipcRenderer.removeListener('screenshot-taken', subscription);
+    };
   },
-  onScreenshotAttached: (
-    callback: (data: { path: string; preview: string }) => void
-  ) => {
-    const subscription = (_: any, data: { path: string; preview: string }) =>
-      callback(data)
-    ipcRenderer.on("screenshot-attached", subscription)
+  onScreenshotAttached: (callback: (data: { path: string; preview: string }) => void) => {
+    const subscription = (_: any, data: { path: string; preview: string }) => callback(data);
+    ipcRenderer.on('screenshot-attached', subscription);
     return () => {
-      ipcRenderer.removeListener("screenshot-attached", subscription)
-    }
+      ipcRenderer.removeListener('screenshot-attached', subscription);
+    };
   },
-  onCaptureAndProcess: (
-    callback: (data: { path: string; preview: string }) => void
-  ) => {
-    const subscription = (_: any, data: { path: string; preview: string }) =>
-      callback(data)
-    ipcRenderer.on("capture-and-process", subscription)
+  onCaptureAndProcess: (callback: (data: { path: string; preview: string }) => void) => {
+    const subscription = (_: any, data: { path: string; preview: string }) => callback(data);
+    ipcRenderer.on('capture-and-process', subscription);
     return () => {
-      ipcRenderer.removeListener("capture-and-process", subscription)
-    }
+      ipcRenderer.removeListener('capture-and-process', subscription);
+    };
   },
   onSolutionsReady: (callback: (solutions: string) => void) => {
-    const subscription = (_: any, solutions: string) => callback(solutions)
-    ipcRenderer.on("solutions-ready", subscription)
+    const subscription = (_: any, solutions: string) => callback(solutions);
+    ipcRenderer.on('solutions-ready', subscription);
     return () => {
-      ipcRenderer.removeListener("solutions-ready", subscription)
-    }
+      ipcRenderer.removeListener('solutions-ready', subscription);
+    };
   },
   onResetView: (callback: () => void) => {
-    const subscription = () => callback()
-    ipcRenderer.on("reset-view", subscription)
+    const subscription = () => callback();
+    ipcRenderer.on('reset-view', subscription);
     return () => {
-      ipcRenderer.removeListener("reset-view", subscription)
-    }
+      ipcRenderer.removeListener('reset-view', subscription);
+    };
   },
   onSolutionStart: (callback: () => void) => {
-    const subscription = () => callback()
-    ipcRenderer.on(PROCESSING_EVENTS.INITIAL_START, subscription)
+    const subscription = () => callback();
+    ipcRenderer.on(PROCESSING_EVENTS.INITIAL_START, subscription);
     return () => {
-      ipcRenderer.removeListener(PROCESSING_EVENTS.INITIAL_START, subscription)
-    }
+      ipcRenderer.removeListener(PROCESSING_EVENTS.INITIAL_START, subscription);
+    };
   },
   onDebugStart: (callback: () => void) => {
-    const subscription = () => callback()
-    ipcRenderer.on(PROCESSING_EVENTS.DEBUG_START, subscription)
+    const subscription = () => callback();
+    ipcRenderer.on(PROCESSING_EVENTS.DEBUG_START, subscription);
     return () => {
-      ipcRenderer.removeListener(PROCESSING_EVENTS.DEBUG_START, subscription)
-    }
+      ipcRenderer.removeListener(PROCESSING_EVENTS.DEBUG_START, subscription);
+    };
   },
 
   onDebugSuccess: (callback: (data: any) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on("debug-success", subscription)
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('debug-success', subscription);
     return () => {
-      ipcRenderer.removeListener("debug-success", subscription)
-    }
+      ipcRenderer.removeListener('debug-success', subscription);
+    };
   },
   onDebugError: (callback: (error: string) => void) => {
-    const subscription = (_: any, error: string) => callback(error)
-    ipcRenderer.on(PROCESSING_EVENTS.DEBUG_ERROR, subscription)
+    const subscription = (_: any, error: string) => callback(error);
+    ipcRenderer.on(PROCESSING_EVENTS.DEBUG_ERROR, subscription);
     return () => {
-      ipcRenderer.removeListener(PROCESSING_EVENTS.DEBUG_ERROR, subscription)
-    }
+      ipcRenderer.removeListener(PROCESSING_EVENTS.DEBUG_ERROR, subscription);
+    };
   },
   onSolutionError: (callback: (error: string) => void) => {
-    const subscription = (_: any, error: string) => callback(error)
-    ipcRenderer.on(PROCESSING_EVENTS.INITIAL_SOLUTION_ERROR, subscription)
+    const subscription = (_: any, error: string) => callback(error);
+    ipcRenderer.on(PROCESSING_EVENTS.INITIAL_SOLUTION_ERROR, subscription);
     return () => {
-      ipcRenderer.removeListener(
-        PROCESSING_EVENTS.INITIAL_SOLUTION_ERROR,
-        subscription
-      )
-    }
+      ipcRenderer.removeListener(PROCESSING_EVENTS.INITIAL_SOLUTION_ERROR, subscription);
+    };
   },
   onProcessingNoScreenshots: (callback: () => void) => {
-    const subscription = () => callback()
-    ipcRenderer.on(PROCESSING_EVENTS.NO_SCREENSHOTS, subscription)
+    const subscription = () => callback();
+    ipcRenderer.on(PROCESSING_EVENTS.NO_SCREENSHOTS, subscription);
     return () => {
-      ipcRenderer.removeListener(PROCESSING_EVENTS.NO_SCREENSHOTS, subscription)
-    }
+      ipcRenderer.removeListener(PROCESSING_EVENTS.NO_SCREENSHOTS, subscription);
+    };
   },
 
   onProblemExtracted: (callback: (data: any) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on(PROCESSING_EVENTS.PROBLEM_EXTRACTED, subscription)
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on(PROCESSING_EVENTS.PROBLEM_EXTRACTED, subscription);
     return () => {
-      ipcRenderer.removeListener(
-        PROCESSING_EVENTS.PROBLEM_EXTRACTED,
-        subscription
-      )
-    }
+      ipcRenderer.removeListener(PROCESSING_EVENTS.PROBLEM_EXTRACTED, subscription);
+    };
   },
   onSolutionSuccess: (callback: (data: any) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on(PROCESSING_EVENTS.SOLUTION_SUCCESS, subscription)
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on(PROCESSING_EVENTS.SOLUTION_SUCCESS, subscription);
     return () => {
-      ipcRenderer.removeListener(
-        PROCESSING_EVENTS.SOLUTION_SUCCESS,
-        subscription
-      )
-    }
+      ipcRenderer.removeListener(PROCESSING_EVENTS.SOLUTION_SUCCESS, subscription);
+    };
   },
   onUnauthorized: (callback: () => void) => {
-    const subscription = () => callback()
-    ipcRenderer.on(PROCESSING_EVENTS.UNAUTHORIZED, subscription)
+    const subscription = () => callback();
+    ipcRenderer.on(PROCESSING_EVENTS.UNAUTHORIZED, subscription);
     return () => {
-      ipcRenderer.removeListener(PROCESSING_EVENTS.UNAUTHORIZED, subscription)
-    }
+      ipcRenderer.removeListener(PROCESSING_EVENTS.UNAUTHORIZED, subscription);
+    };
   },
-  moveWindowLeft: () => ipcRenderer.invoke("move-window-left"),
-  moveWindowRight: () => ipcRenderer.invoke("move-window-right"),
-  moveWindowUp: () => ipcRenderer.invoke("move-window-up"),
-  moveWindowDown: () => ipcRenderer.invoke("move-window-down"),
-  windowMinimize: () => ipcRenderer.invoke("window-minimize"),
-  windowMaximize: () => ipcRenderer.invoke("window-maximize"),
-  windowClose: () => ipcRenderer.invoke("window-close"),
-  windowIsMaximized: () => ipcRenderer.invoke("window-is-maximized"),
+  moveWindowLeft: () => ipcRenderer.invoke('move-window-left'),
+  moveWindowRight: () => ipcRenderer.invoke('move-window-right'),
+  moveWindowUp: () => ipcRenderer.invoke('move-window-up'),
+  moveWindowDown: () => ipcRenderer.invoke('move-window-down'),
+  windowMinimize: () => ipcRenderer.invoke('window-minimize'),
+  windowMaximize: () => ipcRenderer.invoke('window-maximize'),
+  windowClose: () => ipcRenderer.invoke('window-close'),
+  windowIsMaximized: () => ipcRenderer.invoke('window-is-maximized'),
 
-  analyzeImageFile: (path: string) => ipcRenderer.invoke("analyze-image-file", path),
-  quitApp: () => ipcRenderer.invoke("quit-app"),
-  toggleWindow: () => ipcRenderer.invoke("toggle-window"),
-  showWindow: (inactive?: boolean) => ipcRenderer.invoke("show-window", inactive),
-  hideWindow: () => ipcRenderer.invoke("hide-window"),
-  showOverlay: () => ipcRenderer.invoke("show-overlay"),
-  hideOverlay: () => ipcRenderer.invoke("hide-overlay"),
-  getMeetingActive: () => ipcRenderer.invoke("get-meeting-active"),
+  analyzeImageFile: (path: string) => ipcRenderer.invoke('analyze-image-file', path),
+  quitApp: () => ipcRenderer.invoke('quit-app'),
+  toggleWindow: () => ipcRenderer.invoke('toggle-window'),
+  showWindow: (inactive?: boolean) => ipcRenderer.invoke('show-window', inactive),
+  hideWindow: () => ipcRenderer.invoke('hide-window'),
+  showOverlay: () => ipcRenderer.invoke('show-overlay'),
+  hideOverlay: () => ipcRenderer.invoke('hide-overlay'),
+  getMeetingActive: () => ipcRenderer.invoke('get-meeting-active'),
   onMeetingStateChanged: (callback: (data: { isActive: boolean }) => void) => {
     const subscription = (_: any, data: { isActive: boolean }) => callback(data);
     ipcRenderer.on('meeting-state-changed', subscription);
-    return () => { ipcRenderer.removeListener('meeting-state-changed', subscription); };
+    return () => {
+      ipcRenderer.removeListener('meeting-state-changed', subscription);
+    };
   },
   onWindowMaximizedChanged: (callback: (isMaximized: boolean) => void) => {
     const subscription = (_: any, isMaximized: boolean) => callback(isMaximized);
     ipcRenderer.on('window-maximized-changed', subscription);
-    return () => { ipcRenderer.removeListener('window-maximized-changed', subscription); };
+    return () => {
+      ipcRenderer.removeListener('window-maximized-changed', subscription);
+    };
   },
   onEnsureExpanded: (callback: () => void) => {
     const subscription = () => callback();
     ipcRenderer.on('ensure-expanded', subscription);
-    return () => { ipcRenderer.removeListener('ensure-expanded', subscription); };
-  },
-  toggleAdvancedSettings: () => ipcRenderer.invoke("toggle-advanced-settings"),
-  openSettingsTab: (tab: string) => ipcRenderer.invoke("settings:open-tab", tab),
-  onOpenSettingsTab: (callback: (tab: string) => void) => {
-    const subscription = (_: any, tab: string) => callback(tab)
-    ipcRenderer.on('settings:open-tab', subscription)
-    return () => { ipcRenderer.removeListener('settings:open-tab', subscription) }
-  },
-  openExternal: (url: string) => ipcRenderer.invoke("open-external", url),
-  setUndetectable: (state: boolean) => ipcRenderer.invoke("set-undetectable", state),
-  getUndetectable: () => ipcRenderer.invoke("get-undetectable"),
-  setOverlayMousePassthrough: (enabled: boolean) => ipcRenderer.invoke("set-overlay-mouse-passthrough", enabled),
-  toggleOverlayMousePassthrough: () => ipcRenderer.invoke("toggle-overlay-mouse-passthrough"),
-  getOverlayMousePassthrough: () => ipcRenderer.invoke("get-overlay-mouse-passthrough"),
-  setOpenAtLogin: (open: boolean) => ipcRenderer.invoke("set-open-at-login", open),
-  getOpenAtLogin: () => ipcRenderer.invoke("get-open-at-login"),
-  setDisguise: (mode: 'terminal' | 'settings' | 'activity' | 'none') => ipcRenderer.invoke("set-disguise", mode),
-  getDisguise: () => ipcRenderer.invoke("get-disguise"),
-  onDisguiseChanged: (callback: (mode: 'terminal' | 'settings' | 'activity' | 'none') => void) => {
-    const subscription = (_: any, mode: any) => callback(mode)
-    ipcRenderer.on('disguise-changed', subscription)
     return () => {
-      ipcRenderer.removeListener('disguise-changed', subscription)
-    }
+      ipcRenderer.removeListener('ensure-expanded', subscription);
+    };
+  },
+  toggleAdvancedSettings: () => ipcRenderer.invoke('toggle-advanced-settings'),
+  openSettingsTab: (tab: string) => ipcRenderer.invoke('settings:open-tab', tab),
+  onOpenSettingsTab: (callback: (tab: string) => void) => {
+    const subscription = (_: any, tab: string) => callback(tab);
+    ipcRenderer.on('settings:open-tab', subscription);
+    return () => {
+      ipcRenderer.removeListener('settings:open-tab', subscription);
+    };
+  },
+  openExternal: (url: string) => ipcRenderer.invoke('open-external', url),
+  setUndetectable: (state: boolean) => ipcRenderer.invoke('set-undetectable', state),
+  getUndetectable: () => ipcRenderer.invoke('get-undetectable'),
+  setOverlayMousePassthrough: (enabled: boolean) =>
+    ipcRenderer.invoke('set-overlay-mouse-passthrough', enabled),
+  toggleOverlayMousePassthrough: () => ipcRenderer.invoke('toggle-overlay-mouse-passthrough'),
+  getOverlayMousePassthrough: () => ipcRenderer.invoke('get-overlay-mouse-passthrough'),
+  setOpenAtLogin: (open: boolean) => ipcRenderer.invoke('set-open-at-login', open),
+  getOpenAtLogin: () => ipcRenderer.invoke('get-open-at-login'),
+  setDisguise: (mode: 'terminal' | 'settings' | 'activity' | 'none') =>
+    ipcRenderer.invoke('set-disguise', mode),
+  getDisguise: () => ipcRenderer.invoke('get-disguise'),
+  onDisguiseChanged: (callback: (mode: 'terminal' | 'settings' | 'activity' | 'none') => void) => {
+    const subscription = (_: any, mode: any) => callback(mode);
+    ipcRenderer.on('disguise-changed', subscription);
+    return () => {
+      ipcRenderer.removeListener('disguise-changed', subscription);
+    };
   },
 
   // Phone Mirror — stream live AI responses to a paired phone over the LAN.
-  phoneMirrorGetInfo: () => ipcRenderer.invoke("phone-mirror:get-info"),
-  phoneMirrorEnable: (exposeOnLan: boolean) => ipcRenderer.invoke("phone-mirror:enable", exposeOnLan),
-  phoneMirrorDisable: () => ipcRenderer.invoke("phone-mirror:disable"),
-  phoneMirrorSetLan: (exposeOnLan: boolean) => ipcRenderer.invoke("phone-mirror:set-lan", exposeOnLan),
-  phoneMirrorRotateToken: () => ipcRenderer.invoke("phone-mirror:rotate-token"),
-  phoneMirrorPushScreenshot: (screenshotPath?: string) => ipcRenderer.invoke("phone-mirror:push-screenshot", screenshotPath),
+  phoneMirrorGetInfo: () => ipcRenderer.invoke('phone-mirror:get-info'),
+  phoneMirrorEnable: (exposeOnLan: boolean) =>
+    ipcRenderer.invoke('phone-mirror:enable', exposeOnLan),
+  phoneMirrorDisable: () => ipcRenderer.invoke('phone-mirror:disable'),
+  phoneMirrorSetLan: (exposeOnLan: boolean) =>
+    ipcRenderer.invoke('phone-mirror:set-lan', exposeOnLan),
+  phoneMirrorRotateToken: () => ipcRenderer.invoke('phone-mirror:rotate-token'),
+  phoneMirrorPushScreenshot: (screenshotPath?: string) =>
+    ipcRenderer.invoke('phone-mirror:push-screenshot', screenshotPath),
   onPhoneMirrorStatus: (callback: (info: any) => void) => {
-    const subscription = (_: any, info: any) => callback(info)
-    ipcRenderer.on('phone-mirror:status', subscription)
-    return () => { ipcRenderer.removeListener('phone-mirror:status', subscription) }
+    const subscription = (_: any, info: any) => callback(info);
+    ipcRenderer.on('phone-mirror:status', subscription);
+    return () => {
+      ipcRenderer.removeListener('phone-mirror:status', subscription);
+    };
   },
   onPhoneMirrorIncomingChat: (callback: (data: { message: string; streamId: string }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on('phone-mirror:incoming-chat', subscription)
-    return () => { ipcRenderer.removeListener('phone-mirror:incoming-chat', subscription) }
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('phone-mirror:incoming-chat', subscription);
+    return () => {
+      ipcRenderer.removeListener('phone-mirror:incoming-chat', subscription);
+    };
   },
 
   onSettingsVisibilityChange: (callback: (isVisible: boolean) => void) => {
-    const subscription = (_: any, isVisible: boolean) => callback(isVisible)
-    ipcRenderer.on("settings-visibility-changed", subscription)
+    const subscription = (_: any, isVisible: boolean) => callback(isVisible);
+    ipcRenderer.on('settings-visibility-changed', subscription);
     return () => {
-      ipcRenderer.removeListener("settings-visibility-changed", subscription)
-    }
+      ipcRenderer.removeListener('settings-visibility-changed', subscription);
+    };
   },
 
   onToggleExpand: (callback: () => void) => {
-    const subscription = () => callback()
-    ipcRenderer.on("toggle-expand", subscription)
+    const subscription = () => callback();
+    ipcRenderer.on('toggle-expand', subscription);
     return () => {
-      ipcRenderer.removeListener("toggle-expand", subscription)
-    }
+      ipcRenderer.removeListener('toggle-expand', subscription);
+    };
   },
 
   // LLM Model Management
-  getCurrentLlmConfig: () => ipcRenderer.invoke("get-current-llm-config"),
-  getAvailableOllamaModels: () => ipcRenderer.invoke("get-available-ollama-models"),
-  switchToOllama: (model?: string, url?: string) => ipcRenderer.invoke("switch-to-ollama", model, url),
-  switchToGemini: (apiKey?: string, modelId?: string) => ipcRenderer.invoke("switch-to-gemini", apiKey, modelId),
-  testLlmConnection: (provider: 'gemini' | 'groq' | 'openai' | 'claude', apiKey: string) => ipcRenderer.invoke("test-llm-connection", provider, apiKey),
-  selectServiceAccount: () => ipcRenderer.invoke("select-service-account"),
+  getCurrentLlmConfig: () => ipcRenderer.invoke('get-current-llm-config'),
+  getAvailableOllamaModels: () => ipcRenderer.invoke('get-available-ollama-models'),
+  switchToOllama: (model?: string, url?: string) =>
+    ipcRenderer.invoke('switch-to-ollama', model, url),
+  switchToGemini: (apiKey?: string, modelId?: string) =>
+    ipcRenderer.invoke('switch-to-gemini', apiKey, modelId),
+  testLlmConnection: (provider: 'gemini' | 'groq' | 'openai' | 'claude', apiKey: string) =>
+    ipcRenderer.invoke('test-llm-connection', provider, apiKey),
+  selectServiceAccount: () => ipcRenderer.invoke('select-service-account'),
 
   // API Key Management
-  setGeminiApiKey: (apiKey: string) => ipcRenderer.invoke("set-gemini-api-key", apiKey),
-  setGroqApiKey: (apiKey: string) => ipcRenderer.invoke("set-groq-api-key", apiKey),
-  setOpenaiApiKey: (apiKey: string) => ipcRenderer.invoke("set-openai-api-key", apiKey),
-  setClaudeApiKey: (apiKey: string) => ipcRenderer.invoke("set-claude-api-key", apiKey),
-  setNativelyApiKey: (apiKey: string) => ipcRenderer.invoke("set-natively-api-key", apiKey),
-  getNativelyUsage: () => ipcRenderer.invoke("get-natively-usage"),
-  getStoredCredentials: () => ipcRenderer.invoke("get-stored-credentials"),
+  setGeminiApiKey: (apiKey: string) => ipcRenderer.invoke('set-gemini-api-key', apiKey),
+  setGroqApiKey: (apiKey: string) => ipcRenderer.invoke('set-groq-api-key', apiKey),
+  setOpenaiApiKey: (apiKey: string) => ipcRenderer.invoke('set-openai-api-key', apiKey),
+  setClaudeApiKey: (apiKey: string) => ipcRenderer.invoke('set-claude-api-key', apiKey),
+  setNativelyApiKey: (apiKey: string) => ipcRenderer.invoke('set-natively-api-key', apiKey),
+  getNativelyUsage: () => ipcRenderer.invoke('get-natively-usage'),
+  getStoredCredentials: () => ipcRenderer.invoke('get-stored-credentials'),
 
   // Permissions
-  checkPermissions:    () => ipcRenderer.invoke("permissions:check"),
-  requestMicPermission: () => ipcRenderer.invoke("permissions:request-mic"),
+  checkPermissions: () => ipcRenderer.invoke('permissions:check'),
+  requestMicPermission: () => ipcRenderer.invoke('permissions:request-mic'),
 
   // Free Trial
-  startTrial:       () => ipcRenderer.invoke("trial:start"),
-  getTrialStatus:   () => ipcRenderer.invoke("trial:status"),
-  getLocalTrial:    () => ipcRenderer.invoke("trial:get-local"),
-  convertTrial:     (choice: string) => ipcRenderer.invoke("trial:convert", choice),
-  endTrialByok:        () => ipcRenderer.invoke("trial:end-byok"),
-  wipeTrialProfileData: () => ipcRenderer.invoke("trial:wipe-profile-data"),
-  onTrialEnded:     (cb: (data: { choice: string }) => void) => {
+  startTrial: () => ipcRenderer.invoke('trial:start'),
+  getTrialStatus: () => ipcRenderer.invoke('trial:status'),
+  getLocalTrial: () => ipcRenderer.invoke('trial:get-local'),
+  convertTrial: (choice: string) => ipcRenderer.invoke('trial:convert', choice),
+  endTrialByok: () => ipcRenderer.invoke('trial:end-byok'),
+  wipeTrialProfileData: () => ipcRenderer.invoke('trial:wipe-profile-data'),
+  onTrialEnded: (cb: (data: { choice: string }) => void) => {
     const sub = (_: any, data: any) => cb(data);
     ipcRenderer.on('trial-ended', sub);
     return () => ipcRenderer.removeListener('trial-ended', sub);
   },
 
   // STT Provider Management
-  setSttProvider: (provider: 'none' | 'google' | 'groq' | 'openai' | 'deepgram' | 'elevenlabs' | 'azure' | 'ibmwatson' | 'soniox' | 'natively' | 'local-whisper') => ipcRenderer.invoke("set-stt-provider", provider),
-  getSttProvider: () => ipcRenderer.invoke("get-stt-provider"),
-  setGroqSttApiKey: (apiKey: string) => ipcRenderer.invoke("set-groq-stt-api-key", apiKey),
-  setOpenAiSttApiKey: (apiKey: string) => ipcRenderer.invoke("set-openai-stt-api-key", apiKey),
-  setOpenAiSttBaseUrl: (url: string) => ipcRenderer.invoke("set-openai-stt-base-url", url),
-  setDeepgramApiKey: (apiKey: string) => ipcRenderer.invoke("set-deepgram-api-key", apiKey),
-  setElevenLabsApiKey: (apiKey: string) => ipcRenderer.invoke("set-elevenlabs-api-key", apiKey),
-  setAzureApiKey: (apiKey: string) => ipcRenderer.invoke("set-azure-api-key", apiKey),
-  setAzureRegion: (region: string) => ipcRenderer.invoke("set-azure-region", region),
-  setIbmWatsonApiKey: (apiKey: string) => ipcRenderer.invoke("set-ibmwatson-api-key", apiKey),
-  setGroqSttModel: (model: string) => ipcRenderer.invoke("set-groq-stt-model", model),
-  setSonioxApiKey: (apiKey: string) => ipcRenderer.invoke("set-soniox-api-key", apiKey),
-  setIbmWatsonRegion: (region: string) => ipcRenderer.invoke("set-ibmwatson-region", region),
-  testSttConnection: (provider: 'groq' | 'openai' | 'deepgram' | 'elevenlabs' | 'azure' | 'ibmwatson' | 'soniox', apiKey: string, region?: string) => ipcRenderer.invoke("test-stt-connection", provider, apiKey, region),
+  setSttProvider: (
+    provider:
+      | 'none'
+      | 'google'
+      | 'groq'
+      | 'openai'
+      | 'deepgram'
+      | 'elevenlabs'
+      | 'azure'
+      | 'ibmwatson'
+      | 'soniox'
+      | 'natively'
+      | 'local-whisper',
+  ) => ipcRenderer.invoke('set-stt-provider', provider),
+  getSttProvider: () => ipcRenderer.invoke('get-stt-provider'),
+  setGroqSttApiKey: (apiKey: string) => ipcRenderer.invoke('set-groq-stt-api-key', apiKey),
+  setOpenAiSttApiKey: (apiKey: string) => ipcRenderer.invoke('set-openai-stt-api-key', apiKey),
+  setOpenAiSttBaseUrl: (url: string) => ipcRenderer.invoke('set-openai-stt-base-url', url),
+  setDeepgramApiKey: (apiKey: string) => ipcRenderer.invoke('set-deepgram-api-key', apiKey),
+  setElevenLabsApiKey: (apiKey: string) => ipcRenderer.invoke('set-elevenlabs-api-key', apiKey),
+  setAzureApiKey: (apiKey: string) => ipcRenderer.invoke('set-azure-api-key', apiKey),
+  setAzureRegion: (region: string) => ipcRenderer.invoke('set-azure-region', region),
+  setIbmWatsonApiKey: (apiKey: string) => ipcRenderer.invoke('set-ibmwatson-api-key', apiKey),
+  setGroqSttModel: (model: string) => ipcRenderer.invoke('set-groq-stt-model', model),
+  setSonioxApiKey: (apiKey: string) => ipcRenderer.invoke('set-soniox-api-key', apiKey),
+  setIbmWatsonRegion: (region: string) => ipcRenderer.invoke('set-ibmwatson-region', region),
+  testSttConnection: (
+    provider: 'groq' | 'openai' | 'deepgram' | 'elevenlabs' | 'azure' | 'ibmwatson' | 'soniox',
+    apiKey: string,
+    region?: string,
+  ) => ipcRenderer.invoke('test-stt-connection', provider, apiKey, region),
   localWhisperGetModels: () => ipcRenderer.invoke('local-whisper-get-models'),
   localWhisperSetModel: (modelId: string) => ipcRenderer.invoke('local-whisper-set-model', modelId),
-  localWhisperDeleteModel: (modelId: string) => ipcRenderer.invoke('local-whisper-delete-model', modelId),
-  localWhisperStartDownload: (modelId: string) => ipcRenderer.invoke('local-whisper-start-download', modelId),
+  localWhisperDeleteModel: (modelId: string) =>
+    ipcRenderer.invoke('local-whisper-delete-model', modelId),
+  localWhisperStartDownload: (modelId: string) =>
+    ipcRenderer.invoke('local-whisper-start-download', modelId),
   onLocalWhisperDownloadProgress: (cb: (data: { modelId: string; progress: number }) => void) => {
     const listener = (_: any, data: any) => cb(data);
     ipcRenderer.on('local-whisper-download-progress', listener);
@@ -697,340 +1101,433 @@ contextBridge.exposeInMainWorld("electronAPI", {
   onSttConfigChanged: (callback: (data: { configured: boolean; provider: string }) => void) => {
     const subscription = (_: any, data: any) => callback(data);
     ipcRenderer.on('stt-config-changed', subscription);
-    return () => { ipcRenderer.removeListener('stt-config-changed', subscription); };
+    return () => {
+      ipcRenderer.removeListener('stt-config-changed', subscription);
+    };
   },
   onCredentialsChanged: (callback: () => void) => {
     const subscription = () => callback();
     ipcRenderer.on('credentials-changed', subscription);
-    return () => { ipcRenderer.removeListener('credentials-changed', subscription); };
+    return () => {
+      ipcRenderer.removeListener('credentials-changed', subscription);
+    };
   },
 
   // Native Audio Service Events
-  onNativeAudioTranscript: (callback: (transcript: { speaker: string; text: string; final: boolean }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on("native-audio-transcript", subscription)
+  onNativeAudioTranscript: (
+    callback: (transcript: { speaker: string; text: string; final: boolean }) => void,
+  ) => {
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('native-audio-transcript', subscription);
     return () => {
-      ipcRenderer.removeListener("native-audio-transcript", subscription)
-    }
+      ipcRenderer.removeListener('native-audio-transcript', subscription);
+    };
   },
-  onNativeAudioSuggestion: (callback: (suggestion: { context: string; lastQuestion: string; confidence: number }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on("native-audio-suggestion", subscription)
+  onNativeAudioSuggestion: (
+    callback: (suggestion: { context: string; lastQuestion: string; confidence: number }) => void,
+  ) => {
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('native-audio-suggestion', subscription);
     return () => {
-      ipcRenderer.removeListener("native-audio-suggestion", subscription)
-    }
+      ipcRenderer.removeListener('native-audio-suggestion', subscription);
+    };
   },
   onNativeAudioConnected: (callback: () => void) => {
-    const subscription = () => callback()
-    ipcRenderer.on("native-audio-connected", subscription)
+    const subscription = () => callback();
+    ipcRenderer.on('native-audio-connected', subscription);
     return () => {
-      ipcRenderer.removeListener("native-audio-connected", subscription)
-    }
+      ipcRenderer.removeListener('native-audio-connected', subscription);
+    };
   },
   onNativeAudioDisconnected: (callback: () => void) => {
-    const subscription = () => callback()
-    ipcRenderer.on("native-audio-disconnected", subscription)
+    const subscription = () => callback();
+    ipcRenderer.on('native-audio-disconnected', subscription);
     return () => {
-      ipcRenderer.removeListener("native-audio-disconnected", subscription)
-    }
+      ipcRenderer.removeListener('native-audio-disconnected', subscription);
+    };
   },
-  onSuggestionGenerated: (callback: (data: { question: string; suggestion: string; confidence: number }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on("suggestion-generated", subscription)
+  onSuggestionGenerated: (
+    callback: (data: { question: string; suggestion: string; confidence: number }) => void,
+  ) => {
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('suggestion-generated', subscription);
     return () => {
-      ipcRenderer.removeListener("suggestion-generated", subscription)
-    }
+      ipcRenderer.removeListener('suggestion-generated', subscription);
+    };
   },
   onSuggestionProcessingStart: (callback: () => void) => {
-    const subscription = () => callback()
-    ipcRenderer.on("suggestion-processing-start", subscription)
+    const subscription = () => callback();
+    ipcRenderer.on('suggestion-processing-start', subscription);
     return () => {
-      ipcRenderer.removeListener("suggestion-processing-start", subscription)
-    }
+      ipcRenderer.removeListener('suggestion-processing-start', subscription);
+    };
   },
   onSuggestionError: (callback: (error: { error: string }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on("suggestion-error", subscription)
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('suggestion-error', subscription);
     return () => {
-      ipcRenderer.removeListener("suggestion-error", subscription)
-    }
+      ipcRenderer.removeListener('suggestion-error', subscription);
+    };
   },
   generateSuggestion: (context: string, lastQuestion: string) =>
-    ipcRenderer.invoke("generate-suggestion", context, lastQuestion),
+    ipcRenderer.invoke('generate-suggestion', context, lastQuestion),
 
-  getNativeAudioStatus: () => ipcRenderer.invoke("native-audio-status"),
-  getInputDevices: () => ipcRenderer.invoke("get-input-devices"),
-  getOutputDevices: () => ipcRenderer.invoke("get-output-devices"),
-  setRecognitionLanguage: (key: string) => ipcRenderer.invoke("set-recognition-language", key),
-  getAiResponseLanguages: () => ipcRenderer.invoke("get-ai-response-languages"),
-  setAiResponseLanguage: (language: string) => ipcRenderer.invoke("set-ai-response-language", language),
-  getSttLanguage: () => ipcRenderer.invoke("get-stt-language"),
-  getAiResponseLanguage: () => ipcRenderer.invoke("get-ai-response-language"),
+  getNativeAudioStatus: () => ipcRenderer.invoke('native-audio-status'),
+  getInputDevices: () => ipcRenderer.invoke('get-input-devices'),
+  getOutputDevices: () => ipcRenderer.invoke('get-output-devices'),
+  setRecognitionLanguage: (key: string) => ipcRenderer.invoke('set-recognition-language', key),
+  getAiResponseLanguages: () => ipcRenderer.invoke('get-ai-response-languages'),
+  setAiResponseLanguage: (language: string) =>
+    ipcRenderer.invoke('set-ai-response-language', language),
+  getSttLanguage: () => ipcRenderer.invoke('get-stt-language'),
+  getAiResponseLanguage: () => ipcRenderer.invoke('get-ai-response-language'),
   onSttLanguageAutoDetected: (callback: (bcp47: string) => void) => {
     const subscription = (_: any, bcp47: string) => callback(bcp47);
     ipcRenderer.on('stt-language-auto-detected', subscription);
-    return () => { ipcRenderer.removeListener('stt-language-auto-detected', subscription); };
+    return () => {
+      ipcRenderer.removeListener('stt-language-auto-detected', subscription);
+    };
   },
   onSystemAudioPermissionDenied: (callback: (message: string) => void) => {
     const subscription = (_: any, message: string) => callback(message);
     ipcRenderer.on('system-audio-permission-denied', subscription);
-    return () => { ipcRenderer.removeListener('system-audio-permission-denied', subscription); };
+    return () => {
+      ipcRenderer.removeListener('system-audio-permission-denied', subscription);
+    };
   },
-  onDeviceSelectionApplied: (callback: (payload: { kind: 'input' | 'output'; requested: string | null; actual: string | null; fellBack: boolean; reason?: string }) => void) => {
+  onDeviceSelectionApplied: (
+    callback: (payload: {
+      kind: 'input' | 'output';
+      requested: string | null;
+      actual: string | null;
+      fellBack: boolean;
+      reason?: string;
+    }) => void,
+  ) => {
     const subscription = (_: any, payload: any) => callback(payload);
     ipcRenderer.on('device-selection-applied', subscription);
-    return () => { ipcRenderer.removeListener('device-selection-applied', subscription); };
+    return () => {
+      ipcRenderer.removeListener('device-selection-applied', subscription);
+    };
   },
-  onAudioCaptureFailed: (callback: (payload: { channel: 'system' | 'mic'; message: string; attempt: number; maxAttempts: number; terminal?: boolean; stuck?: boolean }) => void) => {
+  onAudioCaptureFailed: (
+    callback: (payload: {
+      channel: 'system' | 'mic';
+      message: string;
+      attempt: number;
+      maxAttempts: number;
+      terminal?: boolean;
+      stuck?: boolean;
+    }) => void,
+  ) => {
     const subscription = (_: any, payload: any) => callback(payload);
     ipcRenderer.on('audio-capture-failed', subscription);
-    return () => { ipcRenderer.removeListener('audio-capture-failed', subscription); };
+    return () => {
+      ipcRenderer.removeListener('audio-capture-failed', subscription);
+    };
   },
 
   // STT Status Events
-  onSttStatusChanged: (callback: (data: { state: 'connected' | 'reconnecting' | 'failed'; provider: string; error?: string; channel: 'user' | 'interviewer'; reconnectAttempts?: number }) => void) => {
+  onSttStatusChanged: (
+    callback: (data: {
+      state: 'connected' | 'reconnecting' | 'failed';
+      provider: string;
+      error?: string;
+      channel: 'user' | 'interviewer';
+      reconnectAttempts?: number;
+    }) => void,
+  ) => {
     const subscription = (_: any, data: any) => callback(data);
     ipcRenderer.on('stt-status', subscription);
-    return () => { ipcRenderer.removeListener('stt-status', subscription); };
+    return () => {
+      ipcRenderer.removeListener('stt-status', subscription);
+    };
   },
 
   // Intelligence Mode IPC
-  generateAssist: () => ipcRenderer.invoke("generate-assist"),
-  generateWhatToSay: (question?: string, imagePaths?: string[], options?: { promptInstruction?: string }) => ipcRenderer.invoke("generate-what-to-say", question, imagePaths, options),
-  generateClarify: () => ipcRenderer.invoke("generate-clarify"),
-  generateCodeHint: (imagePaths?: string[], problemStatement?: string) => ipcRenderer.invoke("generate-code-hint", imagePaths, problemStatement),
-  generateBrainstorm: (imagePaths?: string[], problemStatement?: string) => ipcRenderer.invoke("generate-brainstorm", imagePaths, problemStatement),
-  generateFollowUp: (intent: string, userRequest?: string) => ipcRenderer.invoke("generate-follow-up", intent, userRequest),
-  generateFollowUpQuestions: () => ipcRenderer.invoke("generate-follow-up-questions"),
-  generateRecap: () => ipcRenderer.invoke("generate-recap"),
-  submitManualQuestion: (question: string) => ipcRenderer.invoke("submit-manual-question", question),
-  getIntelligenceContext: () => ipcRenderer.invoke("get-intelligence-context"),
-  testInjectTranscript: (segment: { speaker: string; text: string; timestamp?: number; final?: boolean }) => ipcRenderer.invoke("test-inject-transcript", segment),
-  testGetModeContext: () => ipcRenderer.invoke("test-get-mode-context"),
-  resetIntelligence: () => ipcRenderer.invoke("reset-intelligence"),
+  generateAssist: () => ipcRenderer.invoke('generate-assist'),
+  generateWhatToSay: (
+    question?: string,
+    imagePaths?: string[],
+    options?: { promptInstruction?: string },
+  ) => ipcRenderer.invoke('generate-what-to-say', question, imagePaths, options),
+  generateClarify: () => ipcRenderer.invoke('generate-clarify'),
+  generateCodeHint: (imagePaths?: string[], problemStatement?: string) =>
+    ipcRenderer.invoke('generate-code-hint', imagePaths, problemStatement),
+  generateBrainstorm: (imagePaths?: string[], problemStatement?: string) =>
+    ipcRenderer.invoke('generate-brainstorm', imagePaths, problemStatement),
+  generateFollowUp: (intent: string, userRequest?: string) =>
+    ipcRenderer.invoke('generate-follow-up', intent, userRequest),
+  generateFollowUpQuestions: () => ipcRenderer.invoke('generate-follow-up-questions'),
+  generateRecap: () => ipcRenderer.invoke('generate-recap'),
+  submitManualQuestion: (question: string) =>
+    ipcRenderer.invoke('submit-manual-question', question),
+  getIntelligenceContext: () => ipcRenderer.invoke('get-intelligence-context'),
+  testInjectTranscript: (segment: {
+    speaker: string;
+    text: string;
+    timestamp?: number;
+    final?: boolean;
+  }) => ipcRenderer.invoke('test-inject-transcript', segment),
+  testGetModeContext: () => ipcRenderer.invoke('test-get-mode-context'),
+  resetIntelligence: () => ipcRenderer.invoke('reset-intelligence'),
 
   // Action Button Mode (Dynamic Recap / Brainstorm toggle)
-  getActionButtonMode: () => ipcRenderer.invoke("get-action-button-mode"),
-  setActionButtonMode: (mode: 'recap' | 'brainstorm') => ipcRenderer.invoke("set-action-button-mode", mode),
+  getActionButtonMode: () => ipcRenderer.invoke('get-action-button-mode'),
+  setActionButtonMode: (mode: 'recap' | 'brainstorm') =>
+    ipcRenderer.invoke('set-action-button-mode', mode),
   onActionButtonModeChanged: (callback: (mode: 'recap' | 'brainstorm') => void) => {
     const subscription = (_: any, mode: 'recap' | 'brainstorm') => callback(mode);
     ipcRenderer.on('action-button-mode-changed', subscription);
-    return () => { ipcRenderer.removeListener('action-button-mode-changed', subscription); };
+    return () => {
+      ipcRenderer.removeListener('action-button-mode-changed', subscription);
+    };
   },
 
   onModeChanged: (callback: (data: { id: string | null; name: string | null }) => void) => {
-    const subscription = (_: any, data: { id: string | null; name: string | null }) => callback(data);
+    const subscription = (_: any, data: { id: string | null; name: string | null }) =>
+      callback(data);
     ipcRenderer.on('mode-changed', subscription);
-    return () => { ipcRenderer.removeListener('mode-changed', subscription); };
+    return () => {
+      ipcRenderer.removeListener('mode-changed', subscription);
+    };
   },
 
   // Meeting Lifecycle
-  startMeeting: (metadata?: any) => ipcRenderer.invoke("start-meeting", metadata),
-  endMeeting: () => ipcRenderer.invoke("end-meeting"),
-  finalizeMicSTT: () => ipcRenderer.invoke("finalize-mic-stt"),
-  getRecentMeetings: () => ipcRenderer.invoke("get-recent-meetings"),
-  getMeetingDetails: (id: string) => ipcRenderer.invoke("get-meeting-details", id),
-  updateMeetingTitle: (id: string, title: string) => ipcRenderer.invoke("update-meeting-title", { id, title }),
-  updateMeetingSummary: (id: string, updates: any) => ipcRenderer.invoke("update-meeting-summary", { id, updates }),
-  deleteMeeting: (id: string) => ipcRenderer.invoke("delete-meeting", id),
+  startMeeting: (metadata?: any) => ipcRenderer.invoke('start-meeting', metadata),
+  endMeeting: () => ipcRenderer.invoke('end-meeting'),
+  finalizeMicSTT: () => ipcRenderer.invoke('finalize-mic-stt'),
+  getRecentMeetings: () => ipcRenderer.invoke('get-recent-meetings'),
+  getMeetingDetails: (id: string) => ipcRenderer.invoke('get-meeting-details', id),
+  updateMeetingTitle: (id: string, title: string) =>
+    ipcRenderer.invoke('update-meeting-title', { id, title }),
+  updateMeetingSummary: (id: string, updates: any) =>
+    ipcRenderer.invoke('update-meeting-summary', { id, updates }),
+  deleteMeeting: (id: string) => ipcRenderer.invoke('delete-meeting', id),
 
   onMeetingsUpdated: (callback: () => void) => {
-    const subscription = () => callback()
-    ipcRenderer.on("meetings-updated", subscription)
+    const subscription = () => callback();
+    ipcRenderer.on('meetings-updated', subscription);
     return () => {
-      ipcRenderer.removeListener("meetings-updated", subscription)
-    }
+      ipcRenderer.removeListener('meetings-updated', subscription);
+    };
   },
 
   // Window Mode
-  setWindowMode: (mode: 'launcher' | 'overlay', inactive?: boolean) => ipcRenderer.invoke("set-window-mode", mode, inactive),
+  setWindowMode: (mode: 'launcher' | 'overlay', inactive?: boolean) =>
+    ipcRenderer.invoke('set-window-mode', mode, inactive),
 
   // Intelligence Mode Events
   onIntelligenceAssistUpdate: (callback: (data: { insight: string }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on("intelligence-assist-update", subscription)
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('intelligence-assist-update', subscription);
     return () => {
-      ipcRenderer.removeListener("intelligence-assist-update", subscription)
-    }
+      ipcRenderer.removeListener('intelligence-assist-update', subscription);
+    };
   },
   // Phase 3 — Dynamic Action Cards
   onIntelligenceDynamicAction: (callback: (data: { action: any }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on("intelligence-dynamic-action", subscription)
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('intelligence-dynamic-action', subscription);
     return () => {
-      ipcRenderer.removeListener("intelligence-dynamic-action", subscription)
-    }
+      ipcRenderer.removeListener('intelligence-dynamic-action', subscription);
+    };
   },
-  acceptDynamicAction: (actionId: string) => ipcRenderer.invoke("dynamic-action:accept", actionId),
-  dismissDynamicAction: (actionId: string) => ipcRenderer.invoke("dynamic-action:dismiss", actionId),
-  listDynamicActions: () => ipcRenderer.invoke("dynamic-action:list"),
-  onIntelligenceSuggestedAnswerToken: (callback: (data: { token: string; question: string; confidence: number }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on("intelligence-suggested-answer-token", subscription)
+  acceptDynamicAction: (actionId: string) => ipcRenderer.invoke('dynamic-action:accept', actionId),
+  dismissDynamicAction: (actionId: string) =>
+    ipcRenderer.invoke('dynamic-action:dismiss', actionId),
+  listDynamicActions: () => ipcRenderer.invoke('dynamic-action:list'),
+  onIntelligenceSuggestedAnswerToken: (
+    callback: (data: { token: string; question: string; confidence: number }) => void,
+  ) => {
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('intelligence-suggested-answer-token', subscription);
     return () => {
-      ipcRenderer.removeListener("intelligence-suggested-answer-token", subscription)
-    }
+      ipcRenderer.removeListener('intelligence-suggested-answer-token', subscription);
+    };
   },
-  onIntelligenceSuggestedAnswer: (callback: (data: { answer: string; question: string; confidence: number }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on("intelligence-suggested-answer", subscription)
+  onIntelligenceSuggestedAnswer: (
+    callback: (data: { answer: string; question: string; confidence: number }) => void,
+  ) => {
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('intelligence-suggested-answer', subscription);
     return () => {
-      ipcRenderer.removeListener("intelligence-suggested-answer", subscription)
-    }
+      ipcRenderer.removeListener('intelligence-suggested-answer', subscription);
+    };
   },
   // Sprint 7: dedicated negotiation-coaching channel.
   onIntelligenceNegotiationCoaching: (callback: (data: { payload: any }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on("intelligence-negotiation-coaching", subscription)
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('intelligence-negotiation-coaching', subscription);
     return () => {
-      ipcRenderer.removeListener("intelligence-negotiation-coaching", subscription)
-    }
+      ipcRenderer.removeListener('intelligence-negotiation-coaching', subscription);
+    };
   },
   // Sprint 9: time-batched IPC token channel.
   onIntelligenceTokenBatch: (callback: (data: { kind: string; items: any[] }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on("intelligence-token-batch", subscription)
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('intelligence-token-batch', subscription);
     return () => {
-      ipcRenderer.removeListener("intelligence-token-batch", subscription)
-    }
+      ipcRenderer.removeListener('intelligence-token-batch', subscription);
+    };
   },
-  onIntelligenceRefinedAnswerToken: (callback: (data: { token: string; intent: string }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on("intelligence-refined-answer-token", subscription)
+  onIntelligenceRefinedAnswerToken: (
+    callback: (data: { token: string; intent: string }) => void,
+  ) => {
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('intelligence-refined-answer-token', subscription);
     return () => {
-      ipcRenderer.removeListener("intelligence-refined-answer-token", subscription)
-    }
+      ipcRenderer.removeListener('intelligence-refined-answer-token', subscription);
+    };
   },
   onIntelligenceRefinedAnswer: (callback: (data: { answer: string; intent: string }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on("intelligence-refined-answer", subscription)
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('intelligence-refined-answer', subscription);
     return () => {
-      ipcRenderer.removeListener("intelligence-refined-answer", subscription)
-    }
+      ipcRenderer.removeListener('intelligence-refined-answer', subscription);
+    };
   },
   onIntelligenceRecapToken: (callback: (data: { token: string }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on("intelligence-recap-token", subscription)
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('intelligence-recap-token', subscription);
     return () => {
-      ipcRenderer.removeListener("intelligence-recap-token", subscription)
-    }
+      ipcRenderer.removeListener('intelligence-recap-token', subscription);
+    };
   },
   onIntelligenceRecap: (callback: (data: { summary: string }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on("intelligence-recap", subscription)
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('intelligence-recap', subscription);
     return () => {
-      ipcRenderer.removeListener("intelligence-recap", subscription)
-    }
+      ipcRenderer.removeListener('intelligence-recap', subscription);
+    };
   },
   onIntelligenceClarifyToken: (callback: (data: { token: string }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on("intelligence-clarify-token", subscription)
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('intelligence-clarify-token', subscription);
     return () => {
-      ipcRenderer.removeListener("intelligence-clarify-token", subscription)
-    }
+      ipcRenderer.removeListener('intelligence-clarify-token', subscription);
+    };
   },
   onIntelligenceClarify: (callback: (data: { clarification: string }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on("intelligence-clarify", subscription)
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('intelligence-clarify', subscription);
     return () => {
-      ipcRenderer.removeListener("intelligence-clarify", subscription)
-    }
+      ipcRenderer.removeListener('intelligence-clarify', subscription);
+    };
   },
   onIntelligenceFollowUpQuestionsToken: (callback: (data: { token: string }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on("intelligence-follow-up-questions-token", subscription)
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('intelligence-follow-up-questions-token', subscription);
     return () => {
-      ipcRenderer.removeListener("intelligence-follow-up-questions-token", subscription)
-    }
+      ipcRenderer.removeListener('intelligence-follow-up-questions-token', subscription);
+    };
   },
   onIntelligenceFollowUpQuestionsUpdate: (callback: (data: { questions: string }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on("intelligence-follow-up-questions-update", subscription)
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('intelligence-follow-up-questions-update', subscription);
     return () => {
-      ipcRenderer.removeListener("intelligence-follow-up-questions-update", subscription)
-    }
+      ipcRenderer.removeListener('intelligence-follow-up-questions-update', subscription);
+    };
   },
   onIntelligenceManualStarted: (callback: () => void) => {
-    const subscription = () => callback()
-    ipcRenderer.on("intelligence-manual-started", subscription)
+    const subscription = () => callback();
+    ipcRenderer.on('intelligence-manual-started', subscription);
     return () => {
-      ipcRenderer.removeListener("intelligence-manual-started", subscription)
-    }
+      ipcRenderer.removeListener('intelligence-manual-started', subscription);
+    };
   },
   onIntelligenceManualResult: (callback: (data: { answer: string; question: string }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on("intelligence-manual-result", subscription)
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('intelligence-manual-result', subscription);
     return () => {
-      ipcRenderer.removeListener("intelligence-manual-result", subscription)
-    }
+      ipcRenderer.removeListener('intelligence-manual-result', subscription);
+    };
   },
   onIntelligenceModeChanged: (callback: (data: { mode: string }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on("intelligence-mode-changed", subscription)
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('intelligence-mode-changed', subscription);
     return () => {
-      ipcRenderer.removeListener("intelligence-mode-changed", subscription)
-    }
+      ipcRenderer.removeListener('intelligence-mode-changed', subscription);
+    };
   },
   onIntelligenceError: (callback: (data: { error: string; mode: string }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on("intelligence-error", subscription)
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('intelligence-error', subscription);
     return () => {
-      ipcRenderer.removeListener("intelligence-error", subscription)
-    }
+      ipcRenderer.removeListener('intelligence-error', subscription);
+    };
   },
   onSessionReset: (callback: () => void) => {
-    const subscription = () => callback()
-    ipcRenderer.on("session-reset", subscription)
+    const subscription = () => callback();
+    ipcRenderer.on('session-reset', subscription);
     return () => {
-      ipcRenderer.removeListener("session-reset", subscription)
-    }
+      ipcRenderer.removeListener('session-reset', subscription);
+    };
   },
 
-
   // Streaming Chat
-  streamGeminiChat: (message: string, imagePaths?: string[], context?: string, options?: { skipSystemPrompt?: boolean, ignoreKnowledgeMode?: boolean }) => ipcRenderer.invoke("gemini-chat-stream", message, imagePaths, context, options),
+  streamGeminiChat: (
+    message: string,
+    imagePaths?: string[],
+    context?: string,
+    options?: { skipSystemPrompt?: boolean; ignoreKnowledgeMode?: boolean },
+  ) => ipcRenderer.invoke('gemini-chat-stream', message, imagePaths, context, options),
 
   onGeminiStreamToken: (callback: (token: string) => void) => {
-    const subscription = (_: any, token: string) => callback(token)
-    ipcRenderer.on("gemini-stream-token", subscription)
+    const subscription = (_: any, token: string) => callback(token);
+    ipcRenderer.on('gemini-stream-token', subscription);
     return () => {
-      ipcRenderer.removeListener("gemini-stream-token", subscription)
-    }
+      ipcRenderer.removeListener('gemini-stream-token', subscription);
+    };
   },
 
   onGeminiStreamDone: (callback: () => void) => {
-    const subscription = () => callback()
-    ipcRenderer.on("gemini-stream-done", subscription)
+    const subscription = () => callback();
+    ipcRenderer.on('gemini-stream-done', subscription);
     return () => {
-      ipcRenderer.removeListener("gemini-stream-done", subscription)
-    }
+      ipcRenderer.removeListener('gemini-stream-done', subscription);
+    };
   },
 
   onGeminiStreamError: (callback: (error: string) => void) => {
-    const subscription = (_: any, error: string) => callback(error)
-    ipcRenderer.on("gemini-stream-error", subscription)
+    const subscription = (_: any, error: string) => callback(error);
+    ipcRenderer.on('gemini-stream-error', subscription);
     return () => {
-      ipcRenderer.removeListener("gemini-stream-error", subscription)
-    }
+      ipcRenderer.removeListener('gemini-stream-error', subscription);
+    };
   },
 
   // Model Management
   getDefaultModel: () => ipcRenderer.invoke('get-default-model'),
   setModel: (modelId: string) => ipcRenderer.invoke('set-model', modelId),
   setDefaultModel: (modelId: string) => ipcRenderer.invoke('set-default-model', modelId),
-  toggleModelSelector: (coords: { x: number; y: number }) => ipcRenderer.invoke('toggle-model-selector', coords),
+  toggleModelSelector: (coords: { x: number; y: number }) =>
+    ipcRenderer.invoke('toggle-model-selector', coords),
   modelSelectorCloseIfOpen: () => ipcRenderer.invoke('model-selector:close-if-open'),
   forceRestartOllama: () => ipcRenderer.invoke('force-restart-ollama'),
 
   // Settings Window
-  toggleSettingsWindow: (coords?: { x: number; y: number }) => ipcRenderer.invoke('toggle-settings-window', coords),
+  toggleSettingsWindow: (coords?: { x: number; y: number }) =>
+    ipcRenderer.invoke('toggle-settings-window', coords),
 
   // Groq Fast Text Mode
   getGroqFastTextMode: () => ipcRenderer.invoke('get-groq-fast-text-mode'),
   setGroqFastTextMode: (enabled: boolean) => ipcRenderer.invoke('set-groq-fast-text-mode', enabled),
   getCodexCliConfig: () => ipcRenderer.invoke('get-codex-cli-config'),
-  setCodexCliConfig: (config: { enabled: boolean; path: string; model: string; fastModel: string; timeoutMs: number }) => ipcRenderer.invoke('set-codex-cli-config', config),
-  testCodexCli: (config?: { enabled?: boolean; path?: string; model?: string; fastModel?: string; timeoutMs?: number }) => ipcRenderer.invoke('test-codex-cli', config),
+  setCodexCliConfig: (config: {
+    enabled: boolean;
+    path: string;
+    model: string;
+    fastModel: string;
+    timeoutMs: number;
+  }) => ipcRenderer.invoke('set-codex-cli-config', config),
+  testCodexCli: (config?: {
+    enabled?: boolean;
+    path?: string;
+    model?: string;
+    fastModel?: string;
+    timeoutMs?: number;
+  }) => ipcRenderer.invoke('test-codex-cli', config),
 
   // Demo
   seedDemo: () => ipcRenderer.invoke('seed-demo'),
@@ -1042,83 +1539,85 @@ contextBridge.exposeInMainWorld("electronAPI", {
 
   // Follow-up Email
   generateFollowupEmail: (input: any) => ipcRenderer.invoke('generate-followup-email', input),
-  extractEmailsFromTranscript: (transcript: Array<{ text: string }>) => ipcRenderer.invoke('extract-emails-from-transcript', transcript),
+  extractEmailsFromTranscript: (transcript: Array<{ text: string }>) =>
+    ipcRenderer.invoke('extract-emails-from-transcript', transcript),
   getCalendarAttendees: (eventId: string) => ipcRenderer.invoke('get-calendar-attendees', eventId),
-  openMailto: (params: { to: string; subject: string; body: string }) => ipcRenderer.invoke('open-mailto', params),
+  openMailto: (params: { to: string; subject: string; body: string }) =>
+    ipcRenderer.invoke('open-mailto', params),
 
   // Audio Test
   startAudioTest: (deviceId?: string) => ipcRenderer.invoke('start-audio-test', deviceId),
   stopAudioTest: () => ipcRenderer.invoke('stop-audio-test'),
   onAudioTestLevel: (callback: (level: number) => void) => {
-    const subscription = (_: any, level: number) => callback(level)
-    ipcRenderer.on('audio-test-level', subscription)
+    const subscription = (_: any, level: number) => callback(level);
+    ipcRenderer.on('audio-test-level', subscription);
     return () => {
-      ipcRenderer.removeListener('audio-test-level', subscription)
-    }
+      ipcRenderer.removeListener('audio-test-level', subscription);
+    };
   },
 
   // Database
   flushDatabase: () => ipcRenderer.invoke('flush-database'),
 
-
-
   onUndetectableChanged: (callback: (state: boolean) => void) => {
-    const subscription = (_: any, state: boolean) => callback(state)
-    ipcRenderer.on('undetectable-changed', subscription)
+    const subscription = (_: any, state: boolean) => callback(state);
+    ipcRenderer.on('undetectable-changed', subscription);
     return () => {
-      ipcRenderer.removeListener('undetectable-changed', subscription)
-    }
+      ipcRenderer.removeListener('undetectable-changed', subscription);
+    };
   },
 
   onOverlayMousePassthroughChanged: (callback: (enabled: boolean) => void) => {
-    const subscription = (_: any, enabled: boolean) => callback(enabled)
-    ipcRenderer.on('overlay-mouse-passthrough-changed', subscription)
+    const subscription = (_: any, enabled: boolean) => callback(enabled);
+    ipcRenderer.on('overlay-mouse-passthrough-changed', subscription);
     return () => {
-      ipcRenderer.removeListener('overlay-mouse-passthrough-changed', subscription)
-    }
+      ipcRenderer.removeListener('overlay-mouse-passthrough-changed', subscription);
+    };
   },
 
   onGroqFastTextChanged: (callback: (enabled: boolean) => void) => {
-    const subscription = (_: any, enabled: boolean) => callback(enabled)
-    ipcRenderer.on('groq-fast-text-changed', subscription)
+    const subscription = (_: any, enabled: boolean) => callback(enabled);
+    ipcRenderer.on('groq-fast-text-changed', subscription);
     return () => {
-      ipcRenderer.removeListener('groq-fast-text-changed', subscription)
-    }
+      ipcRenderer.removeListener('groq-fast-text-changed', subscription);
+    };
   },
 
   onModelChanged: (callback: (modelId: string) => void) => {
-    const subscription = (_: any, modelId: string) => callback(modelId)
-    ipcRenderer.on('model-changed', subscription)
+    const subscription = (_: any, modelId: string) => callback(modelId);
+    ipcRenderer.on('model-changed', subscription);
     return () => {
-      ipcRenderer.removeListener('model-changed', subscription)
-    }
+      ipcRenderer.removeListener('model-changed', subscription);
+    };
   },
 
   onOllamaPullProgress: (callback: (data: { status: string; percent: number }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on('ollama:pull-progress', subscription)
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('ollama:pull-progress', subscription);
     return () => {
-      ipcRenderer.removeListener('ollama:pull-progress', subscription)
-    }
+      ipcRenderer.removeListener('ollama:pull-progress', subscription);
+    };
   },
 
   onOllamaPullComplete: (callback: () => void) => {
-    const subscription = () => callback()
-    ipcRenderer.on('ollama:pull-complete', subscription)
+    const subscription = () => callback();
+    ipcRenderer.on('ollama:pull-complete', subscription);
     return () => {
-      ipcRenderer.removeListener('ollama:pull-complete', subscription)
-    }
+      ipcRenderer.removeListener('ollama:pull-complete', subscription);
+    };
   },
 
   // Theme API
   getThemeMode: () => ipcRenderer.invoke('theme:get-mode'),
   setThemeMode: (mode: 'system' | 'light' | 'dark') => ipcRenderer.invoke('theme:set-mode', mode),
-  onThemeChanged: (callback: (data: { mode: 'system' | 'light' | 'dark', resolved: 'light' | 'dark' }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on('theme:changed', subscription)
+  onThemeChanged: (
+    callback: (data: { mode: 'system' | 'light' | 'dark'; resolved: 'light' | 'dark' }) => void,
+  ) => {
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('theme:changed', subscription);
     return () => {
-      ipcRenderer.removeListener('theme:changed', subscription)
-    }
+      ipcRenderer.removeListener('theme:changed', subscription);
+    };
   },
 
   // Calendar API
@@ -1130,118 +1629,128 @@ contextBridge.exposeInMainWorld("electronAPI", {
 
   // Auto-Update
   onUpdateAvailable: (callback: (info: any) => void) => {
-    const subscription = (_: any, info: any) => callback(info)
-    ipcRenderer.on("update-available", subscription)
+    const subscription = (_: any, info: any) => callback(info);
+    ipcRenderer.on('update-available', subscription);
     return () => {
-      ipcRenderer.removeListener("update-available", subscription)
-    }
+      ipcRenderer.removeListener('update-available', subscription);
+    };
   },
   onUpdateDownloaded: (callback: (info: any) => void) => {
-    const subscription = (_: any, info: any) => callback(info)
-    ipcRenderer.on("update-downloaded", subscription)
+    const subscription = (_: any, info: any) => callback(info);
+    ipcRenderer.on('update-downloaded', subscription);
     return () => {
-      ipcRenderer.removeListener("update-downloaded", subscription)
-    }
+      ipcRenderer.removeListener('update-downloaded', subscription);
+    };
   },
   onUpdateChecking: (callback: () => void) => {
-    const subscription = () => callback()
-    ipcRenderer.on("update-checking", subscription)
+    const subscription = () => callback();
+    ipcRenderer.on('update-checking', subscription);
     return () => {
-      ipcRenderer.removeListener("update-checking", subscription)
-    }
+      ipcRenderer.removeListener('update-checking', subscription);
+    };
   },
   onUpdateNotAvailable: (callback: (info: any) => void) => {
-    const subscription = (_: any, info: any) => callback(info)
-    ipcRenderer.on("update-not-available", subscription)
+    const subscription = (_: any, info: any) => callback(info);
+    ipcRenderer.on('update-not-available', subscription);
     return () => {
-      ipcRenderer.removeListener("update-not-available", subscription)
-    }
+      ipcRenderer.removeListener('update-not-available', subscription);
+    };
   },
   onUpdateError: (callback: (err: string) => void) => {
-    const subscription = (_: any, err: string) => callback(err)
-    ipcRenderer.on("update-error", subscription)
+    const subscription = (_: any, err: string) => callback(err);
+    ipcRenderer.on('update-error', subscription);
     return () => {
-      ipcRenderer.removeListener("update-error", subscription)
-    }
+      ipcRenderer.removeListener('update-error', subscription);
+    };
   },
   onDownloadProgress: (callback: (progressObj: any) => void) => {
-    const subscription = (_: any, progressObj: any) => callback(progressObj)
-    ipcRenderer.on("download-progress", subscription)
+    const subscription = (_: any, progressObj: any) => callback(progressObj);
+    ipcRenderer.on('download-progress', subscription);
     return () => {
-      ipcRenderer.removeListener("download-progress", subscription)
-    }
+      ipcRenderer.removeListener('download-progress', subscription);
+    };
   },
-  restartAndInstall: () => ipcRenderer.invoke("quit-and-install-update"),
-  checkForUpdates: () => ipcRenderer.invoke("check-for-updates"),
-  downloadUpdate: () => ipcRenderer.invoke("download-update"),
-  testReleaseFetch: () => ipcRenderer.invoke("test-release-fetch"),
+  restartAndInstall: () => ipcRenderer.invoke('quit-and-install-update'),
+  checkForUpdates: () => ipcRenderer.invoke('check-for-updates'),
+  downloadUpdate: () => ipcRenderer.invoke('download-update'),
+  testReleaseFetch: () => ipcRenderer.invoke('test-release-fetch'),
 
   // RAG API
-  ragQueryMeeting: (meetingId: string, query: string) => ipcRenderer.invoke('rag:query-meeting', { meetingId, query }),
+  ragQueryMeeting: (meetingId: string, query: string) =>
+    ipcRenderer.invoke('rag:query-meeting', { meetingId, query }),
   ragQueryLive: (query: string) => ipcRenderer.invoke('rag:query-live', { query }),
   ragQueryGlobal: (query: string) => ipcRenderer.invoke('rag:query-global', { query }),
-  ragCancelQuery: (options: { meetingId?: string; global?: boolean }) => ipcRenderer.invoke('rag:cancel-query', options),
-  ragIsMeetingProcessed: (meetingId: string) => ipcRenderer.invoke('rag:is-meeting-processed', meetingId),
+  ragCancelQuery: (options: { meetingId?: string; global?: boolean }) =>
+    ipcRenderer.invoke('rag:cancel-query', options),
+  ragIsMeetingProcessed: (meetingId: string) =>
+    ipcRenderer.invoke('rag:is-meeting-processed', meetingId),
   ragGetQueueStatus: () => ipcRenderer.invoke('rag:get-queue-status'),
   ragRetryEmbeddings: () => ipcRenderer.invoke('rag:retry-embeddings'),
 
-  onIncompatibleProviderWarning: (callback: (data: { count: number, oldProvider: string, newProvider: string }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on('embedding:incompatible-provider-warning', subscription)
+  onIncompatibleProviderWarning: (
+    callback: (data: { count: number; oldProvider: string; newProvider: string }) => void,
+  ) => {
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('embedding:incompatible-provider-warning', subscription);
     return () => {
-      ipcRenderer.removeListener('embedding:incompatible-provider-warning', subscription)
-    }
+      ipcRenderer.removeListener('embedding:incompatible-provider-warning', subscription);
+    };
   },
   reindexIncompatibleMeetings: () => ipcRenderer.invoke('rag:reindex-incompatible-meetings'),
 
-  onRAGStreamChunk: (callback: (data: { meetingId?: string; global?: boolean; chunk: string }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on('rag:stream-chunk', subscription)
+  onRAGStreamChunk: (
+    callback: (data: { meetingId?: string; global?: boolean; chunk: string }) => void,
+  ) => {
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('rag:stream-chunk', subscription);
     return () => {
-      ipcRenderer.removeListener('rag:stream-chunk', subscription)
-    }
+      ipcRenderer.removeListener('rag:stream-chunk', subscription);
+    };
   },
   onRAGStreamComplete: (callback: (data: { meetingId?: string; global?: boolean }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on('rag:stream-complete', subscription)
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('rag:stream-complete', subscription);
     return () => {
-      ipcRenderer.removeListener('rag:stream-complete', subscription)
-    }
+      ipcRenderer.removeListener('rag:stream-complete', subscription);
+    };
   },
-  onRAGStreamError: (callback: (data: { meetingId?: string; global?: boolean; error: string }) => void) => {
-    const subscription = (_: any, data: any) => callback(data)
-    ipcRenderer.on('rag:stream-error', subscription)
+  onRAGStreamError: (
+    callback: (data: { meetingId?: string; global?: boolean; error: string }) => void,
+  ) => {
+    const subscription = (_: any, data: any) => callback(data);
+    ipcRenderer.on('rag:stream-error', subscription);
     return () => {
-      ipcRenderer.removeListener('rag:stream-error', subscription)
-    }
+      ipcRenderer.removeListener('rag:stream-error', subscription);
+    };
   },
 
   // Keybind Management
   getKeybinds: () => ipcRenderer.invoke('keybinds:get-all'),
-  setKeybind: (id: string, accelerator: string) => ipcRenderer.invoke('keybinds:set', id, accelerator),
+  setKeybind: (id: string, accelerator: string) =>
+    ipcRenderer.invoke('keybinds:set', id, accelerator),
   resetKeybinds: () => ipcRenderer.invoke('keybinds:reset'),
   onKeybindsUpdate: (callback: (keybinds: Array<any>) => void) => {
-    const subscription = (_: any, keybinds: any) => callback(keybinds)
-    ipcRenderer.on('keybinds:update', subscription)
+    const subscription = (_: any, keybinds: any) => callback(keybinds);
+    ipcRenderer.on('keybinds:update', subscription);
     return () => {
-      ipcRenderer.removeListener('keybinds:update', subscription)
-    }
+      ipcRenderer.removeListener('keybinds:update', subscription);
+    };
   },
   onKeybindRegistrationFailed: (callback: (data: { id: string; accelerator: string }) => void) => {
-    const subscription = (_: any, data: { id: string; accelerator: string }) => callback(data)
-    ipcRenderer.on('keybinds:registration-failed', subscription)
+    const subscription = (_: any, data: { id: string; accelerator: string }) => callback(data);
+    ipcRenderer.on('keybinds:registration-failed', subscription);
     return () => {
-      ipcRenderer.removeListener('keybinds:registration-failed', subscription)
-    }
+      ipcRenderer.removeListener('keybinds:registration-failed', subscription);
+    };
   },
 
   // Global shortcut listener — fired stealthily from main process without focusing the window
   onGlobalShortcut: (callback: (data: { action: string }) => void) => {
-    const subscription = (_: any, data: { action: string }) => callback(data)
-    ipcRenderer.on('global-shortcut', subscription)
+    const subscription = (_: any, data: { action: string }) => callback(data);
+    ipcRenderer.on('global-shortcut', subscription);
     return () => {
-      ipcRenderer.removeListener('global-shortcut', subscription)
-    }
+      ipcRenderer.removeListener('global-shortcut', subscription);
+    };
   },
 
   // Stealth keyboard tap bridge
@@ -1254,19 +1763,28 @@ contextBridge.exposeInMainWorld("electronAPI", {
   stealthTapStart: () => ipcRenderer.invoke('stealth-tap:start'),
   stealthTapShouldAutoEngage: () => ipcRenderer.invoke('stealth-tap:should-auto-engage'),
   onStealthTapState: (cb: (state: { active: boolean; reason?: string }) => void) => {
-    const sub = (_: any, state: { active: boolean; reason?: string }) => cb(state)
-    ipcRenderer.on('stealth-tap-state', sub)
-    return () => { ipcRenderer.removeListener('stealth-tap-state', sub) }
+    const sub = (_: any, state: { active: boolean; reason?: string }) => cb(state);
+    ipcRenderer.on('stealth-tap-state', sub);
+    return () => {
+      ipcRenderer.removeListener('stealth-tap-state', sub);
+    };
   },
-  onStealthKeyCaptured: (cb: (ev: { keyCode: number; chars: string; flags: number; isKeyDown: boolean }) => void) => {
-    const sub = (_: any, ev: { keyCode: number; chars: string; flags: number; isKeyDown: boolean }) => cb(ev)
-    ipcRenderer.on('stealth-key-captured', sub)
-    return () => { ipcRenderer.removeListener('stealth-key-captured', sub) }
+  onStealthKeyCaptured: (
+    cb: (ev: { keyCode: number; chars: string; flags: number; isKeyDown: boolean }) => void,
+  ) => {
+    const sub = (
+      _: any,
+      ev: { keyCode: number; chars: string; flags: number; isKeyDown: boolean },
+    ) => cb(ev);
+    ipcRenderer.on('stealth-key-captured', sub);
+    return () => {
+      ipcRenderer.removeListener('stealth-key-captured', sub);
+    };
   },
 
   // Donation API
-  getDonationStatus: () => ipcRenderer.invoke("get-donation-status"),
-  markDonationToastShown: () => ipcRenderer.invoke("mark-donation-toast-shown"),
+  getDonationStatus: () => ipcRenderer.invoke('get-donation-status'),
+  markDonationToastShown: () => ipcRenderer.invoke('mark-donation-toast-shown'),
   setDonationComplete: () => ipcRenderer.invoke('set-donation-complete'),
 
   // Profile Engine API
@@ -1280,8 +1798,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
   // JD & Research API
   profileUploadJD: (filePath: string) => ipcRenderer.invoke('profile:upload-jd', filePath),
   profileDeleteJD: () => ipcRenderer.invoke('profile:delete-jd'),
-  profileResearchCompany: (companyName: string) => ipcRenderer.invoke('profile:research-company', companyName),
-  profileGenerateNegotiation: (force?: boolean) => ipcRenderer.invoke('profile:generate-negotiation', force),
+  profileResearchCompany: (companyName: string) =>
+    ipcRenderer.invoke('profile:research-company', companyName),
+  profileGenerateNegotiation: (force?: boolean) =>
+    ipcRenderer.invoke('profile:generate-negotiation', force),
   profileGetNegotiationState: () => ipcRenderer.invoke('profile:get-negotiation-state'),
   profileResetNegotiation: () => ipcRenderer.invoke('profile:reset-negotiation'),
   profileGetNotes: () => ipcRenderer.invoke('profile:get-notes'),
@@ -1293,8 +1813,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
   setTavilyApiKey: (apiKey: string) => ipcRenderer.invoke('set-tavily-api-key', apiKey),
 
   // Dynamic Model Discovery
-  fetchProviderModels: (provider: 'gemini' | 'groq' | 'openai' | 'claude', apiKey: string) => ipcRenderer.invoke('fetch-provider-models', provider, apiKey),
-  setProviderPreferredModel: (provider: 'gemini' | 'groq' | 'openai' | 'claude', modelId: string) => ipcRenderer.invoke('set-provider-preferred-model', provider, modelId),
+  fetchProviderModels: (provider: 'gemini' | 'groq' | 'openai' | 'claude', apiKey: string) =>
+    ipcRenderer.invoke('fetch-provider-models', provider, apiKey),
+  setProviderPreferredModel: (provider: 'gemini' | 'groq' | 'openai' | 'claude', modelId: string) =>
+    ipcRenderer.invoke('set-provider-preferred-model', provider, modelId),
 
   // License Management
   licenseActivate: (key: string) => ipcRenderer.invoke('license:activate', key),
@@ -1303,8 +1825,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
   licenseCheckPremiumAsync: () => ipcRenderer.invoke('license:check-premium-async'),
   licenseDeactivate: () => ipcRenderer.invoke('license:deactivate'),
   licenseGetHardwareId: () => ipcRenderer.invoke('license:get-hardware-id'),
-  onLicenseStatusChanged: (callback: (data: { isPremium: boolean, plan?: string }) => void) => {
-    const subscription = (_: any, data: { isPremium: boolean, plan?: string }) => callback(data);
+  onLicenseStatusChanged: (callback: (data: { isPremium: boolean; plan?: string }) => void) => {
+    const subscription = (_: any, data: { isPremium: boolean; plan?: string }) => callback(data);
     ipcRenderer.on('license-status-changed', subscription);
     return () => {
       ipcRenderer.removeListener('license-status-changed', subscription);
@@ -1322,54 +1844,73 @@ contextBridge.exposeInMainWorld("electronAPI", {
   // Overlay Opacity (Stealth Mode)
   setOverlayOpacity: (opacity: number) => ipcRenderer.invoke('set-overlay-opacity', opacity),
   onOverlayOpacityChanged: (callback: (opacity: number) => void) => {
-    const subscription = (_: any, opacity: number) => callback(opacity)
-    ipcRenderer.on('overlay-opacity-changed', subscription)
+    const subscription = (_: any, opacity: number) => callback(opacity);
+    ipcRenderer.on('overlay-opacity-changed', subscription);
     return () => {
-      ipcRenderer.removeListener('overlay-opacity-changed', subscription)
-    }
+      ipcRenderer.removeListener('overlay-opacity-changed', subscription);
+    };
   },
 
   // Verbose / Debug Logging
   getVerboseLogging: () => ipcRenderer.invoke('get-verbose-logging'),
   setVerboseLogging: (enabled: boolean) => ipcRenderer.invoke('set-verbose-logging', enabled),
   getMeetingRetention: () => ipcRenderer.invoke('get-meeting-retention'),
-  setMeetingRetention: (retention: 'forever' | '7d' | '30d' | 'never') => ipcRenderer.invoke('set-meeting-retention', retention),
-  onMeetingRetentionChanged: (callback: (retention: 'forever' | '7d' | '30d' | 'never') => void) => {
-    const subscription = (_: any, retention: 'forever' | '7d' | '30d' | 'never') => callback(retention);
+  setMeetingRetention: (retention: 'forever' | '7d' | '30d' | 'never') =>
+    ipcRenderer.invoke('set-meeting-retention', retention),
+  onMeetingRetentionChanged: (
+    callback: (retention: 'forever' | '7d' | '30d' | 'never') => void,
+  ) => {
+    const subscription = (_: any, retention: 'forever' | '7d' | '30d' | 'never') =>
+      callback(retention);
     ipcRenderer.on('meeting-retention-changed', subscription);
-    return () => { ipcRenderer.removeListener('meeting-retention-changed', subscription); };
+    return () => {
+      ipcRenderer.removeListener('meeting-retention-changed', subscription);
+    };
   },
   getProviderDataScopes: () => ipcRenderer.invoke('get-provider-data-scopes'),
   setProviderDataScopes: (scopes: any) => ipcRenderer.invoke('set-provider-data-scopes', scopes),
   onProviderDataScopesChanged: (callback: (scopes: any) => void) => {
     const subscription = (_: any, scopes: any) => callback(scopes);
     ipcRenderer.on('provider-data-scopes-changed', subscription);
-    return () => { ipcRenderer.removeListener('provider-data-scopes-changed', subscription); };
+    return () => {
+      ipcRenderer.removeListener('provider-data-scopes-changed', subscription);
+    };
   },
   getScreenUnderstandingMode: () => ipcRenderer.invoke('get-screen-understanding-mode'),
   setScreenUnderstandingMode: (mode: 'vision_first' | 'vision_only' | 'private_vision') =>
     ipcRenderer.invoke('set-screen-understanding-mode', mode),
-  onScreenUnderstandingModeChanged: (callback: (mode: 'vision_first' | 'vision_only' | 'private_vision') => void) => {
-    const subscription = (_: any, mode: 'vision_first' | 'vision_only' | 'private_vision') => callback(mode);
+  onScreenUnderstandingModeChanged: (
+    callback: (mode: 'vision_first' | 'vision_only' | 'private_vision') => void,
+  ) => {
+    const subscription = (_: any, mode: 'vision_first' | 'vision_only' | 'private_vision') =>
+      callback(mode);
     ipcRenderer.on('screen-understanding-mode-changed', subscription);
-    return () => { ipcRenderer.removeListener('screen-understanding-mode-changed', subscription); };
+    return () => {
+      ipcRenderer.removeListener('screen-understanding-mode-changed', subscription);
+    };
   },
-  getTechnicalInterviewVisionFirst: () => ipcRenderer.invoke('get-technical-interview-vision-first'),
+  getTechnicalInterviewVisionFirst: () =>
+    ipcRenderer.invoke('get-technical-interview-vision-first'),
   setTechnicalInterviewVisionFirst: (enabled: boolean) =>
     ipcRenderer.invoke('set-technical-interview-vision-first', enabled),
   onTechnicalInterviewVisionFirstChanged: (callback: (enabled: boolean) => void) => {
     const subscription = (_: any, enabled: boolean) => callback(enabled);
     ipcRenderer.on('technical-interview-vision-first-changed', subscription);
-    return () => { ipcRenderer.removeListener('technical-interview-vision-first-changed', subscription); };
+    return () => {
+      ipcRenderer.removeListener('technical-interview-vision-first-changed', subscription);
+    };
   },
   // Deprecated aliases — kept so renderer builds compiled against the old API keep working.
-  getTechnicalInterviewDirectVision: () => ipcRenderer.invoke('get-technical-interview-direct-vision'),
+  getTechnicalInterviewDirectVision: () =>
+    ipcRenderer.invoke('get-technical-interview-direct-vision'),
   setTechnicalInterviewDirectVision: (enabled: boolean) =>
     ipcRenderer.invoke('set-technical-interview-direct-vision', enabled),
   onTechnicalInterviewDirectVisionChanged: (callback: (enabled: boolean) => void) => {
     const subscription = (_: any, enabled: boolean) => callback(enabled);
     ipcRenderer.on('technical-interview-vision-first-changed', subscription);
-    return () => { ipcRenderer.removeListener('technical-interview-vision-first-changed', subscription); };
+    return () => {
+      ipcRenderer.removeListener('technical-interview-vision-first-changed', subscription);
+    };
   },
   getLogFilePath: () => ipcRenderer.invoke('get-log-file-path'),
   openLogFile: () => ipcRenderer.invoke('open-log-file'),
@@ -1382,11 +1923,14 @@ contextBridge.exposeInMainWorld("electronAPI", {
   cropperConfirmed: (bounds: Electron.Rectangle) => ipcRenderer.send('cropper-confirmed', bounds),
   cropperCancelled: () => ipcRenderer.send('cropper-cancelled'),
   onResetCropper: (callback: (data: { hudPosition: { x: number; y: number } }) => void) => {
-    const subscription = (_: Electron.IpcRendererEvent, data: { hudPosition: { x: number; y: number } }) => callback(data)
-    ipcRenderer.on('reset-cropper', subscription)
+    const subscription = (
+      _: Electron.IpcRendererEvent,
+      data: { hudPosition: { x: number; y: number } },
+    ) => callback(data);
+    ipcRenderer.on('reset-cropper', subscription);
     return () => {
-      ipcRenderer.removeListener('reset-cropper', subscription)
-    }
+      ipcRenderer.removeListener('reset-cropper', subscription);
+    };
   },
 
   // Platform
@@ -1395,24 +1939,33 @@ contextBridge.exposeInMainWorld("electronAPI", {
   // Modes API
   modesGetAll: () => ipcRenderer.invoke('modes:get-all'),
   modesGetActive: () => ipcRenderer.invoke('modes:get-active'),
-  modesCreate: (params: { name: string; templateType: string }) => ipcRenderer.invoke('modes:create', params),
-  modesUpdate: (id: string, updates: { name?: string; templateType?: string; customContext?: string }) => ipcRenderer.invoke('modes:update', id, updates),
+  modesCreate: (params: { name: string; templateType: string }) =>
+    ipcRenderer.invoke('modes:create', params),
+  modesUpdate: (
+    id: string,
+    updates: { name?: string; templateType?: string; customContext?: string },
+  ) => ipcRenderer.invoke('modes:update', id, updates),
   modesDelete: (id: string) => ipcRenderer.invoke('modes:delete', id),
   modesSetActive: (id: string | null) => ipcRenderer.invoke('modes:set-active', id),
-  modesGetReferenceFiles: (modeId: string) => ipcRenderer.invoke('modes:get-reference-files', modeId),
-  modesUploadReferenceFile: (modeId: string) => ipcRenderer.invoke('modes:upload-reference-file', modeId),
+  modesGetReferenceFiles: (modeId: string) =>
+    ipcRenderer.invoke('modes:get-reference-files', modeId),
+  modesUploadReferenceFile: (modeId: string) =>
+    ipcRenderer.invoke('modes:upload-reference-file', modeId),
   modesDeleteReferenceFile: (id: string) => ipcRenderer.invoke('modes:delete-reference-file', id),
   modesGetNoteSections: (modeId: string) => ipcRenderer.invoke('modes:get-note-sections', modeId),
-  modesAddNoteSection: (modeId: string, title: string, description: string) => ipcRenderer.invoke('modes:add-note-section', modeId, title, description),
-  modesUpdateNoteSection: (id: string, updates: { title?: string; description?: string }) => ipcRenderer.invoke('modes:update-note-section', id, updates),
+  modesAddNoteSection: (modeId: string, title: string, description: string) =>
+    ipcRenderer.invoke('modes:add-note-section', modeId, title, description),
+  modesUpdateNoteSection: (id: string, updates: { title?: string; description?: string }) =>
+    ipcRenderer.invoke('modes:update-note-section', id, updates),
   modesDeleteNoteSection: (id: string) => ipcRenderer.invoke('modes:delete-note-section', id),
-  modesRemoveAllNoteSections: (modeId: string) => ipcRenderer.invoke('modes:remove-all-note-sections', modeId),
-} as ElectronAPI)
+  modesRemoveAllNoteSections: (modeId: string) =>
+    ipcRenderer.invoke('modes:remove-all-note-sections', modeId),
+} as ElectronAPI);
 
 // Renderer-side console forwarding to main-process log file.
 // When verbose logging is on, patch console.log/warn/error so that renderer
 // output appears in ~/Documents/natively_debug.log alongside main-process logs.
-;(function patchRendererConsole() {
+(function patchRendererConsole() {
   let _verbose = false;
 
   const _origLog = console.log.bind(console);
@@ -1420,11 +1973,19 @@ contextBridge.exposeInMainWorld("electronAPI", {
   const _origError = console.error.bind(console);
 
   function serialize(...args: any[]): string {
-    return args.map(a => {
-      if (a instanceof Error) return a.stack || a.message;
-      if (typeof a === 'object') { try { return JSON.stringify(a); } catch { return String(a); } }
-      return String(a);
-    }).join(' ');
+    return args
+      .map((a) => {
+        if (a instanceof Error) return a.stack || a.message;
+        if (typeof a === 'object') {
+          try {
+            return JSON.stringify(a);
+          } catch {
+            return String(a);
+          }
+        }
+        return String(a);
+      })
+      .join(' ');
   }
 
   console.log = (...args: any[]) => {
@@ -1441,10 +2002,15 @@ contextBridge.exposeInMainWorld("electronAPI", {
   };
 
   // Sync verbose flag from main process at startup
-  ipcRenderer.invoke('get-verbose-logging').then((v: boolean) => { _verbose = v; }).catch(() => {});
+  ipcRenderer
+    .invoke('get-verbose-logging')
+    .then((v: boolean) => {
+      _verbose = v;
+    })
+    .catch(() => {});
 
   // Keep flag in sync when the user toggles verbose in settings
   ipcRenderer.on('verbose-logging-changed', (_event: any, enabled: boolean) => {
     _verbose = enabled;
   });
-})()
+})();

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -594,10 +594,16 @@ contextBridge.exposeInMainWorld("electronAPI", {
   phoneMirrorDisable: () => ipcRenderer.invoke("phone-mirror:disable"),
   phoneMirrorSetLan: (exposeOnLan: boolean) => ipcRenderer.invoke("phone-mirror:set-lan", exposeOnLan),
   phoneMirrorRotateToken: () => ipcRenderer.invoke("phone-mirror:rotate-token"),
+  phoneMirrorPushScreenshot: (screenshotPath?: string) => ipcRenderer.invoke("phone-mirror:push-screenshot", screenshotPath),
   onPhoneMirrorStatus: (callback: (info: any) => void) => {
     const subscription = (_: any, info: any) => callback(info)
     ipcRenderer.on('phone-mirror:status', subscription)
     return () => { ipcRenderer.removeListener('phone-mirror:status', subscription) }
+  },
+  onPhoneMirrorIncomingChat: (callback: (data: { message: string; streamId: string }) => void) => {
+    const subscription = (_: any, data: any) => callback(data)
+    ipcRenderer.on('phone-mirror:incoming-chat', subscription)
+    return () => { ipcRenderer.removeListener('phone-mirror:incoming-chat', subscription) }
   },
 
   onSettingsVisibilityChange: (callback: (isVisible: boolean) => void) => {

--- a/electron/services/OllamaManager.ts
+++ b/electron/services/OllamaManager.ts
@@ -1,142 +1,148 @@
 // electron/services/OllamaManager.ts
-import { spawn, ChildProcess } from 'child_process';
+import { ChildProcess, spawn } from 'child_process';
 import treeKill from 'tree-kill';
 
 export class OllamaManager {
-    private static instance: OllamaManager;
-    private ollamaProcess: ChildProcess | null = null;
-    private isAppManaged: boolean = false;
-    private pollInterval: NodeJS.Timeout | null = null;
-    private maxRetries = 24; // 24 attempts * 5 seconds = 120 seconds (2 minutes)
-    private attempts = 0;
+  private static instance: OllamaManager;
+  private ollamaProcess: ChildProcess | null = null;
+  private isAppManaged: boolean = false;
+  private pollInterval: NodeJS.Timeout | null = null;
+  private maxRetries = 24; // 24 attempts * 5 seconds = 120 seconds (2 minutes)
+  private attempts = 0;
 
-    private constructor() {}
+  private constructor() {}
 
-    public static getInstance(): OllamaManager {
-        if (!OllamaManager.instance) {
-            OllamaManager.instance = new OllamaManager();
-        }
-        return OllamaManager.instance;
+  public static getInstance(): OllamaManager {
+    if (!OllamaManager.instance) {
+      OllamaManager.instance = new OllamaManager();
+    }
+    return OllamaManager.instance;
+  }
+
+  /**
+   * Initialize the manager. Checks if Ollama is running, starts it if not.
+   */
+  public async init(): Promise<void> {
+    console.log('[OllamaManager] Checking if Ollama is already running...');
+    const isRunning = await this.checkIsRunning();
+
+    if (isRunning) {
+      console.log('[OllamaManager] Ollama is already running. App will not manage its lifecycle.');
+      this.isAppManaged = false;
+      return;
     }
 
-    /**
-     * Initialize the manager. Checks if Ollama is running, starts it if not.
-     */
-    public async init(): Promise<void> {
-        console.log('[OllamaManager] Checking if Ollama is already running...');
-        const isRunning = await this.checkIsRunning();
+    console.log('[OllamaManager] Ollama not detected. Attempting to start in background...');
+    this.startOllama();
+    this.pollUntilReady();
+  }
 
-        if (isRunning) {
-            console.log('[OllamaManager] Ollama is already running. App will not manage its lifecycle.');
-            this.isAppManaged = false;
-            return;
-        }
+  /**
+   * Ping the local Ollama server to see if it responds.
+   */
+  private async checkIsRunning(): Promise<boolean> {
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 1000); // 1s timeout
 
-        console.log('[OllamaManager] Ollama not detected. Attempting to start in background...');
-        this.startOllama();
-        this.pollUntilReady();
+      const response = await fetch('http://127.0.0.1:11434/api/tags', {
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+      return response.ok;
+    } catch (error) {
+      // ECONNREFUSED or timeout means it's not running
+      return false;
+    }
+  }
+
+  /**
+   * Spawns the 'ollama serve' command invisibly.
+   */
+  private startOllama(): void {
+    try {
+      this.isAppManaged = true;
+
+      // Spawn detached and hidden
+      this.ollamaProcess = spawn('ollama', ['serve'], {
+        detached: false, // Keep attached to app lifecycle
+        windowsHide: true, // Hide terminal on Windows
+        stdio: 'ignore', // We don't care about its logs
+      });
+
+      this.ollamaProcess.on('error', (err) => {
+        console.error('[OllamaManager] Failed to start Ollama. Is it installed?', err.message);
+        this.isAppManaged = false;
+        this.ollamaProcess = null;
+        if (this.pollInterval) clearInterval(this.pollInterval);
+      });
+
+      this.ollamaProcess.on('close', (code) => {
+        console.log(`[OllamaManager] Process exited with code ${code}`);
+        this.ollamaProcess = null;
+      });
+    } catch (err) {
+      console.error('[OllamaManager] Exception while spawning Ollama:', err);
+      this.isAppManaged = false;
+    }
+  }
+
+  /**
+   * Polls every 5 seconds for up to 2 minutes.
+   */
+  private pollUntilReady(): void {
+    this.attempts = 0;
+
+    this.pollInterval = setInterval(async () => {
+      this.attempts++;
+      const isRunning = await this.checkIsRunning();
+
+      if (isRunning) {
+        console.log(
+          `[OllamaManager] Successfully connected to Ollama after ${this.attempts * 5} seconds!`,
+        );
+        if (this.pollInterval) clearInterval(this.pollInterval);
+        return;
+      }
+
+      if (this.attempts >= this.maxRetries) {
+        console.log(
+          '[OllamaManager] Timeout: Failed to connect to Ollama after 2 minutes. Please check if it is installed properly.',
+        );
+        if (this.pollInterval) clearInterval(this.pollInterval);
+      } else {
+        console.log(
+          `[OllamaManager] Waiting for Ollama... (Attempt ${this.attempts}/${this.maxRetries})`,
+        );
+      }
+    }, 5000);
+    this.pollInterval.unref?.();
+  }
+
+  /**
+   * Kills the Ollama process ONLY if this app started it.
+   * Called when Electron is quitting.
+   */
+  public stop(): void {
+    if (this.pollInterval) {
+      clearInterval(this.pollInterval);
     }
 
-    /**
-     * Ping the local Ollama server to see if it responds.
-     */
-    private async checkIsRunning(): Promise<boolean> {
-        try {
-            const controller = new AbortController();
-            const timeoutId = setTimeout(() => controller.abort(), 1000); // 1s timeout
-            
-            const response = await fetch('http://127.0.0.1:11434/api/tags', {
-                signal: controller.signal
-            });
-            
-            clearTimeout(timeoutId);
-            return response.ok;
-        } catch (error) {
-            // ECONNREFUSED or timeout means it's not running
-            return false;
-        }
+    if (this.isAppManaged && this.ollamaProcess && this.ollamaProcess.pid) {
+      console.log('[OllamaManager] App is quitting. Terminating managed Ollama process tree...');
+      try {
+        // Use tree-kill to ensure Ollama and all its nested runner processes die
+        treeKill(this.ollamaProcess.pid, 'SIGTERM', (err) => {
+          if (err) {
+            console.error('[OllamaManager] Failed to tree-kill Ollama process:', err);
+          } else {
+            console.log('[OllamaManager] Successfully killed Ollama process tree.');
+          }
+        });
+      } catch (e) {
+        console.error('[OllamaManager] Exception during kill:', e);
+      }
     }
-
-    /**
-     * Spawns the 'ollama serve' command invisibly.
-     */
-    private startOllama(): void {
-        try {
-            this.isAppManaged = true;
-            
-            // Spawn detached and hidden
-            this.ollamaProcess = spawn('ollama', ['serve'], {
-                detached: false, // Keep attached to app lifecycle
-                windowsHide: true, // Hide terminal on Windows
-                stdio: 'ignore' // We don't care about its logs
-            });
-
-            this.ollamaProcess.on('error', (err) => {
-                console.error('[OllamaManager] Failed to start Ollama. Is it installed?', err.message);
-                this.isAppManaged = false;
-                this.ollamaProcess = null;
-                if (this.pollInterval) clearInterval(this.pollInterval);
-            });
-
-            this.ollamaProcess.on('close', (code) => {
-                console.log(`[OllamaManager] Process exited with code ${code}`);
-                this.ollamaProcess = null;
-            });
-
-        } catch (err) {
-            console.error('[OllamaManager] Exception while spawning Ollama:', err);
-            this.isAppManaged = false;
-        }
-    }
-
-    /**
-     * Polls every 5 seconds for up to 2 minutes.
-     */
-    private pollUntilReady(): void {
-        this.attempts = 0;
-
-        this.pollInterval = setInterval(async () => {
-            this.attempts++;
-            const isRunning = await this.checkIsRunning();
-
-            if (isRunning) {
-                console.log(`[OllamaManager] Successfully connected to Ollama after ${this.attempts * 5} seconds!`);
-                if (this.pollInterval) clearInterval(this.pollInterval);
-                return;
-            }
-
-            if (this.attempts >= this.maxRetries) {
-                console.log('[OllamaManager] Timeout: Failed to connect to Ollama after 2 minutes. Please check if it is installed properly.');
-                if (this.pollInterval) clearInterval(this.pollInterval);
-            } else {
-                console.log(`[OllamaManager] Waiting for Ollama... (Attempt ${this.attempts}/${this.maxRetries})`);
-            }
-        }, 5000);
-    }
-
-    /**
-     * Kills the Ollama process ONLY if this app started it.
-     * Called when Electron is quitting.
-     */
-    public stop(): void {
-        if (this.pollInterval) {
-            clearInterval(this.pollInterval);
-        }
-
-        if (this.isAppManaged && this.ollamaProcess && this.ollamaProcess.pid) {
-            console.log('[OllamaManager] App is quitting. Terminating managed Ollama process tree...');
-            try {
-                // Use tree-kill to ensure Ollama and all its nested runner processes die
-                treeKill(this.ollamaProcess.pid, 'SIGTERM', (err) => {
-                    if (err) {
-                        console.error('[OllamaManager] Failed to tree-kill Ollama process:', err);
-                    } else {
-                        console.log('[OllamaManager] Successfully killed Ollama process tree.');
-                    }
-                });
-            } catch (e) {
-                console.error('[OllamaManager] Exception during kill:', e);
-            }
-        }
-    }
+  }
 }

--- a/electron/services/PhoneMirrorService.ts
+++ b/electron/services/PhoneMirrorService.ts
@@ -1,10 +1,10 @@
+import crypto from 'crypto';
+import { app } from 'electron';
 import http from 'http';
 import os from 'os';
-import crypto from 'crypto';
-import { URL } from 'url';
-import { WebSocketServer, WebSocket } from 'ws';
 import QRCode from 'qrcode';
-import { app } from 'electron';
+import { URL } from 'url';
+import { WebSocket, WebSocketServer } from 'ws';
 import { SettingsManager } from './SettingsManager';
 import { PHONE_MIRROR_HTML } from './phoneMirrorClient';
 
@@ -28,7 +28,8 @@ export type StreamEvent =
   | { type: 'done'; streamId: string; content: string; createdAt: string }
   | { type: 'error'; streamId: string; message: string }
   | { type: 'assistant'; id: string; content: string; label: string; createdAt: string }
-  | { type: 'screenshot'; id: string; dataUrl: string; createdAt: string };
+  | { type: 'screenshot'; id: string; dataUrl: string; createdAt: string }
+  | { type: 'ack'; action: string; message: string };
 
 /** Command sent from the phone browser to the desktop. */
 export type PhoneCommand =
@@ -64,12 +65,15 @@ export class PhoneMirrorService {
   private token = '';
   private exposeOnLan = false;
   private history: PersistedMessage[] = [];
-  private livePartial: { streamId: string; tokens: string[] } | null = null;
+  // Single string instead of token array: O(1) append, O(1) replay (one WS frame).
+  private livePartial: { streamId: string; content: string } | null = null;
   private rateBuckets = new Map<string, { count: number; resetAt: number }>();
   private statusListeners = new Set<StatusListener>();
   private phoneCommandListeners = new Set<(cmd: PhoneCommand) => void>();
   private cachedInfo: PhoneMirrorInfo | null = null;
   private starting: Promise<PhoneMirrorInfo> | null = null;
+  // Debounce rapid connect/disconnect status events to avoid redundant QR re-renders.
+  private statusDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
   static getInstance(): PhoneMirrorService {
     if (!PhoneMirrorService._instance) PhoneMirrorService._instance = new PhoneMirrorService();
@@ -91,7 +95,8 @@ export class PhoneMirrorService {
       return this.snapshot();
     }
 
-    const exposeOnLan = opts?.exposeOnLan ?? !!SettingsManager.getInstance().get('phoneMirrorExposeOnLan');
+    const exposeOnLan =
+      opts?.exposeOnLan ?? !!SettingsManager.getInstance().get('phoneMirrorExposeOnLan');
     this.starting = this._start(exposeOnLan, opts?.persist !== false);
     try {
       return await this.starting;
@@ -153,16 +158,18 @@ export class PhoneMirrorService {
   publishToken(streamId: string, token: string): void {
     if (!this.isRunning() || !token) return;
     if (!this.livePartial || this.livePartial.streamId !== streamId) {
-      this.livePartial = { streamId, tokens: [] };
+      this.livePartial = { streamId, content: '' };
     }
-    this.livePartial.tokens.push(token);
+    this.livePartial.content += token;
     this.broadcast({ type: 'token', streamId, token });
   }
 
   publishDone(streamId: string, fullContent: string): void {
     if (!this.isRunning()) return;
     const createdAt = new Date().toISOString();
-    const content = fullContent || (this.livePartial?.streamId === streamId ? this.livePartial.tokens.join('') : '');
+    const content =
+      fullContent ||
+      (this.livePartial?.streamId === streamId ? this.livePartial.content : '');
     if (content.trim()) {
       const msg: PersistedMessage = { id: 'a:' + streamId, role: 'assistant', content, createdAt };
       this.recordHistory(msg);
@@ -207,6 +214,21 @@ export class PhoneMirrorService {
   }
 
   /**
+   * Broadcast a one-shot acknowledgement to all connected phones.
+   * Used for stealth operations that succeed silently on the desktop side
+   * (e.g. "Screenshot captured — queued for AI") so the phone shows a toast.
+   */
+  publishAck(action: string, message: string): void {
+    if (!this.isRunning()) return;
+    this.broadcast({ type: 'ack', action, message });
+  }
+
+  /** Returns true when at least one phone browser is connected. */
+  hasClients(): boolean {
+    return !!this.wss && this.wss.clients.size > 0;
+  }
+
+  /**
    * Subscribe to commands sent from the phone browser.
    * Returns an unsubscribe function.
    */
@@ -241,7 +263,7 @@ export class PhoneMirrorService {
       : [];
     // If LAN is on, only advertise a real LAN URL — falling back to 127.0.0.1
     // would print a QR code the phone cannot reach (loopback ≠ phone).
-    const primaryUrl = this.exposeOnLan ? (lanUrls[0] || null) : loopbackUrl;
+    const primaryUrl = this.exposeOnLan ? lanUrls[0] || null : loopbackUrl;
     const qrDataUrl = primaryUrl ? await safeQr(primaryUrl) : null;
     const info: PhoneMirrorInfo = {
       running: true,
@@ -274,7 +296,11 @@ export class PhoneMirrorService {
     const basePort = DEFAULT_PORT;
     const server = http.createServer((req, res) => this.handleHttp(req, res));
     server.on('clientError', (_err, socket) => {
-      try { socket.destroy(); } catch (_) { /* noop */ }
+      try {
+        socket.destroy();
+      } catch (_) {
+        /* noop */
+      }
     });
 
     const port = await listenWithProbe(server, host, basePort, PORT_PROBE_RANGE);
@@ -283,7 +309,9 @@ export class PhoneMirrorService {
 
     const wss = new WebSocketServer({ noServer: true });
     this.wss = wss;
-    server.on('upgrade', (req, socket, head) => this.handleUpgrade(req as http.IncomingMessage, socket as any, head));
+    server.on('upgrade', (req, socket, head) =>
+      this.handleUpgrade(req as http.IncomingMessage, socket as any, head),
+    );
     wss.on('connection', (ws, req) => this.handleWsConnection(ws, req));
 
     if (persistEnabled) {
@@ -298,6 +326,11 @@ export class PhoneMirrorService {
   }
 
   private async _teardown(): Promise<void> {
+    // Cancel any pending debounced status emit so it doesn't fire after teardown.
+    if (this.statusDebounceTimer !== null) {
+      clearTimeout(this.statusDebounceTimer);
+      this.statusDebounceTimer = null;
+    }
     const wss = this.wss;
     const server = this.server;
     this.wss = null;
@@ -308,7 +341,11 @@ export class PhoneMirrorService {
     this.rateBuckets.clear();
     if (wss) {
       for (const c of wss.clients) {
-        try { c.close(1001, 'shutting down'); } catch (_) { /* noop */ }
+        try {
+          c.close(1001, 'shutting down');
+        } catch (_) {
+          /* noop */
+        }
       }
       await new Promise<void>((resolve) => wss.close(() => resolve()));
     }
@@ -374,8 +411,12 @@ export class PhoneMirrorService {
       return;
     }
     let url: URL;
-    try { url = new URL(req.url || '/', 'http://localhost'); }
-    catch { socket.destroy(); return; }
+    try {
+      url = new URL(req.url || '/', 'http://localhost');
+    } catch {
+      socket.destroy();
+      return;
+    }
 
     if (url.pathname !== '/ws') {
       socket.write('HTTP/1.1 404 Not Found\r\n\r\n');
@@ -392,11 +433,16 @@ export class PhoneMirrorService {
     }
 
     const wss = this.wss;
-    if (!wss) { socket.destroy(); return; }
+    if (!wss) {
+      socket.destroy();
+      return;
+    }
 
     // Drop any client that doesn't complete handshake quickly — avoids slow-loris.
     let upgraded = false;
-    const handshakeTimer = setTimeout(() => { if (!upgraded) socket.destroy(); }, HANDSHAKE_TIMEOUT_MS);
+    const handshakeTimer = setTimeout(() => {
+      if (!upgraded) socket.destroy();
+    }, HANDSHAKE_TIMEOUT_MS);
     wss.handleUpgrade(req, socket, head, (ws) => {
       upgraded = true;
       clearTimeout(handshakeTimer);
@@ -408,28 +454,47 @@ export class PhoneMirrorService {
     // Send recent history immediately so a phone joining mid-session has context.
     try {
       ws.send(JSON.stringify({ type: 'history', messages: this.history.slice(-HISTORY_LIMIT) }));
-      // Replay live partial too, so a late joiner sees the in-flight response.
-      if (this.livePartial) {
-        for (const t of this.livePartial.tokens) {
-          ws.send(JSON.stringify({ type: 'token', streamId: this.livePartial.streamId, token: t }));
-        }
+      // Replay in-flight partial as a SINGLE token frame containing the full
+      // accumulated content so far.  Previously this sent one frame per token
+      // (up to 500+ frames for a long response) — now it's always 1 frame.
+      if (this.livePartial && this.livePartial.content) {
+        ws.send(
+          JSON.stringify({
+            type: 'token',
+            streamId: this.livePartial.streamId,
+            token: this.livePartial.content,
+          }),
+        );
       }
-    } catch (_) { /* client may be gone already */ }
+    } catch (_) {
+      /* client may be gone already */
+    }
 
     // Keepalive heartbeat. Drop dead clients within ~45s.
     let alive = true;
-    ws.on('pong', () => { alive = true; });
+    ws.on('pong', () => {
+      alive = true;
+    });
     const ping = setInterval(() => {
-      if (!alive) { try { ws.terminate(); } catch (_) {} return; }
+      if (!alive) {
+        try {
+          ws.terminate();
+        } catch (_) {}
+        return;
+      }
       alive = false;
-      try { ws.ping(); } catch (_) {}
+      try {
+        ws.ping();
+      } catch (_) {}
     }, 15_000);
 
     ws.on('close', () => {
       clearInterval(ping);
       this.emitStatus(); // update client count
     });
-    ws.on('error', () => { /* swallow — close fires next */ });
+    ws.on('error', () => {
+      /* swallow — close fires next */
+    });
 
     // Parse and route commands from the phone browser.
     ws.on('message', (data: any) => {
@@ -441,9 +506,18 @@ export class PhoneMirrorService {
         const c = cmd as Record<string, unknown>;
 
         let validated: PhoneCommand | null = null;
-        if (c.type === 'chat' && typeof c.message === 'string' && c.message.trim().length > 0 && c.message.length <= 2000) {
+        if (
+          c.type === 'chat' &&
+          typeof c.message === 'string' &&
+          c.message.trim().length > 0 &&
+          c.message.length <= 2000
+        ) {
           validated = { type: 'chat', message: c.message.trim() };
-        } else if (c.type === 'action' && typeof c.action === 'string' && /^[a-zA-Z:_-]{1,64}$/.test(c.action)) {
+        } else if (
+          c.type === 'action' &&
+          typeof c.action === 'string' &&
+          /^[a-zA-Z:_-]{1,64}$/.test(c.action)
+        ) {
           validated = { type: 'action', action: c.action };
         } else if (c.type === 'screenshot') {
           validated = { type: 'screenshot' };
@@ -453,7 +527,9 @@ export class PhoneMirrorService {
           console.log(`[PhoneMirror] phone command: ${validated.type}`);
           this.emitPhoneCommand(validated);
         }
-      } catch (_) { /* malformed JSON — ignore */ }
+      } catch (_) {
+        /* malformed JSON — ignore */
+      }
     });
 
     console.log(`[PhoneMirror] phone connected from ${req.socket.remoteAddress}`);
@@ -462,20 +538,27 @@ export class PhoneMirrorService {
 
   private broadcast(event: StreamEvent): void {
     const wss = this.wss;
-    if (!wss) return;
+    // Skip JSON serialization entirely when no phones are watching — this path
+    // is hot (every LLM token goes through it) so the early-exit matters.
+    if (!wss || wss.clients.size === 0) return;
     const payload = JSON.stringify(event);
     for (const client of wss.clients) {
       if (client.readyState !== WebSocket.OPEN) continue;
       // Backpressure guard: skip if buffered amount has run away (slow client).
       if ((client as any).bufferedAmount > 1_000_000) continue;
-      try { client.send(payload); } catch (_) { /* noop */ }
+      try {
+        client.send(payload);
+      } catch (_) {
+        /* noop */
+      }
     }
   }
 
   private recordHistory(msg: PersistedMessage): void {
     this.history.push(msg);
+    // slice+reassign is O(1) GC pressure vs splice(0,n) which shifts every element.
     if (this.history.length > HISTORY_LIMIT * 2) {
-      this.history.splice(0, this.history.length - HISTORY_LIMIT);
+      this.history = this.history.slice(-HISTORY_LIMIT);
     }
   }
 
@@ -499,21 +582,38 @@ export class PhoneMirrorService {
   private disconnectAllClients(code: number, reason: string): void {
     if (!this.wss) return;
     for (const c of this.wss.clients) {
-      try { c.close(code, reason); } catch (_) {}
+      try {
+        c.close(code, reason);
+      } catch (_) {}
     }
   }
 
-  private async emitStatus(prebuilt?: PhoneMirrorInfo): Promise<void> {
+  private emitStatus(prebuilt?: PhoneMirrorInfo): void {
     if (this.statusListeners.size === 0) return;
-    const info = prebuilt || (await this.snapshot());
-    for (const l of this.statusListeners) {
-      try { l(info); } catch (_) { /* noop */ }
-    }
+    // Debounce: rapid connect/disconnect storms (bad network, iOS reconnect loop)
+    // used to regenerate the QR code on every event — each safeQr() call costs
+    // ~3 ms CPU.  Coalesce into one emission within a 150 ms window.
+    if (this.statusDebounceTimer !== null) clearTimeout(this.statusDebounceTimer);
+    this.statusDebounceTimer = setTimeout(async () => {
+      this.statusDebounceTimer = null;
+      const info = prebuilt || (await this.snapshot());
+      for (const l of this.statusListeners) {
+        try {
+          l(info);
+        } catch (_) {
+          /* noop */
+        }
+      }
+    }, 150);
   }
 
   private emitPhoneCommand(cmd: PhoneCommand): void {
     for (const l of this.phoneCommandListeners) {
-      try { l(cmd); } catch (_) { /* noop */ }
+      try {
+        l(cmd);
+      } catch (_) {
+        /* noop */
+      }
     }
   }
 }
@@ -544,7 +644,8 @@ function timingSafeEqualStr(a: string, b: string): boolean {
 // - bridge*: Internet Sharing / Thunderbolt bridge — different subnet
 // - vmnet*, vboxnet*, docker*: virtualization-only networks
 // - veth*, br-*: Linux container networks
-const VIRTUAL_IFACE_RE = /^(utun|awdl|llw|anpi|ap\d|bridge|vmnet|vboxnet|docker|veth|br-|gif|stf|tap)/i;
+const VIRTUAL_IFACE_RE =
+  /^(utun|awdl|llw|anpi|ap\d|bridge|vmnet|vboxnet|docker|veth|br-|gif|stf|tap)/i;
 
 function isPrivateLanIPv4(ip: string): boolean {
   // RFC1918 — the only ranges a phone on the same Wi-Fi will share with the desktop.
@@ -563,7 +664,8 @@ function rankLanIp(name: string, ip: string): number {
   //   2. 192.168.x.x (home routers) over 10.x and 172.16-31.x.
   let score = 100;
   const m = name.match(/^en(\d+)$/i);
-  if (m) score = parseInt(m[1], 10); // en0 -> 0, en1 -> 1, ...
+  if (m)
+    score = parseInt(m[1], 10); // en0 -> 0, en1 -> 1, ...
   else if (/^eth\d+$|^enp/i.test(name)) score = 2;
   else if (/^wlan\d+|^wlp/i.test(name)) score = 1;
   if (ip.startsWith('192.168.')) score += 0;
@@ -596,7 +698,12 @@ function getLanIPs(): string[] {
   return out;
 }
 
-async function listenWithProbe(server: http.Server, host: string, basePort: number, range: number): Promise<number> {
+async function listenWithProbe(
+  server: http.Server,
+  host: string,
+  basePort: number,
+  range: number,
+): Promise<number> {
   for (let i = 0; i < range; i++) {
     const port = basePort + i;
     const ok = await tryListen(server, host, port);
@@ -615,12 +722,21 @@ async function listenWithProbe(server: http.Server, host: string, basePort: numb
 
 function tryListen(server: http.Server, host: string, port: number): Promise<boolean> {
   return new Promise((resolve) => {
-    const onError = () => { server.removeListener('listening', onListening); resolve(false); };
-    const onListening = () => { server.removeListener('error', onError); resolve(true); };
+    const onError = () => {
+      server.removeListener('listening', onListening);
+      resolve(false);
+    };
+    const onListening = () => {
+      server.removeListener('error', onError);
+      resolve(true);
+    };
     server.once('error', onError);
     server.once('listening', onListening);
-    try { server.listen(port, host); }
-    catch (_) { resolve(false); }
+    try {
+      server.listen(port, host);
+    } catch (_) {
+      resolve(false);
+    }
   });
 }
 

--- a/electron/services/PhoneMirrorService.ts
+++ b/electron/services/PhoneMirrorService.ts
@@ -28,7 +28,6 @@ export type StreamEvent =
   | { type: 'done'; streamId: string; content: string; createdAt: string }
   | { type: 'error'; streamId: string; message: string }
   | { type: 'assistant'; id: string; content: string; label: string; createdAt: string }
-  | { type: 'screenshot'; id: string; dataUrl: string; createdAt: string }
   | { type: 'ack'; action: string; message: string };
 
 /** Command sent from the phone browser to the desktop. */
@@ -71,6 +70,8 @@ export class PhoneMirrorService {
   private statusListeners = new Set<StatusListener>();
   private phoneCommandListeners = new Set<(cmd: PhoneCommand) => void>();
   private cachedInfo: PhoneMirrorInfo | null = null;
+  private cachedQrUrl: string | null = null;
+  private cachedQrDataUrl: string | null = null;
   private starting: Promise<PhoneMirrorInfo> | null = null;
   // Debounce rapid connect/disconnect status events to avoid redundant QR re-renders.
   private statusDebounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -129,6 +130,7 @@ export class PhoneMirrorService {
 
   async rotateToken(): Promise<PhoneMirrorInfo> {
     this.token = generateToken();
+    this.invalidateQrCache();
     this.disconnectAllClients(4401, 'Token rotated');
     const info = await this.snapshot();
     this.emitStatus(info);
@@ -168,8 +170,7 @@ export class PhoneMirrorService {
     if (!this.isRunning()) return;
     const createdAt = new Date().toISOString();
     const content =
-      fullContent ||
-      (this.livePartial?.streamId === streamId ? this.livePartial.content : '');
+      fullContent || (this.livePartial?.streamId === streamId ? this.livePartial.content : '');
     if (content.trim()) {
       const msg: PersistedMessage = { id: 'a:' + streamId, role: 'assistant', content, createdAt };
       this.recordHistory(msg);
@@ -201,16 +202,6 @@ export class PhoneMirrorService {
     };
     this.recordHistory(msg);
     this.broadcast({ type: 'assistant', id: msg.id, content: msg.content, label, createdAt });
-  }
-
-  /**
-   * Push a desktop screenshot thumbnail to the phone.  The dataUrl must be a
-   * data:image/jpeg;base64,... string — callers are responsible for compressing
-   * before calling this method so the WebSocket payload stays under ~200 KB.
-   */
-  publishScreenshot(id: string, dataUrl: string): void {
-    if (!this.isRunning() || !dataUrl) return;
-    this.broadcast({ type: 'screenshot', id, dataUrl, createdAt: new Date().toISOString() });
   }
 
   /**
@@ -264,7 +255,19 @@ export class PhoneMirrorService {
     // If LAN is on, only advertise a real LAN URL — falling back to 127.0.0.1
     // would print a QR code the phone cannot reach (loopback ≠ phone).
     const primaryUrl = this.exposeOnLan ? lanUrls[0] || null : loopbackUrl;
-    const qrDataUrl = primaryUrl ? await safeQr(primaryUrl) : null;
+    let qrDataUrl: string | null = null;
+    if (primaryUrl) {
+      if (this.cachedQrUrl === primaryUrl && this.cachedQrDataUrl) {
+        qrDataUrl = this.cachedQrDataUrl;
+      } else {
+        qrDataUrl = await safeQr(primaryUrl);
+        this.cachedQrUrl = primaryUrl;
+        this.cachedQrDataUrl = qrDataUrl;
+      }
+    } else {
+      this.cachedQrUrl = null;
+      this.cachedQrDataUrl = null;
+    }
     const info: PhoneMirrorInfo = {
       running: true,
       enabled,
@@ -291,6 +294,7 @@ export class PhoneMirrorService {
   private async _start(exposeOnLan: boolean, persistEnabled: boolean): Promise<PhoneMirrorInfo> {
     this.exposeOnLan = exposeOnLan;
     this.token = generateToken();
+    this.invalidateQrCache();
 
     const host = exposeOnLan ? '0.0.0.0' : '127.0.0.1';
     const basePort = DEFAULT_PORT;
@@ -490,7 +494,7 @@ export class PhoneMirrorService {
 
     ws.on('close', () => {
       clearInterval(ping);
-      this.emitStatus(); // update client count
+      this.emitStatusClientCount();
     });
     ws.on('error', () => {
       /* swallow — close fires next */
@@ -533,7 +537,7 @@ export class PhoneMirrorService {
     });
 
     console.log(`[PhoneMirror] phone connected from ${req.socket.remoteAddress}`);
-    this.emitStatus();
+    this.emitStatusClientCount();
   }
 
   private broadcast(event: StreamEvent): void {
@@ -586,6 +590,23 @@ export class PhoneMirrorService {
         c.close(code, reason);
       } catch (_) {}
     }
+  }
+
+  private invalidateQrCache(): void {
+    this.cachedQrUrl = null;
+    this.cachedQrDataUrl = null;
+  }
+
+  private emitStatusClientCount(): void {
+    if (this.statusListeners.size === 0) return;
+    const clients = this.wss ? this.wss.clients.size : 0;
+    if (this.cachedInfo && clients !== this.cachedInfo.clients) {
+      const info = { ...this.cachedInfo, clients };
+      this.cachedInfo = info;
+      this.emitStatus(info);
+      return;
+    }
+    this.emitStatus();
   }
 
   private emitStatus(prebuilt?: PhoneMirrorInfo): void {

--- a/electron/services/PhoneMirrorService.ts
+++ b/electron/services/PhoneMirrorService.ts
@@ -26,13 +26,22 @@ export type StreamEvent =
   | { type: 'user'; id: string; content: string; createdAt: string }
   | { type: 'token'; streamId: string; token: string }
   | { type: 'done'; streamId: string; content: string; createdAt: string }
-  | { type: 'error'; streamId: string; message: string };
+  | { type: 'error'; streamId: string; message: string }
+  | { type: 'assistant'; id: string; content: string; label: string; createdAt: string }
+  | { type: 'screenshot'; id: string; dataUrl: string; createdAt: string };
+
+/** Command sent from the phone browser to the desktop. */
+export type PhoneCommand =
+  | { type: 'chat'; message: string }
+  | { type: 'action'; action: string }
+  | { type: 'screenshot' };
 
 interface PersistedMessage {
   id: string;
   role: 'user' | 'assistant';
   content: string;
   createdAt: string;
+  label?: string;
 }
 
 const DEFAULT_PORT = 4123;
@@ -58,6 +67,7 @@ export class PhoneMirrorService {
   private livePartial: { streamId: string; tokens: string[] } | null = null;
   private rateBuckets = new Map<string, { count: number; resetAt: number }>();
   private statusListeners = new Set<StatusListener>();
+  private phoneCommandListeners = new Set<(cmd: PhoneCommand) => void>();
   private cachedInfo: PhoneMirrorInfo | null = null;
   private starting: Promise<PhoneMirrorInfo> | null = null;
 
@@ -123,6 +133,7 @@ export class PhoneMirrorService {
   async dispose(): Promise<void> {
     await this._teardown();
     this.statusListeners.clear();
+    this.phoneCommandListeners.clear();
   }
 
   // ----- public publishing API (called from ipcHandlers) -----
@@ -164,6 +175,44 @@ export class PhoneMirrorService {
     if (!this.isRunning()) return;
     this.broadcast({ type: 'error', streamId, message: String(message || 'Stream error') });
     if (this.livePartial?.streamId === streamId) this.livePartial = null;
+  }
+
+  /**
+   * Publish a non-streaming assistant response (e.g. from shortcut-triggered actions like
+   * Code Hint, What to Answer, Brainstorm, Recap, etc.).  The label is shown in the phone
+   * UI as the card's header (e.g. "Code Hint", "What to Answer").
+   */
+  publishAssistantMessage(id: string, content: string, label: string): void {
+    if (!this.isRunning() || !content?.trim()) return;
+    const createdAt = new Date().toISOString();
+    const msg: PersistedMessage = {
+      id: 'a:' + id,
+      role: 'assistant',
+      content,
+      createdAt,
+      label,
+    };
+    this.recordHistory(msg);
+    this.broadcast({ type: 'assistant', id: msg.id, content: msg.content, label, createdAt });
+  }
+
+  /**
+   * Push a desktop screenshot thumbnail to the phone.  The dataUrl must be a
+   * data:image/jpeg;base64,... string — callers are responsible for compressing
+   * before calling this method so the WebSocket payload stays under ~200 KB.
+   */
+  publishScreenshot(id: string, dataUrl: string): void {
+    if (!this.isRunning() || !dataUrl) return;
+    this.broadcast({ type: 'screenshot', id, dataUrl, createdAt: new Date().toISOString() });
+  }
+
+  /**
+   * Subscribe to commands sent from the phone browser.
+   * Returns an unsubscribe function.
+   */
+  onPhoneCommand(listener: (cmd: PhoneCommand) => void): () => void {
+    this.phoneCommandListeners.add(listener);
+    return () => this.phoneCommandListeners.delete(listener);
   }
 
   // ----- snapshot / status -----
@@ -382,8 +431,30 @@ export class PhoneMirrorService {
     });
     ws.on('error', () => { /* swallow — close fires next */ });
 
-    // Phone is read-only: ignore any inbound frames except control frames.
-    ws.on('message', () => { /* intentionally ignored */ });
+    // Parse and route commands from the phone browser.
+    ws.on('message', (data: any) => {
+      try {
+        const raw = typeof data === 'string' ? data : (data as Buffer).toString('utf8');
+        if (raw.length > 4096) return; // guard oversized payloads
+        const cmd = JSON.parse(raw) as unknown;
+        if (!cmd || typeof cmd !== 'object') return;
+        const c = cmd as Record<string, unknown>;
+
+        let validated: PhoneCommand | null = null;
+        if (c.type === 'chat' && typeof c.message === 'string' && c.message.trim().length > 0 && c.message.length <= 2000) {
+          validated = { type: 'chat', message: c.message.trim() };
+        } else if (c.type === 'action' && typeof c.action === 'string' && /^[a-zA-Z:_-]{1,64}$/.test(c.action)) {
+          validated = { type: 'action', action: c.action };
+        } else if (c.type === 'screenshot') {
+          validated = { type: 'screenshot' };
+        }
+
+        if (validated) {
+          console.log(`[PhoneMirror] phone command: ${validated.type}`);
+          this.emitPhoneCommand(validated);
+        }
+      } catch (_) { /* malformed JSON — ignore */ }
+    });
 
     console.log(`[PhoneMirror] phone connected from ${req.socket.remoteAddress}`);
     this.emitStatus();
@@ -437,6 +508,12 @@ export class PhoneMirrorService {
     const info = prebuilt || (await this.snapshot());
     for (const l of this.statusListeners) {
       try { l(info); } catch (_) { /* noop */ }
+    }
+  }
+
+  private emitPhoneCommand(cmd: PhoneCommand): void {
+    for (const l of this.phoneCommandListeners) {
+      try { l(cmd); } catch (_) { /* noop */ }
     }
   }
 }

--- a/electron/services/__tests__/DynamicActionPromptInstructionWiring.test.mjs
+++ b/electron/services/__tests__/DynamicActionPromptInstructionWiring.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { findSafeHandle, sliceSafeHandleBlock } from './ipcTestUtils.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '../../..');
@@ -21,19 +22,18 @@ test('dynamic action accept uses promptInstruction instead of display label/manu
 
 test('generate-what-to-say IPC forwards promptInstruction option to IntelligenceManager', () => {
   const source = read('electron/ipcHandlers.ts');
-  const handlerStart = source.indexOf('safeHandle("generate-what-to-say"');
-  assert.ok(handlerStart >= 0, 'generate-what-to-say handler should exist');
-  const handlerSource = source.slice(handlerStart, source.indexOf('safeHandle("', handlerStart + 10));
+  const handlerSource = sliceSafeHandleBlock(source, 'generate-what-to-say');
+  assert.ok(findSafeHandle(source, 'generate-what-to-say') >= 0, 'generate-what-to-say handler should exist');
 
   assert.match(handlerSource, /options\?: \{ promptInstruction\?: string \}/);
-  assert.match(handlerSource, /promptInstruction: typeof options\?\.promptInstruction === 'string' \? options\.promptInstruction : undefined/);
+  assert.match(handlerSource, /promptInstruction:[\s\S]{0,120}typeof options\?\.promptInstruction === 'string'[\s\S]{0,80}options\.promptInstruction[\s\S]{0,40}: undefined/);
 });
 
 test('preload and renderer type expose promptInstruction option on generateWhatToSay', () => {
   const preload = read('electron/preload.ts');
   const types = read('src/types/electron.d.ts');
 
-  assert.match(preload, /generateWhatToSay: \(question\?: string, imagePaths\?: string\[\], options\?: \{ promptInstruction\?: string \}\)/);
-  assert.match(preload, /ipcRenderer\.invoke\("generate-what-to-say", question, imagePaths, options\)/);
-  assert.match(types, /generateWhatToSay: \(question\?: string, imagePaths\?: string\[\], options\?: \{ promptInstruction\?: string \}\)/);
+  assert.match(preload, /generateWhatToSay:[\s\S]{0,200}options\?: \{ promptInstruction\?: string \}/);
+  assert.match(preload, /ipcRenderer\.invoke\(['"]generate-what-to-say['"], question, imagePaths, options\)/);
+  assert.match(types, /generateWhatToSay:[\s\S]{0,200}options\?: \{ promptInstruction\?: string \}/);
 });

--- a/electron/services/__tests__/ExternalUrlIpc.test.mjs
+++ b/electron/services/__tests__/ExternalUrlIpc.test.mjs
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
+import { findSafeHandle } from './ipcTestUtils.mjs';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -13,25 +14,25 @@ function read(relativePath) {
 
 test('open-external IPC only allows known external destinations', () => {
   const source = read('electron/ipcHandlers.ts');
-  const start = source.indexOf('safeHandle("open-external"');
+  const start = findSafeHandle(source, 'open-external');
   const end = source.indexOf('// ==========================================', start);
   const handler = source.slice(start, end);
 
   assert.ok(start >= 0, 'open-external handler should exist');
-  assert.match(handler, /parsed\.protocol === 'https:' && parsed\.hostname === 'mail\.google\.com' && parsed\.pathname === '\/mail\/'/);
-  assert.match(handler, /parsed\.protocol === 'x-apple\.systempreferences:'/);
+  assert.match(handler, /parsed\.protocol === 'https:'[\s\S]{0,80}parsed\.hostname === 'mail\.google\.com'[\s\S]{0,80}parsed\.pathname === '\/mail\/'/);
+  assert.match(handler, /parsed\.protocol === 'x-apple\.systempreferences:' && process\.platform === 'darwin'/);
   assert.doesNotMatch(handler, /\['http:', 'https:', 'mailto:'\]\.includes\(parsed\.protocol\)/);
   assert.doesNotMatch(handler, /url\.startsWith\('x-apple\.systempreferences:'\)/);
 });
 
 test('open-external IPC does not log attacker-controlled URLs', () => {
   const source = read('electron/ipcHandlers.ts');
-  const start = source.indexOf('safeHandle("open-external"');
+  const start = findSafeHandle(source, 'open-external');
   const end = source.indexOf('// ==========================================', start);
   const handler = source.slice(start, end);
 
   assert.doesNotMatch(handler, /console\.warn\(`[^`]*\$\{url\}/);
   assert.doesNotMatch(handler, /console\.warn\([^\n]*,\s*url\s*[),]/);
-  assert.match(handler, /Blocked open-external request', \{ protocol: parsed\.protocol, hostname: parsed\.hostname \}/);
+  assert.match(handler, /Blocked open-external request',[\s\S]{0,120}protocol: parsed\.protocol,[\s\S]{0,80}hostname: parsed\.hostname/);
   assert.match(handler, /Invalid URL in open-external'/);
 });

--- a/electron/services/__tests__/ImagePathValidation.test.mjs
+++ b/electron/services/__tests__/ImagePathValidation.test.mjs
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'path';
+import { findSafeHandle, sliceSafeHandleBlock } from './ipcTestUtils.mjs';
 import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -27,16 +28,15 @@ test('generate-code-hint validates imagePaths before using them', () => {
   const engineSource = read('electron/IntelligenceEngine.ts');
 
   // Find generate-code-hint handler in IPC
-  const handlerStart = ipcSource.indexOf('safeHandle("generate-code-hint"');
+  const handlerStart = findSafeHandle(ipcSource, 'generate-code-hint');
   assert.ok(handlerStart >= 0, 'generate-code-hint handler should exist');
 
   // Find generate-brainstorm handler
-  const brainstormStart = ipcSource.indexOf('safeHandle("generate-brainstorm"');
+  const brainstormStart = findSafeHandle(ipcSource, 'generate-brainstorm');
   assert.ok(brainstormStart >= 0, 'generate-brainstorm handler should exist');
 
   // Extract the code-hint handler
-  const handlerEnd = ipcSource.indexOf('safeHandle("', handlerStart + 10);
-  const codeHintHandler = ipcSource.slice(handlerStart, handlerEnd > -1 ? handlerEnd : undefined);
+  const codeHintHandler = sliceSafeHandleBlock(ipcSource, 'generate-code-hint');
 
   // The handler receives imagePaths from renderer and passes them to IntelligenceEngine
   // It should validate paths before passing them
@@ -64,11 +64,10 @@ test('generate-brainstorm validates imagePaths before using them', () => {
   const ipcSource = read('electron/ipcHandlers.ts');
   const engineSource = read('electron/IntelligenceEngine.ts');
 
-  const handlerStart = ipcSource.indexOf('safeHandle("generate-brainstorm"');
+  const handlerStart = findSafeHandle(ipcSource, 'generate-brainstorm');
   assert.ok(handlerStart >= 0, 'generate-brainstorm handler should exist');
 
-  const nextHandler = ipcSource.indexOf('safeHandle("', handlerStart + 10);
-  const brainstormHandler = ipcSource.slice(handlerStart, nextHandler > -1 ? nextHandler : undefined);
+  const brainstormHandler = sliceSafeHandleBlock(ipcSource, 'generate-brainstorm');
 
   const runBrainstormStart = engineSource.indexOf('async runBrainstorm(');
   assert.ok(runBrainstormStart >= 0, 'runBrainstorm should exist');
@@ -98,9 +97,8 @@ test('runWhatShouldISay receives validated imagePaths from IPC handler', () => {
   assert.ok(/imagePaths\??:?\s*string\[\]/.test(methodBody), 'runWhatShouldISay should accept imagePaths');
 
   // But the actual validation happens at the IPC handler level
-  const whatToSayHandler = ipcSource.indexOf('safeHandle("generate-what-to-say"');
-  const handlerEnd = ipcSource.indexOf('safeHandle("', whatToSayHandler + 10);
-  const handler = ipcSource.slice(whatToSayHandler, handlerEnd);
+  const whatToSayHandler = findSafeHandle(ipcSource, 'generate-what-to-say');
+  const handler = sliceSafeHandleBlock(ipcSource, 'generate-what-to-say');
 
   // The handler should validate imagePaths before calling the engine
   assert.ok(
@@ -122,9 +120,7 @@ test('image path validation rejects path traversal attempts', () => {
 
 test('generate-what-to-say rejects malformed image path payloads before OCR or model calls', () => {
   const ipcSource = read('electron/ipcHandlers.ts');
-  const whatToSayStart = ipcSource.indexOf('safeHandle("generate-what-to-say"');
-  const whatToSayEnd = ipcSource.indexOf('safeHandle("', whatToSayStart + 10);
-  const handler = ipcSource.slice(whatToSayStart, whatToSayEnd);
+  const handler = sliceSafeHandleBlock(ipcSource, 'generate-what-to-say');
 
   assert.match(handler, /imagePaths\.length > 5/);
   assert.match(handler, /typeof imagePath !== 'string'/);
@@ -132,30 +128,24 @@ test('generate-what-to-say rejects malformed image path payloads before OCR or m
   assert.match(handler, /malformed image path payload rejected/);
   assert.match(handler, /Invalid image path payload/);
   assert.match(handler, /validatedImagePaths/);
-  assert.match(handler, /runWhatShouldISay\(question, 0\.8, validatedImagePaths/);
+  assert.match(handler, /runWhatShouldISay\([\s\S]{0,120}validatedImagePaths/);
 });
 
 test('image path validation is applied at IPC handler level', () => {
   const ipcSource = read('electron/ipcHandlers.ts');
 
   // Find all handlers that accept imagePaths
-  const generateCodeHint = ipcSource.indexOf('safeHandle("generate-code-hint"');
-  const generateBrainstorm = ipcSource.indexOf('safeHandle("generate-brainstorm"');
-  const generateWhatToSay = ipcSource.indexOf('safeHandle("generate-what-to-say"');
+  const generateCodeHint = findSafeHandle(ipcSource, 'generate-code-hint');
+  const generateBrainstorm = findSafeHandle(ipcSource, 'generate-brainstorm');
+  const generateWhatToSay = findSafeHandle(ipcSource, 'generate-what-to-say');
 
   assert.ok(generateCodeHint >= 0, 'generate-code-hint should exist');
   assert.ok(generateBrainstorm >= 0, 'generate-brainstorm should exist');
   assert.ok(generateWhatToSay >= 0, 'generate-what-to-say should exist');
 
-  // Extract each handler and check for path validation
-  const codeHintEnd = ipcSource.indexOf('safeHandle("', generateCodeHint + 10);
-  const codeHintHandler = ipcSource.slice(generateCodeHint, codeHintEnd);
-
-  const brainstormEnd = ipcSource.indexOf('safeHandle("', generateBrainstorm + 10);
-  const brainstormHandler = ipcSource.slice(generateBrainstorm, brainstormEnd);
-
-  const whatToSayEnd = ipcSource.indexOf('safeHandle("', generateWhatToSay + 10);
-  const whatToSayHandler = ipcSource.slice(generateWhatToSay, whatToSayEnd);
+  const codeHintHandler = sliceSafeHandleBlock(ipcSource, 'generate-code-hint');
+  const brainstormHandler = sliceSafeHandleBlock(ipcSource, 'generate-brainstorm');
+  const whatToSayHandler = sliceSafeHandleBlock(ipcSource, 'generate-what-to-say');
 
   // At least one should have path validation
   const hasValidation =

--- a/electron/services/__tests__/ModeBleeding.test.mjs
+++ b/electron/services/__tests__/ModeBleeding.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'path';
 import { fileURLToPath } from 'node:url';
+import { findSafeHandle, sliceSafeHandleBlock } from './ipcTestUtils.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -109,12 +110,10 @@ describe('BUG-MODE-BLEEDING: Mode-context clearing on mode switch', () => {
     const source = fs.readFileSync(sourcePath, 'utf8');
 
     // Find the modes:set-active handler
-    const handlerStart = source.indexOf('safeHandle("modes:set-active"');
+    const handlerStart = findSafeHandle(source, 'modes:set-active');
     assert.ok(handlerStart >= 0, 'modes:set-active handler should exist');
 
-    // Extract handler body (up to next safeHandle or end of handler)
-    const handlerEnd = source.indexOf('safeHandle("modes:get', handlerStart + 10);
-    const handlerBody = source.slice(handlerStart, handlerEnd > 0 ? handlerEnd : handlerStart + 3000);
+    const handlerBody = sliceSafeHandleBlock(source, 'modes:set-active');
 
     // Must call clearSessionContext before setActiveMode
     const clearIndex = handlerBody.indexOf('clearSessionContext');

--- a/electron/services/__tests__/ModeUploadHardening.test.mjs
+++ b/electron/services/__tests__/ModeUploadHardening.test.mjs
@@ -14,16 +14,16 @@ import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
+import { findSafeHandle, sliceSafeHandleBlock } from './ipcTestUtils.mjs';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SOURCE = fs.readFileSync(path.resolve(__dirname, '../../ipcHandlers.ts'), 'utf8');
 
 function handlerBody() {
-  const start = SOURCE.indexOf('safeHandle("modes:upload-reference-file"');
+  const start = findSafeHandle(SOURCE, 'modes:upload-reference-file');
   assert.ok(start >= 0, 'Upload handler must exist');
-  const end = SOURCE.indexOf('safeHandle("modes:delete-reference-file"', start);
-  return SOURCE.slice(start, end > 0 ? end : start + 6000);
+  return sliceSafeHandleBlock(SOURCE, 'modes:upload-reference-file');
 }
 
 describe('FIX-009: modes:upload-reference-file hardening', () => {
@@ -50,16 +50,16 @@ describe('FIX-009: modes:upload-reference-file hardening', () => {
   test('wraps PDF and DOCX parsers in a timeout to guard against malformed input / zip bombs', () => {
     assert.ok(body.includes('PARSE_TIMEOUT_MS'), 'Parse-timeout constant must be declared');
     assert.ok(body.includes('withTimeout'), 'Handler must define a withTimeout helper');
-    assert.ok(/withTimeout(?:<[^>]+>)?\(parser\.getText\(\)/.test(body), 'PDF parse must be wrapped in withTimeout');
-    assert.ok(/withTimeout(?:<[^>]+>)?\(mammoth\.extractRawText/.test(body), 'DOCX parse must be wrapped in withTimeout');
+    assert.ok(/withTimeout[\s\S]{0,80}parser\.getText\(\)/.test(body), 'PDF parse must be wrapped in withTimeout');
+    assert.ok(/withTimeout[\s\S]{0,120}mammoth\.extractRawText/.test(body), 'DOCX parse must be wrapped in withTimeout');
   });
 
   test('BOM-aware decoding for UTF-16 / UTF-8-BOM text files (no false-positive binary rejection)', () => {
     // UTF-16 LE BOM: 0xFF 0xFE → decode with utf16le, do NOT treat embedded
     // null bytes as a renamed-binary signal.
-    assert.ok(/0xFF.+0xFE/.test(body), 'Handler must detect UTF-16 LE BOM');
-    assert.ok(/0xFE.+0xFF/.test(body), 'Handler must detect UTF-16 BE BOM');
-    assert.ok(/0xEF.+0xBB.+0xBF/.test(body), 'Handler must detect UTF-8 BOM');
+    assert.ok(/0xff.+0xfe/i.test(body), 'Handler must detect UTF-16 LE BOM');
+    assert.ok(/0xfe.+0xff/i.test(body), 'Handler must detect UTF-16 BE BOM');
+    assert.ok(/0xef[\s\S]{0,40}0xbb[\s\S]{0,40}0xbf/i.test(body), 'Handler must detect UTF-8 BOM');
     assert.ok(/utf16le/.test(body), 'Handler must decode UTF-16 with the utf16le codec');
   });
 

--- a/electron/services/__tests__/ProfileIntelligenceGate.test.mjs
+++ b/electron/services/__tests__/ProfileIntelligenceGate.test.mjs
@@ -13,6 +13,7 @@ import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
+import { findSafeHandle, sliceSafeHandleBlock } from './ipcTestUtils.mjs';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -33,13 +34,10 @@ describe('Profile Intelligence IPC: Pro/trial gate', () => {
     test(`handler "${handler}" calls isProOrTrialActive() before doing work`, () => {
       // Find the handler body — start at safeHandle("name", and run until the
       // matching });
-      const marker = `safeHandle("${handler}"`;
-      const idx = source.indexOf(marker);
+      const idx = findSafeHandle(source, handler);
       assert.ok(idx >= 0, `Handler ${handler} not found in ipcHandlers.ts`);
 
-      // Take a generous window from the handler start. Real handlers fit in
-      // well under 3000 chars.
-      const slice = source.slice(idx, idx + 3000);
+      const slice = sliceSafeHandleBlock(source, handler).slice(0, 3000);
 
       // The gate call must appear before the orchestrator is invoked. We
       // assert presence; ordering is verified by a separate index check.
@@ -68,10 +66,9 @@ describe('Profile Intelligence IPC: Pro/trial gate', () => {
   }
 
   test('profile:get-status returns safe defaults when premium is unavailable (does not call ingest)', () => {
-    const marker = `safeHandle("profile:get-status"`;
-    const idx = source.indexOf(marker);
+    const idx = findSafeHandle(source, 'profile:get-status');
     assert.ok(idx >= 0);
-    const slice = source.slice(idx, idx + 1500);
+    const slice = sliceSafeHandleBlock(source, 'profile:get-status').slice(0, 1500);
     // get-status is intentionally NOT gated (it just reports status) — it
     // should return a falsy hasProfile when the orchestrator is missing.
     assert.ok(slice.includes('hasProfile: false'), 'profile:get-status must default to hasProfile=false when orchestrator missing');

--- a/electron/services/__tests__/ProviderGatewayPolicy.test.mjs
+++ b/electron/services/__tests__/ProviderGatewayPolicy.test.mjs
@@ -108,8 +108,8 @@ test('SettingsManager exposes providerDataScopes setting', () => {
 test('IPC handlers expose get/set provider-data-scopes and broadcast updates', () => {
   const ipc = read('electron/ipcHandlers.ts');
 
-  assert.match(ipc, /safeHandle\("get-provider-data-scopes"/);
-  assert.match(ipc, /safeHandle\("set-provider-data-scopes"/);
+  assert.match(ipc, /safeHandle\(['"]get-provider-data-scopes['"]/);
+  assert.match(ipc, /safeHandle\(['"]set-provider-data-scopes['"]/);
   assert.match(ipc, /webContents\.send\('provider-data-scopes-changed', sanitized\)/);
   assert.match(ipc, /SettingsManager\.getInstance\(\)\.set\('providerDataScopes'/);
 });

--- a/electron/services/__tests__/RetentionUiReachability.test.mjs
+++ b/electron/services/__tests__/RetentionUiReachability.test.mjs
@@ -10,9 +10,9 @@ const read = rel => fs.readFileSync(path.join(repoRoot, rel), 'utf8');
 test('meeting retention IPC exposes get/set and broadcasts updates', () => {
   const ipc = read('electron/ipcHandlers.ts');
 
-  assert.match(ipc, /safeHandle\("get-meeting-retention"/);
+  assert.match(ipc, /safeHandle\(['"]get-meeting-retention['"]/);
   assert.match(ipc, /SettingsManager\.getInstance\(\)\.get\('meetingRetention'\) \?\? 'forever'/);
-  assert.match(ipc, /safeHandle\("set-meeting-retention"/);
+  assert.match(ipc, /safeHandle\(['"]set-meeting-retention['"]/);
   assert.match(ipc, /SettingsManager\.getInstance\(\)\.set\('meetingRetention', retention\)/);
   assert.match(ipc, /webContents\.send\('meeting-retention-changed', retention\)/);
 });
@@ -22,7 +22,7 @@ test('preload and renderer types expose meeting retention controls', () => {
   const types = read('src/types/electron.d.ts');
 
   assert.match(preload, /getMeetingRetention: \(\) => ipcRenderer\.invoke\('get-meeting-retention'\)/);
-  assert.match(preload, /setMeetingRetention: \(retention: 'forever' \| '7d' \| '30d' \| 'never'\) => ipcRenderer\.invoke\('set-meeting-retention', retention\)/);
+  assert.match(preload, /setMeetingRetention:[\s\S]{0,120}ipcRenderer\.invoke\('set-meeting-retention', retention\)/);
   assert.match(preload, /ipcRenderer\.on\('meeting-retention-changed', subscription\)/);
   assert.match(types, /getMeetingRetention: \(\) => Promise<'forever' \| '7d' \| '30d' \| 'never'>/);
   assert.match(types, /setMeetingRetention: \(retention: 'forever' \| '7d' \| '30d' \| 'never'\) => Promise<\{ success: boolean; error\?: string \}>/);

--- a/electron/services/__tests__/SensitiveLogRedaction.test.mjs
+++ b/electron/services/__tests__/SensitiveLogRedaction.test.mjs
@@ -72,7 +72,7 @@ test('IPC and meeting summary logs avoid answer and LLM response snippets', () =
   const intent = read('electron/llm/IntentClassifier.ts');
 
   assert.match(ipc, /gemini - chat response received`, \{ length: result\?\.length \?\? 0 \}/);
-  assert.match(ipc, /Updated IntelligenceManager\.Last message`, \{ length: intelligenceManager\.getLastAssistantMessage\(\)\?\.length \?\? 0 \}/);
+  assert.match(ipc, /Updated IntelligenceManager\.Last message`,[\s\S]{0,120}length: intelligenceManager\.getLastAssistantMessage\(\)\?\.length \?\? 0/);
   assert.doesNotMatch(ipc, /console\.log[\s\S]{0,140}result\.substring\(/);
   assert.doesNotMatch(ipc, /console\.log[\s\S]{0,140}getLastAssistantMessage\(\)\?\.substring\(/);
 

--- a/electron/services/__tests__/SttApiKeyRedaction.test.mjs
+++ b/electron/services/__tests__/SttApiKeyRedaction.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { sliceSafeHandleBlock, findSafeHandle } from './ipcTestUtils.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '../../..');
@@ -25,13 +26,15 @@ function read(relativePath) {
 test('get-stored-credentials IPC does not return raw STT API keys', () => {
   const source = read('electron/ipcHandlers.ts');
 
-  // Find the get-stored-credentials handler
-  const handlerStart = source.indexOf('safeHandle("get-stored-credentials"');
-  assert.ok(handlerStart >= 0, 'get-stored-credentials handler should exist');
+  // Find the get-stored-credentials handler (single or double quotes)
+  const handlerMatch = source.match(/safeHandle\(['"]get-stored-credentials['"]/);
+  assert.ok(handlerMatch && handlerMatch.index !== undefined, 'get-stored-credentials handler should exist');
 
   // Extract just this handler (until the next safeHandle)
-  const nextHandler = source.indexOf('safeHandle("', handlerStart + 10);
-  const handlerEnd = nextHandler === -1 ? source.length : nextHandler;
+  const handlerStart = handlerMatch.index;
+  const searchFrom = handlerStart + handlerMatch[0].length;
+  const nextRel = source.slice(searchFrom).search(/safeHandle\(['"]/);
+  const handlerEnd = nextRel === -1 ? source.length : searchFrom + nextRel;
   const handler = source.slice(handlerStart, handlerEnd);
 
   // STT keys should be boolean-only or masked, NOT raw key values
@@ -67,7 +70,7 @@ test('get-stored-credentials IPC does not return raw STT API keys', () => {
 test('error fallback in get-stored-credentials does not return raw STT keys', () => {
   const source = read('electron/ipcHandlers.ts');
 
-  const handlerStart = source.indexOf('safeHandle("get-stored-credentials"');
+  const handlerStart = source.search(/safeHandle\(['"]get-stored-credentials['"]/);
   assert.ok(handlerStart >= 0, 'get-stored-credentials handler should exist');
 
   // Find the catch block that returns the error fallback object
@@ -99,10 +102,7 @@ test('renderer settings overlay does not rely on raw STT keys from IPC', () => {
 
 test('STT key fields in IPC response follow masked or boolean-only pattern', () => {
   const source = read('electron/ipcHandlers.ts');
-  const handlerStart = source.indexOf('safeHandle("get-stored-credentials"');
-  const nextHandler = source.indexOf('safeHandle("', handlerStart + 10);
-  const handlerEnd = nextHandler === -1 ? source.length : nextHandler;
-  const handler = source.slice(handlerStart, handlerEnd);
+  const handler = sliceSafeHandleBlock(source, 'get-stored-credentials');
 
   // Count stt*Key field assignments
   const keyFieldMatches = handler.match(/stt(Groq|Openai|Deepgram|ElevenLabs|Azure|Ibm|Soniox)Key:/g) || [];

--- a/electron/services/__tests__/TrialIpcRedaction.test.mjs
+++ b/electron/services/__tests__/TrialIpcRedaction.test.mjs
@@ -13,11 +13,11 @@ function read(relativePath) {
 
 test('trial IPC handlers do not return raw trial tokens to the renderer', () => {
   const source = read('electron/ipcHandlers.ts');
-  const startStart = source.indexOf('safeHandle("trial:start"');
-  const statusStart = source.indexOf('safeHandle("trial:status"', startStart);
+  const startStart = source.search(/safeHandle\(['"]trial:start['"]/);
+  const statusStart = source.search(/safeHandle\(['"]trial:status['"]/, startStart);
   const startHandler = source.slice(startStart, statusStart);
-  const localStart = source.indexOf('safeHandle("trial:get-local"');
-  const convertStart = source.indexOf('safeHandle("trial:convert"', localStart);
+  const localStart = source.search(/safeHandle\(['"]trial:get-local['"]/);
+  const convertStart = source.search(/safeHandle\(['"]trial:convert['"]/, localStart);
   const localHandler = source.slice(localStart, convertStart);
 
   assert.ok(startStart >= 0, 'trial:start handler should exist');

--- a/electron/services/__tests__/ipcTestUtils.mjs
+++ b/electron/services/__tests__/ipcTestUtils.mjs
@@ -1,0 +1,23 @@
+/** Quote-agnostic helpers for static analysis tests over ipcHandlers.ts. */
+export function findSafeHandle(source, channel) {
+  const escaped = channel.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`safeHandle\\(\\s*['"]${escaped}['"]`, 'm');
+  const m = source.match(re);
+  return m?.index ?? -1;
+}
+
+export function sliceSafeHandleBlock(source, channel) {
+  const escaped = channel.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const startMatch = source.match(new RegExp(`safeHandle\\(\\s*['"]${escaped}['"]`, 'm'));
+  if (!startMatch || startMatch.index === undefined) return '';
+  const start = startMatch.index;
+  const searchFrom = start + startMatch[0].length;
+  const nextRel = source.slice(searchFrom).search(/safeHandle\s*\(\s*['"]/);
+  const end = nextRel === -1 ? source.length : searchFrom + nextRel;
+  return source.slice(start, end);
+}
+
+export function safeHandlePattern(channel) {
+  const escaped = channel.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`safeHandle\\(\\s*['"]${escaped}['"]`, 'm');
+}

--- a/electron/services/phoneMirrorClient.ts
+++ b/electron/services/phoneMirrorClient.ts
@@ -90,12 +90,8 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
       }
       .card.screenshot-card {
         background: rgba(8,12,18,0.95);
-        border-color: rgba(108,240,214,0.12);
-        padding: 10px;
-      }
-      .card.screenshot-card img {
-        width: 100%; border-radius: 7px; display: block;
-        border: 1px solid rgba(255,255,255,0.06);
+        border-color: rgba(85,166,255,0.14);
+        padding: 10px 14px;
       }
       .meta {
         display: flex; align-items: center; justify-content: space-between; gap: 12px;
@@ -320,7 +316,7 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
           <button class="qa-btn" data-action="answer" type="button">Answer</button>
           <button class="qa-btn" data-action="followUp" type="button">Follow Up</button>
           <button class="qa-btn" data-action="dynamicAction4" type="button">Recap</button>
-          <button class="qa-btn screenshot-btn" id="screenshotBtn" type="button">📷 Screenshot</button>
+          <button class="qa-btn screenshot-btn" id="screenshotBtn" type="button" title="Capture desktop screenshot for AI prompt">📷 Capture</button>
         </div>
         <!-- Chat input -->
         <div class="input-row">
@@ -672,8 +668,8 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
         }
 
         function buildCard(m, opts) {
-          // Screenshot card
-          if (m.type === 'screenshot') {
+          // Screenshot-queued notification card (no image — stays on desktop)
+          if (m.type === 'screenshot-queued') {
             const card = document.createElement('article');
             card.className = 'card screenshot-card';
             card.dataset.id = m.id || '';
@@ -682,14 +678,11 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
             const role = document.createElement('span');
             role.className = 'role';
             const pip = document.createElement('span'); pip.className = 'pip';
-            const lbl = document.createElement('span'); lbl.textContent = 'Desktop Screenshot';
+            const lbl = document.createElement('span'); lbl.textContent = '📷 Screenshot queued for AI';
             role.append(pip, lbl);
             const right = document.createElement('span'); right.textContent = fmtTime(m.createdAt);
             meta.append(role, right);
-            const img = document.createElement('img');
-            img.src = m.dataUrl; img.alt = 'Desktop screenshot';
-            img.style.marginTop = '8px';
-            card.append(meta, img);
+            card.append(meta);
             return card;
           }
 
@@ -835,11 +828,24 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
             scrollToLatest(true);
             return;
           }
-          // Desktop screenshot
+          // Desktop screenshot queued-for-AI acknowledgement.
+          // The image itself stays on the PC — we just log it in the feed.
           if (ev.type === 'screenshot') {
-            messages.push({ id: ev.id, type: 'screenshot', dataUrl: ev.dataUrl, createdAt: ev.createdAt });
+            messages.push({ id: ev.id, type: 'screenshot-queued', createdAt: ev.createdAt });
             render();
             scrollToLatest(true);
+            return;
+          }
+          // Ack events from stealth operations (screenshot captured, etc.)
+          if (ev.type === 'ack') {
+            showToast(ev.message || ev.action);
+            // For screenshot acks, also add a small card to the feed.
+            if (ev.action === 'screenshot') {
+              const id = 'ack-' + Date.now();
+              messages.push({ id, type: 'screenshot-queued', createdAt: new Date().toISOString() });
+              render();
+              scrollToLatest(true);
+            }
             return;
           }
           if (ev.type === 'status') {
@@ -911,10 +917,11 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
           });
         });
 
-        // Screenshot button
+        // Screenshot button — triggers a stealth desktop capture queued for AI.
+        // The image stays on the PC; only a confirmation toast appears on the phone.
         document.getElementById('screenshotBtn').addEventListener('click', function () {
           sendCommand({ type: 'screenshot' });
-          showToast('Requesting screenshot…');
+          showToast('Capturing…');
         });
 
         // Utility buttons
@@ -923,7 +930,7 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
         });
         document.getElementById('copyButton').addEventListener('click', async () => {
           const parts = messages
-            .filter(function (m) { return !m.type || m.type !== 'screenshot'; })
+            .filter(function (m) { return !m.type || m.type !== 'screenshot-queued'; })
             .map((m) => (m.role === 'user' ? 'You: ' : (m.label ? '[' + m.label + '] ' : '')) + m.content);
           if (live && live.content) parts.push(live.content);
           const text = parts.join('\\n\\n');

--- a/electron/services/phoneMirrorClient.ts
+++ b/electron/services/phoneMirrorClient.ts
@@ -828,14 +828,6 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
             scrollToLatest(true);
             return;
           }
-          // Desktop screenshot queued-for-AI acknowledgement.
-          // The image itself stays on the PC — we just log it in the feed.
-          if (ev.type === 'screenshot') {
-            messages.push({ id: ev.id, type: 'screenshot-queued', createdAt: ev.createdAt });
-            render();
-            scrollToLatest(true);
-            return;
-          }
           // Ack events from stealth operations (screenshot captured, etc.)
           if (ev.type === 'ack') {
             showToast(ev.message || ev.action);

--- a/electron/services/phoneMirrorClient.ts
+++ b/electron/services/phoneMirrorClient.ts
@@ -23,7 +23,9 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
         --accent: #6cf0d6;
         --accent-2: #55a6ff;
         --danger: #ff5d6c;
-        --bar-h: 84px;
+        --input-h: 56px;
+        --actions-h: 52px;
+        --bar-h: calc(var(--input-h) + var(--actions-h) + 20px);
       }
       * { box-sizing: border-box; }
       html, body { min-height: 100%; }
@@ -44,6 +46,7 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
         min-height: 100dvh;
         padding: env(safe-area-inset-top) 14px env(safe-area-inset-bottom);
       }
+      /* ── Top bar ─────────────────────────────── */
       .topbar {
         position: sticky; top: 0; z-index: 5;
         display: flex; align-items: center; justify-content: space-between; gap: 16px;
@@ -62,15 +65,17 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
       .dot { width: 8px; height: 8px; border-radius: 999px; background: var(--danger); }
       .status.connected { color: var(--text); }
       .status.connected .dot { background: var(--accent); animation: pulse 1.8s ease-in-out infinite; }
+      /* ── Feed ────────────────────────────────── */
       .feed {
         display: flex; flex-direction: column; gap: 12px; min-height: 0;
-        overflow-y: auto; padding: 12px 0 calc(var(--bar-h) + 20px);
+        overflow-y: auto; padding: 12px 0 calc(var(--bar-h) + 24px);
         scroll-behavior: smooth; overscroll-behavior: contain;
       }
       .empty {
-        display: grid; place-items: center; min-height: 58dvh;
+        display: grid; place-items: center; min-height: 50dvh;
         color: var(--muted); text-align: center; font-size: 14px; line-height: 1.55; padding: 0 16px;
       }
+      /* ── Cards ───────────────────────────────── */
       .card {
         position: relative; padding: 14px 14px 16px;
         border: 1px solid var(--line-soft); border-radius: 10px;
@@ -83,6 +88,15 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
         background: linear-gradient(180deg, rgba(20,28,40,0.92), rgba(15,21,30,0.96));
         border-color: rgba(85,166,255,0.16);
       }
+      .card.screenshot-card {
+        background: rgba(8,12,18,0.95);
+        border-color: rgba(108,240,214,0.12);
+        padding: 10px;
+      }
+      .card.screenshot-card img {
+        width: 100%; border-radius: 7px; display: block;
+        border: 1px solid rgba(255,255,255,0.06);
+      }
       .meta {
         display: flex; align-items: center; justify-content: space-between; gap: 12px;
         margin-bottom: 8px; color: var(--muted); font-size: 11px;
@@ -91,6 +105,12 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
       .role { display: inline-flex; align-items: center; gap: 6px; }
       .role .pip { width: 6px; height: 6px; border-radius: 999px; background: var(--accent); }
       .role.user .pip { background: var(--accent-2); }
+      .label-tag {
+        padding: 2px 8px;
+        border: 1px solid rgba(108,240,214,0.22); border-radius: 999px;
+        color: var(--accent); font-size: 10px; font-weight: 700; letter-spacing: 0.5px;
+        text-transform: uppercase;
+      }
       .badge {
         display: none; padding: 3px 7px;
         border: 1px solid rgba(108,240,214,0.32); border-radius: 999px;
@@ -160,20 +180,18 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
       }
       .content .codeblock pre::-webkit-scrollbar { height: 6px; }
       .content .codeblock pre::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.12); border-radius: 3px; }
-      /* Streaming-fence visual cue. */
       .content .codeblock.streaming { border-color: rgba(108,240,214,0.18); }
       .content .codeblock.streaming .codeblock-head { color: var(--accent); }
-      /* ── Syntax tokens. Theme matches the dark surface above; readable in
-         both AMOLED-bright and dim rooms. */
-      .content pre .hl-c    { color: #6b7d99; font-style: italic; }   /* comment */
-      .content pre .hl-s    { color: #a3e9b6; }                        /* string */
-      .content pre .hl-k    { color: #c8a8ff; }                        /* keyword */
-      .content pre .hl-n    { color: #ffd58a; }                        /* number */
-      .content pre .hl-f    { color: #7ec8ff; }                        /* function name */
-      .content pre .hl-t    { color: #ff9bb6; }                        /* tag (html/xml) */
-      .content pre .hl-a    { color: #6cf0d6; }                        /* attribute / property */
-      .content pre .hl-v    { color: #ffb482; font-style: italic; }    /* variable / built-in (self, this) */
-      .content pre .hl-o    { color: #c0d0e0; }                        /* operator / punctuation accent */
+      /* ── Syntax tokens ─────────────────────── */
+      .content pre .hl-c    { color: #6b7d99; font-style: italic; }
+      .content pre .hl-s    { color: #a3e9b6; }
+      .content pre .hl-k    { color: #c8a8ff; }
+      .content pre .hl-n    { color: #ffd58a; }
+      .content pre .hl-f    { color: #7ec8ff; }
+      .content pre .hl-t    { color: #ff9bb6; }
+      .content pre .hl-a    { color: #6cf0d6; }
+      .content pre .hl-v    { color: #ffb482; font-style: italic; }
+      .content pre .hl-o    { color: #c0d0e0; }
       .content hr {
         border: 0; height: 1px;
         background: linear-gradient(90deg, transparent, rgba(255,255,255,0.18), transparent);
@@ -184,24 +202,75 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
         background: var(--accent); border-radius: 2px;
         animation: blink 1s steps(2, end) infinite;
       }
-      .actions {
+      /* ── Bottom panel ─────────────────────── */
+      .bottom-panel {
         position: fixed; left: 14px; right: 14px;
-        bottom: calc(14px + env(safe-area-inset-bottom));
-        display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 9px;
-        min-height: 56px; padding: 8px;
-        border: 1px solid var(--line-soft); border-radius: 12px;
-        background: rgba(8,12,17,0.86);
-        backdrop-filter: blur(18px); -webkit-backdrop-filter: blur(18px);
+        bottom: calc(8px + env(safe-area-inset-bottom));
+        display: flex; flex-direction: column; gap: 8px;
+        padding: 8px;
+        border: 1px solid var(--line-soft); border-radius: 14px;
+        background: rgba(8,12,17,0.88);
+        backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px);
         box-shadow: 0 16px 42px rgba(0,0,0,0.45);
       }
-      .action {
-        min-width: 0; min-height: 42px; border-radius: 8px;
-        background: var(--panel-2); color: var(--text);
-        font-size: 13px; font-weight: 600; letter-spacing: 0.2px;
-        transition: transform 160ms cubic-bezier(0.16,1,0.3,1), background 160ms;
+      /* Quick actions row */
+      .quick-actions {
+        display: flex; gap: 6px; overflow-x: auto; padding-bottom: 2px;
+        scrollbar-width: none;
       }
-      .action:active { transform: scale(0.98) translateY(1px); }
-      .action.primary { background: linear-gradient(180deg, var(--accent), #4dd9bd); color: #00261d; }
+      .quick-actions::-webkit-scrollbar { display: none; }
+      .qa-btn {
+        flex: 0 0 auto;
+        height: 30px; padding: 0 10px;
+        border-radius: 6px; border: 1px solid var(--line-soft);
+        background: rgba(255,255,255,0.04); color: var(--muted);
+        font-size: 11.5px; font-weight: 600; letter-spacing: 0.2px;
+        white-space: nowrap;
+        transition: background 140ms, color 140ms, border-color 140ms;
+      }
+      .qa-btn:active { transform: scale(0.96); }
+      .qa-btn.working {
+        color: var(--accent); border-color: rgba(108,240,214,0.32);
+        background: rgba(108,240,214,0.06);
+      }
+      .qa-btn.screenshot-btn {
+        color: var(--accent-2); border-color: rgba(85,166,255,0.28);
+        background: rgba(85,166,255,0.05);
+      }
+      /* Chat input row */
+      .input-row {
+        display: flex; gap: 8px; align-items: center;
+      }
+      .chat-input {
+        flex: 1; min-width: 0; height: 40px; padding: 0 12px;
+        background: rgba(255,255,255,0.05); border: 1px solid var(--line-soft);
+        border-radius: 8px; color: var(--text); font: inherit; font-size: 14px;
+        outline: none;
+        transition: border-color 160ms;
+      }
+      .chat-input::placeholder { color: var(--muted); }
+      .chat-input:focus { border-color: rgba(108,240,214,0.4); }
+      .send-btn {
+        flex: 0 0 40px; height: 40px; border-radius: 8px;
+        background: linear-gradient(180deg, var(--accent), #4dd9bd); color: #00261d;
+        font-size: 18px; font-weight: 700;
+        display: flex; align-items: center; justify-content: center;
+        transition: transform 120ms;
+      }
+      .send-btn:active { transform: scale(0.94); }
+      .send-btn:disabled { opacity: 0.42; pointer-events: none; }
+      /* Row of utility buttons */
+      .util-row {
+        display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 7px;
+      }
+      .util-btn {
+        height: 38px; border-radius: 8px;
+        background: var(--panel-2); color: var(--text);
+        font-size: 12px; font-weight: 600; letter-spacing: 0.2px;
+        transition: transform 140ms cubic-bezier(0.16,1,0.3,1), background 140ms;
+      }
+      .util-btn:active { transform: scale(0.97) translateY(1px); }
+      /* ── Toast ─────────────────────────────── */
       .toast {
         position: fixed; left: 50%; top: calc(env(safe-area-inset-top) + 70px);
         transform: translateX(-50%);
@@ -209,9 +278,10 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
         background: rgba(8,12,17,0.92); color: var(--text);
         border: 1px solid var(--line-soft);
         font-size: 12px; opacity: 0; pointer-events: none;
-        transition: opacity 160ms ease;
+        transition: opacity 160ms ease; z-index: 20;
       }
       .toast.show { opacity: 1; }
+      /* ── Keyframes ─────────────────────────── */
       @keyframes pulse {
         0%,100% { box-shadow: 0 0 0 0 rgba(108,240,214,0.36); }
         50% { box-shadow: 0 0 0 7px rgba(108,240,214,0); }
@@ -235,15 +305,35 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
 
       <section class="feed" id="feed" aria-live="polite">
         <div class="empty" id="empty">
-          Waiting for the next response from your desktop.
+          Waiting for responses from your desktop.<br/>
+          <span style="font-size:12px;opacity:0.6;margin-top:6px;display:block;">Use the actions below or type a message.</span>
         </div>
       </section>
 
-      <nav class="actions" aria-label="Actions">
-        <button class="action" id="clearButton" type="button">Clear</button>
-        <button class="action primary" id="copyButton" type="button">Copy</button>
-        <button class="action" id="scrollButton" type="button">Bottom</button>
-      </nav>
+      <div class="bottom-panel">
+        <!-- Quick action shortcuts -->
+        <div class="quick-actions" id="quickActions">
+          <button class="qa-btn" data-action="whatToAnswer" type="button">What to Say</button>
+          <button class="qa-btn" data-action="codeHint" type="button">Code Hint</button>
+          <button class="qa-btn" data-action="clarify" type="button">Clarify</button>
+          <button class="qa-btn" data-action="brainstorm" type="button">Brainstorm</button>
+          <button class="qa-btn" data-action="answer" type="button">Answer</button>
+          <button class="qa-btn" data-action="followUp" type="button">Follow Up</button>
+          <button class="qa-btn" data-action="dynamicAction4" type="button">Recap</button>
+          <button class="qa-btn screenshot-btn" id="screenshotBtn" type="button">📷 Screenshot</button>
+        </div>
+        <!-- Chat input -->
+        <div class="input-row">
+          <input class="chat-input" id="chatInput" type="text" placeholder="Ask anything…" autocomplete="off" autocorrect="off" spellcheck="false" />
+          <button class="send-btn" id="sendBtn" type="button" aria-label="Send">↑</button>
+        </div>
+        <!-- Utility buttons -->
+        <div class="util-row">
+          <button class="util-btn" id="clearButton" type="button">Clear</button>
+          <button class="util-btn" id="copyButton" type="button">Copy</button>
+          <button class="util-btn" id="scrollButton" type="button">Bottom</button>
+        </div>
+      </div>
 
       <div class="toast" id="toast" role="status"></div>
     </main>
@@ -256,23 +346,14 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
         const statusText = document.getElementById('statusText');
         const subtitle = document.getElementById('subtitle');
         const toast = document.getElementById('toast');
+        const chatInput = document.getElementById('chatInput');
+        const sendBtn = document.getElementById('sendBtn');
 
         // ───── Markdown renderer ─────────────────────────────────────────
-        // Tiny, dependency-free, XSS-safe (escapes everything before
-        // re-inserting any tag). Built specifically to match what the
-        // desktop app's ReactMarkdown produces: code fences, inline code,
-        // bold/italic, headings, ordered + unordered lists, blockquotes,
-        // links, $math$, and horizontal rules.
         const HTML_ESCAPE = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
         function esc(str) { return String(str || '').replace(/[&<>"']/g, function (c) { return HTML_ESCAPE[c]; }); }
 
         // ───── Syntax highlighter ────────────────────────────────────────
-        // Hand-rolled, language-by-language ordered rules. Each rule is a
-        // [token-class, regex-anchored-at-start]. We walk the source string
-        // left-to-right, taking the first matching rule each step. Token
-        // class shorthand (single char) keeps the served HTML small.
-        // Unknown languages fall back to "generic" which still tints
-        // strings/comments/numbers — useful for SQL dialects, ruby, etc.
         const LANG_ALIAS = {
           js: 'js', javascript: 'js', jsx: 'js',
           ts: 'js', typescript: 'js', tsx: 'js',
@@ -386,8 +467,6 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
             ['f', /^\\b[A-Za-z_]\\w*(?=\\s*\\()/],
           ],
         };
-        // Order-independent fast path: for any language, the ident/whitespace/
-        // single-char fall-through is the same.
         function highlightCode(code, lang) {
           const key = LANG_ALIAS[(lang || '').toLowerCase()] || (lang ? null : null);
           const rules = (key && HL_RULES[key]) || (lang ? HL_RULES.generic : null);
@@ -396,7 +475,6 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
           let i = 0;
           const n = code.length;
           while (i < n) {
-            // Skip whitespace cheaply (no regex per char).
             const ch = code.charCodeAt(i);
             if (ch === 32 || ch === 9 || ch === 10 || ch === 13) {
               const start = i;
@@ -416,7 +494,6 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
               }
             }
             if (consumed === 0) {
-              // No rule matched — consume one ident-ish run or one char.
               const idm = tail.match(/^[A-Za-z_$][\\w$]*/);
               if (idm) { out.push(esc(idm[0])); consumed = idm[0].length; }
               else { out.push(esc(code[i])); consumed = 1; }
@@ -427,19 +504,13 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
         }
 
         function renderInline(text) {
-          // Order matters: inline code first (so its content doesn't get
-          // mangled by other rules), then math, then bold > italic, then links.
           let out = esc(text);
-          // \`inline code\`
           out = out.replace(/\`([^\`\\n]+)\`/g, function (_m, c) { return '<code class="inline">' + c + '</code>'; });
-          // $...$ math (single-dollar, not crossing newlines, not empty)
           out = out.replace(/(^|[^\\\\])\\$([^$\\n]+?)\\$/g, function (_m, pre, c) { return pre + '<span class="math">' + c + '</span>'; });
-          // **bold** before *italic* so we don't eat the inner asterisks.
           out = out.replace(/\\*\\*([^*\\n]+?)\\*\\*/g, '<strong>$1</strong>');
           out = out.replace(/__([^_\\n]+?)__/g, '<strong>$1</strong>');
           out = out.replace(/(^|[^\\*])\\*([^*\\n]+?)\\*(?!\\*)/g, '$1<em>$2</em>');
           out = out.replace(/(^|[^_])_([^_\\n]+?)_(?!_)/g, '$1<em>$2</em>');
-          // [text](url) — only allow http(s) and relative links.
           out = out.replace(/\\[([^\\]\\n]+)\\]\\(([^)\\s]+)\\)/g, function (_m, label, href) {
             const safe = /^https?:\\/\\//i.test(href) ? href : '#';
             return '<a href="' + safe + '" target="_blank" rel="noopener noreferrer">' + label + '</a>';
@@ -449,11 +520,6 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
 
         function renderMarkdown(src) {
           if (!src) return '';
-          // 1. Pull out fenced code blocks first (so their contents stay literal).
-          //    Pass A: closed fences. Pass B: a trailing UNCLOSED fence (live
-          //    streaming case) — anything from the last \`\`\` to end-of-input
-          //    is shown as an "open" code block, so streamed code looks right
-          //    well before the closing fence arrives.
           const fences = [];
           const fenceRe = /\`\`\`([\\w-]*)?\\n?([\\s\\S]*?)\`\`\`/g;
           let placeheld = src.replace(fenceRe, function (_m, lang, code) {
@@ -468,11 +534,10 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
             placeheld = placeheld.slice(0, startIdx) + '\\u0000FENCE' + (fences.length - 1) + '\\u0000';
           }
 
-          // 2. Walk lines, building paragraphs / lists / headings / quotes.
           const lines = placeheld.split(/\\n/);
           const out = [];
           let para = [];
-          let list = null; // { type: 'ul'|'ol', items: string[] }
+          let list = null;
           let quote = [];
 
           function flushPara() {
@@ -497,18 +562,13 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
 
           for (let i = 0; i < lines.length; i++) {
             const raw = lines[i];
-            const line = raw;
-            const trimmed = line.trim();
+            const trimmed = raw.trim();
 
-            // Code fence placeholder restores immediately, ending blocks.
             const fenceMatch = trimmed.match(/^\\u0000FENCE(\\d+)\\u0000$/);
             if (fenceMatch) {
               flushAll();
               const f = fences[parseInt(fenceMatch[1], 10)];
               const langLabel = f.lang ? esc(f.lang) : 'code';
-              // While streaming an open fence: skip highlighting (it would
-              // re-tokenize on every keystroke) and replace the Copy button
-              // with a "Streaming…" label so the user knows it's live.
               const body = f.open ? esc(f.code) : highlightCode(f.code, f.lang);
               const trailing = f.open
                 ? '<span class="codeblock-copy" aria-hidden="true">Streaming…</span>'
@@ -522,23 +582,12 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
               continue;
             }
 
-            // Blank line → paragraph break.
             if (!trimmed) { flushAll(); continue; }
-
-            // Horizontal rule.
-            if (/^(-{3,}|_{3,}|\\*{3,})$/.test(trimmed)) {
-              flushAll(); out.push('<hr />'); continue;
-            }
-
-            // Heading.
+            if (/^(-{3,}|_{3,}|\\*{3,})$/.test(trimmed)) { flushAll(); out.push('<hr />'); continue; }
             const h = trimmed.match(/^(#{1,3})\\s+(.+)$/);
             if (h) { flushAll(); out.push('<h' + h[1].length + '>' + renderInline(h[2]) + '</h' + h[1].length + '>'); continue; }
-
-            // Block quote.
             const q = trimmed.match(/^>\\s?(.*)$/);
             if (q) { flushPara(); flushList(); quote.push(q[1]); continue; }
-
-            // Ordered list.
             const ol = trimmed.match(/^(\\d+)[.)]\\s+(.+)$/);
             if (ol) {
               flushPara(); flushQuote();
@@ -546,8 +595,6 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
               list.items.push(ol[2]);
               continue;
             }
-
-            // Unordered list.
             const ul = trimmed.match(/^[-*+]\\s+(.+)$/);
             if (ul) {
               flushPara(); flushQuote();
@@ -555,8 +602,6 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
               list.items.push(ul[1]);
               continue;
             }
-
-            // Continuation line for the open block.
             if (list) { list.items[list.items.length - 1] += ' ' + trimmed; continue; }
             if (quote.length) { quote.push(trimmed); continue; }
             para.push(trimmed);
@@ -565,8 +610,6 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
           return out.join('');
         }
 
-        // Wires copy buttons inside code blocks. Idempotent — safe to call
-        // after each render or token append.
         function bindCodeCopy(root) {
           const buttons = (root || feed).querySelectorAll('.codeblock-copy:not([data-bound])');
           buttons.forEach(function (btn) {
@@ -587,11 +630,12 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
           });
         }
 
+        // ───── Connection ─────────────────────────────────────────────────
         const params = new URLSearchParams(window.location.search);
         const token = params.get('t') || '';
 
-        const messages = [];           // {id, role, content, createdAt}
-        let live = null;               // { streamId, content, createdAt }
+        const messages = [];        // { id, role, content, createdAt, label? }
+        let live = null;            // { streamId, content, createdAt }
         let socket = null;
         let reconnectTimer = null;
         let reconnectDelay = 800;
@@ -606,7 +650,9 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
         function setConnected(isConnected) {
           status.classList.toggle('connected', isConnected);
           statusText.textContent = isConnected ? 'Connected' : 'Offline';
-          subtitle.textContent = isConnected ? 'Live mirror active' : 'Reconnecting';
+          subtitle.textContent = isConnected ? 'Live mirror active' : 'Reconnecting…';
+          sendBtn.disabled = !isConnected;
+          document.querySelectorAll('.qa-btn').forEach(function (b) { b.disabled = !isConnected; });
         }
 
         function fmtTime(value) {
@@ -626,6 +672,28 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
         }
 
         function buildCard(m, opts) {
+          // Screenshot card
+          if (m.type === 'screenshot') {
+            const card = document.createElement('article');
+            card.className = 'card screenshot-card';
+            card.dataset.id = m.id || '';
+            const meta = document.createElement('div');
+            meta.className = 'meta';
+            const role = document.createElement('span');
+            role.className = 'role';
+            const pip = document.createElement('span'); pip.className = 'pip';
+            const lbl = document.createElement('span'); lbl.textContent = 'Desktop Screenshot';
+            role.append(pip, lbl);
+            const right = document.createElement('span'); right.textContent = fmtTime(m.createdAt);
+            meta.append(role, right);
+            const img = document.createElement('img');
+            img.src = m.dataUrl; img.alt = 'Desktop screenshot';
+            img.style.marginTop = '8px';
+            card.append(meta, img);
+            return card;
+          }
+
+          // Normal message card
           const card = document.createElement('article');
           card.className = 'card' + (m.role === 'user' ? ' user' : '') + (opts && opts.live ? ' live' : '');
           card.dataset.id = m.id || '';
@@ -637,15 +705,18 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
           const roleLabel = document.createElement('span');
           roleLabel.textContent = m.role === 'user' ? 'You' : 'Assistant';
           role.append(pip, roleLabel);
+          // Label tag for shortcut-triggered responses
+          const labelTag = document.createElement('span');
+          labelTag.className = 'label-tag';
+          labelTag.style.display = m.label ? 'inline-block' : 'none';
+          if (m.label) labelTag.textContent = m.label;
           const right = document.createElement('span');
           right.textContent = fmtTime(m.createdAt);
           const badge = document.createElement('span');
           badge.className = 'badge'; badge.textContent = 'Live';
-          meta.append(role, badge, right);
+          meta.append(role, labelTag, badge, right);
           const content = document.createElement('div');
           content.className = 'content';
-          // User messages stay verbatim (they're transcripts/typed text).
-          // Assistant messages get the full markdown treatment.
           if (m.role === 'user') {
             content.style.whiteSpace = 'pre-wrap';
             content.textContent = m.content || '';
@@ -670,10 +741,6 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
           scrollToLatest();
         }
 
-        // Coalesce token-driven renders to one per animation frame so a burst
-        // of buffered tokens (network often delivers 5-20 at once) costs one
-        // re-parse instead of N. requestAnimationFrame also pauses while the
-        // tab is hidden — we'll catch up automatically on visibility return.
         let liveRenderRaf = 0;
         function flushLiveRender() {
           liveRenderRaf = 0;
@@ -706,8 +773,6 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
         }
 
         function finalizeLive(streamId, content, createdAt) {
-          // Cancel any pending live render — we're about to do a final one
-          // with the canonical (server-confirmed) content.
           if (liveRenderRaf) {
             if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(liveRenderRaf);
             else clearTimeout(liveRenderRaf);
@@ -723,8 +788,17 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
           }
         }
 
+        // ───── Send command to server ─────────────────────────────────────
+        function sendCommand(cmd) {
+          if (socket && socket.readyState === WebSocket.OPEN) {
+            try { socket.send(JSON.stringify(cmd)); } catch (_) {}
+          }
+        }
+
+        // ───── Event handler ──────────────────────────────────────────────
         function handleEvent(ev) {
           if (!ev || typeof ev !== 'object') return;
+
           if (ev.type === 'history' && Array.isArray(ev.messages)) {
             messages.length = 0;
             for (const m of ev.messages) messages.push(m);
@@ -754,12 +828,26 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
             showToast('Stream error');
             return;
           }
+          // Non-streaming assistant response from shortcut-triggered actions
+          if (ev.type === 'assistant') {
+            messages.push({ id: ev.id, role: 'assistant', content: ev.content, createdAt: ev.createdAt, label: ev.label });
+            render();
+            scrollToLatest(true);
+            return;
+          }
+          // Desktop screenshot
+          if (ev.type === 'screenshot') {
+            messages.push({ id: ev.id, type: 'screenshot', dataUrl: ev.dataUrl, createdAt: ev.createdAt });
+            render();
+            scrollToLatest(true);
+            return;
+          }
           if (ev.type === 'status') {
-            // server-pushed status, ignored visually beyond connection state
             return;
           }
         }
 
+        // ───── WebSocket ──────────────────────────────────────────────────
         function connect() {
           clearTimeout(reconnectTimer);
           const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -800,11 +888,43 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
           } catch (e) { wakeLock = null; }
         }
 
+        // ───── Interaction handlers ───────────────────────────────────────
+        // Send chat message
+        function submitChat() {
+          const msg = chatInput.value.trim();
+          if (!msg) return;
+          sendCommand({ type: 'chat', message: msg });
+          chatInput.value = '';
+        }
+        sendBtn.addEventListener('click', submitChat);
+        chatInput.addEventListener('keydown', function (e) {
+          if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); submitChat(); }
+        });
+
+        // Quick action buttons
+        document.querySelectorAll('.qa-btn[data-action]').forEach(function (btn) {
+          btn.addEventListener('click', function () {
+            const action = btn.dataset.action;
+            sendCommand({ type: 'action', action });
+            btn.classList.add('working');
+            setTimeout(function () { btn.classList.remove('working'); }, 1200);
+          });
+        });
+
+        // Screenshot button
+        document.getElementById('screenshotBtn').addEventListener('click', function () {
+          sendCommand({ type: 'screenshot' });
+          showToast('Requesting screenshot…');
+        });
+
+        // Utility buttons
         document.getElementById('clearButton').addEventListener('click', () => {
           messages.length = 0; live = null; render();
         });
         document.getElementById('copyButton').addEventListener('click', async () => {
-          const parts = messages.map((m) => (m.role === 'user' ? 'You: ' : '') + m.content);
+          const parts = messages
+            .filter(function (m) { return !m.type || m.type !== 'screenshot'; })
+            .map((m) => (m.role === 'user' ? 'You: ' : (m.label ? '[' + m.label + '] ' : '')) + m.content);
           if (live && live.content) parts.push(live.content);
           const text = parts.join('\\n\\n');
           if (!text) return;
@@ -831,6 +951,10 @@ export const PHONE_MIRROR_HTML = `<!doctype html>
           status.classList.remove('connected');
           return;
         }
+
+        // Start disconnected — buttons disabled until connected
+        sendBtn.disabled = true;
+        document.querySelectorAll('.qa-btn').forEach(function (b) { b.disabled = true; });
 
         requestWakeLock();
         connect();

--- a/package-lock.json
+++ b/package-lock.json
@@ -12973,6 +12973,14 @@
         "node": "^8.11.2 || >=10"
       }
     },
+    "node_modules/iconv-corefoundation/node_modules/node-addon-api": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -15685,14 +15693,6 @@
       "engines": {
         "node": ">=22.12.0"
       }
-    },
-    "node_modules/node-addon-api": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
-      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/node-api-version": {
       "version": "0.2.1",

--- a/src/components/NativelyInterface.tsx
+++ b/src/components/NativelyInterface.tsx
@@ -1,49 +1,58 @@
-import React, { useState, useEffect, useRef, useLayoutEffect, useMemo, useCallback, startTransition as reactStartTransition } from 'react';
+import { animate, AnimatePresence, motion, useMotionValue, useTransform } from 'framer-motion';
 import {
-    Sparkles,
-    Pencil,
-    MessageSquare,
-    RefreshCw,
-    Settings,
-    ArrowUp,
-    ArrowRight,
-    HelpCircle,
-    ChevronUp,
-    ChevronDown,
-    Lightbulb,
-    CornerDownLeft,
-    Mic,
-    MicOff,
-    Image,
-    Camera,
-    X,
-    LogOut,
-    Zap,
-    Edit3,
-    SlidersHorizontal,
-    LayoutGrid,
-    Ghost,
-    Link,
-    Code,
-    Copy,
-    Check,
-    PointerOff,
-    ShieldCheck,
-    Monitor
+  ArrowRight,
+  ChevronDown,
+  Code,
+  Copy,
+  HelpCircle,
+  Image,
+  LayoutGrid,
+  Lightbulb,
+  MessageSquare,
+  Mic,
+  Monitor,
+  Pencil,
+  PointerOff,
+  RefreshCw,
+  ShieldCheck,
+  SlidersHorizontal,
+  X,
+  Zap,
 } from 'lucide-react';
-import { motion, AnimatePresence, useMotionValue, useTransform, animate } from 'framer-motion';
+import React, {
+  startTransition as reactStartTransition,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneLight, vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 // import { ModelSelector } from './ui/ModelSelector'; // REMOVED
-import TopPill from './ui/TopPill';
-import RollingTranscript from './ui/RollingTranscript';
-import { NegotiationCoachingCard } from '../premium';
-import { isMac, getModifierSymbol } from '../utils/platformUtils';
+import 'katex/dist/katex.min.css';
 import ReactMarkdown from 'react-markdown';
+import rehypeKatex from 'rehype-katex';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
-import rehypeKatex from 'rehype-katex';
-import 'katex/dist/katex.min.css';
+import { useResolvedTheme } from '../hooks/useResolvedTheme';
+import { useShortcuts } from '../hooks/useShortcuts';
+import { analytics, detectProviderType } from '../lib/analytics/analytics.service';
+import type { MeetingInterfaceTheme } from '../lib/meetingInterfaceTheme';
+import {
+  getGlassOverlayAppearance,
+  getOverlayAppearance,
+  OVERLAY_OPACITY_DEFAULT,
+} from '../lib/overlayAppearance';
+import { NegotiationCoachingCard } from '../premium';
+import type { DynamicActionPayload } from '../types/electron';
+import { getCodexCliModelDisplayName } from '../utils/modelUtils';
+import { getModifierSymbol, isMac } from '../utils/platformUtils';
+import { DynamicActionBar } from './dynamic-actions/DynamicActionBar';
+import GlassEffectLayer from './ui/GlassEffectLayer';
+import RollingTranscript from './ui/RollingTranscript';
+import TopPill from './ui/TopPill';
 
 // PERF: hoisted plugin arrays. ReactMarkdown receives `remarkPlugins` and
 // `rehypePlugins` as new array literals if defined inline at the call site —
@@ -52,41 +61,32 @@ import 'katex/dist/katex.min.css';
 // across every ReactMarkdown render in this component.
 const REMARK_PLUGINS = [remarkGfm, remarkMath];
 const REHYPE_PLUGINS = [rehypeKatex];
-import { analytics, detectProviderType } from '../lib/analytics/analytics.service';
-import { useShortcuts } from '../hooks/useShortcuts';
-import { useResolvedTheme } from '../hooks/useResolvedTheme';
-import { getOverlayAppearance, OVERLAY_OPACITY_DEFAULT, getGlassOverlayAppearance } from '../lib/overlayAppearance';
-import type { MeetingInterfaceTheme } from '../lib/meetingInterfaceTheme';
-import GlassEffectLayer from './ui/GlassEffectLayer';
-import { getCodexCliModelDisplayName } from '../utils/modelUtils';
-import { DynamicActionBar } from './dynamic-actions/DynamicActionBar';
-import type { DynamicActionPayload } from '../types/electron';
 
 interface Message {
-    id: string;
-    role: 'user' | 'system' | 'interviewer';
-    text: string;
-    isStreaming?: boolean;
-    hasScreenshot?: boolean;
-    screenshotPreview?: string;
-    isCode?: boolean;
-    intent?: string;
-    isNegotiationCoaching?: boolean;
-    negotiationCoachingData?: {
-        tacticalNote: string;
-        exactScript: string;
-        showSilenceTimer: boolean;
-        phase: string;
-        theirOffer: number | null;
-        yourTarget: number | null;
-        currency: string;
-    };
+  id: string;
+  role: 'user' | 'system' | 'interviewer';
+  text: string;
+  isStreaming?: boolean;
+  hasScreenshot?: boolean;
+  screenshotPreview?: string;
+  isCode?: boolean;
+  intent?: string;
+  isNegotiationCoaching?: boolean;
+  negotiationCoachingData?: {
+    tacticalNote: string;
+    exactScript: string;
+    showSilenceTimer: boolean;
+    phase: string;
+    theirOffer: number | null;
+    yourTarget: number | null;
+    currency: string;
+  };
 }
 
 interface NativelyInterfaceProps {
-    onEndMeeting?: () => void;
-    overlayOpacity?: number;
-    interfaceTheme?: MeetingInterfaceTheme;
+  onEndMeeting?: () => void;
+  overlayOpacity?: number;
+  interfaceTheme?: MeetingInterfaceTheme;
 }
 
 // PERF: HighlightedCode renders a single fenced code block. Hoisted to module
@@ -96,60 +96,81 @@ interface NativelyInterfaceProps {
 // block in history. The customStyle / lineNumberStyle objects are also at
 // module scope so their referential identity stays stable too.
 const HC_CUSTOM_STYLE = {
-    margin: 0,
-    borderRadius: 0,
-    fontSize: '13px',
-    lineHeight: '1.6',
-    background: 'transparent',
-    padding: '16px',
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+  margin: 0,
+  borderRadius: 0,
+  fontSize: '13px',
+  lineHeight: '1.6',
+  background: 'transparent',
+  padding: '16px',
+  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
 } as const;
 
 interface HighlightedCodeProps {
-    code: string;
-    lang: string;
-    isLightTheme: boolean;
-    codeTheme: any;
-    codeBlockClass: string;
-    codeHeaderClass: string;
-    codeHeaderTextClass: string;
-    codeLineNumberColor: string;
-    appearance: any;
+  code: string;
+  lang: string;
+  isLightTheme: boolean;
+  codeTheme: any;
+  codeBlockClass: string;
+  codeHeaderClass: string;
+  codeHeaderTextClass: string;
+  codeLineNumberColor: string;
+  appearance: any;
 }
-const HighlightedCode = React.memo(function HighlightedCode({
-    code, lang, codeTheme, codeBlockClass, codeHeaderClass, codeHeaderTextClass, codeLineNumberColor, appearance,
-}: HighlightedCodeProps) {
+const HighlightedCode = React.memo(
+  function HighlightedCode({
+    code,
+    lang,
+    codeTheme,
+    codeBlockClass,
+    codeHeaderClass,
+    codeHeaderTextClass,
+    codeLineNumberColor,
+    appearance,
+  }: HighlightedCodeProps) {
     return (
-        <div className={`my-3 rounded-xl overflow-hidden border shadow-lg ${codeBlockClass}`} style={appearance.codeBlockStyle}>
-            {/* Minimalist Apple Header */}
-            <div className={`px-3 py-1.5 border-b ${codeHeaderClass}`} style={appearance.codeHeaderStyle}>
-                <span className={`text-[10px] uppercase tracking-widest font-semibold font-mono ${codeHeaderTextClass}`}>
-                    {lang || 'CODE'}
-                </span>
-            </div>
-            {/* No-wrap horizontal scroll: code line layout stays stable as the
+      <div
+        className={`my-3 rounded-xl overflow-hidden border shadow-lg ${codeBlockClass}`}
+        style={appearance.codeBlockStyle}
+      >
+        {/* Minimalist Apple Header */}
+        <div
+          className={`px-3 py-1.5 border-b ${codeHeaderClass}`}
+          style={appearance.codeHeaderStyle}
+        >
+          <span
+            className={`text-[10px] uppercase tracking-widest font-semibold font-mono ${codeHeaderTextClass}`}
+          >
+            {lang || 'CODE'}
+          </span>
+        </div>
+        {/* No-wrap horizontal scroll: code line layout stays stable as the
                 canvas grows/shrinks. Without this, wrapped lines re-flow at every
                 spring tick, the block height jitters, and content below shifts. */}
-            <div className="bg-transparent overflow-x-auto">
-                <SyntaxHighlighter
-                    language={lang}
-                    style={codeTheme}
-                    customStyle={HC_CUSTOM_STYLE}
-                    wrapLongLines={false}
-                    showLineNumbers={true}
-                    lineNumberStyle={{ minWidth: '2.5em', paddingRight: '1.2em', color: codeLineNumberColor, textAlign: 'right', fontSize: '11px' }}
-                >
-                    {code}
-                </SyntaxHighlighter>
-            </div>
+        <div className="bg-transparent overflow-x-auto">
+          <SyntaxHighlighter
+            language={lang}
+            style={codeTheme}
+            customStyle={HC_CUSTOM_STYLE}
+            wrapLongLines={false}
+            showLineNumbers={true}
+            lineNumberStyle={{
+              minWidth: '2.5em',
+              paddingRight: '1.2em',
+              color: codeLineNumberColor,
+              textAlign: 'right',
+              fontSize: '11px',
+            }}
+          >
+            {code}
+          </SyntaxHighlighter>
         </div>
+      </div>
     );
-}, (prev, next) =>
+  },
+  (prev, next) =>
     // codeTheme / codeBlockClass / appearance are all theme-derived; checking
     // appearance (a useMemo'd ref) covers them transitively.
-    prev.code === next.code &&
-    prev.lang === next.lang &&
-    prev.appearance === next.appearance
+    prev.code === next.code && prev.lang === next.lang && prev.appearance === next.appearance,
 );
 
 // PERF: MessageRow renders one chat-message bubble. Module-scope + React.memo
@@ -170,1778 +191,2095 @@ const HighlightedCode = React.memo(function HighlightedCode({
 //   - appearance: useMemo'd in parent on [overlayOpacity, isLightTheme].
 //   - onCopy / renderMessageText: useCallback'd in parent.
 interface MessageRowProps {
-    msg: Message;
-    isLightTheme: boolean;
-    appearance: any;
-    onCopy: (text: string) => void;
-    renderMessageText: (msg: Message) => React.ReactNode;
+  msg: Message;
+  isLightTheme: boolean;
+  appearance: any;
+  onCopy: (text: string) => void;
+  renderMessageText: (msg: Message) => React.ReactNode;
 }
 const formatProviderLabel = (provider?: string | null): string => {
-    if (!provider) return 'not set';
-    return provider
-        .split(/[-_\s]+/)
-        .filter(Boolean)
-        .map(part => part.charAt(0).toUpperCase() + part.slice(1))
-        .join(' ');
+  if (!provider) return 'not set';
+  return provider
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
 };
 
 const getSttSummary = (
-    userStatus: 'connected' | 'reconnecting' | 'failed',
-    interviewerStatus: 'connected' | 'reconnecting' | 'failed',
-    userProvider: string,
-    interviewerProvider: string,
-    notConfigured: boolean
+  userStatus: 'connected' | 'reconnecting' | 'failed',
+  interviewerStatus: 'connected' | 'reconnecting' | 'failed',
+  userProvider: string,
+  interviewerProvider: string,
+  notConfigured: boolean,
 ): { label: string; tone: 'ok' | 'warn' | 'error'; detail: string } => {
-    if (notConfigured) {
-        return { label: 'STT not configured', tone: 'error', detail: 'Open Audio settings to select a provider' };
-    }
-    if (userStatus === 'failed' || interviewerStatus === 'failed') {
-        return { label: 'STT needs attention', tone: 'error', detail: `${formatProviderLabel(userProvider)} mic · ${formatProviderLabel(interviewerProvider)} system` };
-    }
-    if (userStatus === 'reconnecting' || interviewerStatus === 'reconnecting') {
-        return { label: 'STT reconnecting', tone: 'warn', detail: `${formatProviderLabel(userProvider)} mic · ${formatProviderLabel(interviewerProvider)} system` };
-    }
-    return { label: 'STT healthy', tone: 'ok', detail: `${formatProviderLabel(userProvider)} mic · ${formatProviderLabel(interviewerProvider)} system` };
+  if (notConfigured) {
+    return {
+      label: 'STT not configured',
+      tone: 'error',
+      detail: 'Open Audio settings to select a provider',
+    };
+  }
+  if (userStatus === 'failed' || interviewerStatus === 'failed') {
+    return {
+      label: 'STT needs attention',
+      tone: 'error',
+      detail: `${formatProviderLabel(userProvider)} mic · ${formatProviderLabel(interviewerProvider)} system`,
+    };
+  }
+  if (userStatus === 'reconnecting' || interviewerStatus === 'reconnecting') {
+    return {
+      label: 'STT reconnecting',
+      tone: 'warn',
+      detail: `${formatProviderLabel(userProvider)} mic · ${formatProviderLabel(interviewerProvider)} system`,
+    };
+  }
+  return {
+    label: 'STT healthy',
+    tone: 'ok',
+    detail: `${formatProviderLabel(userProvider)} mic · ${formatProviderLabel(interviewerProvider)} system`,
+  };
 };
 
 const getStatusToneClass = (tone: 'ok' | 'warn' | 'error'): string => {
-    if (tone === 'error') return 'text-rose-600 dark:text-rose-300 border-rose-500/20 bg-rose-500/10';
-    if (tone === 'warn') return 'text-amber-600 dark:text-amber-300 border-amber-500/20 bg-amber-500/10';
-    return 'text-emerald-600 dark:text-emerald-300 border-emerald-500/20 bg-emerald-500/10';
+  if (tone === 'error') return 'text-rose-600 dark:text-rose-300 border-rose-500/20 bg-rose-500/10';
+  if (tone === 'warn')
+    return 'text-amber-600 dark:text-amber-300 border-amber-500/20 bg-amber-500/10';
+  return 'text-emerald-600 dark:text-emerald-300 border-emerald-500/20 bg-emerald-500/10';
 };
 
-const MessageRow = React.memo(function MessageRow({
-    msg, isLightTheme, appearance, onCopy, renderMessageText,
-}: MessageRowProps) {
+const MessageRow = React.memo(
+  function MessageRow({
+    msg,
+    isLightTheme,
+    appearance,
+    onCopy,
+    renderMessageText,
+  }: MessageRowProps) {
     const isCodeMsg = msg.role === 'system' && (msg.isCode || msg.text.includes('```'));
     // bubbleMaxClass: user bubbles are tighter; system + code use the same width.
-    const bubbleMaxClass = msg.role === 'user'
-        ? 'max-w-[72%] px-[13.6px] py-[10.2px]'
-        : 'max-w-[85%] px-4 py-3';
+    const bubbleMaxClass =
+      msg.role === 'user' ? 'max-w-[72%] px-[13.6px] py-[10.2px]' : 'max-w-[85%] px-4 py-3';
     return (
+      <div className="w-full" {...(isCodeMsg ? { 'data-code-msg': 'true' } : {})}>
         <div
-            className="w-full"
-            {...(isCodeMsg ? { 'data-code-msg': 'true' } : {})}
+          className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'} animate-fade-in-up`}
         >
-            <div className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'} animate-fade-in-up`}>
-                <div className={`
+          <div
+            className={`
               ${bubbleMaxClass} text-[14px] leading-relaxed relative group whitespace-pre-wrap
-              ${msg.role === 'user'
-                        ? (isLightTheme
-                            ? 'bg-blue-500/10 backdrop-blur-md border border-blue-500/20 text-blue-900 rounded-[20px] rounded-tr-[4px] shadow-sm font-medium'
-                            : 'bg-blue-600/20 backdrop-blur-md border border-blue-500/30 text-blue-100 rounded-[20px] rounded-tr-[4px] shadow-sm font-medium')
-                        : ''
-                    }
-              ${msg.role === 'system'
-                        ? 'overlay-text-primary font-normal'
-                        : ''
-                    }
-              ${msg.role === 'interviewer'
-                        ? 'overlay-text-muted italic pl-0 text-[13px]'
-                        : ''
-                    }
-            `}>
-                    {msg.role === 'interviewer' && (
-                        <div className="flex items-center gap-1.5 mb-1 text-[10px] font-medium uppercase tracking-wider overlay-text-muted">
-                            Interviewer
-                            {msg.isStreaming && <span className="w-1 h-1 bg-green-500 rounded-full animate-pulse" />}
-                        </div>
-                    )}
-                    {msg.role === 'user' && msg.hasScreenshot && (
-                        <div className={`flex items-center gap-1 text-[10px] opacity-70 mb-1 border-b pb-1 ${isLightTheme ? 'border-black/10' : 'border-white/10'}`}>
-                            <Image className="w-2.5 h-2.5" />
-                            <span>Screenshot attached</span>
-                        </div>
-                    )}
-                    {msg.role === 'system' && !msg.isStreaming && (
-                        <button
-                            onClick={() => onCopy(msg.text)}
-                            className="absolute top-2 right-2 p-1.5 rounded-md opacity-0 group-hover:opacity-100 transition-opacity overlay-icon-surface overlay-icon-surface-hover overlay-text-interactive"
-                            title="Copy to clipboard"
-                            style={appearance.iconStyle}
-                        >
-                            <Copy className="w-3.5 h-3.5" />
-                        </button>
-                    )}
-                    {renderMessageText(msg)}
-                </div>
-            </div>
+              ${
+                msg.role === 'user'
+                  ? isLightTheme
+                    ? 'bg-blue-500/10 backdrop-blur-md border border-blue-500/20 text-blue-900 rounded-[20px] rounded-tr-[4px] shadow-sm font-medium'
+                    : 'bg-blue-600/20 backdrop-blur-md border border-blue-500/30 text-blue-100 rounded-[20px] rounded-tr-[4px] shadow-sm font-medium'
+                  : ''
+              }
+              ${msg.role === 'system' ? 'overlay-text-primary font-normal' : ''}
+              ${msg.role === 'interviewer' ? 'overlay-text-muted italic pl-0 text-[13px]' : ''}
+            `}
+          >
+            {msg.role === 'interviewer' && (
+              <div className="flex items-center gap-1.5 mb-1 text-[10px] font-medium uppercase tracking-wider overlay-text-muted">
+                Interviewer
+                {msg.isStreaming && (
+                  <span className="w-1 h-1 bg-green-500 rounded-full animate-pulse" />
+                )}
+              </div>
+            )}
+            {msg.role === 'user' && msg.hasScreenshot && (
+              <div
+                className={`flex items-center gap-1 text-[10px] opacity-70 mb-1 border-b pb-1 ${isLightTheme ? 'border-black/10' : 'border-white/10'}`}
+              >
+                <Image className="w-2.5 h-2.5" />
+                <span>Screenshot attached</span>
+              </div>
+            )}
+            {msg.role === 'system' && !msg.isStreaming && (
+              <button
+                onClick={() => onCopy(msg.text)}
+                className="absolute top-2 right-2 p-1.5 rounded-md opacity-0 group-hover:opacity-100 transition-opacity overlay-icon-surface overlay-icon-surface-hover overlay-text-interactive"
+                title="Copy to clipboard"
+                style={appearance.iconStyle}
+              >
+                <Copy className="w-3.5 h-3.5" />
+              </button>
+            )}
+            {renderMessageText(msg)}
+          </div>
         </div>
+      </div>
     );
-}, (prev, next) =>
+  },
+  (prev, next) =>
     prev.msg === next.msg &&
     prev.isLightTheme === next.isLightTheme &&
     prev.appearance === next.appearance &&
     prev.renderMessageText === next.renderMessageText &&
-    prev.onCopy === next.onCopy
+    prev.onCopy === next.onCopy,
 );
 
 const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
-    onEndMeeting,
-    overlayOpacity = OVERLAY_OPACITY_DEFAULT,
-    interfaceTheme = 'default',
+  onEndMeeting,
+  overlayOpacity = OVERLAY_OPACITY_DEFAULT,
+  interfaceTheme = 'default',
 }) => {
-    const isLightTheme = useResolvedTheme() === 'light';
-    const isGlassTheme = interfaceTheme === 'liquid-glass';
-    const shellRef = React.useRef<HTMLDivElement>(null);
-    const [isExpanded, setIsExpanded] = useState(true);
-    const [inputValue, setInputValue] = useState('');
-    const { shortcuts, isShortcutPressed } = useShortcuts();
-    const [messages, setMessages] = useState<Message[]>([]);
-    const [isConnected, setIsConnected] = useState(false);
-    const [sttUserStatus, setSttUserStatus] = useState<'connected' | 'reconnecting' | 'failed'>('connected');
-    const [sttUserError, setSttUserError] = useState<string>('');
-    const [sttUserProvider, setSttUserProvider] = useState<string>('');
-    const [sttInterviewerStatus, setSttInterviewerStatus] = useState<'connected' | 'reconnecting' | 'failed'>('connected');
-    const [sttInterviewerError, setSttInterviewerError] = useState<string>('');
-    const [sttInterviewerProvider, setSttInterviewerProvider] = useState<string>('');
-    const [isProcessing, setIsProcessing] = useState(false);
-    const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-    const [conversationContext, setConversationContext] = useState<string>('');
-    const [isManualRecording, setIsManualRecording] = useState(false);
-    const isRecordingRef = useRef(false);  // Ref to track recording state (avoids stale closure)
-    const [manualTranscript, setManualTranscript] = useState('');
-    const manualTranscriptRef = useRef<string>('');
-    const [showTranscript, setShowTranscript] = useState(() => {
-        const stored = localStorage.getItem('natively_interviewer_transcript');
-        return stored !== 'false';
-    });
-    const [autoScroll, setAutoScroll] = useState(() => {
-        const stored = localStorage.getItem('natively_auto_scroll');
-        return stored === 'true';
-    });
+  const isLightTheme = useResolvedTheme() === 'light';
+  const isGlassTheme = interfaceTheme === 'liquid-glass';
+  const shellRef = React.useRef<HTMLDivElement>(null);
+  const [isExpanded, setIsExpanded] = useState(true);
+  const [inputValue, setInputValue] = useState('');
+  const { shortcuts, isShortcutPressed } = useShortcuts();
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [isConnected, setIsConnected] = useState(false);
+  const [sttUserStatus, setSttUserStatus] = useState<'connected' | 'reconnecting' | 'failed'>(
+    'connected',
+  );
+  const [sttUserError, setSttUserError] = useState<string>('');
+  const [sttUserProvider, setSttUserProvider] = useState<string>('');
+  const [sttInterviewerStatus, setSttInterviewerStatus] = useState<
+    'connected' | 'reconnecting' | 'failed'
+  >('connected');
+  const [sttInterviewerError, setSttInterviewerError] = useState<string>('');
+  const [sttInterviewerProvider, setSttInterviewerProvider] = useState<string>('');
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [conversationContext, setConversationContext] = useState<string>('');
+  const [isManualRecording, setIsManualRecording] = useState(false);
+  const isRecordingRef = useRef(false); // Ref to track recording state (avoids stale closure)
+  const [manualTranscript, setManualTranscript] = useState('');
+  const manualTranscriptRef = useRef<string>('');
+  const [showTranscript, setShowTranscript] = useState(() => {
+    const stored = localStorage.getItem('natively_interviewer_transcript');
+    return stored !== 'false';
+  });
+  const [autoScroll, setAutoScroll] = useState(() => {
+    const stored = localStorage.getItem('natively_auto_scroll');
+    return stored === 'true';
+  });
 
-    // Analytics State
-    const requestStartTimeRef = useRef<number | null>(null);
+  // Analytics State
+  const requestStartTimeRef = useRef<number | null>(null);
 
-    // Sync transcript setting
-    useEffect(() => {
-        const handleStorage = () => {
-            const stored = localStorage.getItem('natively_interviewer_transcript');
-            setShowTranscript(stored !== 'false');
-        };
-        window.addEventListener('storage', handleStorage);
-        return () => window.removeEventListener('storage', handleStorage);
-    }, []);
+  // Sync transcript setting
+  useEffect(() => {
+    const handleStorage = () => {
+      const stored = localStorage.getItem('natively_interviewer_transcript');
+      setShowTranscript(stored !== 'false');
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, []);
 
+  // Sync auto-scroll setting
+  useEffect(() => {
+    const handleStorage = () => {
+      const stored = localStorage.getItem('natively_auto_scroll');
+      setAutoScroll(stored === 'true');
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, []);
 
-    // Sync auto-scroll setting
-    useEffect(() => {
-        const handleStorage = () => {
-            const stored = localStorage.getItem('natively_auto_scroll');
-            setAutoScroll(stored === 'true');
-        };
-        window.addEventListener('storage', handleStorage);
-        return () => window.removeEventListener('storage', handleStorage);
-    }, []);
+  // Auto-scroll to bottom on every messages update when toggle is enabled.
+  // 'auto' (instant) instead of 'smooth' is intentional: streaming tokens fire
+  // this effect tens of times per second; smooth would restart the animation
+  // each time and never reach bottom, producing visible chase/jitter.
+  useEffect(() => {
+    if (!autoScroll) return;
+    if (messages.length === 0) return;
+    messagesEndRef.current?.scrollIntoView({ behavior: 'auto' });
+  }, [messages, autoScroll]);
 
-    // Auto-scroll to bottom on every messages update when toggle is enabled.
-    // 'auto' (instant) instead of 'smooth' is intentional: streaming tokens fire
-    // this effect tens of times per second; smooth would restart the animation
-    // each time and never reach bottom, producing visible chase/jitter.
-    useEffect(() => {
-        if (!autoScroll) return;
-        if (messages.length === 0) return;
-        messagesEndRef.current?.scrollIntoView({ behavior: 'auto' });
-    }, [messages, autoScroll]);
+  const [rollingTranscript, setRollingTranscript] = useState(''); // For interviewer rolling text bar
+  const [isInterviewerSpeaking, setIsInterviewerSpeaking] = useState(false); // Track if actively speaking
+  const [voiceInput, setVoiceInput] = useState(''); // Accumulated user voice input
+  const voiceInputRef = useRef<string>(''); // Ref for capturing in async handlers
+  const textInputRef = useRef<HTMLInputElement>(null); // Ref for input focus
+  const isStealthRef = useRef<boolean>(false); // Tracks if the next expansion should be stealthy
+  // CGEventTap stealth-typing state. Driven by IPC from main; ref shadows
+  // the state so the captured-key handler can early-out without depending
+  // on React's render cycle for stop signals.
+  const [stealthTapActive, setStealthTapActive] = useState<boolean>(false);
+  const stealthTapActiveRef = useRef<boolean>(false);
+  // True when the click-to-engage stealth path is safe. False when an IME
+  // (Pinyin / Hangul / Kanji / …) is enabled in macOS HIToolbox: the tap
+  // captures below the IME so composition would never reach the chat box.
+  // Resolved once on mount via IPC (default true so non-macOS / probe
+  // failure falls back to existing behaviour).
+  const stealthAutoEngageOkRef = useRef<boolean>(true);
+  // True when CGEventTap is available on this platform. Set once at mount
+  // via IPC. Used to decide whether to block DOM focus in blockInputFocus -
+  // without this synchronous signal, blockInputFocus cannot distinguish "tap
+  // not yet active" (macOS: block anyway) from "tap not available" (Windows:
+  // never block, or the input becomes permanently trapped).
+  // Set synchronously from preload — platform is known immediately at render time.
+  const isCgEventTapAvailableRef = useRef<boolean>(window.electronAPI?.platform === 'darwin');
+  // Latest-handler ref so the captured-key listener (mounted with [] deps)
+  // calls the CURRENT handleManualSubmit closure — not the one captured at
+  // first render, which reads inputValue="" and silently no-ops on submit.
+  // Updated on every render below.
+  const handleManualSubmitRef = useRef<() => void>(() => {});
+  // Set when the user tried to engage the tap but Accessibility isn't
+  // granted yet. Renders the inline permission banner so we never silently
+  // fail — Cluely's onboarding is its UX moat; we mirror it.
+  const [stealthPermissionMissing, setStealthPermissionMissing] = useState<boolean>(false);
+  // Set when KeybindManager reports the stealth-typing global shortcut
+  // failed to register (OS already owns it — common with Cmd+Shift+Space
+  // if another app claimed it, or with the macOS input source switcher
+  // in some configs). Stores the attempted accelerator so the banner can
+  // tell the user exactly what conflicted.
+  const [stealthHotkeyConflict, setStealthHotkeyConflict] = useState<string | null>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const rafDimUpdateRef = useRef<number | null>(null);
+  const codeExpandedRef = useRef(false);
+  const animationControlsRef = useRef<ReturnType<typeof animate> | null>(null);
+  // Stability gate for code-visibility transitions. Scroll fires at ~60Hz;
+  // without this, fast scrolls cancel and restart the 0.7s tween repeatedly,
+  // producing stutter (and sometimes a snap when start≈target). The pending
+  // visibility must hold its new state for STABILITY_MS before we commit to
+  // a transition.
+  const stableVisibilityTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingVisibilityRef = useRef<boolean | null>(null);
+  // Sticky-bottom across expand/contract. Captured at the start of each
+  // transition: if the chat was scrolled to (or within 8 px of) the bottom,
+  // the rAF loop pins scrollTop to bottom on every spring frame so the
+  // bottom of the conversation stays visually pinned as scrollMaxH grows.
+  // iMessage does the same when its window resizes.
+  const wasAtBottomRef = useRef<boolean>(true);
+  // Captures data from onCaptureAndProcess before the React state flush so
+  // handleWhatToSay() can access it even in React 18 concurrent mode (where
+  // a plain setTimeout(0) may fire before setAttachedContext flushes).
+  const pendingCaptureRef = useRef<{ path: string; preview: string } | null>(null);
 
-    const [rollingTranscript, setRollingTranscript] = useState('');  // For interviewer rolling text bar
-    const [isInterviewerSpeaking, setIsInterviewerSpeaking] = useState(false);  // Track if actively speaking
-    const [voiceInput, setVoiceInput] = useState('');  // Accumulated user voice input
-    const voiceInputRef = useRef<string>('');  // Ref for capturing in async handlers
-    const textInputRef = useRef<HTMLInputElement>(null); // Ref for input focus
-    const isStealthRef = useRef<boolean>(false); // Tracks if the next expansion should be stealthy
-    // CGEventTap stealth-typing state. Driven by IPC from main; ref shadows
-    // the state so the captured-key handler can early-out without depending
-    // on React's render cycle for stop signals.
-    const [stealthTapActive, setStealthTapActive] = useState<boolean>(false);
-    const stealthTapActiveRef = useRef<boolean>(false);
-    // True when the click-to-engage stealth path is safe. False when an IME
-    // (Pinyin / Hangul / Kanji / …) is enabled in macOS HIToolbox: the tap
-    // captures below the IME so composition would never reach the chat box.
-    // Resolved once on mount via IPC (default true so non-macOS / probe
-    // failure falls back to existing behaviour).
-    const stealthAutoEngageOkRef = useRef<boolean>(true);
-    // True when CGEventTap is available on this platform. Set once at mount
-    // via IPC. Used to decide whether to block DOM focus in blockInputFocus -
-    // without this synchronous signal, blockInputFocus cannot distinguish "tap
-    // not yet active" (macOS: block anyway) from "tap not available" (Windows:
-    // never block, or the input becomes permanently trapped).
-    // Set synchronously from preload — platform is known immediately at render time.
-    const isCgEventTapAvailableRef = useRef<boolean>(window.electronAPI?.platform === "darwin");
-    // Latest-handler ref so the captured-key listener (mounted with [] deps)
-    // calls the CURRENT handleManualSubmit closure — not the one captured at
-    // first render, which reads inputValue="" and silently no-ops on submit.
-    // Updated on every render below.
-    const handleManualSubmitRef = useRef<() => void>(() => {});
-    // Set when the user tried to engage the tap but Accessibility isn't
-    // granted yet. Renders the inline permission banner so we never silently
-    // fail — Cluely's onboarding is its UX moat; we mirror it.
-    const [stealthPermissionMissing, setStealthPermissionMissing] = useState<boolean>(false);
-    // Set when KeybindManager reports the stealth-typing global shortcut
-    // failed to register (OS already owns it — common with Cmd+Shift+Space
-    // if another app claimed it, or with the macOS input source switcher
-    // in some configs). Stores the attempted accelerator so the banner can
-    // tell the user exactly what conflicted.
-    const [stealthHotkeyConflict, setStealthHotkeyConflict] = useState<string | null>(null);
-    const messagesEndRef = useRef<HTMLDivElement>(null);
-    const contentRef = useRef<HTMLDivElement>(null);
-    const scrollContainerRef = useRef<HTMLDivElement>(null);
-    const rafDimUpdateRef = useRef<number | null>(null);
-    const codeExpandedRef = useRef(false);
-    const animationControlsRef = useRef<ReturnType<typeof animate> | null>(null);
-    // Stability gate for code-visibility transitions. Scroll fires at ~60Hz;
-    // without this, fast scrolls cancel and restart the 0.7s tween repeatedly,
-    // producing stutter (and sometimes a snap when start≈target). The pending
-    // visibility must hold its new state for STABILITY_MS before we commit to
-    // a transition.
-    const stableVisibilityTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const pendingVisibilityRef = useRef<boolean | null>(null);
-    // Sticky-bottom across expand/contract. Captured at the start of each
-    // transition: if the chat was scrolled to (or within 8 px of) the bottom,
-    // the rAF loop pins scrollTop to bottom on every spring frame so the
-    // bottom of the conversation stays visually pinned as scrollMaxH grows.
-    // iMessage does the same when its window resizes.
-    const wasAtBottomRef = useRef<boolean>(true);
-    // Captures data from onCaptureAndProcess before the React state flush so
-    // handleWhatToSay() can access it even in React 18 concurrent mode (where
-    // a plain setTimeout(0) may fire before setAttachedContext flushes).
-    const pendingCaptureRef = useRef<{ path: string; preview: string } | null>(null);
+  // Latent Context State (Screenshots attached but not sent)
+  const [attachedContext, setAttachedContext] = useState<Array<{ path: string; preview: string }>>(
+    [],
+  );
 
-    // Latent Context State (Screenshots attached but not sent)
-    const [attachedContext, setAttachedContext] = useState<Array<{ path: string, preview: string }>>([]);
+  // Settings State with Persistence
+  const [isUndetectable, setIsUndetectable] = useState(false);
+  const [hideChatHidesWidget, setHideChatHidesWidget] = useState(() => {
+    const stored = localStorage.getItem('natively_hideChatHidesWidget');
+    return stored ? stored === 'true' : true;
+  });
 
-    // Settings State with Persistence
-    const [isUndetectable, setIsUndetectable] = useState(false);
-    const [hideChatHidesWidget, setHideChatHidesWidget] = useState(() => {
-        const stored = localStorage.getItem('natively_hideChatHidesWidget');
-        return stored ? stored === 'true' : true;
-    });
+  // Active mode name (shown as a badge near the Modes button)
+  const [activeModeLabel, setActiveModeLabel] = useState<string | null>(null);
+  const [llmProviderLabel, setLlmProviderLabel] = useState<string>('unknown');
+  const [llmPrivacyLabel, setLlmPrivacyLabel] = useState<string>('Checking privacy route');
+  const [screenContextStatus, setScreenContextStatus] = useState<
+    'not_available' | 'available' | 'failed'
+  >('not_available');
+  const [latestUsedImageInput, setLatestUsedImageInput] = useState(false);
+  // Vision-first provenance — populated from the generateWhatToSay response.
+  const [latestVisionProviderUsed, setLatestVisionProviderUsed] = useState<string | undefined>(
+    undefined,
+  );
+  const [latestVisionModelUsed, setLatestVisionModelUsed] = useState<string | undefined>(undefined);
+  const [latestVisionFailureReason, setLatestVisionFailureReason] = useState<string | undefined>(
+    undefined,
+  );
 
-    // Active mode name (shown as a badge near the Modes button)
-    const [activeModeLabel, setActiveModeLabel] = useState<string | null>(null);
-    const [llmProviderLabel, setLlmProviderLabel] = useState<string>('unknown');
-    const [llmPrivacyLabel, setLlmPrivacyLabel] = useState<string>('Checking privacy route');
-    const [screenContextStatus, setScreenContextStatus] = useState<'not_available' | 'available' | 'failed'>('not_available');
-    const [latestUsedImageInput, setLatestUsedImageInput] = useState(false);
-    // Vision-first provenance — populated from the generateWhatToSay response.
-    const [latestVisionProviderUsed, setLatestVisionProviderUsed] = useState<string | undefined>(undefined);
-    const [latestVisionModelUsed, setLatestVisionModelUsed] = useState<string | undefined>(undefined);
-    const [latestVisionFailureReason, setLatestVisionFailureReason] = useState<string | undefined>(undefined);
-
-    useEffect(() => {
-        // Load initial active mode name
-        window.electronAPI?.modesGetActive?.()
-            .then((mode: { name: string } | null) => setActiveModeLabel(mode?.name ?? null))
-            .catch(() => { });
-        // Live-update whenever mode is activated/deactivated
-        const unsub = window.electronAPI?.onModeChanged?.((data: { id: string | null; name: string | null }) => {
-            setActiveModeLabel(data.name);
-        });
-        return () => unsub?.();
-    }, []);
-
-    useEffect(() => {
-        let mounted = true;
-        const loadLlmRoute = async () => {
-            const config = await window.electronAPI?.getCurrentLlmConfig?.().catch(() => null);
-            if (!mounted || !config) return;
-            setLlmProviderLabel(formatProviderLabel(config.provider));
-            setLlmPrivacyLabel(config.provider === 'ollama' || config.provider === 'codex-cli'
-                ? 'Local/private route'
-                : config.provider === 'custom'
-                    ? 'Custom endpoint route'
-                    : 'Cloud LLM route');
-        };
-        loadLlmRoute();
-        const unsub = window.electronAPI?.onModelChanged?.(() => { loadLlmRoute(); });
-        return () => {
-            mounted = false;
-            unsub?.();
-        };
-    }, []);
-
-    // Model Selection State
-    const [currentModel, setCurrentModel] = useState<string>('gemini-3-flash-preview');
-
-    // Dynamic Action Button Mode (Recap vs Brainstorm)
-    const [actionButtonMode, setActionButtonMode] = useState<'recap' | 'brainstorm'>('recap');
-
-    useEffect(() => {
-        // Load persisted mode
-        window.electronAPI?.getActionButtonMode?.()?.then((mode: 'recap' | 'brainstorm') => {
-            if (mode) setActionButtonMode(mode);
-        }).catch(() => { });
-
-        // Listen for live changes from SettingsPopup / IPC
-        const unsubscribe = window.electronAPI?.onActionButtonModeChanged?.((mode: 'recap' | 'brainstorm') => {
-            setActionButtonMode(mode);
-        });
-        return () => { unsubscribe?.(); };
-    }, []);
-
-    const codeTheme = isLightTheme ? oneLight : vscDarkPlus;
-    const codeLineNumberColor = isLightTheme ? 'rgba(15,23,42,0.35)' : 'rgba(255,255,255,0.2)';
-    const appearance = useMemo(
-        () => isGlassTheme
-            ? getGlassOverlayAppearance()
-            : getOverlayAppearance(overlayOpacity, isLightTheme ? 'light' : 'dark'),
-        [overlayOpacity, isLightTheme, isGlassTheme]
+  useEffect(() => {
+    // Load initial active mode name
+    window.electronAPI
+      ?.modesGetActive?.()
+      .then((mode: { name: string } | null) => setActiveModeLabel(mode?.name ?? null))
+      .catch(() => {});
+    // Live-update whenever mode is activated/deactivated
+    const unsub = window.electronAPI?.onModeChanged?.(
+      (data: { id: string | null; name: string | null }) => {
+        setActiveModeLabel(data.name);
+      },
     );
-    const overlayPanelClass = 'overlay-text-primary';
-    const subtleSurfaceClass = 'overlay-subtle-surface';
-    const codeBlockClass = 'overlay-code-block-surface';
-    const codeHeaderClass = 'overlay-code-header-surface';
-    const codeHeaderTextClass = 'overlay-text-muted';
-    const quickActionClass = 'overlay-chip-surface overlay-text-interactive';
-    const inputClass = `${isLightTheme ? 'focus:ring-black/10' : 'focus:ring-white/10'} overlay-input-surface overlay-input-text`;
-    const controlSurfaceClass = 'overlay-control-surface overlay-text-interactive';
+    return () => unsub?.();
+  }, []);
 
-    // PERF: hoist ReactMarkdown `components` maps for every streaming intent
-    // into a single useMemo so their identity is stable across renders. Each
-    // inline <ReactMarkdown components={{...}}> would create a fresh object
-    // literal per render — defeating ReactMarkdown's internal render-bailout.
-    //
-    // ALL 6 message-intent branches stream tokens (per IntelligenceEngine emits):
-    //   - standard:              plain system text bubbles (fallback render)
-    //   - codeText:              text parts inside a code-bubble
-    //   - whatToAnswerText:      `what_to_answer` card body (suggested_answer_token;
-    //                            emerald theme)
-    //   - recapText:             `recap` body (recap_token; indigo theme)
-    //   - followUpQuestionsText: `follow_up_questions` body
-    //                            (follow_up_questions_token; amber theme)
-    //   - shortenText:           `shorten` body — IMPORTANT: shorten streams
-    //                            via refined_answer_token with intent='shorten'
-    //                            (IntelligenceEngine.ts:406, triggered by
-    //                            handleFollowUp('shorten') at line 2657);
-    //                            cyan theme.
-    //
-    // No intent is rendered with an inline `components={{...}}` literal.
-    const mdComponents = useMemo(() => ({
-        standard: {
-            p: ({ node, ...props }: any) => <p className="mb-2 last:mb-0 whitespace-pre-wrap" {...props} />,
-            strong: ({ node, ...props }: any) => <strong className="font-bold opacity-100 overlay-text-strong" {...props} />,
-            em: ({ node, ...props }: any) => <em className="italic opacity-90 overlay-text-secondary" {...props} />,
-            ul: ({ node, ...props }: any) => <ul className="list-disc ml-4 mb-2 space-y-1" {...props} />,
-            ol: ({ node, ...props }: any) => <ol className="list-decimal ml-4 mb-2 space-y-1" {...props} />,
-            li: ({ node, ...props }: any) => <li className="pl-1" {...props} />,
-            code: ({ node, ...props }: any) => <code className={`overlay-inline-code-surface rounded px-1 py-0.5 text-xs font-mono ${isLightTheme ? 'text-slate-800' : ''}`} {...props} />,
-            a: ({ node, ...props }: any) => <a className="underline hover:opacity-80" target="_blank" rel="noopener noreferrer" {...props} />,
-        },
-        codeText: {
-            p: ({ node, ...props }: any) => <p className="mb-2 last:mb-0 whitespace-pre-wrap" {...props} />,
-            strong: ({ node, ...props }: any) => <strong className="font-bold overlay-text-strong" {...props} />,
-            em: ({ node, ...props }: any) => <em className="italic overlay-text-secondary" {...props} />,
-            ul: ({ node, ...props }: any) => <ul className="list-disc ml-4 mb-2 space-y-1" {...props} />,
-            ol: ({ node, ...props }: any) => <ol className="list-decimal ml-4 mb-2 space-y-1" {...props} />,
-            li: ({ node, ...props }: any) => <li className="pl-1" {...props} />,
-            h1: ({ node, ...props }: any) => <h1 className="text-lg font-bold mb-2 mt-3 overlay-text-strong" {...props} />,
-            h2: ({ node, ...props }: any) => <h2 className="text-base font-bold mb-2 mt-3 overlay-text-strong" {...props} />,
-            h3: ({ node, ...props }: any) => <h3 className="text-sm font-bold mb-1 mt-2 overlay-text-primary" {...props} />,
-            code: ({ node, ...props }: any) => <code className={`overlay-inline-code-surface rounded px-1 py-0.5 text-xs font-mono whitespace-pre-wrap ${isLightTheme ? 'text-violet-700' : 'text-purple-200'}`} {...props} />,
-            blockquote: ({ node, ...props }: any) => <blockquote className={`border-l-2 pl-3 italic my-2 ${isLightTheme ? 'border-violet-500/30 text-slate-600' : 'border-purple-500/50 text-slate-400'}`} {...props} />,
-            a: ({ node, ...props }: any) => <a className={`hover:underline ${isLightTheme ? 'text-blue-600 hover:text-blue-700' : 'text-blue-400 hover:text-blue-300'}`} target="_blank" rel="noopener noreferrer" {...props} />,
-        },
-        whatToAnswerText: {
-            p: ({ node, ...props }: any) => <p className="mb-2 last:mb-0" {...props} />,
-            strong: ({ node, ...props }: any) => <strong className={`font-bold ${isLightTheme ? 'text-emerald-700' : 'text-emerald-100'}`} {...props} />,
-            em: ({ node, ...props }: any) => <em className={`italic ${isLightTheme ? 'text-emerald-700/80' : 'text-emerald-200/80'}`} {...props} />,
-            ul: ({ node, ...props }: any) => <ul className="list-disc ml-4 mb-2 space-y-1" {...props} />,
-            ol: ({ node, ...props }: any) => <ol className="list-decimal ml-4 mb-2 space-y-1" {...props} />,
-            li: ({ node, ...props }: any) => <li className="pl-1" {...props} />,
-        },
-        recapText: {
-            p: ({ node, ...props }: any) => <p className="mb-2 last:mb-0" {...props} />,
-            strong: ({ node, ...props }: any) => <strong className={`font-bold ${isLightTheme ? 'text-indigo-800' : 'text-indigo-100'}`} {...props} />,
-            ul: ({ node, ...props }: any) => <ul className="list-disc ml-4 mb-2" {...props} />,
-            li: ({ node, ...props }: any) => <li className="pl-1" {...props} />,
-        },
-        followUpQuestionsText: {
-            p: ({ node, ...props }: any) => <p className="mb-2 last:mb-0" {...props} />,
-            strong: ({ node, ...props }: any) => <strong className={`font-bold ${isLightTheme ? 'text-amber-800' : 'text-[#FFF9C4]'}`} {...props} />,
-            ul: ({ node, ...props }: any) => <ul className="list-disc ml-4 mb-2" {...props} />,
-            li: ({ node, ...props }: any) => <li className="pl-1" {...props} />,
-        },
-        shortenText: {
-            p: ({ node, ...props }: any) => <p className="mb-2 last:mb-0" {...props} />,
-            strong: ({ node, ...props }: any) => <strong className={`font-bold ${isLightTheme ? 'text-cyan-800' : 'text-cyan-100'}`} {...props} />,
-            ul: ({ node, ...props }: any) => <ul className="list-disc ml-4 mb-2" {...props} />,
-            li: ({ node, ...props }: any) => <li className="pl-1" {...props} />,
-        },
-    }), [isLightTheme]);
-
-    // ── Code-expansion spring ────────────────────────────────────────────────
-    // Architecture: stable canvas, renderer-only animation.
-    //
-    // The OS window is pinned to STABLE_OVERLAY_WIDTH for the entire chat-
-    // expanded session — its width never changes when code becomes visible or
-    // hidden. The shell width animates 600 ↔ 780 purely in renderer CSS via a
-    // Framer spring. mx-auto centers the shell against a STABLE 780 parent, so
-    // its margin animates symmetrically (90 → 0 on expand, 0 → 90 on contract).
-    //
-    // Why this anchors the TopPill to its screen position:
-    //   • OS window X never moves during code expand/contract (no IPC).
-    //   • OS window content area is always 780 wide.
-    //   • TopPill and shell sit in a flex column centered horizontally inside
-    //     that stable canvas → TopPill's screen X is invariant of the spring.
-    //   • OS window Y is preserved by setBounds → TopPill's screen Y is fixed.
-    //   • Shell height growth is driven by content; ResizeObserver feeds height
-    //     (only) to the OS, which extends downward (Y preserved).
-    //
-    // The 90px transparent gutters on each side when shellWidth == 600 are
-    // invisible (window background is transparent) and click-through.
-    const SHELL_WIDTH_COLLAPSED = 600;
-    const SHELL_WIDTH_EXPANDED = 780;
-    const STABLE_OVERLAY_WIDTH = SHELL_WIDTH_EXPANDED;
-    const shellWidth = useMotionValue(SHELL_WIDTH_COLLAPSED);
-    const scrollMaxH = useTransform(shellWidth, [SHELL_WIDTH_COLLAPSED, SHELL_WIDTH_EXPANDED], [320, 560]);
-
-    // isExpanded mirror for closures inside refs/observers that must not
-    // re-bind on every toggle.
-    const isExpandedRef = useRef(true);
-
-    useEffect(() => {
-        // Load the persisted default model (not the runtime model)
-        // Each new meeting starts with the default from settings
-        if (window.electronAPI?.getDefaultModel) {
-            window.electronAPI.getDefaultModel()
-                .then((result: any) => {
-                    if (result && result.model) {
-                        setCurrentModel(result.model);
-                        // Also set the runtime model to the default
-                        window.electronAPI.setModel(result.model).catch(() => { });
-                    }
-                })
-                .catch((err: any) => console.error("Failed to fetch default model:", err));
-        }
-    }, []);
-
-    const handleModelSelect = (modelId: string) => {
-        setCurrentModel(modelId);
-        // Session-only: update runtime but don't persist as default
-        window.electronAPI.setModel(modelId)
-            .catch((err: any) => console.error("Failed to set model:", err));
+  useEffect(() => {
+    let mounted = true;
+    const loadLlmRoute = async () => {
+      const config = await window.electronAPI?.getCurrentLlmConfig?.().catch(() => null);
+      if (!mounted || !config) return;
+      setLlmProviderLabel(formatProviderLabel(config.provider));
+      setLlmPrivacyLabel(
+        config.provider === 'ollama' || config.provider === 'codex-cli'
+          ? 'Local/private route'
+          : config.provider === 'custom'
+            ? 'Custom endpoint route'
+            : 'Cloud LLM route',
+      );
     };
-
-    // Listen for default model changes from Settings
-    useEffect(() => {
-        if (!window.electronAPI?.onModelChanged) return;
-        const unsubscribe = window.electronAPI.onModelChanged((modelId: string) => {
-            setCurrentModel(prev => prev === modelId ? prev : modelId);
-        });
-        return () => unsubscribe();
-    }, []);
-
-    // Global State Sync
-    useEffect(() => {
-        // Fetch initial state
-        if (window.electronAPI?.getUndetectable) {
-            window.electronAPI.getUndetectable().then(setIsUndetectable);
-        }
-
-        if (window.electronAPI?.onUndetectableChanged) {
-            const unsubscribe = window.electronAPI.onUndetectableChanged((state) => {
-                setIsUndetectable(state);
-            });
-            return () => unsubscribe();
-        }
-    }, []);
-
-    // Persist Settings
-    useEffect(() => {
-        localStorage.setItem('natively_undetectable', String(isUndetectable));
-        localStorage.setItem('natively_hideChatHidesWidget', String(hideChatHidesWidget));
-    }, [isUndetectable, hideChatHidesWidget]);
-
-    // Mouse Passthrough State
-    const [isMousePassthrough, setIsMousePassthrough] = useState(false);
-    useEffect(() => {
-        window.electronAPI?.getOverlayMousePassthrough?.().then(setIsMousePassthrough).catch(() => { });
-        const unsub = window.electronAPI?.onOverlayMousePassthroughChanged?.((v) => setIsMousePassthrough(v));
-        return () => unsub?.();
-    }, []);
-
-    // Audio capture / screen-recording warning banner. Two distinct IPC
-    // events feed the same banner surface but require different title and
-    // action: the macOS screen-recording-permission denial points at the
-    // OS Privacy pane, while generic audio-capture failures (no-chunks
-    // watchdog, TCC zero-fill, terminal STT init failure, SCK errors) are
-    // cross-platform and should open Natively's own Settings. Bundling
-    // both under a hardcoded "Screen Recording Permission Denied" title
-    // with an x-apple.systempreferences action was issue #252: on Windows
-    // the audio-capture-failed path fired, the user saw a macOS-only title
-    // and the Open Settings button handed Windows shell a URI scheme it
-    // couldn't resolve (Microsoft Store popup).
-    type SystemAudioWarning = {
-        kind: 'screen-recording-permission' | 'audio-capture-failure';
-        message: string;
+    loadLlmRoute();
+    const unsub = window.electronAPI?.onModelChanged?.(() => {
+      loadLlmRoute();
+    });
+    return () => {
+      mounted = false;
+      unsub?.();
     };
-    const [systemAudioWarning, setSystemAudioWarning] = useState<SystemAudioWarning | null>(null);
-    useEffect(() => {
-        const unsub = window.electronAPI?.onSystemAudioPermissionDenied?.((message: string) => {
-            setSystemAudioWarning({ kind: 'screen-recording-permission', message });
-            setIsExpanded(true); // Force overlay open so user sees the warning
-        });
-        return () => unsub?.();
-    }, []);
+  }, []);
 
-    useEffect(() => {
-        const unsub = window.electronAPI?.onAudioCaptureFailed?.((payload) => {
-            if (payload.channel !== 'system') return;  // mic failures already shown via STT status
-            // Only surface terminal failures or the stuck signal — transient
-            // recovery attempts shouldn't spam the banner since recovery
-            // typically succeeds within ~1.5s.
-            if (payload.terminal || payload.stuck) {
-                setSystemAudioWarning({ kind: 'audio-capture-failure', message: payload.message });
-                setIsExpanded(true);
-            }
-        });
-        return () => unsub?.();
-    }, []);
+  // Model Selection State
+  const [currentModel, setCurrentModel] = useState<string>('gemini-3-flash-preview');
 
-    // PR #173: STT not configured warning — shown when provider is 'none' during a meeting
-    const [sttNotConfigured, setSttNotConfigured] = useState(false);
-    useEffect(() => {
-        let mounted = true;
-        // Check current STT config on mount
-        window.electronAPI?.getSttProvider?.().then((provider: string) => {
-            if (mounted) setSttNotConfigured(provider === 'none');
-        }).catch(() => { });
+  // Dynamic Action Button Mode (Recap vs Brainstorm)
+  const [actionButtonMode, setActionButtonMode] = useState<'recap' | 'brainstorm'>('recap');
 
-        // Listen for live config changes (e.g. user saves a key in Settings while meeting is active)
-        const unsub = window.electronAPI?.onSttConfigChanged?.((data: { configured: boolean; provider: string }) => {
-            if (mounted) setSttNotConfigured(!data.configured);
-        });
-        return () => {
-            mounted = false;
-            unsub?.();
-        };
-    }, []);
+  useEffect(() => {
+    // Load persisted mode
+    window.electronAPI
+      ?.getActionButtonMode?.()
+      ?.then((mode: 'recap' | 'brainstorm') => {
+        if (mode) setActionButtonMode(mode);
+      })
+      .catch(() => {});
 
-    // Keep the closure-free isExpanded mirror in sync.
-    useEffect(() => { isExpandedRef.current = isExpanded; }, [isExpanded]);
+    // Listen for live changes from SettingsPopup / IPC
+    const unsubscribe = window.electronAPI?.onActionButtonModeChanged?.(
+      (mode: 'recap' | 'brainstorm') => {
+        setActionButtonMode(mode);
+      },
+    );
+    return () => {
+      unsubscribe?.();
+    };
+  }, []);
 
-    // Single canonical size-reporter. While the chat overlay is expanded we
-    // pin the OS window to STABLE_OVERLAY_WIDTH (=SHELL_WIDTH_EXPANDED) so the
-    // shell can spring 600↔780 in renderer CSS without ever resizing the OS
-    // window — no IPC race, no clip, no jump. Centered IPC is used so the
-    // first chat-mode entry (when the OS window may grow from a smaller mode
-    // into the stable canvas) keeps the TopPill's center fixed; subsequent
-    // height-only updates have widthDelta=0 and don't shift X.
-    const reportShellSize = useCallback(() => {
-        if (!contentRef.current) return;
-        const rect = contentRef.current.getBoundingClientRect();
-        const width = isExpandedRef.current ? STABLE_OVERLAY_WIDTH : Math.ceil(rect.width);
-        const height = Math.ceil(rect.height);
-        const api = window.electronAPI as any;
-        if (api?.updateContentDimensionsCentered) {
-            api.updateContentDimensionsCentered({ width, height });
-        } else {
-            window.electronAPI?.updateContentDimensions({ width, height });
+  const codeTheme = isLightTheme ? oneLight : vscDarkPlus;
+  const codeLineNumberColor = isLightTheme ? 'rgba(15,23,42,0.35)' : 'rgba(255,255,255,0.2)';
+  const appearance = useMemo(
+    () =>
+      isGlassTheme
+        ? getGlassOverlayAppearance()
+        : getOverlayAppearance(overlayOpacity, isLightTheme ? 'light' : 'dark'),
+    [overlayOpacity, isLightTheme, isGlassTheme],
+  );
+  const overlayPanelClass = 'overlay-text-primary';
+  const subtleSurfaceClass = 'overlay-subtle-surface';
+  const codeBlockClass = 'overlay-code-block-surface';
+  const codeHeaderClass = 'overlay-code-header-surface';
+  const codeHeaderTextClass = 'overlay-text-muted';
+  const quickActionClass = 'overlay-chip-surface overlay-text-interactive';
+  const inputClass = `${isLightTheme ? 'focus:ring-black/10' : 'focus:ring-white/10'} overlay-input-surface overlay-input-text`;
+  const controlSurfaceClass = 'overlay-control-surface overlay-text-interactive';
+
+  // PERF: hoist ReactMarkdown `components` maps for every streaming intent
+  // into a single useMemo so their identity is stable across renders. Each
+  // inline <ReactMarkdown components={{...}}> would create a fresh object
+  // literal per render — defeating ReactMarkdown's internal render-bailout.
+  //
+  // ALL 6 message-intent branches stream tokens (per IntelligenceEngine emits):
+  //   - standard:              plain system text bubbles (fallback render)
+  //   - codeText:              text parts inside a code-bubble
+  //   - whatToAnswerText:      `what_to_answer` card body (suggested_answer_token;
+  //                            emerald theme)
+  //   - recapText:             `recap` body (recap_token; indigo theme)
+  //   - followUpQuestionsText: `follow_up_questions` body
+  //                            (follow_up_questions_token; amber theme)
+  //   - shortenText:           `shorten` body — IMPORTANT: shorten streams
+  //                            via refined_answer_token with intent='shorten'
+  //                            (IntelligenceEngine.ts:406, triggered by
+  //                            handleFollowUp('shorten') at line 2657);
+  //                            cyan theme.
+  //
+  // No intent is rendered with an inline `components={{...}}` literal.
+  const mdComponents = useMemo(
+    () => ({
+      standard: {
+        p: ({ node, ...props }: any) => (
+          <p className="mb-2 last:mb-0 whitespace-pre-wrap" {...props} />
+        ),
+        strong: ({ node, ...props }: any) => (
+          <strong className="font-bold opacity-100 overlay-text-strong" {...props} />
+        ),
+        em: ({ node, ...props }: any) => (
+          <em className="italic opacity-90 overlay-text-secondary" {...props} />
+        ),
+        ul: ({ node, ...props }: any) => (
+          <ul className="list-disc ml-4 mb-2 space-y-1" {...props} />
+        ),
+        ol: ({ node, ...props }: any) => (
+          <ol className="list-decimal ml-4 mb-2 space-y-1" {...props} />
+        ),
+        li: ({ node, ...props }: any) => <li className="pl-1" {...props} />,
+        code: ({ node, ...props }: any) => (
+          <code
+            className={`overlay-inline-code-surface rounded px-1 py-0.5 text-xs font-mono ${isLightTheme ? 'text-slate-800' : ''}`}
+            {...props}
+          />
+        ),
+        a: ({ node, ...props }: any) => (
+          <a
+            className="underline hover:opacity-80"
+            target="_blank"
+            rel="noopener noreferrer"
+            {...props}
+          />
+        ),
+      },
+      codeText: {
+        p: ({ node, ...props }: any) => (
+          <p className="mb-2 last:mb-0 whitespace-pre-wrap" {...props} />
+        ),
+        strong: ({ node, ...props }: any) => (
+          <strong className="font-bold overlay-text-strong" {...props} />
+        ),
+        em: ({ node, ...props }: any) => (
+          <em className="italic overlay-text-secondary" {...props} />
+        ),
+        ul: ({ node, ...props }: any) => (
+          <ul className="list-disc ml-4 mb-2 space-y-1" {...props} />
+        ),
+        ol: ({ node, ...props }: any) => (
+          <ol className="list-decimal ml-4 mb-2 space-y-1" {...props} />
+        ),
+        li: ({ node, ...props }: any) => <li className="pl-1" {...props} />,
+        h1: ({ node, ...props }: any) => (
+          <h1 className="text-lg font-bold mb-2 mt-3 overlay-text-strong" {...props} />
+        ),
+        h2: ({ node, ...props }: any) => (
+          <h2 className="text-base font-bold mb-2 mt-3 overlay-text-strong" {...props} />
+        ),
+        h3: ({ node, ...props }: any) => (
+          <h3 className="text-sm font-bold mb-1 mt-2 overlay-text-primary" {...props} />
+        ),
+        code: ({ node, ...props }: any) => (
+          <code
+            className={`overlay-inline-code-surface rounded px-1 py-0.5 text-xs font-mono whitespace-pre-wrap ${isLightTheme ? 'text-violet-700' : 'text-purple-200'}`}
+            {...props}
+          />
+        ),
+        blockquote: ({ node, ...props }: any) => (
+          <blockquote
+            className={`border-l-2 pl-3 italic my-2 ${isLightTheme ? 'border-violet-500/30 text-slate-600' : 'border-purple-500/50 text-slate-400'}`}
+            {...props}
+          />
+        ),
+        a: ({ node, ...props }: any) => (
+          <a
+            className={`hover:underline ${isLightTheme ? 'text-blue-600 hover:text-blue-700' : 'text-blue-400 hover:text-blue-300'}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            {...props}
+          />
+        ),
+      },
+      whatToAnswerText: {
+        p: ({ node, ...props }: any) => <p className="mb-2 last:mb-0" {...props} />,
+        strong: ({ node, ...props }: any) => (
+          <strong
+            className={`font-bold ${isLightTheme ? 'text-emerald-700' : 'text-emerald-100'}`}
+            {...props}
+          />
+        ),
+        em: ({ node, ...props }: any) => (
+          <em
+            className={`italic ${isLightTheme ? 'text-emerald-700/80' : 'text-emerald-200/80'}`}
+            {...props}
+          />
+        ),
+        ul: ({ node, ...props }: any) => (
+          <ul className="list-disc ml-4 mb-2 space-y-1" {...props} />
+        ),
+        ol: ({ node, ...props }: any) => (
+          <ol className="list-decimal ml-4 mb-2 space-y-1" {...props} />
+        ),
+        li: ({ node, ...props }: any) => <li className="pl-1" {...props} />,
+      },
+      recapText: {
+        p: ({ node, ...props }: any) => <p className="mb-2 last:mb-0" {...props} />,
+        strong: ({ node, ...props }: any) => (
+          <strong
+            className={`font-bold ${isLightTheme ? 'text-indigo-800' : 'text-indigo-100'}`}
+            {...props}
+          />
+        ),
+        ul: ({ node, ...props }: any) => <ul className="list-disc ml-4 mb-2" {...props} />,
+        li: ({ node, ...props }: any) => <li className="pl-1" {...props} />,
+      },
+      followUpQuestionsText: {
+        p: ({ node, ...props }: any) => <p className="mb-2 last:mb-0" {...props} />,
+        strong: ({ node, ...props }: any) => (
+          <strong
+            className={`font-bold ${isLightTheme ? 'text-amber-800' : 'text-[#FFF9C4]'}`}
+            {...props}
+          />
+        ),
+        ul: ({ node, ...props }: any) => <ul className="list-disc ml-4 mb-2" {...props} />,
+        li: ({ node, ...props }: any) => <li className="pl-1" {...props} />,
+      },
+      shortenText: {
+        p: ({ node, ...props }: any) => <p className="mb-2 last:mb-0" {...props} />,
+        strong: ({ node, ...props }: any) => (
+          <strong
+            className={`font-bold ${isLightTheme ? 'text-cyan-800' : 'text-cyan-100'}`}
+            {...props}
+          />
+        ),
+        ul: ({ node, ...props }: any) => <ul className="list-disc ml-4 mb-2" {...props} />,
+        li: ({ node, ...props }: any) => <li className="pl-1" {...props} />,
+      },
+    }),
+    [isLightTheme],
+  );
+
+  // ── Code-expansion spring ────────────────────────────────────────────────
+  // Architecture: stable canvas, renderer-only animation.
+  //
+  // The OS window is pinned to STABLE_OVERLAY_WIDTH for the entire chat-
+  // expanded session — its width never changes when code becomes visible or
+  // hidden. The shell width animates 600 ↔ 780 purely in renderer CSS via a
+  // Framer spring. mx-auto centers the shell against a STABLE 780 parent, so
+  // its margin animates symmetrically (90 → 0 on expand, 0 → 90 on contract).
+  //
+  // Why this anchors the TopPill to its screen position:
+  //   • OS window X never moves during code expand/contract (no IPC).
+  //   • OS window content area is always 780 wide.
+  //   • TopPill and shell sit in a flex column centered horizontally inside
+  //     that stable canvas → TopPill's screen X is invariant of the spring.
+  //   • OS window Y is preserved by setBounds → TopPill's screen Y is fixed.
+  //   • Shell height growth is driven by content; ResizeObserver feeds height
+  //     (only) to the OS, which extends downward (Y preserved).
+  //
+  // The 90px transparent gutters on each side when shellWidth == 600 are
+  // invisible (window background is transparent) and click-through.
+  const SHELL_WIDTH_COLLAPSED = 600;
+  const SHELL_WIDTH_EXPANDED = 780;
+  const STABLE_OVERLAY_WIDTH = SHELL_WIDTH_EXPANDED;
+  const shellWidth = useMotionValue(SHELL_WIDTH_COLLAPSED);
+  const scrollMaxH = useTransform(
+    shellWidth,
+    [SHELL_WIDTH_COLLAPSED, SHELL_WIDTH_EXPANDED],
+    [320, 560],
+  );
+
+  // isExpanded mirror for closures inside refs/observers that must not
+  // re-bind on every toggle.
+  const isExpandedRef = useRef(true);
+
+  useEffect(() => {
+    // Load the persisted default model (not the runtime model)
+    // Each new meeting starts with the default from settings
+    if (window.electronAPI?.getDefaultModel) {
+      window.electronAPI
+        .getDefaultModel()
+        .then((result: any) => {
+          if (result && result.model) {
+            setCurrentModel(result.model);
+            // Also set the runtime model to the default
+            window.electronAPI.setModel(result.model).catch(() => {});
+          }
+        })
+        .catch((err: any) => console.error('Failed to fetch default model:', err));
+    }
+  }, []);
+
+  const handleModelSelect = (modelId: string) => {
+    setCurrentModel(modelId);
+    // Session-only: update runtime but don't persist as default
+    window.electronAPI
+      .setModel(modelId)
+      .catch((err: any) => console.error('Failed to set model:', err));
+  };
+
+  // Listen for default model changes from Settings
+  useEffect(() => {
+    if (!window.electronAPI?.onModelChanged) return;
+    const unsubscribe = window.electronAPI.onModelChanged((modelId: string) => {
+      setCurrentModel((prev) => (prev === modelId ? prev : modelId));
+    });
+    return () => unsubscribe();
+  }, []);
+
+  // Global State Sync
+  useEffect(() => {
+    // Fetch initial state
+    if (window.electronAPI?.getUndetectable) {
+      window.electronAPI.getUndetectable().then(setIsUndetectable);
+    }
+
+    if (window.electronAPI?.onUndetectableChanged) {
+      const unsubscribe = window.electronAPI.onUndetectableChanged((state) => {
+        setIsUndetectable(state);
+      });
+      return () => unsubscribe();
+    }
+  }, []);
+
+  // Persist Settings
+  useEffect(() => {
+    localStorage.setItem('natively_undetectable', String(isUndetectable));
+    localStorage.setItem('natively_hideChatHidesWidget', String(hideChatHidesWidget));
+  }, [isUndetectable, hideChatHidesWidget]);
+
+  // Mouse Passthrough State
+  const [isMousePassthrough, setIsMousePassthrough] = useState(false);
+  useEffect(() => {
+    window.electronAPI
+      ?.getOverlayMousePassthrough?.()
+      .then(setIsMousePassthrough)
+      .catch(() => {});
+    const unsub = window.electronAPI?.onOverlayMousePassthroughChanged?.((v) =>
+      setIsMousePassthrough(v),
+    );
+    return () => unsub?.();
+  }, []);
+
+  // Audio capture / screen-recording warning banner. Two distinct IPC
+  // events feed the same banner surface but require different title and
+  // action: the macOS screen-recording-permission denial points at the
+  // OS Privacy pane, while generic audio-capture failures (no-chunks
+  // watchdog, TCC zero-fill, terminal STT init failure, SCK errors) are
+  // cross-platform and should open Natively's own Settings. Bundling
+  // both under a hardcoded "Screen Recording Permission Denied" title
+  // with an x-apple.systempreferences action was issue #252: on Windows
+  // the audio-capture-failed path fired, the user saw a macOS-only title
+  // and the Open Settings button handed Windows shell a URI scheme it
+  // couldn't resolve (Microsoft Store popup).
+  type SystemAudioWarning = {
+    kind: 'screen-recording-permission' | 'audio-capture-failure';
+    message: string;
+  };
+  const [systemAudioWarning, setSystemAudioWarning] = useState<SystemAudioWarning | null>(null);
+  useEffect(() => {
+    const unsub = window.electronAPI?.onSystemAudioPermissionDenied?.((message: string) => {
+      setSystemAudioWarning({ kind: 'screen-recording-permission', message });
+      setIsExpanded(true); // Force overlay open so user sees the warning
+    });
+    return () => unsub?.();
+  }, []);
+
+  useEffect(() => {
+    const unsub = window.electronAPI?.onAudioCaptureFailed?.((payload) => {
+      if (payload.channel !== 'system') return; // mic failures already shown via STT status
+      // Only surface terminal failures or the stuck signal — transient
+      // recovery attempts shouldn't spam the banner since recovery
+      // typically succeeds within ~1.5s.
+      if (payload.terminal || payload.stuck) {
+        setSystemAudioWarning({ kind: 'audio-capture-failure', message: payload.message });
+        setIsExpanded(true);
+      }
+    });
+    return () => unsub?.();
+  }, []);
+
+  // PR #173: STT not configured warning — shown when provider is 'none' during a meeting
+  const [sttNotConfigured, setSttNotConfigured] = useState(false);
+  useEffect(() => {
+    let mounted = true;
+    // Check current STT config on mount
+    window.electronAPI
+      ?.getSttProvider?.()
+      .then((provider: string) => {
+        if (mounted) setSttNotConfigured(provider === 'none');
+      })
+      .catch(() => {});
+
+    // Listen for live config changes (e.g. user saves a key in Settings while meeting is active)
+    const unsub = window.electronAPI?.onSttConfigChanged?.(
+      (data: { configured: boolean; provider: string }) => {
+        if (mounted) setSttNotConfigured(!data.configured);
+      },
+    );
+    return () => {
+      mounted = false;
+      unsub?.();
+    };
+  }, []);
+
+  // Keep the closure-free isExpanded mirror in sync.
+  useEffect(() => {
+    isExpandedRef.current = isExpanded;
+  }, [isExpanded]);
+
+  // Single canonical size-reporter. While the chat overlay is expanded we
+  // pin the OS window to STABLE_OVERLAY_WIDTH (=SHELL_WIDTH_EXPANDED) so the
+  // shell can spring 600↔780 in renderer CSS without ever resizing the OS
+  // window — no IPC race, no clip, no jump. Centered IPC is used so the
+  // first chat-mode entry (when the OS window may grow from a smaller mode
+  // into the stable canvas) keeps the TopPill's center fixed; subsequent
+  // height-only updates have widthDelta=0 and don't shift X.
+  const reportShellSize = useCallback(() => {
+    if (!contentRef.current) return;
+    const rect = contentRef.current.getBoundingClientRect();
+    const width = isExpandedRef.current ? STABLE_OVERLAY_WIDTH : Math.ceil(rect.width);
+    const height = Math.ceil(rect.height);
+    const api = window.electronAPI as any;
+    if (api?.updateContentDimensionsCentered) {
+      api.updateContentDimensionsCentered({ width, height });
+    } else {
+      window.electronAPI?.updateContentDimensions({ width, height });
+    }
+  }, [STABLE_OVERLAY_WIDTH]);
+
+  // ResizeObserver: rAF-debounced so the spring can update height without
+  // flooding IPC. Width is constant in expanded mode, so per-frame updates
+  // only carry height changes — no race with the renderer's CSS spring.
+  useLayoutEffect(() => {
+    if (!contentRef.current) return;
+
+    const observer = new ResizeObserver(() => {
+      if (rafDimUpdateRef.current) cancelAnimationFrame(rafDimUpdateRef.current);
+      rafDimUpdateRef.current = requestAnimationFrame(() => {
+        rafDimUpdateRef.current = null;
+        reportShellSize();
+      });
+    });
+
+    observer.observe(contentRef.current);
+    return () => {
+      observer.disconnect();
+      if (rafDimUpdateRef.current) {
+        cancelAnimationFrame(rafDimUpdateRef.current);
+        rafDimUpdateRef.current = null;
+      }
+    };
+  }, [reportShellSize]);
+
+  // attachedContext (screenshots add/remove) and initial-sizing safety:
+  // both just re-run the canonical reporter — no more "what width should I
+  // use right now?" branching against animation flags.
+  useEffect(() => {
+    const id = requestAnimationFrame(reportShellSize);
+    return () => cancelAnimationFrame(id);
+  }, [attachedContext, reportShellSize]);
+
+  useEffect(() => {
+    const timer = setTimeout(reportShellSize, 600);
+    return () => clearTimeout(timer);
+  }, [reportShellSize]);
+
+  // ── Code-expansion ──────────────────────────────────────────────────────
+  // The shell's width animates 600↔780 with a renderer-only spring against a
+  // STABLE 780-wide OS canvas. mx-auto on the wrapper distributes the width
+  // delta as symmetric horizontal margin → expansion grows from the center,
+  // TopPill stays anchored, no IPC during the animation. Height growth is
+  // picked up by the ResizeObserver and forwarded to the OS as height-only
+  // updates (width is unchanged so no X shift, no jump).
+  const startTransition = useCallback(
+    (targetWidth: number) => {
+      codeExpandedRef.current = targetWidth === SHELL_WIDTH_EXPANDED;
+      if (animationControlsRef.current) animationControlsRef.current.stop();
+
+      // iMessage-style sticky bottom. Capture the user's scroll intent now,
+      // before scrollMaxH starts changing. If they were at (or near) the
+      // bottom, we keep them pinned there throughout the spring so growing
+      // viewport height doesn't reveal stale history below the visible chat.
+      // If they were scrolled up to read history, we leave their position
+      // alone — the extra viewport extends downward into empty space, which
+      // is the correct behavior for a reader.
+      const container = scrollContainerRef.current;
+      if (container) {
+        const distanceFromBottom =
+          container.scrollHeight - (container.scrollTop + container.clientHeight);
+        wasAtBottomRef.current = distanceFromBottom <= 8;
+      }
+
+      // Symmetric ease-in-out-cubic. Smooth ramp on both ends — no perceived
+      // velocity break at the start or finish, which is what makes a width
+      // animation read as "buttery" rather than "snappy". The cubic poly
+      // is gentle enough that the 1px-per-frame motion at the edges is
+      // visually subliminal at 60Hz, eliminating the "settle" jitter you
+      // get with steeper ease-out curves on width-driven reflow.
+      animationControlsRef.current = animate(shellWidth, targetWidth, {
+        type: 'tween' as const,
+        ease: [0.65, 0, 0.35, 1],
+        duration: 0.7,
+        onUpdate: () => {
+          if (!wasAtBottomRef.current) return;
+          const c = scrollContainerRef.current;
+          if (!c) return;
+          // scrollMaxH is derived from shellWidth, so on every tick the
+          // viewport height has just changed. Re-pin to bottom in the
+          // SAME frame — single layout read, single write, no flush.
+          c.scrollTop = c.scrollHeight - c.clientHeight;
+        },
+        onComplete: () => {
+          animationControlsRef.current = null;
+        },
+      });
+    },
+    [shellWidth, SHELL_WIDTH_EXPANDED],
+  );
+
+  // Scan [data-code-msg] elements and check if any intersect the scroll container
+  // viewport. Called on every scroll event and after every messages update.
+  // Uses a stability gate: the visibility must hold its new state for
+  // STABILITY_MS before a transition fires. This filters out the rapid
+  // visible↔invisible flicker that occurs when a code block crosses the
+  // viewport edge during a fast scroll, which would otherwise interrupt
+  // the 0.7s tween mid-flight and cause stutter.
+  const STABILITY_MS = 120;
+  const checkCodeVisibility = useCallback(() => {
+    const container = scrollContainerRef.current;
+
+    // Scroll container unmounted (session reset / messages cleared) — force
+    // contraction so the shell returns to its collapsed width.
+    if (!container) {
+      if (stableVisibilityTimerRef.current) {
+        clearTimeout(stableVisibilityTimerRef.current);
+        stableVisibilityTimerRef.current = null;
+      }
+      pendingVisibilityRef.current = null;
+      if (codeExpandedRef.current) startTransition(SHELL_WIDTH_COLLAPSED);
+      return;
+    }
+
+    const codeEls = container.querySelectorAll('[data-code-msg]');
+    let visible = false;
+    if (codeEls.length > 0) {
+      const cRect = container.getBoundingClientRect();
+      for (const el of codeEls) {
+        const r = el.getBoundingClientRect();
+        if (r.bottom > cRect.top && r.top < cRect.bottom) {
+          visible = true;
+          break;
         }
-    }, [STABLE_OVERLAY_WIDTH]);
+      }
+    }
 
-    // ResizeObserver: rAF-debounced so the spring can update height without
-    // flooding IPC. Width is constant in expanded mode, so per-frame updates
-    // only carry height changes — no race with the renderer's CSS spring.
-    useLayoutEffect(() => {
-        if (!contentRef.current) return;
+    // Already in the correct state — clear any pending change so a
+    // mid-flight tween isn't interrupted by a stale timer firing.
+    if (visible === codeExpandedRef.current) {
+      pendingVisibilityRef.current = null;
+      if (stableVisibilityTimerRef.current) {
+        clearTimeout(stableVisibilityTimerRef.current);
+        stableVisibilityTimerRef.current = null;
+      }
+      return;
+    }
 
-        const observer = new ResizeObserver(() => {
-            if (rafDimUpdateRef.current) cancelAnimationFrame(rafDimUpdateRef.current);
-            rafDimUpdateRef.current = requestAnimationFrame(() => {
-                rafDimUpdateRef.current = null;
-                reportShellSize();
-            });
-        });
+    // State change detected. If we're already waiting on the SAME pending
+    // change, let the timer continue ticking — don't reset it on every
+    // scroll frame, or fast scroll would never let the timer fire.
+    if (pendingVisibilityRef.current === visible) return;
 
-        observer.observe(contentRef.current);
-        return () => {
-            observer.disconnect();
-            if (rafDimUpdateRef.current) {
-                cancelAnimationFrame(rafDimUpdateRef.current);
-                rafDimUpdateRef.current = null;
-            }
-        };
-    }, [reportShellSize]);
+    pendingVisibilityRef.current = visible;
+    if (stableVisibilityTimerRef.current) clearTimeout(stableVisibilityTimerRef.current);
+    stableVisibilityTimerRef.current = setTimeout(() => {
+      stableVisibilityTimerRef.current = null;
+      const target = pendingVisibilityRef.current;
+      pendingVisibilityRef.current = null;
+      if (target !== null && target !== codeExpandedRef.current) {
+        startTransition(target ? SHELL_WIDTH_EXPANDED : SHELL_WIDTH_COLLAPSED);
+      }
+    }, STABILITY_MS);
+  }, [startTransition, SHELL_WIDTH_COLLAPSED, SHELL_WIDTH_EXPANDED]);
 
-    // attachedContext (screenshots add/remove) and initial-sizing safety:
-    // both just re-run the canonical reporter — no more "what width should I
-    // use right now?" branching against animation flags.
-    useEffect(() => {
-        const id = requestAnimationFrame(reportShellSize);
-        return () => cancelAnimationFrame(id);
-    }, [attachedContext, reportShellSize]);
+  // Re-check after every messages update (catches mid-stream code fences).
+  useEffect(() => {
+    const raf = requestAnimationFrame(() => checkCodeVisibility());
+    return () => cancelAnimationFrame(raf);
+  }, [messages, checkCodeVisibility]);
 
-    useEffect(() => {
-        const timer = setTimeout(reportShellSize, 600);
-        return () => clearTimeout(timer);
-    }, [reportShellSize]);
+  // Re-attach scroll listener whenever messages change — the scroll container
+  // is conditionally rendered so scrollContainerRef.current is null at mount.
+  //
+  // The visibility check does layout reads (querySelectorAll +
+  // getBoundingClientRect on every code element). Running it synchronously
+  // on every scroll event forces a layout flush mid-scroll-frame, which
+  // shows up as text jitter during fast scrolls. rAF-coalescing it ensures
+  // at most one check per frame and lets the read happen at the natural
+  // post-scroll layout point in the frame lifecycle.
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    let rafId: number | null = null;
+    const onScroll = () => {
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        checkCodeVisibility();
+      });
+    };
+    container.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      container.removeEventListener('scroll', onScroll);
+      if (rafId !== null) cancelAnimationFrame(rafId);
+    };
+  }, [messages, checkCodeVisibility]);
 
-    // ── Code-expansion ──────────────────────────────────────────────────────
-    // The shell's width animates 600↔780 with a renderer-only spring against a
-    // STABLE 780-wide OS canvas. mx-auto on the wrapper distributes the width
-    // delta as symmetric horizontal margin → expansion grows from the center,
-    // TopPill stays anchored, no IPC during the animation. Height growth is
-    // picked up by the ResizeObserver and forwarded to the OS as height-only
-    // updates (width is unchanged so no X shift, no jump).
-    const startTransition = useCallback((targetWidth: number) => {
-        codeExpandedRef.current = targetWidth === SHELL_WIDTH_EXPANDED;
-        if (animationControlsRef.current) animationControlsRef.current.stop();
+  // Cancel all in-flight async work on unmount.
+  useEffect(() => {
+    return () => {
+      animationControlsRef.current?.stop();
+      animationControlsRef.current = null;
+      if (rafDimUpdateRef.current) {
+        cancelAnimationFrame(rafDimUpdateRef.current);
+        rafDimUpdateRef.current = null;
+      }
+      if (stableVisibilityTimerRef.current) {
+        clearTimeout(stableVisibilityTimerRef.current);
+        stableVisibilityTimerRef.current = null;
+      }
+      pendingVisibilityRef.current = null;
+      // PERF: cancel any pending token-flush RAF so we don't try to
+      // setState on an unmounted component.
+      if (tokenBufRef.current.raf !== null) {
+        cancelAnimationFrame(tokenBufRef.current.raf);
+        tokenBufRef.current.raf = null;
+        tokenBufRef.current.text = '';
+      }
+    };
+  }, []);
+  // ────────────────────────────────────────────────────────────────────────
 
-        // iMessage-style sticky bottom. Capture the user's scroll intent now,
-        // before scrollMaxH starts changing. If they were at (or near) the
-        // bottom, we keep them pinned there throughout the spring so growing
-        // viewport height doesn't reveal stale history below the visible chat.
-        // If they were scrolled up to read history, we leave their position
-        // alone — the extra viewport extends downward into empty space, which
-        // is the correct behavior for a reader.
-        const container = scrollContainerRef.current;
-        if (container) {
-            const distanceFromBottom = container.scrollHeight - (container.scrollTop + container.clientHeight);
-            wasAtBottomRef.current = distanceFromBottom <= 8;
-        }
+  // Build conversation context from messages
+  useEffect(() => {
+    const context = messages
+      .filter((m) => m.role !== 'user' || !m.hasScreenshot)
+      .map(
+        (m) =>
+          `${m.role === 'interviewer' ? 'Interviewer' : m.role === 'user' ? 'User' : 'Assistant'}: ${m.text}`,
+      )
+      .slice(-20)
+      .join('\n');
+    setConversationContext(context);
+  }, [messages]);
 
-        // Symmetric ease-in-out-cubic. Smooth ramp on both ends — no perceived
-        // velocity break at the start or finish, which is what makes a width
-        // animation read as "buttery" rather than "snappy". The cubic poly
-        // is gentle enough that the 1px-per-frame motion at the edges is
-        // visually subliminal at 60Hz, eliminating the "settle" jitter you
-        // get with steeper ease-out curves on width-driven reflow.
-        animationControlsRef.current = animate(shellWidth, targetWidth, {
-            type: 'tween' as const,
-            ease: [0.65, 0, 0.35, 1],
-            duration: 0.7,
-            onUpdate: () => {
-                if (!wasAtBottomRef.current) return;
-                const c = scrollContainerRef.current;
-                if (!c) return;
-                // scrollMaxH is derived from shellWidth, so on every tick the
-                // viewport height has just changed. Re-pin to bottom in the
-                // SAME frame — single layout read, single write, no flush.
-                c.scrollTop = c.scrollHeight - c.clientHeight;
+  // Listen for settings window visibility changes
+  useEffect(() => {
+    if (!window.electronAPI?.onSettingsVisibilityChange) return;
+    const unsubscribe = window.electronAPI.onSettingsVisibilityChange((isVisible) => {
+      setIsSettingsOpen(isVisible);
+    });
+    return () => unsubscribe();
+  }, []);
+
+  // Sync Window Visibility with Expanded State
+  useEffect(() => {
+    if (isExpanded) {
+      window.electronAPI.showWindow(isStealthRef.current);
+      isStealthRef.current = false; // Reset back to default
+    } else {
+      // Slight delay to allow animation to clean up if needed, though immediate is safer for click-through
+      // Using setTimeout to ensure the render cycle completes first
+      // Increased to 400ms to allow "contract to bottom" exit animation to finish
+      setTimeout(() => window.electronAPI.hideWindow(), 400);
+    }
+  }, [isExpanded]);
+
+  // Keyboard shortcut to toggle expanded state (via Main Process)
+  useEffect(() => {
+    if (!window.electronAPI?.onToggleExpand) return;
+    const unsubscribe = window.electronAPI.onToggleExpand(() => {
+      setIsExpanded((prev) => !prev);
+    });
+    return () => unsubscribe();
+  }, []);
+
+  // Ensure overlay is expanded when requested by main process (e.g. after switching to overlay mode).
+  // IMPORTANT: set isStealthRef before setIsExpanded so that if isExpanded was false, the
+  // isExpanded effect fires showWindow(true) instead of showWindow(false). Without this,
+  // ensure-expanded on a collapsed overlay would trigger show()+focus(), breaking stealth.
+  useEffect(() => {
+    if (!window.electronAPI?.onEnsureExpanded) return;
+    const unsubscribe = window.electronAPI.onEnsureExpanded(() => {
+      isStealthRef.current = true;
+      setIsExpanded(true);
+    });
+    return () => unsubscribe();
+  }, []);
+
+  // Session Reset Listener - Clears UI when a NEW meeting starts
+  useEffect(() => {
+    if (!window.electronAPI?.onSessionReset) return;
+    const unsubscribe = window.electronAPI.onSessionReset(() => {
+      console.log('[NativelyInterface] Resetting session state...');
+      setMessages([]);
+      setInputValue('');
+      setAttachedContext([]);
+      setManualTranscript('');
+      setVoiceInput('');
+      setIsProcessing(false);
+      // Optionally reset connection status if needed, but connection persists
+
+      // Track new conversation/session if applicable?
+      // Actually 'app_opened' is global, 'assistant_started' is overlay.
+      // Maybe 'conversation_started' event?
+      analytics.trackConversationStarted();
+    });
+    return () => unsubscribe();
+  }, []);
+
+  const handleScreenshotAttach = (data: { path: string; preview: string }) => {
+    setIsExpanded(true);
+    setAttachedContext((prev) => {
+      // Prevent duplicates and cap at 5
+      if (prev.some((s) => s.path === data.path)) return prev;
+      const updated = [...prev, data];
+      return updated.slice(-5); // Keep last 5
+    });
+  };
+
+  // STT Status listener — must survive isExpanded changes.
+  // If registered inside the [isExpanded] effect, events are dropped during cleanup.
+  useEffect(() => {
+    return window.electronAPI.onSttStatusChanged((data) => {
+      if (data.channel === 'user') {
+        setSttUserStatus(data.state);
+        setSttUserProvider(data.provider);
+        if (data.error) setSttUserError(data.error);
+        if (data.state === 'connected') setSttUserError('');
+      } else if (data.channel === 'interviewer') {
+        setSttInterviewerStatus(data.state);
+        setSttInterviewerProvider(data.provider);
+        if (data.error) setSttInterviewerError(data.error);
+        if (data.state === 'connected') setSttInterviewerError('');
+      }
+    });
+  }, []);
+
+  // ── PERF: streaming-token rAF coalescing ─────────────────────────────────
+  // Token streams (LLM answers) used to call setMessages PER TOKEN. Groq
+  // emits ~200–400 tok/s, so a 400-token answer triggered 400 React renders
+  // — each one cloning the messages array and re-rendering every prior row.
+  //
+  // queueToken accumulates incoming tokens for a given intent into a ref-
+  // backed buffer; the FIRST token in a frame schedules a single
+  // requestAnimationFrame that flushes the buffer with one setMessages.
+  // Result: at most ~60 setMessages/sec regardless of token rate.
+  //
+  // flushToken() is called by the "final answer" handlers BEFORE they apply
+  // their own setMessages, so any tokens still pending in the buffer are
+  // committed to the streaming row first — guarantees no token is lost on
+  // stream completion.
+  //
+  // Single-buffer design (not per-intent) is fine because LLM streams never
+  // overlap by intent in this app. If the intent changes mid-stream we
+  // synchronously flush the previous intent's buffer before queuing.
+  const tokenBufRef = useRef<{ intent: string; text: string; raf: number | null }>({
+    intent: '',
+    text: '',
+    raf: null,
+  });
+
+  // Sprint 13: React 18 concurrent mode — wrap streaming setMessages in
+  // reactStartTransition (React's startTransition, aliased to avoid the
+  // name clash with the local shell-width tween helper) so user input
+  // (clicks, keypresses, scrolling) gets higher render priority than
+  // streaming reconciliation. React can interrupt and resume the messages
+  // render between frames if a higher-priority update arrives. Negligible
+  // cost on small renders, real win when long history is in flight.
+  const queueToken = useCallback((intent: string, token: string) => {
+    const buf = tokenBufRef.current;
+    // If the intent changed, flush the prior buffer immediately so we don't
+    // append text from one stream onto another.
+    if (buf.text && buf.intent !== intent) {
+      const oldIntent = buf.intent;
+      const oldText = buf.text;
+      buf.text = '';
+      if (buf.raf !== null) {
+        cancelAnimationFrame(buf.raf);
+        buf.raf = null;
+      }
+      reactStartTransition(() => {
+        setMessages((prev) => {
+          const lastMsg = prev[prev.length - 1];
+          if (lastMsg && lastMsg.isStreaming && lastMsg.intent === oldIntent) {
+            const updated = [...prev];
+            updated[prev.length - 1] = { ...lastMsg, text: lastMsg.text + oldText };
+            return updated;
+          }
+          return [
+            ...prev,
+            {
+              id: Date.now().toString(),
+              role: 'system',
+              text: oldText,
+              intent: oldIntent,
+              isStreaming: true,
             },
-            onComplete: () => { animationControlsRef.current = null; },
+          ];
         });
-    }, [shellWidth, SHELL_WIDTH_EXPANDED]);
-
-    // Scan [data-code-msg] elements and check if any intersect the scroll container
-    // viewport. Called on every scroll event and after every messages update.
-    // Uses a stability gate: the visibility must hold its new state for
-    // STABILITY_MS before a transition fires. This filters out the rapid
-    // visible↔invisible flicker that occurs when a code block crosses the
-    // viewport edge during a fast scroll, which would otherwise interrupt
-    // the 0.7s tween mid-flight and cause stutter.
-    const STABILITY_MS = 120;
-    const checkCodeVisibility = useCallback(() => {
-        const container = scrollContainerRef.current;
-
-        // Scroll container unmounted (session reset / messages cleared) — force
-        // contraction so the shell returns to its collapsed width.
-        if (!container) {
-            if (stableVisibilityTimerRef.current) {
-                clearTimeout(stableVisibilityTimerRef.current);
-                stableVisibilityTimerRef.current = null;
-            }
-            pendingVisibilityRef.current = null;
-            if (codeExpandedRef.current) startTransition(SHELL_WIDTH_COLLAPSED);
-            return;
-        }
-
-        const codeEls = container.querySelectorAll('[data-code-msg]');
-        let visible = false;
-        if (codeEls.length > 0) {
-            const cRect = container.getBoundingClientRect();
-            for (const el of codeEls) {
-                const r = el.getBoundingClientRect();
-                if (r.bottom > cRect.top && r.top < cRect.bottom) { visible = true; break; }
-            }
-        }
-
-        // Already in the correct state — clear any pending change so a
-        // mid-flight tween isn't interrupted by a stale timer firing.
-        if (visible === codeExpandedRef.current) {
-            pendingVisibilityRef.current = null;
-            if (stableVisibilityTimerRef.current) {
-                clearTimeout(stableVisibilityTimerRef.current);
-                stableVisibilityTimerRef.current = null;
-            }
-            return;
-        }
-
-        // State change detected. If we're already waiting on the SAME pending
-        // change, let the timer continue ticking — don't reset it on every
-        // scroll frame, or fast scroll would never let the timer fire.
-        if (pendingVisibilityRef.current === visible) return;
-
-        pendingVisibilityRef.current = visible;
-        if (stableVisibilityTimerRef.current) clearTimeout(stableVisibilityTimerRef.current);
-        stableVisibilityTimerRef.current = setTimeout(() => {
-            stableVisibilityTimerRef.current = null;
-            const target = pendingVisibilityRef.current;
-            pendingVisibilityRef.current = null;
-            if (target !== null && target !== codeExpandedRef.current) {
-                startTransition(target ? SHELL_WIDTH_EXPANDED : SHELL_WIDTH_COLLAPSED);
-            }
-        }, STABILITY_MS);
-    }, [startTransition, SHELL_WIDTH_COLLAPSED, SHELL_WIDTH_EXPANDED]);
-
-    // Re-check after every messages update (catches mid-stream code fences).
-    useEffect(() => {
-        const raf = requestAnimationFrame(() => checkCodeVisibility());
-        return () => cancelAnimationFrame(raf);
-    }, [messages, checkCodeVisibility]);
-
-    // Re-attach scroll listener whenever messages change — the scroll container
-    // is conditionally rendered so scrollContainerRef.current is null at mount.
-    //
-    // The visibility check does layout reads (querySelectorAll +
-    // getBoundingClientRect on every code element). Running it synchronously
-    // on every scroll event forces a layout flush mid-scroll-frame, which
-    // shows up as text jitter during fast scrolls. rAF-coalescing it ensures
-    // at most one check per frame and lets the read happen at the natural
-    // post-scroll layout point in the frame lifecycle.
-    useEffect(() => {
-        const container = scrollContainerRef.current;
-        if (!container) return;
-        let rafId: number | null = null;
-        const onScroll = () => {
-            if (rafId !== null) return;
-            rafId = requestAnimationFrame(() => {
-                rafId = null;
-                checkCodeVisibility();
-            });
-        };
-        container.addEventListener('scroll', onScroll, { passive: true });
-        return () => {
-            container.removeEventListener('scroll', onScroll);
-            if (rafId !== null) cancelAnimationFrame(rafId);
-        };
-    }, [messages, checkCodeVisibility]);
-
-    // Cancel all in-flight async work on unmount.
-    useEffect(() => {
-        return () => {
-            animationControlsRef.current?.stop();
-            animationControlsRef.current = null;
-            if (rafDimUpdateRef.current) {
-                cancelAnimationFrame(rafDimUpdateRef.current);
-                rafDimUpdateRef.current = null;
-            }
-            if (stableVisibilityTimerRef.current) {
-                clearTimeout(stableVisibilityTimerRef.current);
-                stableVisibilityTimerRef.current = null;
-            }
-            pendingVisibilityRef.current = null;
-            // PERF: cancel any pending token-flush RAF so we don't try to
-            // setState on an unmounted component.
-            if (tokenBufRef.current.raf !== null) {
-                cancelAnimationFrame(tokenBufRef.current.raf);
-                tokenBufRef.current.raf = null;
-                tokenBufRef.current.text = '';
-            }
-        };
-    }, []);
-    // ────────────────────────────────────────────────────────────────────────
-
-    // Build conversation context from messages
-    useEffect(() => {
-        const context = messages
-            .filter(m => m.role !== 'user' || !m.hasScreenshot)
-            .map(m => `${m.role === 'interviewer' ? 'Interviewer' : m.role === 'user' ? 'User' : 'Assistant'}: ${m.text}`)
-            .slice(-20)
-            .join('\n');
-        setConversationContext(context);
-    }, [messages]);
-
-    // Listen for settings window visibility changes
-    useEffect(() => {
-        if (!window.electronAPI?.onSettingsVisibilityChange) return;
-        const unsubscribe = window.electronAPI.onSettingsVisibilityChange((isVisible) => {
-            setIsSettingsOpen(isVisible);
-        });
-        return () => unsubscribe();
-    }, []);
-
-    // Sync Window Visibility with Expanded State
-    useEffect(() => {
-        if (isExpanded) {
-            window.electronAPI.showWindow(isStealthRef.current);
-            isStealthRef.current = false; // Reset back to default
-        } else {
-            // Slight delay to allow animation to clean up if needed, though immediate is safer for click-through
-            // Using setTimeout to ensure the render cycle completes first
-            // Increased to 400ms to allow "contract to bottom" exit animation to finish
-            setTimeout(() => window.electronAPI.hideWindow(), 400);
-        }
-    }, [isExpanded]);
-
-    // Keyboard shortcut to toggle expanded state (via Main Process)
-    useEffect(() => {
-        if (!window.electronAPI?.onToggleExpand) return;
-        const unsubscribe = window.electronAPI.onToggleExpand(() => {
-            setIsExpanded(prev => !prev);
-        });
-        return () => unsubscribe();
-    }, []);
-
-    // Ensure overlay is expanded when requested by main process (e.g. after switching to overlay mode).
-    // IMPORTANT: set isStealthRef before setIsExpanded so that if isExpanded was false, the
-    // isExpanded effect fires showWindow(true) instead of showWindow(false). Without this,
-    // ensure-expanded on a collapsed overlay would trigger show()+focus(), breaking stealth.
-    useEffect(() => {
-        if (!window.electronAPI?.onEnsureExpanded) return;
-        const unsubscribe = window.electronAPI.onEnsureExpanded(() => {
-            isStealthRef.current = true;
-            setIsExpanded(true);
-        });
-        return () => unsubscribe();
-    }, []);
-
-    // Session Reset Listener - Clears UI when a NEW meeting starts
-    useEffect(() => {
-        if (!window.electronAPI?.onSessionReset) return;
-        const unsubscribe = window.electronAPI.onSessionReset(() => {
-            console.log('[NativelyInterface] Resetting session state...');
-            setMessages([]);
-            setInputValue('');
-            setAttachedContext([]);
-            setManualTranscript('');
-            setVoiceInput('');
-            setIsProcessing(false);
-            // Optionally reset connection status if needed, but connection persists
-
-            // Track new conversation/session if applicable?
-            // Actually 'app_opened' is global, 'assistant_started' is overlay.
-            // Maybe 'conversation_started' event?
-            analytics.trackConversationStarted();
-        });
-        return () => unsubscribe();
-    }, []);
-
-
-    const handleScreenshotAttach = (data: { path: string; preview: string }) => {
-        setIsExpanded(true);
-        setAttachedContext(prev => {
-            // Prevent duplicates and cap at 5
-            if (prev.some(s => s.path === data.path)) return prev;
-            const updated = [...prev, data];
-            return updated.slice(-5); // Keep last 5
-        });
-    };
-
-    // STT Status listener — must survive isExpanded changes.
-    // If registered inside the [isExpanded] effect, events are dropped during cleanup.
-    useEffect(() => {
-        return window.electronAPI.onSttStatusChanged((data) => {
-            if (data.channel === 'user') {
-                setSttUserStatus(data.state);
-                setSttUserProvider(data.provider);
-                if (data.error) setSttUserError(data.error);
-                if (data.state === 'connected') setSttUserError('');
-            } else if (data.channel === 'interviewer') {
-                setSttInterviewerStatus(data.state);
-                setSttInterviewerProvider(data.provider);
-                if (data.error) setSttInterviewerError(data.error);
-                if (data.state === 'connected') setSttInterviewerError('');
-            }
-        });
-    }, []);
-
-    // ── PERF: streaming-token rAF coalescing ─────────────────────────────────
-    // Token streams (LLM answers) used to call setMessages PER TOKEN. Groq
-    // emits ~200–400 tok/s, so a 400-token answer triggered 400 React renders
-    // — each one cloning the messages array and re-rendering every prior row.
-    //
-    // queueToken accumulates incoming tokens for a given intent into a ref-
-    // backed buffer; the FIRST token in a frame schedules a single
-    // requestAnimationFrame that flushes the buffer with one setMessages.
-    // Result: at most ~60 setMessages/sec regardless of token rate.
-    //
-    // flushToken() is called by the "final answer" handlers BEFORE they apply
-    // their own setMessages, so any tokens still pending in the buffer are
-    // committed to the streaming row first — guarantees no token is lost on
-    // stream completion.
-    //
-    // Single-buffer design (not per-intent) is fine because LLM streams never
-    // overlap by intent in this app. If the intent changes mid-stream we
-    // synchronously flush the previous intent's buffer before queuing.
-    const tokenBufRef = useRef<{ intent: string; text: string; raf: number | null }>({ intent: '', text: '', raf: null });
-
-    // Sprint 13: React 18 concurrent mode — wrap streaming setMessages in
-    // reactStartTransition (React's startTransition, aliased to avoid the
-    // name clash with the local shell-width tween helper) so user input
-    // (clicks, keypresses, scrolling) gets higher render priority than
-    // streaming reconciliation. React can interrupt and resume the messages
-    // render between frames if a higher-priority update arrives. Negligible
-    // cost on small renders, real win when long history is in flight.
-    const queueToken = useCallback((intent: string, token: string) => {
-        const buf = tokenBufRef.current;
-        // If the intent changed, flush the prior buffer immediately so we don't
-        // append text from one stream onto another.
-        if (buf.text && buf.intent !== intent) {
-            const oldIntent = buf.intent;
-            const oldText = buf.text;
-            buf.text = '';
-            if (buf.raf !== null) { cancelAnimationFrame(buf.raf); buf.raf = null; }
-            reactStartTransition(() => {
-                setMessages(prev => {
-                    const lastMsg = prev[prev.length - 1];
-                    if (lastMsg && lastMsg.isStreaming && lastMsg.intent === oldIntent) {
-                        const updated = [...prev];
-                        updated[prev.length - 1] = { ...lastMsg, text: lastMsg.text + oldText };
-                        return updated;
-                    }
-                    return [...prev, { id: Date.now().toString(), role: 'system', text: oldText, intent: oldIntent, isStreaming: true }];
-                });
-            });
-        }
-        buf.intent = intent;
-        buf.text += token;
-        if (buf.raf === null) {
-            buf.raf = requestAnimationFrame(() => {
-                buf.raf = null;
-                const text = buf.text;
-                const i = buf.intent;
-                buf.text = '';
-                if (!text) return;
-                reactStartTransition(() => {
-                    setMessages(prev => {
-                        const lastMsg = prev[prev.length - 1];
-                        if (lastMsg && lastMsg.isStreaming && lastMsg.intent === i) {
-                            const updated = [...prev];
-                            updated[prev.length - 1] = { ...lastMsg, text: lastMsg.text + text };
-                            return updated;
-                        }
-                        return [...prev, { id: Date.now().toString(), role: 'system', text, intent: i, isStreaming: true }];
-                    });
-                });
-            });
-        }
-    }, []);
-
-    const flushToken = useCallback(() => {
-        const buf = tokenBufRef.current;
-        if (buf.raf !== null) { cancelAnimationFrame(buf.raf); buf.raf = null; }
-        if (!buf.text) return;
+      });
+    }
+    buf.intent = intent;
+    buf.text += token;
+    if (buf.raf === null) {
+      buf.raf = requestAnimationFrame(() => {
+        buf.raf = null;
         const text = buf.text;
-        const intent = buf.intent;
+        const i = buf.intent;
         buf.text = '';
-        // NOT wrapped in startTransition — flush is called synchronously
-        // before a final-answer setMessages, and we want the trailing tokens
-        // to be in DOM before the final state is committed (so React's batch
-        // doesn't reorder them after the final). The ordering must hold.
-        setMessages(prev => {
+        if (!text) return;
+        reactStartTransition(() => {
+          setMessages((prev) => {
             const lastMsg = prev[prev.length - 1];
-            if (lastMsg && lastMsg.isStreaming && lastMsg.intent === intent) {
-                const updated = [...prev];
-                updated[prev.length - 1] = { ...lastMsg, text: lastMsg.text + text };
-                return updated;
+            if (lastMsg && lastMsg.isStreaming && lastMsg.intent === i) {
+              const updated = [...prev];
+              updated[prev.length - 1] = { ...lastMsg, text: lastMsg.text + text };
+              return updated;
             }
-            return [...prev, { id: Date.now().toString(), role: 'system', text, intent, isStreaming: true }];
+            return [
+              ...prev,
+              { id: Date.now().toString(), role: 'system', text, intent: i, isStreaming: true },
+            ];
+          });
         });
-    }, []);
-    // ──────────────────────────────────────────────────────────────────────────
+      });
+    }
+  }, []);
 
-    // Connect to Native Audio Backend
-    useEffect(() => {
-        const cleanups: (() => void)[] = [];
+  const flushToken = useCallback(() => {
+    const buf = tokenBufRef.current;
+    if (buf.raf !== null) {
+      cancelAnimationFrame(buf.raf);
+      buf.raf = null;
+    }
+    if (!buf.text) return;
+    const text = buf.text;
+    const intent = buf.intent;
+    buf.text = '';
+    // NOT wrapped in startTransition — flush is called synchronously
+    // before a final-answer setMessages, and we want the trailing tokens
+    // to be in DOM before the final state is committed (so React's batch
+    // doesn't reorder them after the final). The ordering must hold.
+    setMessages((prev) => {
+      const lastMsg = prev[prev.length - 1];
+      if (lastMsg && lastMsg.isStreaming && lastMsg.intent === intent) {
+        const updated = [...prev];
+        updated[prev.length - 1] = { ...lastMsg, text: lastMsg.text + text };
+        return updated;
+      }
+      return [
+        ...prev,
+        { id: Date.now().toString(), role: 'system', text, intent, isStreaming: true },
+      ];
+    });
+  }, []);
+  // ──────────────────────────────────────────────────────────────────────────
 
-        // Connection Status
-        window.electronAPI.getNativeAudioStatus().then((status) => {
-            setIsConnected(status.connected);
-        }).catch(() => setIsConnected(false));
+  // Connect to Native Audio Backend
+  useEffect(() => {
+    const cleanups: (() => void)[] = [];
 
-        cleanups.push(window.electronAPI.onNativeAudioConnected(() => {
-            setIsConnected(true);
-        }));
-        cleanups.push(window.electronAPI.onNativeAudioDisconnected(() => {
-            setIsConnected(false);
-        }));
+    // Connection Status
+    window.electronAPI
+      .getNativeAudioStatus()
+      .then((status) => {
+        setIsConnected(status.connected);
+      })
+      .catch(() => setIsConnected(false));
 
-        // Real-time Transcripts
-        cleanups.push(window.electronAPI.onNativeAudioTranscript((transcript) => {
-            // When Answer button is active, capture USER transcripts for voice input
-            // Use ref to avoid stale closure issue
-            if (isRecordingRef.current && transcript.speaker === 'user') {
-                if (transcript.final) {
-                    // Accumulate final transcripts
-                    setVoiceInput(prev => {
-                        const updated = prev + (prev ? ' ' : '') + transcript.text;
-                        voiceInputRef.current = updated;
-                        return updated;
-                    });
-                    setManualTranscript('');  // Clear partial preview
-                    manualTranscriptRef.current = '';
-                } else {
-                    // Show live partial transcript
-                    setManualTranscript(transcript.text);
-                    manualTranscriptRef.current = transcript.text;
-                }
-                return;  // Don't add to messages while recording
-            }
+    cleanups.push(
+      window.electronAPI.onNativeAudioConnected(() => {
+        setIsConnected(true);
+      }),
+    );
+    cleanups.push(
+      window.electronAPI.onNativeAudioDisconnected(() => {
+        setIsConnected(false);
+      }),
+    );
 
-            // Ignore user mic transcripts when not recording
-            // Only interviewer (system audio) transcripts should appear in chat
-            if (transcript.speaker === 'user') {
-                return;  // Skip user mic input - only relevant when Answer button is active
-            }
-
-            // Only show interviewer (system audio) transcripts in rolling bar
-            if (transcript.speaker !== 'interviewer') {
-                return;  // Safety check for any other speaker types
-            }
-
-            // Route to rolling transcript bar - accumulate text continuously
-            setIsInterviewerSpeaking(!transcript.final);
-
-            if (transcript.final) {
-                // Append finalized text to accumulated transcript
-                setRollingTranscript(prev => {
-                    const separator = prev ? '  ·  ' : '';
-                    return prev + separator + transcript.text;
-                });
-
-                // Clear speaking indicator after pause
-                setTimeout(() => {
-                    setIsInterviewerSpeaking(false);
-                }, 3000);
-            } else {
-                // For partial transcripts, show current segment appended to accumulated
-                setRollingTranscript(prev => {
-                    // Find where previous finalized content ends (look for last separator)
-                    const lastSeparator = prev.lastIndexOf('  ·  ');
-                    const accumulated = lastSeparator >= 0 ? prev.substring(0, lastSeparator + 5) : '';
-                    return accumulated + transcript.text;
-                });
-            }
-        }));
-
-        // AI Suggestions from native audio (legacy)
-        cleanups.push(window.electronAPI.onSuggestionProcessingStart(() => {
-            setIsProcessing(true);
-            setIsExpanded(true);
-        }));
-
-        cleanups.push(window.electronAPI.onSuggestionGenerated((data) => {
-            setIsProcessing(false);
-            setMessages(prev => [...prev, {
-                id: Date.now().toString(),
-                role: 'system',
-                text: data.suggestion
-            }]);
-        }));
-
-        cleanups.push(window.electronAPI.onSuggestionError((err) => {
-            setIsProcessing(false);
-            setMessages(prev => [...prev, {
-                id: Date.now().toString(),
-                role: 'system',
-                text: `Error: ${err.error}`
-            }]);
-        }));
-
-
-
-        cleanups.push(window.electronAPI.onIntelligenceSuggestedAnswerToken((data) => {
-            // Coaching now arrives via onIntelligenceNegotiationCoaching only —
-            // sentinel detection on this stream has been removed.
-            queueToken('what_to_answer', data.token);
-        }));
-
-        cleanups.push(window.electronAPI.onIntelligenceSuggestedAnswer((data) => {
-            // PERF: flush any tokens still pending in the rAF buffer onto the
-            // streaming row BEFORE we apply the final-answer setMessages, so no
-            // tokens are lost on stream completion.
-            flushToken();
-            setIsProcessing(false);
-
-            setMessages(prev => {
-                const lastMsg = prev[prev.length - 1];
-                if (lastMsg && lastMsg.isStreaming && lastMsg.intent === 'what_to_answer') {
-                    const updated = [...prev];
-                    updated[prev.length - 1] = {
-                        ...lastMsg,
-                        text: data.answer,
-                        isStreaming: false
-                    };
-                    return updated;
-                }
-                return [...prev, {
-                    id: Date.now().toString(),
-                    role: 'system',
-                    text: data.answer,
-                    intent: 'what_to_answer'
-                }];
+    // Real-time Transcripts
+    cleanups.push(
+      window.electronAPI.onNativeAudioTranscript((transcript) => {
+        // When Answer button is active, capture USER transcripts for voice input
+        // Use ref to avoid stale closure issue
+        if (isRecordingRef.current && transcript.speaker === 'user') {
+          if (transcript.final) {
+            // Accumulate final transcripts
+            setVoiceInput((prev) => {
+              const updated = prev + (prev ? ' ' : '') + transcript.text;
+              voiceInputRef.current = updated;
+              return updated;
             });
-        }));
-
-        // Sprint 9: time-batched token channel — single subscription that
-        // unrolls a kind-tagged items array onto the existing queueToken path.
-        // The 5 per-token channels (intelligence-suggested-answer-token,
-        // intelligence-refined-answer-token, etc.) are no longer being sent
-        // by main.ts for these streams — their handlers above are now inert
-        // safety nets and only fire if some other code path emits them.
-        cleanups.push(window.electronAPI.onIntelligenceTokenBatch((data) => {
-            const { kind, items } = data;
-            if (!items || items.length === 0) return;
-            if (kind === 'suggested_answer') {
-                for (const it of items) queueToken('what_to_answer', (it as any).token);
-            } else if (kind === 'refined_answer') {
-                for (const it of items) queueToken((it as any).intent, (it as any).token);
-            } else if (kind === 'recap') {
-                for (const it of items) queueToken('recap', (it as any).token);
-            } else if (kind === 'clarify') {
-                for (const it of items) queueToken('clarify', (it as any).token);
-            } else if (kind === 'follow_up_questions') {
-                for (const it of items) queueToken('follow_up_questions', (it as any).token);
-            }
-        }));
-
-        // Sprint 7: dedicated negotiation-coaching channel.
-        // The engine now intercepts the coaching sentinel server-side and
-        // emits this event INSTEAD of suggested_answer / suggested_answer_token.
-        // Renderer no longer needs JSON.parse-per-token detection (the
-        // existing prefix-gated detection paths above are kept as defense-
-        // in-depth — they are inert because the engine never sends sentinel
-        // tokens through suggested_answer anymore).
-        cleanups.push(window.electronAPI.onIntelligenceNegotiationCoaching((data) => {
-            // Flush any pending streamed tokens before swapping the streaming
-            // row to a coaching card; otherwise rAF-buffered text would be
-            // appended onto the card row's empty text after this setMessages.
-            flushToken();
-            setIsProcessing(false);
-            const coaching = data.payload;
-            setMessages(prev => {
-                const lastMsg = prev[prev.length - 1];
-                // If a what_to_answer streaming row is in flight, replace it
-                // with the coaching card so the user doesn't see two bubbles.
-                if (lastMsg && lastMsg.isStreaming && lastMsg.intent === 'what_to_answer') {
-                    const updated = [...prev];
-                    updated[prev.length - 1] = {
-                        ...lastMsg,
-                        text: '',
-                        isStreaming: false,
-                        isNegotiationCoaching: true,
-                        negotiationCoachingData: coaching,
-                    };
-                    return updated;
-                }
-                return [...prev, {
-                    id: Date.now().toString(),
-                    role: 'system',
-                    text: '',
-                    intent: 'what_to_answer',
-                    isNegotiationCoaching: true,
-                    negotiationCoachingData: coaching,
-                }];
-            });
-        }));
-
-        // STREAMING: Refinement
-        cleanups.push(window.electronAPI.onIntelligenceRefinedAnswerToken((data) => {
-            // PERF: rAF-coalesce per-token state updates.
-            queueToken(data.intent, data.token);
-        }));
-
-        cleanups.push(window.electronAPI.onIntelligenceRefinedAnswer((data) => {
-            flushToken();
-            setIsProcessing(false);
-            setMessages(prev => {
-                const lastMsg = prev[prev.length - 1];
-                if (lastMsg && lastMsg.isStreaming && lastMsg.intent === data.intent) {
-                    const updated = [...prev];
-                    updated[prev.length - 1] = {
-                        ...lastMsg,
-                        text: data.answer,
-                        isStreaming: false
-                    };
-                    return updated;
-                }
-                return [...prev, {
-                    id: Date.now().toString(),
-                    role: 'system',
-                    text: data.answer,
-                    intent: data.intent
-                }];
-            });
-        }));
-
-        // STREAMING: Recap
-        cleanups.push(window.electronAPI.onIntelligenceRecapToken((data) => {
-            queueToken('recap', data.token);
-        }));
-
-        cleanups.push(window.electronAPI.onIntelligenceRecap((data) => {
-            flushToken();
-            setIsProcessing(false);
-            setMessages(prev => {
-                const lastMsg = prev[prev.length - 1];
-                if (lastMsg && lastMsg.isStreaming && lastMsg.intent === 'recap') {
-                    const updated = [...prev];
-                    updated[prev.length - 1] = {
-                        ...lastMsg,
-                        text: data.summary,
-                        isStreaming: false
-                    };
-                    return updated;
-                }
-                return [...prev, {
-                    id: Date.now().toString(),
-                    role: 'system',
-                    text: data.summary,
-                    intent: 'recap'
-                }];
-            });
-        }));
-
-        // STREAMING: Follow-Up Questions (Rendered as message? Or specific UI?)
-        // Currently interface typically renders follow-up Qs as a message or button update.
-        // Let's assume message for now based on existing 'follow_up_questions_update' handling
-        // But wait, existing handle just sets state?
-        // Let's check how 'follow_up_questions_update' was handled.
-        // It was handled separate locally in this component maybe?
-        // Ah, I need to see the existing listener for 'onIntelligenceFollowUpQuestionsUpdate'
-
-        // Let's implemented token streaming for it anyway, likely it updates a message bubble
-        // OR it might update a specialized "Suggested Questions" area.
-        // Assuming it's a message for consistency with "Copilot" approach.
-
-        cleanups.push(window.electronAPI.onIntelligenceFollowUpQuestionsToken((data) => {
-            queueToken('follow_up_questions', data.token);
-        }));
-
-        cleanups.push(window.electronAPI.onIntelligenceFollowUpQuestionsUpdate((data) => {
-            flushToken();
-            // This event name is slightly different ('update' vs 'answer')
-            setIsProcessing(false);
-            setMessages(prev => {
-                const lastMsg = prev[prev.length - 1];
-                if (lastMsg && lastMsg.isStreaming && lastMsg.intent === 'follow_up_questions') {
-                    const updated = [...prev];
-                    updated[prev.length - 1] = {
-                        ...lastMsg,
-                        text: data.questions,
-                        isStreaming: false
-                    };
-                    return updated;
-                }
-                return [...prev, {
-                    id: Date.now().toString(),
-                    role: 'system',
-                    text: data.questions,
-                    intent: 'follow_up_questions'
-                }];
-            });
-        }));
-
-        cleanups.push(window.electronAPI.onIntelligenceManualResult((data) => {
-            setIsProcessing(false);
-            setMessages(prev => [...prev, {
-                id: Date.now().toString(),
-                role: 'system',
-                text: `🎯 **Answer:**\n\n${data.answer}`
-            }]);
-        }));
-
-        cleanups.push(window.electronAPI.onIntelligenceError((data) => {
-            setIsProcessing(false);
-            setMessages(prev => [...prev, {
-                id: Date.now().toString(),
-                role: 'system',
-                text: `❌ Error (${data.mode}): ${data.error}`
-            }]);
-        }));
-        return () => cleanups.forEach(fn => fn());
-    }, [isExpanded]);
-
-    // Stable mount-only effect for screenshot listeners.
-    // These MUST NOT be inside the [isExpanded] effect — when a screenshot is
-    // taken, `switchToOverlay` fires `ensure-expanded` which can flip isExpanded
-    // from false→true, triggering the [isExpanded] effect cleanup. If `screenshot-taken`
-    // arrives during that teardown gap the event is silently dropped (same issue
-    // as clarify streaming listeners below). handleScreenshotAttach only uses stable
-    // useState setters so a mount-only closure is safe here.
-    useEffect(() => {
-        const cleanupTaken = window.electronAPI.onScreenshotTaken(handleScreenshotAttach);
-        const cleanupAttached = window.electronAPI.onScreenshotAttached?.(handleScreenshotAttach);
-        return () => {
-            cleanupTaken?.();
-            cleanupAttached?.();
-        };
-    }, []);
-
-    // Stable mount-only effect for clarify streaming listeners.
-    // These MUST NOT be inside the [isExpanded] effect — if the user
-    // expands/collapses the panel while a clarify stream is in-flight,
-    // the [isExpanded] effect would tear down and re-register listeners,
-    // orphaning the final 'clarify' event and leaving isProcessing=true forever.
-    useEffect(() => {
-        const cleanupToken = window.electronAPI.onIntelligenceClarifyToken((data) => {
-            queueToken('clarify', data.token);
-        });
-
-        const cleanupFinal = window.electronAPI.onIntelligenceClarify((data) => {
-            flushToken();
-            setIsProcessing(false);
-            setMessages(prev => {
-                const lastMsg = prev[prev.length - 1];
-                if (lastMsg && lastMsg.isStreaming && lastMsg.intent === 'clarify') {
-                    const updated = [...prev];
-                    updated[prev.length - 1] = { ...lastMsg, text: data.clarification, isStreaming: false };
-                    return updated;
-                }
-                return [...prev, {
-                    id: Date.now().toString(),
-                    role: 'system' as const,
-                    text: data.clarification,
-                    intent: 'clarify'
-                }];
-            });
-        });
-
-        return () => {
-            cleanupToken();
-            cleanupFinal();
-        };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []); // intentionally empty — these listeners must survive isExpanded changes
-
-    // Quick Actions - Updated to use new Intelligence APIs
-
-    // PERF: useCallback so the reference is stable between renders. MessageRow
-    // (memoized below) receives this as a prop; without a stable identity its
-    // memo comparator would never match and the bailout would not fire.
-    const handleCopy = useCallback((text: string) => {
-        navigator.clipboard.writeText(text);
-        analytics.trackCopyAnswer();
-        // Optional: Trigger a small toast or state change for visual feedback
-    }, []);
-
-    const handleWhatToSay = async (promptInstruction?: string | React.MouseEvent) => {
-        const dynamicPromptInstruction = typeof promptInstruction === 'string' ? promptInstruction : undefined;
-        setIsExpanded(true);
-        setIsProcessing(true);
-        analytics.trackCommandExecuted('what_to_say');
-
-        // Capture and clear attached image context.
-        // Also merge in any screenshot from the capture-and-process shortcut that
-        // arrived via pendingCaptureRef before the React state flush (React 18 fix).
-        const pending = pendingCaptureRef.current;
-        let currentAttachments = attachedContext;
-        if (pending && !currentAttachments.some(s => s.path === pending.path)) {
-            currentAttachments = [...currentAttachments, pending].slice(-5);
-        }
-
-        if (currentAttachments.length > 0) {
-            setAttachedContext([]);
-            // Show the attached image in chat
-            setMessages(prev => [...prev, {
-                id: Date.now().toString(),
-                role: 'user',
-                text: 'What should I say about this?',
-                hasScreenshot: true,
-                screenshotPreview: currentAttachments[0].preview
-            }]);
-            // Scroll to bottom when user sends message
-            setTimeout(() => {
-                messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-            }, 50);
-        }
-
-        try {
-            // Pass imagePath if attached
-            const result = await window.electronAPI.generateWhatToSay(
-                undefined,
-                currentAttachments.length > 0 ? currentAttachments.map(s => s.path) : undefined,
-                dynamicPromptInstruction ? { promptInstruction: dynamicPromptInstruction } : undefined
-            );
-            setScreenContextStatus(result.screenContextStatus || 'not_available');
-            setLatestUsedImageInput(Boolean(result.usedImageInput));
-            setLatestVisionProviderUsed(result.visionProviderUsed);
-            setLatestVisionModelUsed(result.visionModelUsed);
-            setLatestVisionFailureReason(result.visionFailureReason);
-        } catch (err) {
-            setMessages(prev => [...prev, {
-                id: Date.now().toString(),
-                role: 'system',
-                text: `Error: ${err}`
-            }]);
-        } finally {
-            setIsProcessing(false);
-        }
-    };
-
-    const handleFollowUp = async (intent: string = 'rephrase') => {
-        setIsExpanded(true);
-        setIsProcessing(true);
-        analytics.trackCommandExecuted('follow_up_' + intent);
-
-        try {
-            await window.electronAPI.generateFollowUp(intent);
-        } catch (err) {
-            setMessages(prev => [...prev, {
-                id: Date.now().toString(),
-                role: 'system',
-                text: `Error: ${err}`
-            }]);
-        } finally {
-            setIsProcessing(false);
-        }
-    };
-
-    const handleRecap = async () => {
-        setIsExpanded(true);
-        setIsProcessing(true);
-        analytics.trackCommandExecuted('recap');
-
-        try {
-            await window.electronAPI.generateRecap();
-        } catch (err) {
-            setMessages(prev => [...prev, {
-                id: Date.now().toString(),
-                role: 'system',
-                text: `Error: ${err}`
-            }]);
-        } finally {
-            setIsProcessing(false);
-        }
-    };
-
-    const handleFollowUpQuestions = async () => {
-        setIsExpanded(true);
-        setIsProcessing(true);
-        analytics.trackCommandExecuted('suggest_questions');
-
-        try {
-            await window.electronAPI.generateFollowUpQuestions();
-        } catch (err) {
-            setMessages(prev => [...prev, {
-                id: Date.now().toString(),
-                role: 'system',
-                text: `Error: ${err}`
-            }]);
-        } finally {
-            setIsProcessing(false);
-        }
-    };
-
-    const handleClarify = async () => {
-        setIsExpanded(true);
-        setIsProcessing(true);
-        analytics.trackCommandExecuted('clarify');
-
-        try {
-            await window.electronAPI.generateClarify();
-        } catch (err) {
-            setMessages(prev => [...prev, {
-                id: Date.now().toString(),
-                role: 'system',
-                text: `Error: ${err}`
-            }]);
-        } finally {
-            setIsProcessing(false);
-        }
-    };
-
-    const handleCodeHint = async () => {
-        setIsExpanded(true);
-        setIsProcessing(true);
-        analytics.trackCommandExecuted('code_hint');
-
-        const currentAttachments = attachedContext;
-        if (currentAttachments.length > 0) {
-            setAttachedContext([]);
-            // Show the attached image in chat
-            setMessages(prev => [...prev, {
-                id: Date.now().toString(),
-                role: 'user',
-                text: 'Give me a code hint for this',
-                hasScreenshot: true,
-                screenshotPreview: currentAttachments[0].preview
-            }]);
-            // Scroll to bottom when user sends message
-            setTimeout(() => {
-                messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-            }, 50);
-        }
-
-        try {
-            await window.electronAPI.generateCodeHint(currentAttachments.length > 0 ? currentAttachments.map(s => s.path) : undefined);
-        } catch (err) {
-            setMessages(prev => [...prev, {
-                id: Date.now().toString(),
-                role: 'system',
-                text: `Error: ${err}`
-            }]);
-        } finally {
-            setIsProcessing(false);
-        }
-    };
-
-    const handleBrainstorm = async () => {
-        setIsExpanded(true);
-        setIsProcessing(true);
-        analytics.trackCommandExecuted('brainstorm');
-
-        const currentAttachments = attachedContext;
-        if (currentAttachments.length > 0) {
-            setAttachedContext([]);
-            // Show the attached image in chat
-            setMessages(prev => [...prev, {
-                id: Date.now().toString(),
-                role: 'user',
-                text: 'Brainstorm with this context',
-                hasScreenshot: true,
-                screenshotPreview: currentAttachments[0].preview
-            }]);
-            // Scroll to bottom when user sends message
-            setTimeout(() => {
-                messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-            }, 50);
-        }
-
-        try {
-            await window.electronAPI.generateBrainstorm(currentAttachments.length > 0 ? currentAttachments.map(s => s.path) : undefined);
-        } catch (err) {
-            setMessages(prev => [...prev, {
-                id: Date.now().toString(),
-                role: 'system',
-                text: `Error: ${err}`
-            }]);
-        } finally {
-            setIsProcessing(false);
-        }
-    };
-
-
-    // Setup Streaming Listeners
-    useEffect(() => {
-        const cleanups: (() => void)[] = [];
-
-        // Stream Token
-        cleanups.push(window.electronAPI.onGeminiStreamToken((token) => {
-            setMessages(prev => {
-                const lastMsg = prev[prev.length - 1];
-                if (lastMsg && lastMsg.isStreaming && lastMsg.role === 'system') {
-                    const updated = [...prev];
-                    updated[prev.length - 1] = {
-                        ...lastMsg,
-                        text: lastMsg.text + token,
-                        // re-check code status on every token? Expensive but needed for progressive highlighting
-                        isCode: (lastMsg.text + token).includes('```') || (lastMsg.text + token).includes('def ') || (lastMsg.text + token).includes('function ')
-                    };
-                    return updated;
-                }
-                return prev;
-            });
-        }));
-
-        // Stream Done
-        cleanups.push(window.electronAPI.onGeminiStreamDone(() => {
-            setIsProcessing(false);
-
-            // Calculate latency if we have a start time
-            let latency = 0;
-            if (requestStartTimeRef.current) {
-                latency = Date.now() - requestStartTimeRef.current;
-                requestStartTimeRef.current = null;
-            }
-
-            // Track Usage
-            analytics.trackModelUsed({
-                model_name: currentModel,
-                provider_type: detectProviderType(currentModel),
-                latency_ms: latency
-            });
-
-            setMessages(prev => {
-                const lastMsg = prev[prev.length - 1];
-                if (lastMsg && lastMsg.isStreaming && lastMsg.role === 'system') {
-                    return [...prev.slice(0, -1), { ...lastMsg, isStreaming: false }];
-                }
-                return prev;
-            });
-        }));
-
-        // Stream Error
-        cleanups.push(window.electronAPI.onGeminiStreamError((error) => {
-            setIsProcessing(false);
-            requestStartTimeRef.current = null; // Clear timer on error
-            setMessages(prev => {
-                // Append error to the current message or add new one?
-                // Let's add a new error block if the previous one confusing,
-                // or just update status.
-                // Ideally we want to show the partial response AND the error.
-                const lastMsg = prev[prev.length - 1];
-                if (lastMsg && lastMsg.isStreaming) {
-                    const updated = [...prev];
-                    updated[prev.length - 1] = {
-                        ...lastMsg,
-                        isStreaming: false,
-                        text: lastMsg.text + `\n\n[Error: ${error}]`
-                    };
-                    return updated;
-                }
-                return [...prev, {
-                    id: Date.now().toString(),
-                    role: 'system',
-                    text: `❌ Error: ${error}`
-                }];
-            });
-        }));
-
-        // JIT RAG Stream listeners (for live meeting RAG responses)
-        if (window.electronAPI.onRAGStreamChunk) {
-            cleanups.push(window.electronAPI.onRAGStreamChunk((data: { chunk: string }) => {
-                setMessages(prev => {
-                    const lastMsg = prev[prev.length - 1];
-                    if (lastMsg && lastMsg.isStreaming && lastMsg.role === 'system') {
-                        const updated = [...prev];
-                        updated[prev.length - 1] = {
-                            ...lastMsg,
-                            text: lastMsg.text + data.chunk,
-                            isCode: (lastMsg.text + data.chunk).includes('```')
-                        };
-                        return updated;
-                    }
-                    return prev;
-                });
-            }));
-        }
-
-        if (window.electronAPI.onRAGStreamComplete) {
-            cleanups.push(window.electronAPI.onRAGStreamComplete(() => {
-                setIsProcessing(false);
-                requestStartTimeRef.current = null;
-                setMessages(prev => {
-                    const lastMsg = prev[prev.length - 1];
-                    if (lastMsg && lastMsg.isStreaming && lastMsg.role === 'system') {
-                        return [...prev.slice(0, -1), { ...lastMsg, isStreaming: false }];
-                    }
-                    if (lastMsg && lastMsg.isStreaming) {
-                        const updated = [...prev];
-                        updated[prev.length - 1] = { ...lastMsg, isStreaming: false };
-                        return updated;
-                    }
-                    return prev;
-                });
-            }));
-        }
-
-        if (window.electronAPI.onRAGStreamError) {
-            cleanups.push(window.electronAPI.onRAGStreamError((data: { error: string }) => {
-                setIsProcessing(false);
-                requestStartTimeRef.current = null;
-                setMessages(prev => {
-                    const lastMsg = prev[prev.length - 1];
-                    if (lastMsg && lastMsg.isStreaming) {
-                        const updated = [...prev];
-                        updated[prev.length - 1] = {
-                            ...lastMsg,
-                            isStreaming: false,
-                            text: lastMsg.text + `\n\n[RAG Error: ${data.error}]`
-                        };
-                        return updated;
-                    }
-                    return prev;
-                });
-            }));
-        }
-
-        return () => cleanups.forEach(fn => fn());
-    }, [currentModel]); // Ensure tracking captures correct model
-
-
-    const handleAnswerNow = async () => {
-        if (isManualRecording) {
-            // Stop recording - send accumulated voice input to Gemini
-            isRecordingRef.current = false;  // Update ref immediately
-            setIsManualRecording(false);
-            setManualTranscript('');  // Clear live preview
-
-            // Send manual finalization signal to STT Providers
-            window.electronAPI.finalizeMicSTT().catch(err => console.error('[NativelyInterface] Failed to send finalizeMicSTT:', err));
-
-            const currentAttachments = attachedContext;
-            setAttachedContext([]); // Clear context immediately on send
-
-            const question = (voiceInputRef.current + (manualTranscriptRef.current ? ' ' + manualTranscriptRef.current : '')).trim();
-            setVoiceInput('');
-            voiceInputRef.current = '';
-            setManualTranscript('');
+            setManualTranscript(''); // Clear partial preview
             manualTranscriptRef.current = '';
+          } else {
+            // Show live partial transcript
+            setManualTranscript(transcript.text);
+            manualTranscriptRef.current = transcript.text;
+          }
+          return; // Don't add to messages while recording
+        }
 
-            if (!question && currentAttachments.length === 0) {
-                // No voice input and no image — show real STT error if available
-                if (sttUserStatus === 'failed' && sttUserError) {
-                    setMessages(prev => [...prev, {
-                        id: Date.now().toString(),
-                        role: 'system',
-                        text: `❌ STT Error: ${sttUserError}`
-                    }]);
-                } else if (sttUserStatus === 'reconnecting') {
-                    setMessages(prev => [...prev, {
-                        id: Date.now().toString(),
-                        role: 'system',
-                        text: '⏳ STT is reconnecting, try again in a moment.'
-                    }]);
-                } else {
-                    setMessages(prev => [...prev, {
-                        id: Date.now().toString(),
-                        role: 'system',
-                        text: '⚠️ No speech detected. Try speaking closer to your microphone.'
-                    }]);
-                }
-                return;
+        // Ignore user mic transcripts when not recording
+        // Only interviewer (system audio) transcripts should appear in chat
+        if (transcript.speaker === 'user') {
+          return; // Skip user mic input - only relevant when Answer button is active
+        }
+
+        // Only show interviewer (system audio) transcripts in rolling bar
+        if (transcript.speaker !== 'interviewer') {
+          return; // Safety check for any other speaker types
+        }
+
+        // Route to rolling transcript bar - accumulate text continuously
+        setIsInterviewerSpeaking(!transcript.final);
+
+        if (transcript.final) {
+          // Append finalized text to accumulated transcript
+          setRollingTranscript((prev) => {
+            const separator = prev ? '  ·  ' : '';
+            return prev + separator + transcript.text;
+          });
+
+          // Clear speaking indicator after pause
+          setTimeout(() => {
+            setIsInterviewerSpeaking(false);
+          }, 3000);
+        } else {
+          // For partial transcripts, show current segment appended to accumulated
+          setRollingTranscript((prev) => {
+            // Find where previous finalized content ends (look for last separator)
+            const lastSeparator = prev.lastIndexOf('  ·  ');
+            const accumulated = lastSeparator >= 0 ? prev.substring(0, lastSeparator + 5) : '';
+            return accumulated + transcript.text;
+          });
+        }
+      }),
+    );
+
+    // AI Suggestions from native audio (legacy)
+    cleanups.push(
+      window.electronAPI.onSuggestionProcessingStart(() => {
+        setIsProcessing(true);
+        setIsExpanded(true);
+      }),
+    );
+
+    cleanups.push(
+      window.electronAPI.onSuggestionGenerated((data) => {
+        setIsProcessing(false);
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: Date.now().toString(),
+            role: 'system',
+            text: data.suggestion,
+          },
+        ]);
+      }),
+    );
+
+    cleanups.push(
+      window.electronAPI.onSuggestionError((err) => {
+        setIsProcessing(false);
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: Date.now().toString(),
+            role: 'system',
+            text: `Error: ${err.error}`,
+          },
+        ]);
+      }),
+    );
+
+    cleanups.push(
+      window.electronAPI.onIntelligenceSuggestedAnswerToken((data) => {
+        // Coaching now arrives via onIntelligenceNegotiationCoaching only —
+        // sentinel detection on this stream has been removed.
+        queueToken('what_to_answer', data.token);
+      }),
+    );
+
+    cleanups.push(
+      window.electronAPI.onIntelligenceSuggestedAnswer((data) => {
+        // PERF: flush any tokens still pending in the rAF buffer onto the
+        // streaming row BEFORE we apply the final-answer setMessages, so no
+        // tokens are lost on stream completion.
+        flushToken();
+        setIsProcessing(false);
+
+        setMessages((prev) => {
+          const lastMsg = prev[prev.length - 1];
+          if (lastMsg && lastMsg.isStreaming && lastMsg.intent === 'what_to_answer') {
+            const updated = [...prev];
+            updated[prev.length - 1] = {
+              ...lastMsg,
+              text: data.answer,
+              isStreaming: false,
+            };
+            return updated;
+          }
+          return [
+            ...prev,
+            {
+              id: Date.now().toString(),
+              role: 'system',
+              text: data.answer,
+              intent: 'what_to_answer',
+            },
+          ];
+        });
+      }),
+    );
+
+    // Sprint 9: time-batched token channel — single subscription that
+    // unrolls a kind-tagged items array onto the existing queueToken path.
+    // The 5 per-token channels (intelligence-suggested-answer-token,
+    // intelligence-refined-answer-token, etc.) are no longer being sent
+    // by main.ts for these streams — their handlers above are now inert
+    // safety nets and only fire if some other code path emits them.
+    cleanups.push(
+      window.electronAPI.onIntelligenceTokenBatch((data) => {
+        const { kind, items } = data;
+        if (!items || items.length === 0) return;
+        if (kind === 'suggested_answer') {
+          for (const it of items) queueToken('what_to_answer', (it as any).token);
+        } else if (kind === 'refined_answer') {
+          for (const it of items) queueToken((it as any).intent, (it as any).token);
+        } else if (kind === 'recap') {
+          for (const it of items) queueToken('recap', (it as any).token);
+        } else if (kind === 'clarify') {
+          for (const it of items) queueToken('clarify', (it as any).token);
+        } else if (kind === 'follow_up_questions') {
+          for (const it of items) queueToken('follow_up_questions', (it as any).token);
+        }
+      }),
+    );
+
+    // Sprint 7: dedicated negotiation-coaching channel.
+    // The engine now intercepts the coaching sentinel server-side and
+    // emits this event INSTEAD of suggested_answer / suggested_answer_token.
+    // Renderer no longer needs JSON.parse-per-token detection (the
+    // existing prefix-gated detection paths above are kept as defense-
+    // in-depth — they are inert because the engine never sends sentinel
+    // tokens through suggested_answer anymore).
+    cleanups.push(
+      window.electronAPI.onIntelligenceNegotiationCoaching((data) => {
+        // Flush any pending streamed tokens before swapping the streaming
+        // row to a coaching card; otherwise rAF-buffered text would be
+        // appended onto the card row's empty text after this setMessages.
+        flushToken();
+        setIsProcessing(false);
+        const coaching = data.payload;
+        setMessages((prev) => {
+          const lastMsg = prev[prev.length - 1];
+          // If a what_to_answer streaming row is in flight, replace it
+          // with the coaching card so the user doesn't see two bubbles.
+          if (lastMsg && lastMsg.isStreaming && lastMsg.intent === 'what_to_answer') {
+            const updated = [...prev];
+            updated[prev.length - 1] = {
+              ...lastMsg,
+              text: '',
+              isStreaming: false,
+              isNegotiationCoaching: true,
+              negotiationCoachingData: coaching,
+            };
+            return updated;
+          }
+          return [
+            ...prev,
+            {
+              id: Date.now().toString(),
+              role: 'system',
+              text: '',
+              intent: 'what_to_answer',
+              isNegotiationCoaching: true,
+              negotiationCoachingData: coaching,
+            },
+          ];
+        });
+      }),
+    );
+
+    // STREAMING: Refinement
+    cleanups.push(
+      window.electronAPI.onIntelligenceRefinedAnswerToken((data) => {
+        // PERF: rAF-coalesce per-token state updates.
+        queueToken(data.intent, data.token);
+      }),
+    );
+
+    cleanups.push(
+      window.electronAPI.onIntelligenceRefinedAnswer((data) => {
+        flushToken();
+        setIsProcessing(false);
+        setMessages((prev) => {
+          const lastMsg = prev[prev.length - 1];
+          if (lastMsg && lastMsg.isStreaming && lastMsg.intent === data.intent) {
+            const updated = [...prev];
+            updated[prev.length - 1] = {
+              ...lastMsg,
+              text: data.answer,
+              isStreaming: false,
+            };
+            return updated;
+          }
+          return [
+            ...prev,
+            {
+              id: Date.now().toString(),
+              role: 'system',
+              text: data.answer,
+              intent: data.intent,
+            },
+          ];
+        });
+      }),
+    );
+
+    // STREAMING: Recap
+    cleanups.push(
+      window.electronAPI.onIntelligenceRecapToken((data) => {
+        queueToken('recap', data.token);
+      }),
+    );
+
+    cleanups.push(
+      window.electronAPI.onIntelligenceRecap((data) => {
+        flushToken();
+        setIsProcessing(false);
+        setMessages((prev) => {
+          const lastMsg = prev[prev.length - 1];
+          if (lastMsg && lastMsg.isStreaming && lastMsg.intent === 'recap') {
+            const updated = [...prev];
+            updated[prev.length - 1] = {
+              ...lastMsg,
+              text: data.summary,
+              isStreaming: false,
+            };
+            return updated;
+          }
+          return [
+            ...prev,
+            {
+              id: Date.now().toString(),
+              role: 'system',
+              text: data.summary,
+              intent: 'recap',
+            },
+          ];
+        });
+      }),
+    );
+
+    // STREAMING: Follow-Up Questions (Rendered as message? Or specific UI?)
+    // Currently interface typically renders follow-up Qs as a message or button update.
+    // Let's assume message for now based on existing 'follow_up_questions_update' handling
+    // But wait, existing handle just sets state?
+    // Let's check how 'follow_up_questions_update' was handled.
+    // It was handled separate locally in this component maybe?
+    // Ah, I need to see the existing listener for 'onIntelligenceFollowUpQuestionsUpdate'
+
+    // Let's implemented token streaming for it anyway, likely it updates a message bubble
+    // OR it might update a specialized "Suggested Questions" area.
+    // Assuming it's a message for consistency with "Copilot" approach.
+
+    cleanups.push(
+      window.electronAPI.onIntelligenceFollowUpQuestionsToken((data) => {
+        queueToken('follow_up_questions', data.token);
+      }),
+    );
+
+    cleanups.push(
+      window.electronAPI.onIntelligenceFollowUpQuestionsUpdate((data) => {
+        flushToken();
+        // This event name is slightly different ('update' vs 'answer')
+        setIsProcessing(false);
+        setMessages((prev) => {
+          const lastMsg = prev[prev.length - 1];
+          if (lastMsg && lastMsg.isStreaming && lastMsg.intent === 'follow_up_questions') {
+            const updated = [...prev];
+            updated[prev.length - 1] = {
+              ...lastMsg,
+              text: data.questions,
+              isStreaming: false,
+            };
+            return updated;
+          }
+          return [
+            ...prev,
+            {
+              id: Date.now().toString(),
+              role: 'system',
+              text: data.questions,
+              intent: 'follow_up_questions',
+            },
+          ];
+        });
+      }),
+    );
+
+    cleanups.push(
+      window.electronAPI.onIntelligenceManualResult((data) => {
+        setIsProcessing(false);
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: Date.now().toString(),
+            role: 'system',
+            text: `🎯 **Answer:**\n\n${data.answer}`,
+          },
+        ]);
+      }),
+    );
+
+    cleanups.push(
+      window.electronAPI.onIntelligenceError((data) => {
+        setIsProcessing(false);
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: Date.now().toString(),
+            role: 'system',
+            text: `❌ Error (${data.mode}): ${data.error}`,
+          },
+        ]);
+      }),
+    );
+    return () => cleanups.forEach((fn) => fn());
+  }, [isExpanded]);
+
+  // Stable mount-only effect for screenshot listeners.
+  // These MUST NOT be inside the [isExpanded] effect — when a screenshot is
+  // taken, `switchToOverlay` fires `ensure-expanded` which can flip isExpanded
+  // from false→true, triggering the [isExpanded] effect cleanup. If `screenshot-taken`
+  // arrives during that teardown gap the event is silently dropped (same issue
+  // as clarify streaming listeners below). handleScreenshotAttach only uses stable
+  // useState setters so a mount-only closure is safe here.
+  useEffect(() => {
+    const cleanupTaken = window.electronAPI.onScreenshotTaken(handleScreenshotAttach);
+    const cleanupAttached = window.electronAPI.onScreenshotAttached?.(handleScreenshotAttach);
+    return () => {
+      cleanupTaken?.();
+      cleanupAttached?.();
+    };
+  }, []);
+
+  // Stable mount-only effect for clarify streaming listeners.
+  // These MUST NOT be inside the [isExpanded] effect — if the user
+  // expands/collapses the panel while a clarify stream is in-flight,
+  // the [isExpanded] effect would tear down and re-register listeners,
+  // orphaning the final 'clarify' event and leaving isProcessing=true forever.
+  useEffect(() => {
+    const cleanupToken = window.electronAPI.onIntelligenceClarifyToken((data) => {
+      queueToken('clarify', data.token);
+    });
+
+    const cleanupFinal = window.electronAPI.onIntelligenceClarify((data) => {
+      flushToken();
+      setIsProcessing(false);
+      setMessages((prev) => {
+        const lastMsg = prev[prev.length - 1];
+        if (lastMsg && lastMsg.isStreaming && lastMsg.intent === 'clarify') {
+          const updated = [...prev];
+          updated[prev.length - 1] = { ...lastMsg, text: data.clarification, isStreaming: false };
+          return updated;
+        }
+        return [
+          ...prev,
+          {
+            id: Date.now().toString(),
+            role: 'system' as const,
+            text: data.clarification,
+            intent: 'clarify',
+          },
+        ];
+      });
+    });
+
+    return () => {
+      cleanupToken();
+      cleanupFinal();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // intentionally empty — these listeners must survive isExpanded changes
+
+  // Quick Actions - Updated to use new Intelligence APIs
+
+  // PERF: useCallback so the reference is stable between renders. MessageRow
+  // (memoized below) receives this as a prop; without a stable identity its
+  // memo comparator would never match and the bailout would not fire.
+  const handleCopy = useCallback((text: string) => {
+    navigator.clipboard.writeText(text);
+    analytics.trackCopyAnswer();
+    // Optional: Trigger a small toast or state change for visual feedback
+  }, []);
+
+  const handleWhatToSay = async (promptInstruction?: string | React.MouseEvent) => {
+    const dynamicPromptInstruction =
+      typeof promptInstruction === 'string' ? promptInstruction : undefined;
+    setIsExpanded(true);
+    setIsProcessing(true);
+    analytics.trackCommandExecuted('what_to_say');
+
+    // Capture and clear attached image context.
+    // Also merge in any screenshot from the capture-and-process shortcut that
+    // arrived via pendingCaptureRef before the React state flush (React 18 fix).
+    const pending = pendingCaptureRef.current;
+    let currentAttachments = attachedContext;
+    if (pending && !currentAttachments.some((s) => s.path === pending.path)) {
+      currentAttachments = [...currentAttachments, pending].slice(-5);
+    }
+
+    if (currentAttachments.length > 0) {
+      setAttachedContext([]);
+      // Show the attached image in chat
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: Date.now().toString(),
+          role: 'user',
+          text: 'What should I say about this?',
+          hasScreenshot: true,
+          screenshotPreview: currentAttachments[0].preview,
+        },
+      ]);
+      // Scroll to bottom when user sends message
+      setTimeout(() => {
+        messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+      }, 50);
+    }
+
+    try {
+      // Pass imagePath if attached
+      const result = await window.electronAPI.generateWhatToSay(
+        undefined,
+        currentAttachments.length > 0 ? currentAttachments.map((s) => s.path) : undefined,
+        dynamicPromptInstruction ? { promptInstruction: dynamicPromptInstruction } : undefined,
+      );
+      setScreenContextStatus(result.screenContextStatus || 'not_available');
+      setLatestUsedImageInput(Boolean(result.usedImageInput));
+      setLatestVisionProviderUsed(result.visionProviderUsed);
+      setLatestVisionModelUsed(result.visionModelUsed);
+      setLatestVisionFailureReason(result.visionFailureReason);
+    } catch (err) {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: Date.now().toString(),
+          role: 'system',
+          text: `Error: ${err}`,
+        },
+      ]);
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const handleFollowUp = async (intent: string = 'rephrase') => {
+    setIsExpanded(true);
+    setIsProcessing(true);
+    analytics.trackCommandExecuted('follow_up_' + intent);
+
+    try {
+      await window.electronAPI.generateFollowUp(intent);
+    } catch (err) {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: Date.now().toString(),
+          role: 'system',
+          text: `Error: ${err}`,
+        },
+      ]);
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const handleRecap = async () => {
+    setIsExpanded(true);
+    setIsProcessing(true);
+    analytics.trackCommandExecuted('recap');
+
+    try {
+      await window.electronAPI.generateRecap();
+    } catch (err) {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: Date.now().toString(),
+          role: 'system',
+          text: `Error: ${err}`,
+        },
+      ]);
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const handleFollowUpQuestions = async () => {
+    setIsExpanded(true);
+    setIsProcessing(true);
+    analytics.trackCommandExecuted('suggest_questions');
+
+    try {
+      await window.electronAPI.generateFollowUpQuestions();
+    } catch (err) {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: Date.now().toString(),
+          role: 'system',
+          text: `Error: ${err}`,
+        },
+      ]);
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const handleClarify = async () => {
+    setIsExpanded(true);
+    setIsProcessing(true);
+    analytics.trackCommandExecuted('clarify');
+
+    try {
+      await window.electronAPI.generateClarify();
+    } catch (err) {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: Date.now().toString(),
+          role: 'system',
+          text: `Error: ${err}`,
+        },
+      ]);
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const handleCodeHint = async () => {
+    setIsExpanded(true);
+    setIsProcessing(true);
+    analytics.trackCommandExecuted('code_hint');
+
+    const currentAttachments = attachedContext;
+    if (currentAttachments.length > 0) {
+      setAttachedContext([]);
+      // Show the attached image in chat
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: Date.now().toString(),
+          role: 'user',
+          text: 'Give me a code hint for this',
+          hasScreenshot: true,
+          screenshotPreview: currentAttachments[0].preview,
+        },
+      ]);
+      // Scroll to bottom when user sends message
+      setTimeout(() => {
+        messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+      }, 50);
+    }
+
+    try {
+      await window.electronAPI.generateCodeHint(
+        currentAttachments.length > 0 ? currentAttachments.map((s) => s.path) : undefined,
+      );
+    } catch (err) {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: Date.now().toString(),
+          role: 'system',
+          text: `Error: ${err}`,
+        },
+      ]);
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const handleBrainstorm = async () => {
+    setIsExpanded(true);
+    setIsProcessing(true);
+    analytics.trackCommandExecuted('brainstorm');
+
+    const currentAttachments = attachedContext;
+    if (currentAttachments.length > 0) {
+      setAttachedContext([]);
+      // Show the attached image in chat
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: Date.now().toString(),
+          role: 'user',
+          text: 'Brainstorm with this context',
+          hasScreenshot: true,
+          screenshotPreview: currentAttachments[0].preview,
+        },
+      ]);
+      // Scroll to bottom when user sends message
+      setTimeout(() => {
+        messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+      }, 50);
+    }
+
+    try {
+      await window.electronAPI.generateBrainstorm(
+        currentAttachments.length > 0 ? currentAttachments.map((s) => s.path) : undefined,
+      );
+    } catch (err) {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: Date.now().toString(),
+          role: 'system',
+          text: `Error: ${err}`,
+        },
+      ]);
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  // Setup Streaming Listeners
+  useEffect(() => {
+    const cleanups: (() => void)[] = [];
+
+    // Stream Token — rAF-coalesced via queueToken (same path as intelligence streams)
+    cleanups.push(
+      window.electronAPI.onGeminiStreamToken((token) => {
+        queueToken('chat', token);
+      }),
+    );
+
+    // Stream Done
+    cleanups.push(
+      window.electronAPI.onGeminiStreamDone(() => {
+        flushToken();
+        setIsProcessing(false);
+
+        // Calculate latency if we have a start time
+        let latency = 0;
+        if (requestStartTimeRef.current) {
+          latency = Date.now() - requestStartTimeRef.current;
+          requestStartTimeRef.current = null;
+        }
+
+        // Track Usage
+        analytics.trackModelUsed({
+          model_name: currentModel,
+          provider_type: detectProviderType(currentModel),
+          latency_ms: latency,
+        });
+
+        setMessages((prev) => {
+          const lastMsg = prev[prev.length - 1];
+          if (lastMsg && lastMsg.isStreaming && lastMsg.role === 'system') {
+            const text = lastMsg.text;
+            const isCode =
+              text.includes('```') || text.includes('def ') || text.includes('function ');
+            return [...prev.slice(0, -1), { ...lastMsg, isStreaming: false, isCode }];
+          }
+          return prev;
+        });
+      }),
+    );
+
+    // Stream Error
+    cleanups.push(
+      window.electronAPI.onGeminiStreamError((error) => {
+        flushToken();
+        setIsProcessing(false);
+        requestStartTimeRef.current = null; // Clear timer on error
+        setMessages((prev) => {
+          // Append error to the current message or add new one?
+          // Let's add a new error block if the previous one confusing,
+          // or just update status.
+          // Ideally we want to show the partial response AND the error.
+          const lastMsg = prev[prev.length - 1];
+          if (lastMsg && lastMsg.isStreaming) {
+            const updated = [...prev];
+            updated[prev.length - 1] = {
+              ...lastMsg,
+              isStreaming: false,
+              text: lastMsg.text + `\n\n[Error: ${error}]`,
+            };
+            return updated;
+          }
+          return [
+            ...prev,
+            {
+              id: Date.now().toString(),
+              role: 'system',
+              text: `❌ Error: ${error}`,
+            },
+          ];
+        });
+      }),
+    );
+
+    // JIT RAG Stream listeners (for live meeting RAG responses)
+    if (window.electronAPI.onRAGStreamChunk) {
+      cleanups.push(
+        window.electronAPI.onRAGStreamChunk((data: { chunk: string }) => {
+          setMessages((prev) => {
+            const lastMsg = prev[prev.length - 1];
+            if (lastMsg && lastMsg.isStreaming && lastMsg.role === 'system') {
+              const updated = [...prev];
+              updated[prev.length - 1] = {
+                ...lastMsg,
+                text: lastMsg.text + data.chunk,
+                isCode: (lastMsg.text + data.chunk).includes('```'),
+              };
+              return updated;
             }
+            return prev;
+          });
+        }),
+      );
+    }
 
-            // Show user's spoken question
-            setMessages(prev => [...prev, {
-                id: Date.now().toString(),
-                role: 'user',
-                text: question,
-                hasScreenshot: currentAttachments.length > 0,
-                screenshotPreview: currentAttachments[0]?.preview
-            }]);
+    if (window.electronAPI.onRAGStreamComplete) {
+      cleanups.push(
+        window.electronAPI.onRAGStreamComplete(() => {
+          setIsProcessing(false);
+          requestStartTimeRef.current = null;
+          setMessages((prev) => {
+            const lastMsg = prev[prev.length - 1];
+            if (lastMsg && lastMsg.isStreaming && lastMsg.role === 'system') {
+              return [...prev.slice(0, -1), { ...lastMsg, isStreaming: false }];
+            }
+            if (lastMsg && lastMsg.isStreaming) {
+              const updated = [...prev];
+              updated[prev.length - 1] = { ...lastMsg, isStreaming: false };
+              return updated;
+            }
+            return prev;
+          });
+        }),
+      );
+    }
 
-            // Scroll to bottom when user sends message
-            setTimeout(() => {
-                messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-            }, 50);
+    if (window.electronAPI.onRAGStreamError) {
+      cleanups.push(
+        window.electronAPI.onRAGStreamError((data: { error: string }) => {
+          setIsProcessing(false);
+          requestStartTimeRef.current = null;
+          setMessages((prev) => {
+            const lastMsg = prev[prev.length - 1];
+            if (lastMsg && lastMsg.isStreaming) {
+              const updated = [...prev];
+              updated[prev.length - 1] = {
+                ...lastMsg,
+                isStreaming: false,
+                text: lastMsg.text + `\n\n[RAG Error: ${data.error}]`,
+              };
+              return updated;
+            }
+            return prev;
+          });
+        }),
+      );
+    }
 
-            // Add placeholder for streaming response
-            setMessages(prev => [...prev, {
-                id: Date.now().toString(),
-                role: 'system',
-                text: '',
-                isStreaming: true
-            }]);
+    return () => cleanups.forEach((fn) => fn());
+  }, [currentModel, queueToken, flushToken]); // Ensure tracking captures correct model
 
-            setIsProcessing(true);
+  const handleAnswerNow = async () => {
+    if (isManualRecording) {
+      // Stop recording - send accumulated voice input to Gemini
+      isRecordingRef.current = false; // Update ref immediately
+      setIsManualRecording(false);
+      setManualTranscript(''); // Clear live preview
 
-            try {
-                let prompt = '';
+      // Send manual finalization signal to STT Providers
+      window.electronAPI
+        .finalizeMicSTT()
+        .catch((err) => console.error('[NativelyInterface] Failed to send finalizeMicSTT:', err));
 
-                if (currentAttachments.length > 0) {
-                    // Image + Voice Context
-                    prompt = `You are a helper. The user has provided a screenshot and a spoken question/command.
+      const currentAttachments = attachedContext;
+      setAttachedContext([]); // Clear context immediately on send
+
+      const question = (
+        voiceInputRef.current +
+        (manualTranscriptRef.current ? ' ' + manualTranscriptRef.current : '')
+      ).trim();
+      setVoiceInput('');
+      voiceInputRef.current = '';
+      setManualTranscript('');
+      manualTranscriptRef.current = '';
+
+      if (!question && currentAttachments.length === 0) {
+        // No voice input and no image — show real STT error if available
+        if (sttUserStatus === 'failed' && sttUserError) {
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: Date.now().toString(),
+              role: 'system',
+              text: `❌ STT Error: ${sttUserError}`,
+            },
+          ]);
+        } else if (sttUserStatus === 'reconnecting') {
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: Date.now().toString(),
+              role: 'system',
+              text: '⏳ STT is reconnecting, try again in a moment.',
+            },
+          ]);
+        } else {
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: Date.now().toString(),
+              role: 'system',
+              text: '⚠️ No speech detected. Try speaking closer to your microphone.',
+            },
+          ]);
+        }
+        return;
+      }
+
+      // Show user's spoken question
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: Date.now().toString(),
+          role: 'user',
+          text: question,
+          hasScreenshot: currentAttachments.length > 0,
+          screenshotPreview: currentAttachments[0]?.preview,
+        },
+      ]);
+
+      // Scroll to bottom when user sends message
+      setTimeout(() => {
+        messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+      }, 50);
+
+      // Add placeholder for streaming response
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: Date.now().toString(),
+          role: 'system',
+          text: '',
+          intent: 'chat',
+          isStreaming: true,
+        },
+      ]);
+
+      setIsProcessing(true);
+
+      try {
+        let prompt = '';
+
+        if (currentAttachments.length > 0) {
+          // Image + Voice Context
+          prompt = `You are a helper. The user has provided a screenshot and a spoken question/command.
 User said: "${question}"
 
 Instructions:
 1. Analyze the screenshot in the context of what the user said.
 2. Provide a direct, helpful answer.
 3. Be concise.`;
-                } else {
-                    // JIT RAG pre-flight: try to use indexed meeting context first
-                    const ragResult = await window.electronAPI.ragQueryLive?.(question);
-                    if (ragResult?.success) {
-                        // JIT RAG handled it — response streamed via rag:stream-chunk events
-                        return;
-                    }
+        } else {
+          // JIT RAG pre-flight: try to use indexed meeting context first
+          const ragResult = await window.electronAPI.ragQueryLive?.(question);
+          if (ragResult?.success) {
+            // JIT RAG handled it — response streamed via rag:stream-chunk events
+            return;
+          }
 
-                    // Voice Only (Smart Extract) — fallback
-                    prompt = `You are a real-time interview assistant. The user just repeated or paraphrased a question from their interviewer.
+          // Voice Only (Smart Extract) — fallback
+          prompt = `You are a real-time interview assistant. The user just repeated or paraphrased a question from their interviewer.
 Instructions:
 1. Extract the core question being asked
 2. Provide a clear, concise, and professional answer that the user can say out loud
@@ -1950,1356 +2288,1557 @@ Instructions:
 5. Format for speaking out loud, not for reading
 
 Provide only the answer, nothing else.`;
-                }
-
-                // Call Streaming API: message = question, context = instructions
-                requestStartTimeRef.current = Date.now();
-                await window.electronAPI.streamGeminiChat(question, currentAttachments.length > 0 ? currentAttachments.map(s => s.path) : undefined, prompt, { skipSystemPrompt: true });
-
-            } catch (err) {
-                // Initial invocation failing (e.g. IPC error before stream starts)
-                setIsProcessing(false);
-                setMessages(prev => {
-                    const last = prev[prev.length - 1];
-                    // If we just added the empty streaming placeholder, remove it or fill it with error
-                    if (last && last.isStreaming && last.text === '') {
-                        return prev.slice(0, -1).concat({
-                            id: Date.now().toString(),
-                            role: 'system',
-                            text: `❌ Error starting stream: ${err}`
-                        });
-                    }
-                    return [...prev, {
-                        id: Date.now().toString(),
-                        role: 'system',
-                        text: `❌ Error: ${err}`
-                    }];
-                });
-            }
-        } else {
-            // Start recording - reset voice input state
-            setVoiceInput('');
-            voiceInputRef.current = '';
-            setManualTranscript('');
-            isRecordingRef.current = true;  // Update ref immediately
-            setIsManualRecording(true);
-
-
-            // Ensure native audio is connected
-            try {
-                // Native audio is now managed by main process
-                // await window.electronAPI.invoke('native-audio-connect');
-            } catch (err) {
-                // Already connected, that's fine
-            }
         }
-    };
 
-    const handleManualSubmit = async () => {
-        if (!inputValue.trim() && attachedContext.length === 0) return;
+        // Call Streaming API: message = question, context = instructions
+        requestStartTimeRef.current = Date.now();
+        await window.electronAPI.streamGeminiChat(
+          question,
+          currentAttachments.length > 0 ? currentAttachments.map((s) => s.path) : undefined,
+          prompt,
+          { skipSystemPrompt: true },
+        );
+      } catch (err) {
+        // Initial invocation failing (e.g. IPC error before stream starts)
+        setIsProcessing(false);
+        setMessages((prev) => {
+          const last = prev[prev.length - 1];
+          // If we just added the empty streaming placeholder, remove it or fill it with error
+          if (last && last.isStreaming && last.text === '') {
+            return prev.slice(0, -1).concat({
+              id: Date.now().toString(),
+              role: 'system',
+              text: `❌ Error starting stream: ${err}`,
+            });
+          }
+          return [
+            ...prev,
+            {
+              id: Date.now().toString(),
+              role: 'system',
+              text: `❌ Error: ${err}`,
+            },
+          ];
+        });
+      }
+    } else {
+      // Start recording - reset voice input state
+      setVoiceInput('');
+      voiceInputRef.current = '';
+      setManualTranscript('');
+      isRecordingRef.current = true; // Update ref immediately
+      setIsManualRecording(true);
 
-        const userText = inputValue;
-        const currentAttachments = attachedContext;
+      // Ensure native audio is connected
+      try {
+        // Native audio is now managed by main process
+        // await window.electronAPI.invoke('native-audio-connect');
+      } catch (err) {
+        // Already connected, that's fine
+      }
+    }
+  };
 
-        // Clear inputs immediately
-        setInputValue('');
-        setAttachedContext([]);
+  const handleManualSubmit = async () => {
+    if (!inputValue.trim() && attachedContext.length === 0) return;
 
-        // Seal any in-flight streaming rows from a previous turn before we
-        // append the new user message + placeholder. Without this, the rAF
-        // token coalescer (queueToken) can append tokens of the next stream
-        // onto the prior row whenever the streaming intent matches —
-        // surfacing as the next answer starting mid-sentence with leftover
-        // text from the previous turn. Also flush any tokens still pending
-        // in the rAF buffer so they land on the prior row, not the new one.
-        flushToken();
-        tokenBufRef.current.intent = '';
-        tokenBufRef.current.text = '';
-        if (tokenBufRef.current.raf !== null) {
-            cancelAnimationFrame(tokenBufRef.current.raf);
-            tokenBufRef.current.raf = null;
+    const userText = inputValue;
+    const currentAttachments = attachedContext;
+
+    // Clear inputs immediately
+    setInputValue('');
+    setAttachedContext([]);
+
+    // Seal any in-flight streaming rows from a previous turn before we
+    // append the new user message + placeholder. Without this, the rAF
+    // token coalescer (queueToken) can append tokens of the next stream
+    // onto the prior row whenever the streaming intent matches —
+    // surfacing as the next answer starting mid-sentence with leftover
+    // text from the previous turn. Also flush any tokens still pending
+    // in the rAF buffer so they land on the prior row, not the new one.
+    flushToken();
+    tokenBufRef.current.intent = '';
+    tokenBufRef.current.text = '';
+    if (tokenBufRef.current.raf !== null) {
+      cancelAnimationFrame(tokenBufRef.current.raf);
+      tokenBufRef.current.raf = null;
+    }
+    setMessages((prev) =>
+      prev.some((m) => m.isStreaming)
+        ? prev.map((m) => (m.isStreaming ? { ...m, isStreaming: false } : m))
+        : prev,
+    );
+
+    setMessages((prev) => [
+      ...prev,
+      {
+        id: Date.now().toString(),
+        role: 'user',
+        text: userText || (currentAttachments.length > 0 ? 'Analyze this screenshot' : ''),
+        hasScreenshot: currentAttachments.length > 0,
+        screenshotPreview: currentAttachments[0]?.preview,
+      },
+    ]);
+
+    // Scroll to bottom when user sends message
+    setTimeout(() => {
+      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }, 50);
+
+    // Add placeholder for streaming response
+    setMessages((prev) => [
+      ...prev,
+      {
+        id: Date.now().toString(),
+        role: 'system',
+        text: '',
+        intent: 'chat',
+        isStreaming: true,
+      },
+    ]);
+
+    setIsExpanded(true);
+    setIsProcessing(true);
+
+    try {
+      // JIT RAG pre-flight: try to use indexed meeting context first
+      if (currentAttachments.length === 0) {
+        const ragResult = await window.electronAPI.ragQueryLive?.(userText || '');
+        if (ragResult?.success) {
+          // JIT RAG handled it — response streamed via rag:stream-chunk events
+          return;
         }
-        setMessages(prev => prev.some(m => m.isStreaming)
-            ? prev.map(m => m.isStreaming ? { ...m, isStreaming: false } : m)
-            : prev);
+      }
 
-        setMessages(prev => [...prev, {
-            id: Date.now().toString(),
-            role: 'user',
-            text: userText || (currentAttachments.length > 0 ? 'Analyze this screenshot' : ''),
-            hasScreenshot: currentAttachments.length > 0,
-            screenshotPreview: currentAttachments[0]?.preview
-        }]);
-
-        // Scroll to bottom when user sends message
-        setTimeout(() => {
-            messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-        }, 50);
-
-        // Add placeholder for streaming response
-        setMessages(prev => [...prev, {
+      // Pass imagePath if attached, AND conversation context
+      requestStartTimeRef.current = Date.now();
+      await window.electronAPI.streamGeminiChat(
+        userText || 'Analyze this screenshot',
+        currentAttachments.length > 0 ? currentAttachments.map((s) => s.path) : undefined,
+        conversationContext, // Pass context so "answer this" works
+      );
+    } catch (err) {
+      setIsProcessing(false);
+      setMessages((prev) => {
+        const last = prev[prev.length - 1];
+        if (last && last.isStreaming && last.text === '') {
+          // remove the empty placeholder
+          return prev.slice(0, -1).concat({
             id: Date.now().toString(),
             role: 'system',
-            text: '',
-            isStreaming: true
-        }]);
-
-        setIsExpanded(true);
-        setIsProcessing(true);
-
-        try {
-            // JIT RAG pre-flight: try to use indexed meeting context first
-            if (currentAttachments.length === 0) {
-                const ragResult = await window.electronAPI.ragQueryLive?.(userText || '');
-                if (ragResult?.success) {
-                    // JIT RAG handled it — response streamed via rag:stream-chunk events
-                    return;
-                }
-            }
-
-            // Pass imagePath if attached, AND conversation context
-            requestStartTimeRef.current = Date.now();
-            await window.electronAPI.streamGeminiChat(
-                userText || 'Analyze this screenshot',
-                currentAttachments.length > 0 ? currentAttachments.map(s => s.path) : undefined,
-                conversationContext // Pass context so "answer this" works
-            );
-        } catch (err) {
-            setIsProcessing(false);
-            setMessages(prev => {
-                const last = prev[prev.length - 1];
-                if (last && last.isStreaming && last.text === '') {
-                    // remove the empty placeholder
-                    return prev.slice(0, -1).concat({
-                        id: Date.now().toString(),
-                        role: 'system',
-                        text: `❌ Error starting stream: ${err}`
-                    });
-                }
-                return [...prev, {
-                    id: Date.now().toString(),
-                    role: 'system',
-                    text: `❌ Error: ${err}`
-                }];
-            });
+            text: `❌ Error starting stream: ${err}`,
+          });
         }
-    };
+        return [
+          ...prev,
+          {
+            id: Date.now().toString(),
+            role: 'system',
+            text: `❌ Error: ${err}`,
+          },
+        ];
+      });
+    }
+  };
 
-    // Refresh the latest-handler ref on every render so the captured-key
-    // listener (mounted with [] deps) calls the CURRENT closure, not a
-    // stale snapshot from first render.
-    handleManualSubmitRef.current = handleManualSubmit;
+  // Refresh the latest-handler ref on every render so the captured-key
+  // listener (mounted with [] deps) calls the CURRENT closure, not a
+  // stale snapshot from first render.
+  handleManualSubmitRef.current = handleManualSubmit;
 
-    const clearChat = () => {
-        setMessages([]);
-    };
+  const clearChat = () => {
+    setMessages([]);
+  };
 
-
-
-
-    // PERF: useCallback so MessageRow's memo comparator can rely on a stable
-    // function identity. Deps are the things the closure actually reads that
-    // can change: theme + memoized markdown components + memoized appearance.
-    // setMessages is a stable React setter and isLightTheme drives both the
-    // other deps so its inclusion is mostly defensive.
-    const renderMessageText = useCallback((msg: Message) => {
-        // Negotiation coaching card takes priority
-        if (msg.isNegotiationCoaching && msg.negotiationCoachingData) {
-            return (
-                <NegotiationCoachingCard
-                    {...msg.negotiationCoachingData}
-                    phase={msg.negotiationCoachingData.phase as any}
-                    onSilenceTimerEnd={() => {
-                        setMessages(prev => prev.map(m =>
-                            m.id === msg.id
-                                ? { ...m, negotiationCoachingData: m.negotiationCoachingData ? { ...m.negotiationCoachingData, showSilenceTimer: false } : undefined }
-                                : m
-                        ));
-                    }}
-                />
-            );
-        }
-
-        // Code-containing messages get special styling
-        // We split by code blocks to keep the "Code Solution" UI intact for the code parts
-        // But use ReactMarkdown for the text parts around it
-        if (msg.isCode || (msg.role === 'system' && msg.text.includes('```'))) {
-            const parts = msg.text.split(/(```[\s\S]*?```)/g);
-            return (
-                <div className={`rounded-lg p-3 my-1 border ${subtleSurfaceClass}`} style={appearance.subtleStyle}>
-                    <div className={`flex items-center gap-2 mb-2 font-semibold text-xs uppercase tracking-wide ${isLightTheme ? 'text-violet-600' : 'text-purple-300'}`}>
-                        <Code className="w-3.5 h-3.5" />
-                        <span>Code Solution</span>
-                    </div>
-                    <div className={`space-y-2 text-[13px] leading-relaxed ${isLightTheme ? 'text-slate-800' : 'text-slate-200'}`}>
-                        {parts.map((part, i) => {
-                            if (part.startsWith('```')) {
-                                const match = part.match(/```(\w+)?\n?([\s\S]*?)```/);
-                                if (match) {
-                                    const lang = match[1] || 'python';
-                                    const code = match[2].trim();
-                                    return (
-                                        <HighlightedCode
-                                            key={i}
-                                            code={code}
-                                            lang={lang}
-                                            isLightTheme={isLightTheme}
-                                            codeTheme={codeTheme}
-                                            codeBlockClass={codeBlockClass}
-                                            codeHeaderClass={codeHeaderClass}
-                                            codeHeaderTextClass={codeHeaderTextClass}
-                                            codeLineNumberColor={codeLineNumberColor}
-                                            appearance={appearance}
-                                        />
-                                    );
-                                }
-                            }
-                            // Regular text - Render with Markdown
-                            return (
-                                <div key={i} className="markdown-content">
-                                    <ReactMarkdown
-                                        remarkPlugins={REMARK_PLUGINS}
-                                        rehypePlugins={REHYPE_PLUGINS}
-                                        components={mdComponents.codeText}
-                                    >
-                                        {part}
-                                    </ReactMarkdown>
-                                </div>
-                            );
-                        })}
-                    </div>
-                </div>
-            );
-        }
-
-        // Custom Styled Labels (Shorten, Recap, Follow-up) - also use Markdown for content
-        if (msg.intent === 'shorten') {
-            return (
-                <div className={`rounded-lg p-3 my-1 border ${subtleSurfaceClass}`} style={appearance.subtleStyle}>
-                    <div className={`flex items-center gap-2 mb-2 font-semibold text-xs uppercase tracking-wide ${isLightTheme ? 'text-cyan-700' : 'text-cyan-300'}`}>
-                        <MessageSquare className="w-3.5 h-3.5" />
-                        <span>Shortened</span>
-                    </div>
-                    <div className={`text-[13px] leading-relaxed markdown-content ${isLightTheme ? 'text-slate-800' : 'text-slate-200'}`}>
-                        <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS} components={mdComponents.shortenText}>
-                            {msg.text}
-                        </ReactMarkdown>
-                    </div>
-                </div>
-            );
-        }
-
-        if (msg.intent === 'recap') {
-            return (
-                <div className={`rounded-lg p-3 my-1 border ${subtleSurfaceClass}`} style={appearance.subtleStyle}>
-                    <div className={`flex items-center gap-2 mb-2 font-semibold text-xs uppercase tracking-wide ${isLightTheme ? 'text-indigo-700' : 'text-indigo-300'}`}>
-                        <RefreshCw className="w-3.5 h-3.5" />
-                        <span>Recap</span>
-                    </div>
-                    <div className={`text-[13px] leading-relaxed markdown-content ${isLightTheme ? 'text-slate-800' : 'text-slate-200'}`}>
-                        <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS} components={mdComponents.recapText}>
-                            {msg.text}
-                        </ReactMarkdown>
-                    </div>
-                </div>
-            );
-        }
-
-        if (msg.intent === 'follow_up_questions') {
-            return (
-                <div className={`rounded-lg p-3 my-1 border ${subtleSurfaceClass}`} style={appearance.subtleStyle}>
-                    <div className={`flex items-center gap-2 mb-2 font-semibold text-xs uppercase tracking-wide ${isLightTheme ? 'text-amber-700' : 'text-[#FFD60A]'}`}>
-                        <HelpCircle className="w-3.5 h-3.5" />
-                        <span>Follow-Up Questions</span>
-                    </div>
-                    <div className={`text-[13px] leading-relaxed markdown-content ${isLightTheme ? 'text-slate-800' : 'text-slate-200'}`}>
-                        <ReactMarkdown remarkPlugins={REMARK_PLUGINS} rehypePlugins={REHYPE_PLUGINS} components={mdComponents.followUpQuestionsText}>
-                            {msg.text}
-                        </ReactMarkdown>
-                    </div>
-                </div>
-            );
-        }
-
-        if (msg.intent === 'what_to_answer') {
-            // Split text by code blocks (Handle unclosed blocks at EOF)
-            const parts = msg.text.split(/(```[\s\S]*?(?:```|$))/g);
-
-            return (
-                <div className={`rounded-lg p-3 my-1 border ${subtleSurfaceClass}`} style={appearance.subtleStyle}>
-                    <div className="flex items-center gap-2 mb-2 text-emerald-400 font-semibold text-xs uppercase tracking-wide">
-                        <span>Say this</span>
-                    </div>
-                    <div className="text-[14px] leading-relaxed overlay-text-primary">
-                        {parts.map((part, i) => {
-                            if (part.startsWith('```')) {
-                                // Robust matching: handles unclosed blocks for streaming (```...$)
-                                const match = part.match(/```(\w*)\s+([\s\S]*?)(?:```|$)/);
-
-                                // Fallback logic: if it starts with ticks, treat as code (even if unclosed)
-                                if (match || part.startsWith('```')) {
-                                    const lang = (match && match[1]) ? match[1] : 'python';
-                                    let code = '';
-
-                                    if (match && match[2]) {
-                                        code = match[2].trim();
-                                    } else {
-                                        // Manual strip if regex failed
-                                        code = part.replace(/^```\w*\s*/, '').replace(/```$/, '').trim();
-                                    }
-
-                                    return (
-                                        <HighlightedCode
-                                            key={i}
-                                            code={code}
-                                            lang={lang}
-                                            isLightTheme={isLightTheme}
-                                            codeTheme={codeTheme}
-                                            codeBlockClass={codeBlockClass}
-                                            codeHeaderClass={codeHeaderClass}
-                                            codeHeaderTextClass={codeHeaderTextClass}
-                                            codeLineNumberColor={codeLineNumberColor}
-                                            appearance={appearance}
-                                        />
-                                    );
-                                }
-                            }
-                            // Regular text - Render Markdown
-                            // PERF: hoisted components map — see mdComponents useMemo
-                            // at top of component. Inline literal here would create a
-                            // fresh object on every streaming token, defeating
-                            // ReactMarkdown's internal render-bailout.
-                            return (
-                                <div key={i} className="markdown-content">
-                                    <ReactMarkdown
-                                        remarkPlugins={REMARK_PLUGINS}
-                                        rehypePlugins={REHYPE_PLUGINS}
-                                        components={mdComponents.whatToAnswerText}
-                                    >
-                                        {part}
-                                    </ReactMarkdown>
-                                </div>
-                            );
-                        })}
-                    </div>
-                </div>
-            );
-        }
-
-        // Standard Text Messages (e.g. from User or Interviewer)
-        // We still want basic markdown support here too
+  // PERF: useCallback so MessageRow's memo comparator can rely on a stable
+  // function identity. Deps are the things the closure actually reads that
+  // can change: theme + memoized markdown components + memoized appearance.
+  // setMessages is a stable React setter and isLightTheme drives both the
+  // other deps so its inclusion is mostly defensive.
+  const renderMessageText = useCallback(
+    (msg: Message) => {
+      // Negotiation coaching card takes priority
+      if (msg.isNegotiationCoaching && msg.negotiationCoachingData) {
         return (
-            <div className="markdown-content">
-                <ReactMarkdown
-                    remarkPlugins={REMARK_PLUGINS}
-                    rehypePlugins={REHYPE_PLUGINS}
-                    components={mdComponents.standard}
-                >
-                    {msg.text}
-                </ReactMarkdown>
-            </div>
+          <NegotiationCoachingCard
+            {...msg.negotiationCoachingData}
+            phase={msg.negotiationCoachingData.phase as any}
+            onSilenceTimerEnd={() => {
+              setMessages((prev) =>
+                prev.map((m) =>
+                  m.id === msg.id
+                    ? {
+                        ...m,
+                        negotiationCoachingData: m.negotiationCoachingData
+                          ? { ...m.negotiationCoachingData, showSilenceTimer: false }
+                          : undefined,
+                      }
+                    : m,
+                ),
+              );
+            }}
+          />
         );
-    }, [isLightTheme, mdComponents, appearance]);
+      }
 
-
-    // We use a ref to hold the latest handlers to avoid re-binding the event listener on every render
-    const handlersRef = useRef({
-        handleWhatToSay,
-        handleFollowUp,
-        handleFollowUpQuestions,
-        handleRecap,
-        handleAnswerNow,
-        handleClarify,
-        handleCodeHint,
-        handleBrainstorm
-    });
-
-    // Update ref on every render so the event listener always access latest state/props
-    handlersRef.current = {
-        handleWhatToSay,
-        handleFollowUp,
-        handleFollowUpQuestions,
-        handleRecap,
-        handleAnswerNow,
-        handleClarify,
-        handleCodeHint,
-        handleBrainstorm
-    };
-
-    useEffect(() => {
-        // ── Continuous, frame-rate-independent scroll with momentum ──
-        // Velocity is integrated against real elapsed time so 60Hz, 120Hz, and
-        // dropped-frame paths all produce the same physical speed. While a key
-        // is held we ease velocity up to TERMINAL; on release we decay it
-        // exponentially, which is what makes the stop feel weighted instead of
-        // snapped. Sub-pixel motion is preserved via a fractional accumulator,
-        // and we write `scrollTop` directly to bypass any browser scroll-behavior
-        // smoothing that would fight the loop.
-        const TERMINAL_VELOCITY = 1400;   // px/s at full hold
-        const ACCEL_SECONDS = 0.18;       // time to reach terminal from rest
-        const DECAY_HALF_LIFE = 0.09;     // seconds for velocity to halve after release
-        const DECAY_K = Math.LN2 / DECAY_HALF_LIFE;
-        const MIN_VELOCITY = 6;           // px/s — snap to 0 below this
-        const MAX_FRAME_DT = 0.05;        // clamp to absorb tab-throttle hiccups
-
-        let direction: -1 | 0 | 1 = 0;    // -1 up, 0 idle, 1 down (or both up+down → 0)
-        let upHeld = false;
-        let downHeld = false;
-        let velocity = 0;                 // signed px/s
-        let positionFraction = 0;         // sub-pixel accumulator
-        let lastTs = 0;
-        let rafId: number | null = null;
-
-        const recomputeDirection = () => {
-            direction = upHeld === downHeld ? 0 : upHeld ? -1 : 1;
-        };
-
-        const tick = (ts: number) => {
-            const container = scrollContainerRef.current;
-            if (!container) {
-                rafId = null;
-                lastTs = 0;
-                return;
-            }
-            if (lastTs === 0) lastTs = ts;
-            const dt = Math.min((ts - lastTs) / 1000, MAX_FRAME_DT);
-            lastTs = ts;
-
-            if (direction !== 0) {
-                const target = direction * TERMINAL_VELOCITY;
-                const step = (TERMINAL_VELOCITY / ACCEL_SECONDS) * dt;
-                if (Math.abs(target - velocity) <= step) velocity = target;
-                else velocity += Math.sign(target - velocity) * step;
-            } else {
-                velocity *= Math.exp(-DECAY_K * dt);
-                if (Math.abs(velocity) < MIN_VELOCITY) velocity = 0;
-            }
-
-            // Cache layout reads once per frame, then a single scrollTop write.
-            const maxScroll = container.scrollHeight - container.clientHeight;
-            const current = container.scrollTop;
-            const move = velocity * dt + positionFraction;
-            const intMove = Math.trunc(move);
-            positionFraction = move - intMove;
-
-            if (intMove !== 0) {
-                let next = current + intMove;
-                if (next <= 0) {
-                    next = 0;
-                    if (velocity < 0) { velocity = 0; positionFraction = 0; }
-                } else if (next >= maxScroll) {
-                    next = maxScroll;
-                    if (velocity > 0) { velocity = 0; positionFraction = 0; }
+      // Code-containing messages get special styling
+      // We split by code blocks to keep the "Code Solution" UI intact for the code parts
+      // But use ReactMarkdown for the text parts around it
+      if (msg.isCode || (msg.role === 'system' && msg.text.includes('```'))) {
+        const parts = msg.text.split(/(```[\s\S]*?```)/g);
+        return (
+          <div
+            className={`rounded-lg p-3 my-1 border ${subtleSurfaceClass}`}
+            style={appearance.subtleStyle}
+          >
+            <div
+              className={`flex items-center gap-2 mb-2 font-semibold text-xs uppercase tracking-wide ${isLightTheme ? 'text-violet-600' : 'text-purple-300'}`}
+            >
+              <Code className="w-3.5 h-3.5" />
+              <span>Code Solution</span>
+            </div>
+            <div
+              className={`space-y-2 text-[13px] leading-relaxed ${isLightTheme ? 'text-slate-800' : 'text-slate-200'}`}
+            >
+              {parts.map((part, i) => {
+                if (part.startsWith('```')) {
+                  const match = part.match(/```(\w+)?\n?([\s\S]*?)```/);
+                  if (match) {
+                    const lang = match[1] || 'python';
+                    const code = match[2].trim();
+                    return (
+                      <HighlightedCode
+                        key={i}
+                        code={code}
+                        lang={lang}
+                        isLightTheme={isLightTheme}
+                        codeTheme={codeTheme}
+                        codeBlockClass={codeBlockClass}
+                        codeHeaderClass={codeHeaderClass}
+                        codeHeaderTextClass={codeHeaderTextClass}
+                        codeLineNumberColor={codeLineNumberColor}
+                        appearance={appearance}
+                      />
+                    );
+                  }
                 }
-                if (next !== current) container.scrollTop = next;
-            }
-
-            if (direction !== 0 || velocity !== 0) {
-                rafId = requestAnimationFrame(tick);
-            } else {
-                rafId = null;
-                lastTs = 0;
-                positionFraction = 0;
-            }
-        };
-
-        const startScrollLoop = () => {
-            if (rafId === null) rafId = requestAnimationFrame(tick);
-        };
-        const releaseScroll = () => {
-            upHeld = false;
-            downHeld = false;
-            recomputeDirection();
-        };
-
-        const handleKeyDown = (e: KeyboardEvent) => {
-            const { handleWhatToSay, handleFollowUp, handleFollowUpQuestions, handleRecap, handleAnswerNow, handleClarify, handleCodeHint, handleBrainstorm } = handlersRef.current;
-
-            // Chat Shortcuts (Scope: Local to Chat/Overlay usually, but we allow them here if focused)
-            if (isShortcutPressed(e, 'whatToAnswer')) {
-                e.preventDefault();
-                handleWhatToSay();
-            } else if (isShortcutPressed(e, 'clarify')) {
-                e.preventDefault();
-                handleClarify();
-            } else if (isShortcutPressed(e, 'followUp')) {
-                e.preventDefault();
-                handleFollowUpQuestions();
-            } else if (isShortcutPressed(e, 'dynamicAction4')) {
-                e.preventDefault();
-                if (actionButtonMode === 'brainstorm') {
-                    handleBrainstorm();
-                } else {
-                    handleRecap();
-                }
-            } else if (isShortcutPressed(e, 'answer')) {
-                e.preventDefault();
-                handleAnswerNow();
-            } else if (isShortcutPressed(e, 'clarify')) {
-                e.preventDefault();
-                handleClarify();
-            } else if (isShortcutPressed(e, 'codeHint')) {
-                e.preventDefault();
-                handleCodeHint();
-            } else if (isShortcutPressed(e, 'brainstorm')) {
-                e.preventDefault();
-                handleBrainstorm();
-            } else if (isShortcutPressed(e, 'scrollUp')) {
-                e.preventDefault();
-                upHeld = true;
-                recomputeDirection();
-                startScrollLoop();
-            } else if (isShortcutPressed(e, 'scrollDown')) {
-                e.preventDefault();
-                downHeld = true;
-                recomputeDirection();
-                startScrollLoop();
-            } else if (isShortcutPressed(e, 'moveWindowUp') || isShortcutPressed(e, 'moveWindowDown')) {
-                // Prevent default scrolling when moving window
-                e.preventDefault();
-            }
-        };
-
-        const handleKeyUp = (e: KeyboardEvent) => {
-            // Users typically lift the modifier (Cmd/Ctrl) first, so releasing
-            // either it or the arrow ends the hold and lets momentum decay.
-            if (e.key === 'ArrowUp') {
-                upHeld = false;
-                recomputeDirection();
-            } else if (e.key === 'ArrowDown') {
-                downHeld = false;
-                recomputeDirection();
-            } else if (e.key === 'Meta' || e.key === 'Control') {
-                releaseScroll();
-            }
-        };
-
-        // Window blur swallows keyup; reset to avoid stuck scrolling.
-        const handleBlur = () => releaseScroll();
-
-        window.addEventListener('keydown', handleKeyDown);
-        window.addEventListener('keyup', handleKeyUp);
-        window.addEventListener('blur', handleBlur);
-        return () => {
-            window.removeEventListener('keydown', handleKeyDown);
-            window.removeEventListener('keyup', handleKeyUp);
-            window.removeEventListener('blur', handleBlur);
-            if (rafId !== null) cancelAnimationFrame(rafId);
-        };
-    }, [isShortcutPressed]);
-
-    // General Global Shortcuts (Rebindable)
-    // We listen here to handle them when the window is focused (renderer side)
-    // Global shortcuts (when window blurred) are handled by Main process -> GlobalShortcuts
-    // But Main process events might not reach here if we don't listen, or we want unified handling.
-    // Actually, KeybindManager registers global shortcuts. If they are registered as global,
-    // Electron might consume them before they reach here?
-    // 'toggle-app' is Global.
-    // 'toggle-visibility' is NOT Global in default config (isGlobal: false), so it depends on focus.
-    // So we MUST listen for them here.
-
-    const generalHandlersRef = useRef({
-        toggleVisibility: () => window.electronAPI.toggleWindow(),
-        processScreenshots: handleWhatToSay,
-        resetCancel: async () => {
-            if (isProcessing) {
-                setIsProcessing(false);
-            } else {
-                await window.electronAPI.resetIntelligence();
-                setMessages([]);
-                setAttachedContext([]);
-                setInputValue('');
-            }
-        },
-        toggleMousePassthrough: () => {
-            const newState = !isMousePassthrough;
-            setIsMousePassthrough(newState);
-            window.electronAPI?.setOverlayMousePassthrough?.(newState);
-        },
-        takeScreenshot: async () => {
-            try {
-                const data = await window.electronAPI.takeScreenshot();
-                if (data && data.path) {
-                    handleScreenshotAttach(data as { path: string; preview: string });
-                }
-            } catch (err) {
-                console.error("Error triggering screenshot:", err);
-            }
-        },
-        selectiveScreenshot: async () => {
-            try {
-                const data = await window.electronAPI.takeSelectiveScreenshot();
-                if (data && !data.cancelled && data.path) {
-                    handleScreenshotAttach(data as { path: string; preview: string });
-                }
-            } catch (err) {
-                console.error("Error triggering selective screenshot:", err);
-            }
-        }
-    });
-
-    // Update ref
-    generalHandlersRef.current = {
-        toggleVisibility: () => window.electronAPI.toggleWindow(),
-        processScreenshots: handleWhatToSay,
-        resetCancel: async () => {
-            if (isProcessing) {
-                setIsProcessing(false);
-            } else {
-                await window.electronAPI.resetIntelligence();
-                setMessages([]);
-                setAttachedContext([]);
-                setInputValue('');
-            }
-        },
-        toggleMousePassthrough: () => {
-            const newState = !isMousePassthrough;
-            setIsMousePassthrough(newState);
-            window.electronAPI?.setOverlayMousePassthrough?.(newState);
-        },
-        takeScreenshot: async () => {
-            try {
-                const data = await window.electronAPI.takeScreenshot();
-                if (data && data.path) {
-                    handleScreenshotAttach(data as { path: string; preview: string });
-                }
-            } catch (err) {
-                console.error("Error triggering screenshot:", err);
-            }
-        },
-        selectiveScreenshot: async () => {
-            try {
-                const data = await window.electronAPI.takeSelectiveScreenshot();
-                if (data && !data.cancelled && data.path) {
-                    handleScreenshotAttach(data as { path: string; preview: string });
-                }
-            } catch (err) {
-                console.error("Error triggering selective screenshot:", err);
-            }
-        }
-    };
-
-    useEffect(() => {
-        const handleGeneralKeyDown = (e: KeyboardEvent) => {
-            const handlers = generalHandlersRef.current;
-            const target = e.target as HTMLElement;
-            const isInput = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
-
-            if (isShortcutPressed(e, 'toggleVisibility')) {
-                // Always allow toggling visibility
-                e.preventDefault();
-                handlers.toggleVisibility();
-            } else if (isShortcutPressed(e, 'processScreenshots')) {
-                if (!isInput) {
-                    e.preventDefault();
-                    handlers.processScreenshots();
-                }
-                // If input focused, let default behavior (Enter) happen or handle it via onKeyDown in Input
-            } else if (isShortcutPressed(e, 'resetCancel')) {
-                e.preventDefault();
-                handlers.resetCancel();
-            } else if (isShortcutPressed(e, 'takeScreenshot')) {
-                e.preventDefault();
-                handlers.takeScreenshot();
-            } else if (isShortcutPressed(e, 'selectiveScreenshot')) {
-                e.preventDefault();
-                handlers.selectiveScreenshot();
-            } else if (isShortcutPressed(e, 'toggleMousePassthrough')) {
-                e.preventDefault();
-                handlers.toggleMousePassthrough();
-            }
-        };
-
-        window.addEventListener('keydown', handleGeneralKeyDown);
-        return () => window.removeEventListener('keydown', handleGeneralKeyDown);
-    }, [isShortcutPressed]);
-
-    // Global "Capture & Process" shortcut handler (issue #90)
-    // Registered separately so it always has the latest handlersRef via stable ref access.
-    // Main process takes the screenshot and sends "capture-and-process" with path+preview;
-    // we attach the screenshot to context and immediately trigger AI analysis.
-    useEffect(() => {
-        if (!window.electronAPI.onCaptureAndProcess) return;
-        const unsubscribe = window.electronAPI.onCaptureAndProcess((data) => {
-            setIsExpanded(true);
-
-            // Store screenshot in a stable ref BEFORE updating React state.
-            // This fixes the React 18 concurrent mode timing race where setTimeout(0)
-            // could fire before setAttachedContext had flushed, leaving handleWhatToSay
-            // with an empty attachedContext and causing silent failures.
-            pendingCaptureRef.current = data;
-
-            setAttachedContext(prev => {
-                if (prev.some(s => s.path === data.path)) return prev;
-                return [...prev, data].slice(-5);
-            });
-
-            // Use requestAnimationFrame so we wait for at least one paint cycle —
-            // more reliable than setTimeout(0) under React 18 concurrent scheduling.
-            // The ref guarantees handleWhatToSay has the screenshot regardless of
-            // whether the state update has flushed yet.
-            requestAnimationFrame(() => {
-                try {
-                    handlersRef.current.handleWhatToSay();
-                } finally {
-                    pendingCaptureRef.current = null;
-                }
-            });
-        });
-        return unsubscribe;
-    }, []);
-
-    // Inertial-scroll engine. Each globalShortcut fire kicks velocity on one
-    // axis; a single RAF loop integrates position with friction. A lone tap
-    // glides ~250ms then decays; rapid taps sustain motion. Needed because
-    // Carbon HotKey on macOS does not auto-repeat with Cmd held, so naive
-    // per-fire scrollBy(100px) produces stuttery, taps-only motion.
-    const inertialScrollRef = useRef<{
-        kick: (axis: 'vert' | 'horiz', direction: -1 | 1) => void;
-    } | null>(null);
-
-    useEffect(() => {
-        const KICK_VELOCITY = 900;     // px/s added per press
-        const TERMINAL_VELOCITY = 3200; // px/s clamp
-        const FRICTION_HALF_LIFE = 0.16; // seconds for velocity to halve
-        const MIN_VELOCITY = 8;         // px/s — snap to zero below
-        const MAX_FRAME_DT = 0.05;      // clamp for tab-throttle hiccups
-
-        const state = {
-            raf: null as number | null,
-            lastTs: 0,
-            vert: { vel: 0, target: null as HTMLElement | null, frac: 0 },
-            horiz: { vel: 0, target: null as HTMLElement | null, frac: 0 },
-        };
-
-        const resolveHorizontalTarget = (container: HTMLElement): HTMLElement | null => {
-            const containerRect = container.getBoundingClientRect();
-            const containerCenter = (containerRect.top + containerRect.bottom) / 2;
-
-            const preElements = container.querySelectorAll('pre');
-            let best: HTMLElement | null = null;
-            let bestDistance = Infinity;
-
-            preElements.forEach((pre) => {
-                // Walk up from <pre> until we find the actual horizontal scroller.
-                // Markdown renderers often wrap <pre> in a div that holds overflow-x.
-                let scroller: HTMLElement | null = pre as HTMLElement;
-                while (scroller && scroller !== container) {
-                    if (scroller.scrollWidth > scroller.clientWidth + 1) break;
-                    scroller = scroller.parentElement;
-                }
-                if (!scroller || scroller === container) return;
-                if (scroller.scrollWidth <= scroller.clientWidth + 1) return;
-
-                const rect = scroller.getBoundingClientRect();
-                if (rect.bottom < containerRect.top || rect.top > containerRect.bottom) return;
-
-                const distance = Math.abs((rect.top + rect.bottom) / 2 - containerCenter);
-                if (distance < bestDistance) { bestDistance = distance; best = scroller; }
-            });
-
-            return best;
-        };
-
-        const tick = (ts: number) => {
-            if (state.lastTs === 0) state.lastTs = ts;
-            const dt = Math.min((ts - state.lastTs) / 1000, MAX_FRAME_DT);
-            state.lastTs = ts;
-            const decay = Math.pow(0.5, dt / FRICTION_HALF_LIFE);
-
-            const stepAxis = (axis: 'vert' | 'horiz') => {
-                const a = state[axis];
-                if (Math.abs(a.vel) < MIN_VELOCITY || !a.target) {
-                    a.vel = 0; a.frac = 0; a.target = null;
-                    return false;
-                }
-                const move = a.vel * dt + a.frac;
-                const intMove = Math.trunc(move);
-                a.frac = move - intMove;
-                if (intMove !== 0) {
-                    if (axis === 'vert') a.target.scrollTop += intMove;
-                    else a.target.scrollLeft += intMove;
-                }
-                a.vel *= decay;
-                return true;
-            };
-
-            const vertActive = stepAxis('vert');
-            const horizActive = stepAxis('horiz');
-
-            if (vertActive || horizActive) {
-                state.raf = requestAnimationFrame(tick);
-            } else {
-                state.raf = null;
-                state.lastTs = 0;
-            }
-        };
-
-        const kick = (axis: 'vert' | 'horiz', direction: -1 | 1) => {
-            const container = scrollContainerRef.current;
-            if (!container) return;
-
-            let target: HTMLElement | null;
-            if (axis === 'vert') {
-                target = container;
-            } else {
-                target = resolveHorizontalTarget(container);
-                // No visible scrollable code block → no-op rather than scrolling
-                // an off-screen one or shaking the chat container sideways.
-                if (!target) return;
-            }
-
-            const a = state[axis];
-            // Reverse direction: reset rather than fight existing momentum.
-            if (a.target !== target || Math.sign(a.vel) === -direction) {
-                a.vel = 0;
-                a.frac = 0;
-            }
-            a.target = target;
-            const next = a.vel + direction * KICK_VELOCITY;
-            a.vel = Math.max(-TERMINAL_VELOCITY, Math.min(TERMINAL_VELOCITY, next));
-
-            if (state.raf === null) state.raf = requestAnimationFrame(tick);
-        };
-
-        inertialScrollRef.current = { kick };
-
-        return () => {
-            if (state.raf !== null) cancelAnimationFrame(state.raf);
-            inertialScrollRef.current = null;
-        };
-    }, []);
-
-    // Stealth Global Shortcuts Handler
-    // Listens for shortcuts triggered when the app is in the background
-    useEffect(() => {
-        if (!window.electronAPI.onGlobalShortcut) return;
-        const unsubscribe = window.electronAPI.onGlobalShortcut(({ action }) => {
-            const handlers = handlersRef.current;
-            const generalHandlers = generalHandlersRef.current;
-
-            isStealthRef.current = true;
-
-            if (action === 'whatToAnswer') handlers.handleWhatToSay();
-            else if (action === 'shorten') handlers.handleFollowUp('shorten');
-            else if (action === 'followUp') handlers.handleFollowUpQuestions();
-            else if (action === 'recap') handlers.handleRecap();
-            else if (action === 'dynamicAction4') {
-                if (actionButtonMode === 'brainstorm') handlers.handleBrainstorm();
-                else handlers.handleRecap();
-            }
-            else if (action === 'answer') handlers.handleAnswerNow();
-            else if (action === 'clarify') handlers.handleClarify();
-            else if (action === 'codeHint') handlers.handleCodeHint();
-            else if (action === 'brainstorm') handlers.handleBrainstorm();
-            else if (action === 'scrollUp') inertialScrollRef.current?.kick('vert', -1);
-            else if (action === 'scrollDown') inertialScrollRef.current?.kick('vert', 1);
-            else if (action === 'scrollLeft') inertialScrollRef.current?.kick('horiz', -1);
-            else if (action === 'scrollRight') inertialScrollRef.current?.kick('horiz', 1);
-            else if (action === 'focusInput') {
-                // Stealth-focus the chat input: the panel-type overlay (macOS) is
-                // already key without activating the app. We just need the input
-                // element to be the active DOM target so keystrokes land in it.
-                // Defer to next frame so an expand-from-collapsed has time to
-                // mount the input before .focus() runs.
-                setIsExpanded(true);
-                requestAnimationFrame(() => {
-                    requestAnimationFrame(() => textInputRef.current?.focus());
-                });
-            }
-            else if (action === 'processScreenshots') generalHandlers.processScreenshots();
-            else if (action === 'resetCancel') generalHandlers.resetCancel();
-            else if (action === 'takeScreenshot') generalHandlers.takeScreenshot();
-            else if (action === 'selectiveScreenshot') generalHandlers.selectiveScreenshot();
-
-            // Safety reset if it didn't trigger an expansion
-            setTimeout(() => { isStealthRef.current = false; }, 500);
-        });
-        return unsubscribe;
-    }, []);
-
-    // ── Stealth keyboard tap (CGEventTap) — true Cluely-grade input path ──
-    //
-    // When the OS-level tap is engaged (toggled by Cmd/Ctrl+Shift+Space),
-    // every keystroke is captured BEFORE the foreground app sees it and
-    // forwarded here. We append `chars` directly to inputValue without ever
-    // touching DOM focus — the chat input never has to be the active element,
-    // so the panel never has to be the key window. Zoom/browser stays as the
-    // OS frontmost+key application throughout the entire typing session.
-    //
-    // HID virtual keycodes referenced below (stable across layouts):
-    //   36 = Return,  48 = Tab,  51 = Delete (Backspace),  53 = Esc,
-    //   76 = Numpad Enter,  123 = Left,  124 = Right,  125 = Down,  126 = Up.
-    useEffect(() => {
-        if (!window.electronAPI?.onStealthTapState || !window.electronAPI?.onStealthKeyCaptured) return;
-
-        // Effect-scoped flag set when Esc is observed in the captured-key
-        // stream. Suppresses non-Esc events that may have been queued by the
-        // worker thread before the user pressed Esc. Cleared on each new
-        // active=true state event (a new tap session). Hoisted here so both
-        // listeners see the same binding.
-        let escSuppressUntilNextActive = false;
-
-        const unsubState = window.electronAPI.onStealthTapState(({ active, reason }) => {
-            stealthTapActiveRef.current = active;
-            setStealthTapActive(active);
-            if (active) {
-                // Auto-expand the overlay so the user can see what they're
-                // typing. We do NOT call .focus() — the whole point of the
-                // tap is to avoid window-level focus.
-                isStealthRef.current = true;
-                setIsExpanded(true);
-                setStealthPermissionMissing(false);
-                escSuppressUntilNextActive = false;
-            }
-            if (!active && reason === 'permission') {
-                setStealthPermissionMissing(true);
-            }
-        });
-
-        const unsubKey = window.electronAPI.onStealthKeyCaptured((ev) => {
-            // CONTRACT WITH RUST: keyboard_tap.rs pass-through filter (R3)
-            // returns the event unmodified for ANY system-modifier key
-            // (Cmd / Ctrl / Option / Fn) and for ALL F-keys, so the OS
-            // routes those normally to the foreground app. Consequence:
-            // (ev.flags & CMD) is NEVER true here, neither is OPT or CTRL.
-            // The previous round had Cmd+Enter / Cmd+Backspace / Cmd+A /
-            // Option+Backspace branches — all dead code under R3. Removed
-            // to prevent a false sense of feature support; if Rust ever
-            // changes the filter to deliver Cmd events, those branches
-            // need to be REINTRODUCED with explicit testing, not
-            // resurrected from a TODO.
-
-            // Esc handled regardless of active state (main process broadcasts
-            // it BEFORE stopping the tap, so we get here while still active;
-            // see StealthKeyboardManager.handleCapturedKey ordering).
-            if (ev.isKeyDown && ev.keyCode === 53) {
-                setInputValue('');
-                escSuppressUntilNextActive = true;
-                return;
-            }
-
-            // Belt-and-braces clear of the Esc-suppress flag on the first
-            // key event of a new session. State and captured-key arrive on
-            // separate IPC channels and ordering across channels is NOT
-            // guaranteed — if the first keystroke of a new session arrives
-            // before the state-active broadcast, the suppress flag (set by
-            // a prior Esc) would still be true and the keystroke would be
-            // dropped. We re-check the ref (which the state listener flips
-            // synchronously on receipt): if the ref is now true, this is a
-            // legitimate new-session keystroke → clear suppress and proceed.
-            if (escSuppressUntilNextActive && stealthTapActiveRef.current) {
-                console.warn('[stealth] cross-channel race resolved by ref check — captured-key arrived before state event');
-                escSuppressUntilNextActive = false;
-            }
-            if (escSuppressUntilNextActive) return; // drop late-arriving keys after Esc
-            if (!stealthTapActiveRef.current) return; // ignore other events after stop
-            if (!ev.isKeyDown) return; // we only act on keyDown
-
-            switch (ev.keyCode) {
-                case 36: // Return
-                case 76: // Numpad Enter
-                    handleManualSubmitRef.current();
-                    window.electronAPI.stealthTapStop().catch(() => {});
-                    return;
-                case 51: // Backspace — delete one char
-                    setInputValue(prev => prev.slice(0, -1));
-                    return;
-                // ROUND 4 FIX (#6): Tab (48) and arrows (123-126) used to
-                // be no-op'd here. They're now passed through at the Rust
-                // layer (keyboard_tap.rs F-key whitelist) so they reach the
-                // user's foreground app normally. Removing the dead cases
-                // keeps the contract honest: this switch only sees text-
-                // worthy keys + Backspace + Enter. If anyone ever changes
-                // the Rust filter to deliver Tab again, decide explicitly
-                // what it should do here rather than copy-pasting a no-op.
-            }
-
-            // Append printable chars. CGEventKeyboardGetUnicodeString already
-            // honors the active layout, dead keys, and IME — we don't need to
-            // re-derive characters from keyCode + modifiers ourselves. Filter
-            // shift-only modifier (it's already encoded in the chars).
-            if (ev.chars && ev.chars.length > 0 && ev.chars !== '\r' && ev.chars !== '\n' && ev.chars !== '\t') {
-                setInputValue(prev => prev + ev.chars);
-            }
-        });
-
-        return () => { unsubState(); unsubKey(); };
-    }, []);
-
-    // ── Stealth hotkey registration-failure listener ──
-    //
-    // KeybindManager fires this when globalShortcut.register() returns false
-    // (the OS or another app owns the accelerator). Without surfacing it,
-    // the user presses the hotkey, nothing happens, and they assume the
-    // stealth feature is broken. We filter to the stealth-typing keybind
-    // and render an inline banner pointing to Settings → Shortcuts.
-    useEffect(() => {
-        if (!window.electronAPI?.onKeybindRegistrationFailed) return;
-        const unsubscribe = window.electronAPI.onKeybindRegistrationFailed(({ id, accelerator }) => {
-            if (id !== 'chat:focusInput') return;
-            setStealthHotkeyConflict(accelerator);
-        });
-        return unsubscribe;
-    }, []);
-
-    // ── Click-to-activate: engage CGEventTap on chat-input click only
-    //    (opt-IN model) ──
-    //
-    // ROUND 3 FIX (#1): previously this listener engaged the tap on ANY
-    // mousedown anywhere in the overlay (opt-OUT via data-stealth-ignore).
-    // That model broke hard: clicking the Settings button engaged the tap,
-    // then Settings opened and the user couldn't type their API key (tap
-    // intercepted at OS level → keystrokes went to Natively's read-only
-    // chat input). Worse, every NEW button added to the overlay was a
-    // regression risk — forgetting `data-stealth-ignore` re-introduced the
-    // bug silently.
-    //
-    // Inverted to opt-IN: tap ONLY engages when the user clicks an element
-    // marked with `data-stealth-engage="true"` (the chat input wrapper).
-    // Buttons run their normal onClick handlers without engaging the tap.
-    // Two paths still let the user start typing stealth-style:
-    //   • Click the chat input → tap engages → DOM focus blocked → type
-    //   • Press the activation hotkey (Cmd/Ctrl+Shift+Space) → tap engages
-    //
-    // mousedown (not click) so we engage BEFORE the input would otherwise
-    // take DOM focus — preventing the panel from becoming key window, which
-    // is the precise event coding-interview platforms detect via blur.
-    useEffect(() => {
-        if (!window.electronAPI?.stealthTapStart) return;
-
-        // Resolve the IME-safety policy once at mount. While the promise is in
-        // flight we keep the default (true) so users on plain ASCII layouts
-        // see no behaviour change. The probe runs on the main process via
-        // `defaults read com.apple.HIToolbox`; see electron/services/
-        // ImeDetector.ts for the reason this gate exists at all.
-        // Probe for IME state (Pinyin, Hangul, Kanji). Result refines
-        // stealthAutoEngageOkRef from its safe-true default; we do NOT
-        // need to re-check CGEventTap availability here — the synchronous
-        // window.electronAPI.platform guard above already covers that.
-        if (window.electronAPI.stealthTapShouldAutoEngage) {
-            window.electronAPI.stealthTapShouldAutoEngage()
-                .then((ok) => { stealthAutoEngageOkRef.current = !!ok; })
-                .catch(() => { /* fail open — keep default */ });
-        }
-
-        const onMouseDown = (e: MouseEvent) => {
-            if (stealthTapActiveRef.current) return; // already on
-            // IME present → never auto-engage. The user can still press the
-            // explicit hotkey if they want true OS-level invisible typing
-            // (they'll lose composition in that path by design).
-            if (!stealthAutoEngageOkRef.current) return;
-            const target = e.target as HTMLElement | null;
-            if (!target?.closest?.('[data-stealth-engage="true"]')) return;
-            window.electronAPI.stealthTapStart().catch(() => {});
-        };
-
-        document.addEventListener('mousedown', onMouseDown, true); // capture phase
-        return () => document.removeEventListener('mousedown', onMouseDown, true);
-    }, []);
-
-    // ── ModelSelector click-outside close ──
-    //
-    // ROUND 3 FIX (#4): replaces the dead `on('blur')` handler in the
-    // ModelSelectorWindowHelper. With NSPanel-nonactivating the model-
-    // selector window may never become key on click, so its blur listener
-    // never fires and the dropdown stays open forever. We close it here
-    // by firing an IPC on every overlay mousedown EXCEPT clicks on the
-    // toggle button itself (which would race with toggleWindow's open/close
-    // logic). Main process no-ops the IPC if model selector is already
-    // closed.
-    useEffect(() => {
-        if (!window.electronAPI?.modelSelectorCloseIfOpen) return;
-        const onMouseDown = (e: MouseEvent) => {
-            const target = e.target as HTMLElement | null;
-            if (target?.closest?.('[data-model-selector-toggle="true"]')) return;
-            window.electronAPI.modelSelectorCloseIfOpen().catch(() => {});
-        };
-        document.addEventListener('mousedown', onMouseDown);
-        return () => document.removeEventListener('mousedown', onMouseDown);
-    }, []);
-
-    // ── Input-click DOM-focus block ──
-    //
-    // When the user clicks the chat input, the browser tries to focus the
-    // <input> element. That focus promotes the NSPanel to key window —
-    // which fires window.onblur on whatever app was previously focused
-    // (Zoom, browser, IDE). preventDefault() on mousedown blocks the focus
-    // attempt entirely. The above mousedown listener has already fired
-    // stealthTapStart() in capture phase, so by the time we get here, the
-    // tap is engaging and DOM focus is no longer the typing path.
-    const blockInputFocus = useCallback((e: React.MouseEvent<HTMLInputElement>) => {
-        // When auto-engage is disabled (composition IME present), the click
-        // does NOT engage the tap — so blocking DOM focus would leave the
-        // user with no way to type. Let the browser focus the input so the
-        // OS Text Input System can route keystrokes through the active IME
-        // and compose CJK characters normally.
-        if (!stealthAutoEngageOkRef.current) return;
-        // Only block DOM focus when CGEventTap is available on this platform.
-        // On Windows, CGEventTap is never available so this guard exits early
-        // and allows normal input focus. On macOS, the tap is available so we
-        // block focus to prevent the panel from becoming key window.
-        if (!isCgEventTapAvailableRef.current) return;
-        e.preventDefault();
-        // Don't blur an already-focused element — that itself fires events.
-        if (document.activeElement === textInputRef.current) {
-            textInputRef.current?.blur();
-        }
-    }, []);
-
-    // ── Derived STT status for the rolling transcript indicator (interviewer channel) ──
-    const interviewerSttIndicatorStatus = sttInterviewerStatus;
-    // Strip consecutive error count from display — show only in expanded diagnostics
-    const interviewerSttIndicatorError = sttInterviewerError?.replace(/\s*\(\d+ consecutive errors\):?/gi, '');
-    const sttSummary = getSttSummary(sttUserStatus, sttInterviewerStatus, sttUserProvider, sttInterviewerProvider, sttNotConfigured);
-    const statusPillBaseClass = `flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[10px] font-medium shadow-sm backdrop-blur-xl ${isLightTheme ? 'bg-white/55 border-black/10' : 'bg-black/20 border-white/10'}`;
-
-    const copyDiagnostics = async () => {
-        const version = import.meta.env.VITE_APP_VERSION || 'unknown';
-        const [arch, osVersion] = await Promise.all([
-            window.electronAPI?.getArch?.().catch(() => 'unknown'),
-            window.electronAPI?.getOsVersion?.().catch(() => 'unknown'),
-        ]);
-        const { categorizeSttError } = await import('../lib/sttErrorMapper');
-        const userCat = sttUserError ? categorizeSttError(sttUserError) : null;
-        const interviewerCat = sttInterviewerError ? categorizeSttError(sttInterviewerError) : null;
-        const report = [
-            '## STT Diagnostic Report',
-            `App Version: ${version}`,
-            `Platform: ${osVersion} (${arch})`,
-            `---`,
-            `Microphone Provider: ${sttUserProvider}`,
-            `Microphone Status: ${sttUserStatus}`,
-            userCat ? `Microphone Category: ${userCat.title} [${userCat.category}]` : '',
-            `Microphone Error: ${sttUserError || 'N/A'}`,
-            `---`,
-            `System Audio Provider: ${sttInterviewerProvider}`,
-            `System Audio Status: ${sttInterviewerStatus}`,
-            interviewerCat ? `System Audio Category: ${interviewerCat.title} [${interviewerCat.category}]` : '',
-            `System Audio Error: ${sttInterviewerError || 'N/A'}`,
-            `Timestamp: ${new Date().toISOString()}`,
-        ].filter(Boolean).join('\n');
-        try {
-            await navigator.clipboard.writeText(report);
-        } catch {
-            const ta = document.createElement('textarea');
-            ta.value = report;
-            document.body.appendChild(ta);
-            ta.select();
-            document.execCommand('copy');
-            document.body.removeChild(ta);
-        }
-    };
-
-    return (
-        <div ref={contentRef} data-interface-theme={isGlassTheme ? 'liquid-glass' : undefined} className="flex flex-col items-center w-fit mx-auto h-fit min-h-0 bg-transparent p-0 rounded-[24px] font-sans gap-2 overlay-text-primary">
-
-            <AnimatePresence>
-                {isExpanded && (
-                    <motion.div
-                        initial={{ opacity: 0, y: 20, scale: 0.95 }}
-                        animate={{ opacity: 1, y: 0, scale: 1 }}
-                        exit={{ opacity: 0, y: 20, scale: 0.95 }}
-                        transition={{ duration: 0.3, ease: "easeInOut" }}
-                        className="flex flex-col items-center gap-2 w-full"
+                // Regular text - Render with Markdown
+                return (
+                  <div key={i} className="markdown-content">
+                    <ReactMarkdown
+                      remarkPlugins={REMARK_PLUGINS}
+                      rehypePlugins={REHYPE_PLUGINS}
+                      components={mdComponents.codeText}
                     >
-                        <TopPill
-                            expanded={isExpanded}
-                            onToggle={() => setIsExpanded(!isExpanded)}
-                            onQuit={() => onEndMeeting ? onEndMeeting() : window.electronAPI.quitApp()}
-                            appearance={appearance}
-                            onLogoClick={() => window.electronAPI?.setWindowMode?.('launcher')}
-                        />
-                        <motion.div
-                            ref={shellRef}
-                            className={`relative max-w-full backdrop-blur-2xl border rounded-[24px] overflow-hidden flex flex-col draggable-area overlay-shell-surface ${overlayPanelClass}`}
-                            style={{
-                                ...appearance.shellStyle,
-                                width: shellWidth,
-                                // Removed will-change: 'width' — Framer Motion animates shellWidth
-                                // using transform (translateX), not CSS width, so this hint created
-                                // a ghost compositor layer with stale dimensions from the first
-                                // meeting's layout, blocking correct compositing on remount.
-                            }}
+                      {part}
+                    </ReactMarkdown>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      }
+
+      // Custom Styled Labels (Shorten, Recap, Follow-up) - also use Markdown for content
+      if (msg.intent === 'shorten') {
+        return (
+          <div
+            className={`rounded-lg p-3 my-1 border ${subtleSurfaceClass}`}
+            style={appearance.subtleStyle}
+          >
+            <div
+              className={`flex items-center gap-2 mb-2 font-semibold text-xs uppercase tracking-wide ${isLightTheme ? 'text-cyan-700' : 'text-cyan-300'}`}
+            >
+              <MessageSquare className="w-3.5 h-3.5" />
+              <span>Shortened</span>
+            </div>
+            <div
+              className={`text-[13px] leading-relaxed markdown-content ${isLightTheme ? 'text-slate-800' : 'text-slate-200'}`}
+            >
+              <ReactMarkdown
+                remarkPlugins={REMARK_PLUGINS}
+                rehypePlugins={REHYPE_PLUGINS}
+                components={mdComponents.shortenText}
+              >
+                {msg.text}
+              </ReactMarkdown>
+            </div>
+          </div>
+        );
+      }
+
+      if (msg.intent === 'recap') {
+        return (
+          <div
+            className={`rounded-lg p-3 my-1 border ${subtleSurfaceClass}`}
+            style={appearance.subtleStyle}
+          >
+            <div
+              className={`flex items-center gap-2 mb-2 font-semibold text-xs uppercase tracking-wide ${isLightTheme ? 'text-indigo-700' : 'text-indigo-300'}`}
+            >
+              <RefreshCw className="w-3.5 h-3.5" />
+              <span>Recap</span>
+            </div>
+            <div
+              className={`text-[13px] leading-relaxed markdown-content ${isLightTheme ? 'text-slate-800' : 'text-slate-200'}`}
+            >
+              <ReactMarkdown
+                remarkPlugins={REMARK_PLUGINS}
+                rehypePlugins={REHYPE_PLUGINS}
+                components={mdComponents.recapText}
+              >
+                {msg.text}
+              </ReactMarkdown>
+            </div>
+          </div>
+        );
+      }
+
+      if (msg.intent === 'follow_up_questions') {
+        return (
+          <div
+            className={`rounded-lg p-3 my-1 border ${subtleSurfaceClass}`}
+            style={appearance.subtleStyle}
+          >
+            <div
+              className={`flex items-center gap-2 mb-2 font-semibold text-xs uppercase tracking-wide ${isLightTheme ? 'text-amber-700' : 'text-[#FFD60A]'}`}
+            >
+              <HelpCircle className="w-3.5 h-3.5" />
+              <span>Follow-Up Questions</span>
+            </div>
+            <div
+              className={`text-[13px] leading-relaxed markdown-content ${isLightTheme ? 'text-slate-800' : 'text-slate-200'}`}
+            >
+              <ReactMarkdown
+                remarkPlugins={REMARK_PLUGINS}
+                rehypePlugins={REHYPE_PLUGINS}
+                components={mdComponents.followUpQuestionsText}
+              >
+                {msg.text}
+              </ReactMarkdown>
+            </div>
+          </div>
+        );
+      }
+
+      if (msg.intent === 'what_to_answer') {
+        // Split text by code blocks (Handle unclosed blocks at EOF)
+        const parts = msg.text.split(/(```[\s\S]*?(?:```|$))/g);
+
+        return (
+          <div
+            className={`rounded-lg p-3 my-1 border ${subtleSurfaceClass}`}
+            style={appearance.subtleStyle}
+          >
+            <div className="flex items-center gap-2 mb-2 text-emerald-400 font-semibold text-xs uppercase tracking-wide">
+              <span>Say this</span>
+            </div>
+            <div className="text-[14px] leading-relaxed overlay-text-primary">
+              {parts.map((part, i) => {
+                if (part.startsWith('```')) {
+                  // Robust matching: handles unclosed blocks for streaming (```...$)
+                  const match = part.match(/```(\w*)\s+([\s\S]*?)(?:```|$)/);
+
+                  // Fallback logic: if it starts with ticks, treat as code (even if unclosed)
+                  if (match || part.startsWith('```')) {
+                    const lang = match && match[1] ? match[1] : 'python';
+                    let code = '';
+
+                    if (match && match[2]) {
+                      code = match[2].trim();
+                    } else {
+                      // Manual strip if regex failed
+                      code = part
+                        .replace(/^```\w*\s*/, '')
+                        .replace(/```$/, '')
+                        .trim();
+                    }
+
+                    return (
+                      <HighlightedCode
+                        key={i}
+                        code={code}
+                        lang={lang}
+                        isLightTheme={isLightTheme}
+                        codeTheme={codeTheme}
+                        codeBlockClass={codeBlockClass}
+                        codeHeaderClass={codeHeaderClass}
+                        codeHeaderTextClass={codeHeaderTextClass}
+                        codeLineNumberColor={codeLineNumberColor}
+                        appearance={appearance}
+                      />
+                    );
+                  }
+                }
+                // Regular text - Render Markdown
+                // PERF: hoisted components map — see mdComponents useMemo
+                // at top of component. Inline literal here would create a
+                // fresh object on every streaming token, defeating
+                // ReactMarkdown's internal render-bailout.
+                return (
+                  <div key={i} className="markdown-content">
+                    <ReactMarkdown
+                      remarkPlugins={REMARK_PLUGINS}
+                      rehypePlugins={REHYPE_PLUGINS}
+                      components={mdComponents.whatToAnswerText}
+                    >
+                      {part}
+                    </ReactMarkdown>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        );
+      }
+
+      // Standard Text Messages (e.g. from User or Interviewer)
+      // We still want basic markdown support here too
+      return (
+        <div className="markdown-content">
+          <ReactMarkdown
+            remarkPlugins={REMARK_PLUGINS}
+            rehypePlugins={REHYPE_PLUGINS}
+            components={mdComponents.standard}
+          >
+            {msg.text}
+          </ReactMarkdown>
+        </div>
+      );
+    },
+    [isLightTheme, mdComponents, appearance],
+  );
+
+  // We use a ref to hold the latest handlers to avoid re-binding the event listener on every render
+  const handlersRef = useRef({
+    handleWhatToSay,
+    handleFollowUp,
+    handleFollowUpQuestions,
+    handleRecap,
+    handleAnswerNow,
+    handleClarify,
+    handleCodeHint,
+    handleBrainstorm,
+  });
+
+  // Update ref on every render so the event listener always access latest state/props
+  handlersRef.current = {
+    handleWhatToSay,
+    handleFollowUp,
+    handleFollowUpQuestions,
+    handleRecap,
+    handleAnswerNow,
+    handleClarify,
+    handleCodeHint,
+    handleBrainstorm,
+  };
+
+  useEffect(() => {
+    // ── Continuous, frame-rate-independent scroll with momentum ──
+    // Velocity is integrated against real elapsed time so 60Hz, 120Hz, and
+    // dropped-frame paths all produce the same physical speed. While a key
+    // is held we ease velocity up to TERMINAL; on release we decay it
+    // exponentially, which is what makes the stop feel weighted instead of
+    // snapped. Sub-pixel motion is preserved via a fractional accumulator,
+    // and we write `scrollTop` directly to bypass any browser scroll-behavior
+    // smoothing that would fight the loop.
+    const TERMINAL_VELOCITY = 1400; // px/s at full hold
+    const ACCEL_SECONDS = 0.18; // time to reach terminal from rest
+    const DECAY_HALF_LIFE = 0.09; // seconds for velocity to halve after release
+    const DECAY_K = Math.LN2 / DECAY_HALF_LIFE;
+    const MIN_VELOCITY = 6; // px/s — snap to 0 below this
+    const MAX_FRAME_DT = 0.05; // clamp to absorb tab-throttle hiccups
+
+    let direction: -1 | 0 | 1 = 0; // -1 up, 0 idle, 1 down (or both up+down → 0)
+    let upHeld = false;
+    let downHeld = false;
+    let velocity = 0; // signed px/s
+    let positionFraction = 0; // sub-pixel accumulator
+    let lastTs = 0;
+    let rafId: number | null = null;
+
+    const recomputeDirection = () => {
+      direction = upHeld === downHeld ? 0 : upHeld ? -1 : 1;
+    };
+
+    const tick = (ts: number) => {
+      const container = scrollContainerRef.current;
+      if (!container) {
+        rafId = null;
+        lastTs = 0;
+        return;
+      }
+      if (lastTs === 0) lastTs = ts;
+      const dt = Math.min((ts - lastTs) / 1000, MAX_FRAME_DT);
+      lastTs = ts;
+
+      if (direction !== 0) {
+        const target = direction * TERMINAL_VELOCITY;
+        const step = (TERMINAL_VELOCITY / ACCEL_SECONDS) * dt;
+        if (Math.abs(target - velocity) <= step) velocity = target;
+        else velocity += Math.sign(target - velocity) * step;
+      } else {
+        velocity *= Math.exp(-DECAY_K * dt);
+        if (Math.abs(velocity) < MIN_VELOCITY) velocity = 0;
+      }
+
+      // Cache layout reads once per frame, then a single scrollTop write.
+      const maxScroll = container.scrollHeight - container.clientHeight;
+      const current = container.scrollTop;
+      const move = velocity * dt + positionFraction;
+      const intMove = Math.trunc(move);
+      positionFraction = move - intMove;
+
+      if (intMove !== 0) {
+        let next = current + intMove;
+        if (next <= 0) {
+          next = 0;
+          if (velocity < 0) {
+            velocity = 0;
+            positionFraction = 0;
+          }
+        } else if (next >= maxScroll) {
+          next = maxScroll;
+          if (velocity > 0) {
+            velocity = 0;
+            positionFraction = 0;
+          }
+        }
+        if (next !== current) container.scrollTop = next;
+      }
+
+      if (direction !== 0 || velocity !== 0) {
+        rafId = requestAnimationFrame(tick);
+      } else {
+        rafId = null;
+        lastTs = 0;
+        positionFraction = 0;
+      }
+    };
+
+    const startScrollLoop = () => {
+      if (rafId === null) rafId = requestAnimationFrame(tick);
+    };
+    const releaseScroll = () => {
+      upHeld = false;
+      downHeld = false;
+      recomputeDirection();
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const {
+        handleWhatToSay,
+        handleFollowUp,
+        handleFollowUpQuestions,
+        handleRecap,
+        handleAnswerNow,
+        handleClarify,
+        handleCodeHint,
+        handleBrainstorm,
+      } = handlersRef.current;
+
+      // Chat Shortcuts (Scope: Local to Chat/Overlay usually, but we allow them here if focused)
+      if (isShortcutPressed(e, 'whatToAnswer')) {
+        e.preventDefault();
+        handleWhatToSay();
+      } else if (isShortcutPressed(e, 'clarify')) {
+        e.preventDefault();
+        handleClarify();
+      } else if (isShortcutPressed(e, 'followUp')) {
+        e.preventDefault();
+        handleFollowUpQuestions();
+      } else if (isShortcutPressed(e, 'dynamicAction4')) {
+        e.preventDefault();
+        if (actionButtonMode === 'brainstorm') {
+          handleBrainstorm();
+        } else {
+          handleRecap();
+        }
+      } else if (isShortcutPressed(e, 'answer')) {
+        e.preventDefault();
+        handleAnswerNow();
+      } else if (isShortcutPressed(e, 'clarify')) {
+        e.preventDefault();
+        handleClarify();
+      } else if (isShortcutPressed(e, 'codeHint')) {
+        e.preventDefault();
+        handleCodeHint();
+      } else if (isShortcutPressed(e, 'brainstorm')) {
+        e.preventDefault();
+        handleBrainstorm();
+      } else if (isShortcutPressed(e, 'scrollUp')) {
+        e.preventDefault();
+        upHeld = true;
+        recomputeDirection();
+        startScrollLoop();
+      } else if (isShortcutPressed(e, 'scrollDown')) {
+        e.preventDefault();
+        downHeld = true;
+        recomputeDirection();
+        startScrollLoop();
+      } else if (isShortcutPressed(e, 'moveWindowUp') || isShortcutPressed(e, 'moveWindowDown')) {
+        // Prevent default scrolling when moving window
+        e.preventDefault();
+      }
+    };
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      // Users typically lift the modifier (Cmd/Ctrl) first, so releasing
+      // either it or the arrow ends the hold and lets momentum decay.
+      if (e.key === 'ArrowUp') {
+        upHeld = false;
+        recomputeDirection();
+      } else if (e.key === 'ArrowDown') {
+        downHeld = false;
+        recomputeDirection();
+      } else if (e.key === 'Meta' || e.key === 'Control') {
+        releaseScroll();
+      }
+    };
+
+    // Window blur swallows keyup; reset to avoid stuck scrolling.
+    const handleBlur = () => releaseScroll();
+
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+    window.addEventListener('blur', handleBlur);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+      window.removeEventListener('blur', handleBlur);
+      if (rafId !== null) cancelAnimationFrame(rafId);
+    };
+  }, [isShortcutPressed]);
+
+  // General Global Shortcuts (Rebindable)
+  // We listen here to handle them when the window is focused (renderer side)
+  // Global shortcuts (when window blurred) are handled by Main process -> GlobalShortcuts
+  // But Main process events might not reach here if we don't listen, or we want unified handling.
+  // Actually, KeybindManager registers global shortcuts. If they are registered as global,
+  // Electron might consume them before they reach here?
+  // 'toggle-app' is Global.
+  // 'toggle-visibility' is NOT Global in default config (isGlobal: false), so it depends on focus.
+  // So we MUST listen for them here.
+
+  const generalHandlersRef = useRef({
+    toggleVisibility: () => window.electronAPI.toggleWindow(),
+    processScreenshots: handleWhatToSay,
+    resetCancel: async () => {
+      if (isProcessing) {
+        setIsProcessing(false);
+      } else {
+        await window.electronAPI.resetIntelligence();
+        setMessages([]);
+        setAttachedContext([]);
+        setInputValue('');
+      }
+    },
+    toggleMousePassthrough: () => {
+      const newState = !isMousePassthrough;
+      setIsMousePassthrough(newState);
+      window.electronAPI?.setOverlayMousePassthrough?.(newState);
+    },
+    takeScreenshot: async () => {
+      try {
+        const data = await window.electronAPI.takeScreenshot();
+        if (data && data.path) {
+          handleScreenshotAttach(data as { path: string; preview: string });
+        }
+      } catch (err) {
+        console.error('Error triggering screenshot:', err);
+      }
+    },
+    selectiveScreenshot: async () => {
+      try {
+        const data = await window.electronAPI.takeSelectiveScreenshot();
+        if (data && !data.cancelled && data.path) {
+          handleScreenshotAttach(data as { path: string; preview: string });
+        }
+      } catch (err) {
+        console.error('Error triggering selective screenshot:', err);
+      }
+    },
+  });
+
+  // Update ref
+  generalHandlersRef.current = {
+    toggleVisibility: () => window.electronAPI.toggleWindow(),
+    processScreenshots: handleWhatToSay,
+    resetCancel: async () => {
+      if (isProcessing) {
+        setIsProcessing(false);
+      } else {
+        await window.electronAPI.resetIntelligence();
+        setMessages([]);
+        setAttachedContext([]);
+        setInputValue('');
+      }
+    },
+    toggleMousePassthrough: () => {
+      const newState = !isMousePassthrough;
+      setIsMousePassthrough(newState);
+      window.electronAPI?.setOverlayMousePassthrough?.(newState);
+    },
+    takeScreenshot: async () => {
+      try {
+        const data = await window.electronAPI.takeScreenshot();
+        if (data && data.path) {
+          handleScreenshotAttach(data as { path: string; preview: string });
+        }
+      } catch (err) {
+        console.error('Error triggering screenshot:', err);
+      }
+    },
+    selectiveScreenshot: async () => {
+      try {
+        const data = await window.electronAPI.takeSelectiveScreenshot();
+        if (data && !data.cancelled && data.path) {
+          handleScreenshotAttach(data as { path: string; preview: string });
+        }
+      } catch (err) {
+        console.error('Error triggering selective screenshot:', err);
+      }
+    },
+  };
+
+  useEffect(() => {
+    const handleGeneralKeyDown = (e: KeyboardEvent) => {
+      const handlers = generalHandlersRef.current;
+      const target = e.target as HTMLElement;
+      const isInput =
+        target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
+
+      if (isShortcutPressed(e, 'toggleVisibility')) {
+        // Always allow toggling visibility
+        e.preventDefault();
+        handlers.toggleVisibility();
+      } else if (isShortcutPressed(e, 'processScreenshots')) {
+        if (!isInput) {
+          e.preventDefault();
+          handlers.processScreenshots();
+        }
+        // If input focused, let default behavior (Enter) happen or handle it via onKeyDown in Input
+      } else if (isShortcutPressed(e, 'resetCancel')) {
+        e.preventDefault();
+        handlers.resetCancel();
+      } else if (isShortcutPressed(e, 'takeScreenshot')) {
+        e.preventDefault();
+        handlers.takeScreenshot();
+      } else if (isShortcutPressed(e, 'selectiveScreenshot')) {
+        e.preventDefault();
+        handlers.selectiveScreenshot();
+      } else if (isShortcutPressed(e, 'toggleMousePassthrough')) {
+        e.preventDefault();
+        handlers.toggleMousePassthrough();
+      }
+    };
+
+    window.addEventListener('keydown', handleGeneralKeyDown);
+    return () => window.removeEventListener('keydown', handleGeneralKeyDown);
+  }, [isShortcutPressed]);
+
+  // Global "Capture & Process" shortcut handler (issue #90)
+  // Registered separately so it always has the latest handlersRef via stable ref access.
+  // Main process takes the screenshot and sends "capture-and-process" with path+preview;
+  // we attach the screenshot to context and immediately trigger AI analysis.
+  useEffect(() => {
+    if (!window.electronAPI.onCaptureAndProcess) return;
+    const unsubscribe = window.electronAPI.onCaptureAndProcess((data) => {
+      setIsExpanded(true);
+
+      // Store screenshot in a stable ref BEFORE updating React state.
+      // This fixes the React 18 concurrent mode timing race where setTimeout(0)
+      // could fire before setAttachedContext had flushed, leaving handleWhatToSay
+      // with an empty attachedContext and causing silent failures.
+      pendingCaptureRef.current = data;
+
+      setAttachedContext((prev) => {
+        if (prev.some((s) => s.path === data.path)) return prev;
+        return [...prev, data].slice(-5);
+      });
+
+      // Use requestAnimationFrame so we wait for at least one paint cycle —
+      // more reliable than setTimeout(0) under React 18 concurrent scheduling.
+      // The ref guarantees handleWhatToSay has the screenshot regardless of
+      // whether the state update has flushed yet.
+      requestAnimationFrame(() => {
+        try {
+          handlersRef.current.handleWhatToSay();
+        } finally {
+          pendingCaptureRef.current = null;
+        }
+      });
+    });
+    return unsubscribe;
+  }, []);
+
+  // Inertial-scroll engine. Each globalShortcut fire kicks velocity on one
+  // axis; a single RAF loop integrates position with friction. A lone tap
+  // glides ~250ms then decays; rapid taps sustain motion. Needed because
+  // Carbon HotKey on macOS does not auto-repeat with Cmd held, so naive
+  // per-fire scrollBy(100px) produces stuttery, taps-only motion.
+  const inertialScrollRef = useRef<{
+    kick: (axis: 'vert' | 'horiz', direction: -1 | 1) => void;
+  } | null>(null);
+
+  useEffect(() => {
+    const KICK_VELOCITY = 900; // px/s added per press
+    const TERMINAL_VELOCITY = 3200; // px/s clamp
+    const FRICTION_HALF_LIFE = 0.16; // seconds for velocity to halve
+    const MIN_VELOCITY = 8; // px/s — snap to zero below
+    const MAX_FRAME_DT = 0.05; // clamp for tab-throttle hiccups
+
+    const state = {
+      raf: null as number | null,
+      lastTs: 0,
+      vert: { vel: 0, target: null as HTMLElement | null, frac: 0 },
+      horiz: { vel: 0, target: null as HTMLElement | null, frac: 0 },
+    };
+
+    const resolveHorizontalTarget = (container: HTMLElement): HTMLElement | null => {
+      const containerRect = container.getBoundingClientRect();
+      const containerCenter = (containerRect.top + containerRect.bottom) / 2;
+
+      const preElements = container.querySelectorAll('pre');
+      let best: HTMLElement | null = null;
+      let bestDistance = Infinity;
+
+      preElements.forEach((pre) => {
+        // Walk up from <pre> until we find the actual horizontal scroller.
+        // Markdown renderers often wrap <pre> in a div that holds overflow-x.
+        let scroller: HTMLElement | null = pre as HTMLElement;
+        while (scroller && scroller !== container) {
+          if (scroller.scrollWidth > scroller.clientWidth + 1) break;
+          scroller = scroller.parentElement;
+        }
+        if (!scroller || scroller === container) return;
+        if (scroller.scrollWidth <= scroller.clientWidth + 1) return;
+
+        const rect = scroller.getBoundingClientRect();
+        if (rect.bottom < containerRect.top || rect.top > containerRect.bottom) return;
+
+        const distance = Math.abs((rect.top + rect.bottom) / 2 - containerCenter);
+        if (distance < bestDistance) {
+          bestDistance = distance;
+          best = scroller;
+        }
+      });
+
+      return best;
+    };
+
+    const tick = (ts: number) => {
+      if (state.lastTs === 0) state.lastTs = ts;
+      const dt = Math.min((ts - state.lastTs) / 1000, MAX_FRAME_DT);
+      state.lastTs = ts;
+      const decay = Math.pow(0.5, dt / FRICTION_HALF_LIFE);
+
+      const stepAxis = (axis: 'vert' | 'horiz') => {
+        const a = state[axis];
+        if (Math.abs(a.vel) < MIN_VELOCITY || !a.target) {
+          a.vel = 0;
+          a.frac = 0;
+          a.target = null;
+          return false;
+        }
+        const move = a.vel * dt + a.frac;
+        const intMove = Math.trunc(move);
+        a.frac = move - intMove;
+        if (intMove !== 0) {
+          if (axis === 'vert') a.target.scrollTop += intMove;
+          else a.target.scrollLeft += intMove;
+        }
+        a.vel *= decay;
+        return true;
+      };
+
+      const vertActive = stepAxis('vert');
+      const horizActive = stepAxis('horiz');
+
+      if (vertActive || horizActive) {
+        state.raf = requestAnimationFrame(tick);
+      } else {
+        state.raf = null;
+        state.lastTs = 0;
+      }
+    };
+
+    const kick = (axis: 'vert' | 'horiz', direction: -1 | 1) => {
+      const container = scrollContainerRef.current;
+      if (!container) return;
+
+      let target: HTMLElement | null;
+      if (axis === 'vert') {
+        target = container;
+      } else {
+        target = resolveHorizontalTarget(container);
+        // No visible scrollable code block → no-op rather than scrolling
+        // an off-screen one or shaking the chat container sideways.
+        if (!target) return;
+      }
+
+      const a = state[axis];
+      // Reverse direction: reset rather than fight existing momentum.
+      if (a.target !== target || Math.sign(a.vel) === -direction) {
+        a.vel = 0;
+        a.frac = 0;
+      }
+      a.target = target;
+      const next = a.vel + direction * KICK_VELOCITY;
+      a.vel = Math.max(-TERMINAL_VELOCITY, Math.min(TERMINAL_VELOCITY, next));
+
+      if (state.raf === null) state.raf = requestAnimationFrame(tick);
+    };
+
+    inertialScrollRef.current = { kick };
+
+    return () => {
+      if (state.raf !== null) cancelAnimationFrame(state.raf);
+      inertialScrollRef.current = null;
+    };
+  }, []);
+
+  // Stealth Global Shortcuts Handler
+  // Listens for shortcuts triggered when the app is in the background
+  useEffect(() => {
+    if (!window.electronAPI.onGlobalShortcut) return;
+    const unsubscribe = window.electronAPI.onGlobalShortcut(({ action }) => {
+      const handlers = handlersRef.current;
+      const generalHandlers = generalHandlersRef.current;
+
+      isStealthRef.current = true;
+
+      if (action === 'whatToAnswer') handlers.handleWhatToSay();
+      else if (action === 'shorten') handlers.handleFollowUp('shorten');
+      else if (action === 'followUp') handlers.handleFollowUpQuestions();
+      else if (action === 'recap') handlers.handleRecap();
+      else if (action === 'dynamicAction4') {
+        if (actionButtonMode === 'brainstorm') handlers.handleBrainstorm();
+        else handlers.handleRecap();
+      } else if (action === 'answer') handlers.handleAnswerNow();
+      else if (action === 'clarify') handlers.handleClarify();
+      else if (action === 'codeHint') handlers.handleCodeHint();
+      else if (action === 'brainstorm') handlers.handleBrainstorm();
+      else if (action === 'scrollUp') inertialScrollRef.current?.kick('vert', -1);
+      else if (action === 'scrollDown') inertialScrollRef.current?.kick('vert', 1);
+      else if (action === 'scrollLeft') inertialScrollRef.current?.kick('horiz', -1);
+      else if (action === 'scrollRight') inertialScrollRef.current?.kick('horiz', 1);
+      else if (action === 'focusInput') {
+        // Stealth-focus the chat input: the panel-type overlay (macOS) is
+        // already key without activating the app. We just need the input
+        // element to be the active DOM target so keystrokes land in it.
+        // Defer to next frame so an expand-from-collapsed has time to
+        // mount the input before .focus() runs.
+        setIsExpanded(true);
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => textInputRef.current?.focus());
+        });
+      } else if (action === 'processScreenshots') generalHandlers.processScreenshots();
+      else if (action === 'resetCancel') generalHandlers.resetCancel();
+      else if (action === 'takeScreenshot') generalHandlers.takeScreenshot();
+      else if (action === 'selectiveScreenshot') generalHandlers.selectiveScreenshot();
+
+      // Safety reset if it didn't trigger an expansion
+      setTimeout(() => {
+        isStealthRef.current = false;
+      }, 500);
+    });
+    return unsubscribe;
+  }, []);
+
+  // ── Stealth keyboard tap (CGEventTap) — true Cluely-grade input path ──
+  //
+  // When the OS-level tap is engaged (toggled by Cmd/Ctrl+Shift+Space),
+  // every keystroke is captured BEFORE the foreground app sees it and
+  // forwarded here. We append `chars` directly to inputValue without ever
+  // touching DOM focus — the chat input never has to be the active element,
+  // so the panel never has to be the key window. Zoom/browser stays as the
+  // OS frontmost+key application throughout the entire typing session.
+  //
+  // HID virtual keycodes referenced below (stable across layouts):
+  //   36 = Return,  48 = Tab,  51 = Delete (Backspace),  53 = Esc,
+  //   76 = Numpad Enter,  123 = Left,  124 = Right,  125 = Down,  126 = Up.
+  useEffect(() => {
+    if (!window.electronAPI?.onStealthTapState || !window.electronAPI?.onStealthKeyCaptured) return;
+
+    // Effect-scoped flag set when Esc is observed in the captured-key
+    // stream. Suppresses non-Esc events that may have been queued by the
+    // worker thread before the user pressed Esc. Cleared on each new
+    // active=true state event (a new tap session). Hoisted here so both
+    // listeners see the same binding.
+    let escSuppressUntilNextActive = false;
+
+    const unsubState = window.electronAPI.onStealthTapState(({ active, reason }) => {
+      stealthTapActiveRef.current = active;
+      setStealthTapActive(active);
+      if (active) {
+        // Auto-expand the overlay so the user can see what they're
+        // typing. We do NOT call .focus() — the whole point of the
+        // tap is to avoid window-level focus.
+        isStealthRef.current = true;
+        setIsExpanded(true);
+        setStealthPermissionMissing(false);
+        escSuppressUntilNextActive = false;
+      }
+      if (!active && reason === 'permission') {
+        setStealthPermissionMissing(true);
+      }
+    });
+
+    const unsubKey = window.electronAPI.onStealthKeyCaptured((ev) => {
+      // CONTRACT WITH RUST: keyboard_tap.rs pass-through filter (R3)
+      // returns the event unmodified for ANY system-modifier key
+      // (Cmd / Ctrl / Option / Fn) and for ALL F-keys, so the OS
+      // routes those normally to the foreground app. Consequence:
+      // (ev.flags & CMD) is NEVER true here, neither is OPT or CTRL.
+      // The previous round had Cmd+Enter / Cmd+Backspace / Cmd+A /
+      // Option+Backspace branches — all dead code under R3. Removed
+      // to prevent a false sense of feature support; if Rust ever
+      // changes the filter to deliver Cmd events, those branches
+      // need to be REINTRODUCED with explicit testing, not
+      // resurrected from a TODO.
+
+      // Esc handled regardless of active state (main process broadcasts
+      // it BEFORE stopping the tap, so we get here while still active;
+      // see StealthKeyboardManager.handleCapturedKey ordering).
+      if (ev.isKeyDown && ev.keyCode === 53) {
+        setInputValue('');
+        escSuppressUntilNextActive = true;
+        return;
+      }
+
+      // Belt-and-braces clear of the Esc-suppress flag on the first
+      // key event of a new session. State and captured-key arrive on
+      // separate IPC channels and ordering across channels is NOT
+      // guaranteed — if the first keystroke of a new session arrives
+      // before the state-active broadcast, the suppress flag (set by
+      // a prior Esc) would still be true and the keystroke would be
+      // dropped. We re-check the ref (which the state listener flips
+      // synchronously on receipt): if the ref is now true, this is a
+      // legitimate new-session keystroke → clear suppress and proceed.
+      if (escSuppressUntilNextActive && stealthTapActiveRef.current) {
+        console.warn(
+          '[stealth] cross-channel race resolved by ref check — captured-key arrived before state event',
+        );
+        escSuppressUntilNextActive = false;
+      }
+      if (escSuppressUntilNextActive) return; // drop late-arriving keys after Esc
+      if (!stealthTapActiveRef.current) return; // ignore other events after stop
+      if (!ev.isKeyDown) return; // we only act on keyDown
+
+      switch (ev.keyCode) {
+        case 36: // Return
+        case 76: // Numpad Enter
+          handleManualSubmitRef.current();
+          window.electronAPI.stealthTapStop().catch(() => {});
+          return;
+        case 51: // Backspace — delete one char
+          setInputValue((prev) => prev.slice(0, -1));
+          return;
+        // ROUND 4 FIX (#6): Tab (48) and arrows (123-126) used to
+        // be no-op'd here. They're now passed through at the Rust
+        // layer (keyboard_tap.rs F-key whitelist) so they reach the
+        // user's foreground app normally. Removing the dead cases
+        // keeps the contract honest: this switch only sees text-
+        // worthy keys + Backspace + Enter. If anyone ever changes
+        // the Rust filter to deliver Tab again, decide explicitly
+        // what it should do here rather than copy-pasting a no-op.
+      }
+
+      // Append printable chars. CGEventKeyboardGetUnicodeString already
+      // honors the active layout, dead keys, and IME — we don't need to
+      // re-derive characters from keyCode + modifiers ourselves. Filter
+      // shift-only modifier (it's already encoded in the chars).
+      if (
+        ev.chars &&
+        ev.chars.length > 0 &&
+        ev.chars !== '\r' &&
+        ev.chars !== '\n' &&
+        ev.chars !== '\t'
+      ) {
+        setInputValue((prev) => prev + ev.chars);
+      }
+    });
+
+    return () => {
+      unsubState();
+      unsubKey();
+    };
+  }, []);
+
+  // ── Stealth hotkey registration-failure listener ──
+  //
+  // KeybindManager fires this when globalShortcut.register() returns false
+  // (the OS or another app owns the accelerator). Without surfacing it,
+  // the user presses the hotkey, nothing happens, and they assume the
+  // stealth feature is broken. We filter to the stealth-typing keybind
+  // and render an inline banner pointing to Settings → Shortcuts.
+  useEffect(() => {
+    if (!window.electronAPI?.onKeybindRegistrationFailed) return;
+    const unsubscribe = window.electronAPI.onKeybindRegistrationFailed(({ id, accelerator }) => {
+      if (id !== 'chat:focusInput') return;
+      setStealthHotkeyConflict(accelerator);
+    });
+    return unsubscribe;
+  }, []);
+
+  // ── Click-to-activate: engage CGEventTap on chat-input click only
+  //    (opt-IN model) ──
+  //
+  // ROUND 3 FIX (#1): previously this listener engaged the tap on ANY
+  // mousedown anywhere in the overlay (opt-OUT via data-stealth-ignore).
+  // That model broke hard: clicking the Settings button engaged the tap,
+  // then Settings opened and the user couldn't type their API key (tap
+  // intercepted at OS level → keystrokes went to Natively's read-only
+  // chat input). Worse, every NEW button added to the overlay was a
+  // regression risk — forgetting `data-stealth-ignore` re-introduced the
+  // bug silently.
+  //
+  // Inverted to opt-IN: tap ONLY engages when the user clicks an element
+  // marked with `data-stealth-engage="true"` (the chat input wrapper).
+  // Buttons run their normal onClick handlers without engaging the tap.
+  // Two paths still let the user start typing stealth-style:
+  //   • Click the chat input → tap engages → DOM focus blocked → type
+  //   • Press the activation hotkey (Cmd/Ctrl+Shift+Space) → tap engages
+  //
+  // mousedown (not click) so we engage BEFORE the input would otherwise
+  // take DOM focus — preventing the panel from becoming key window, which
+  // is the precise event coding-interview platforms detect via blur.
+  useEffect(() => {
+    if (!window.electronAPI?.stealthTapStart) return;
+
+    // Resolve the IME-safety policy once at mount. While the promise is in
+    // flight we keep the default (true) so users on plain ASCII layouts
+    // see no behaviour change. The probe runs on the main process via
+    // `defaults read com.apple.HIToolbox`; see electron/services/
+    // ImeDetector.ts for the reason this gate exists at all.
+    // Probe for IME state (Pinyin, Hangul, Kanji). Result refines
+    // stealthAutoEngageOkRef from its safe-true default; we do NOT
+    // need to re-check CGEventTap availability here — the synchronous
+    // window.electronAPI.platform guard above already covers that.
+    if (window.electronAPI.stealthTapShouldAutoEngage) {
+      window.electronAPI
+        .stealthTapShouldAutoEngage()
+        .then((ok) => {
+          stealthAutoEngageOkRef.current = !!ok;
+        })
+        .catch(() => {
+          /* fail open — keep default */
+        });
+    }
+
+    const onMouseDown = (e: MouseEvent) => {
+      if (stealthTapActiveRef.current) return; // already on
+      // IME present → never auto-engage. The user can still press the
+      // explicit hotkey if they want true OS-level invisible typing
+      // (they'll lose composition in that path by design).
+      if (!stealthAutoEngageOkRef.current) return;
+      const target = e.target as HTMLElement | null;
+      if (!target?.closest?.('[data-stealth-engage="true"]')) return;
+      window.electronAPI.stealthTapStart().catch(() => {});
+    };
+
+    document.addEventListener('mousedown', onMouseDown, true); // capture phase
+    return () => document.removeEventListener('mousedown', onMouseDown, true);
+  }, []);
+
+  // ── ModelSelector click-outside close ──
+  //
+  // ROUND 3 FIX (#4): replaces the dead `on('blur')` handler in the
+  // ModelSelectorWindowHelper. With NSPanel-nonactivating the model-
+  // selector window may never become key on click, so its blur listener
+  // never fires and the dropdown stays open forever. We close it here
+  // by firing an IPC on every overlay mousedown EXCEPT clicks on the
+  // toggle button itself (which would race with toggleWindow's open/close
+  // logic). Main process no-ops the IPC if model selector is already
+  // closed.
+  useEffect(() => {
+    if (!window.electronAPI?.modelSelectorCloseIfOpen) return;
+    const onMouseDown = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (target?.closest?.('[data-model-selector-toggle="true"]')) return;
+      window.electronAPI.modelSelectorCloseIfOpen().catch(() => {});
+    };
+    document.addEventListener('mousedown', onMouseDown);
+    return () => document.removeEventListener('mousedown', onMouseDown);
+  }, []);
+
+  // ── Input-click DOM-focus block ──
+  //
+  // When the user clicks the chat input, the browser tries to focus the
+  // <input> element. That focus promotes the NSPanel to key window —
+  // which fires window.onblur on whatever app was previously focused
+  // (Zoom, browser, IDE). preventDefault() on mousedown blocks the focus
+  // attempt entirely. The above mousedown listener has already fired
+  // stealthTapStart() in capture phase, so by the time we get here, the
+  // tap is engaging and DOM focus is no longer the typing path.
+  const blockInputFocus = useCallback((e: React.MouseEvent<HTMLInputElement>) => {
+    // When auto-engage is disabled (composition IME present), the click
+    // does NOT engage the tap — so blocking DOM focus would leave the
+    // user with no way to type. Let the browser focus the input so the
+    // OS Text Input System can route keystrokes through the active IME
+    // and compose CJK characters normally.
+    if (!stealthAutoEngageOkRef.current) return;
+    // Only block DOM focus when CGEventTap is available on this platform.
+    // On Windows, CGEventTap is never available so this guard exits early
+    // and allows normal input focus. On macOS, the tap is available so we
+    // block focus to prevent the panel from becoming key window.
+    if (!isCgEventTapAvailableRef.current) return;
+    e.preventDefault();
+    // Don't blur an already-focused element — that itself fires events.
+    if (document.activeElement === textInputRef.current) {
+      textInputRef.current?.blur();
+    }
+  }, []);
+
+  // ── Derived STT status for the rolling transcript indicator (interviewer channel) ──
+  const interviewerSttIndicatorStatus = sttInterviewerStatus;
+  // Strip consecutive error count from display — show only in expanded diagnostics
+  const interviewerSttIndicatorError = sttInterviewerError?.replace(
+    /\s*\(\d+ consecutive errors\):?/gi,
+    '',
+  );
+  const sttSummary = getSttSummary(
+    sttUserStatus,
+    sttInterviewerStatus,
+    sttUserProvider,
+    sttInterviewerProvider,
+    sttNotConfigured,
+  );
+  const statusPillBaseClass = `flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[10px] font-medium shadow-sm backdrop-blur-xl ${isLightTheme ? 'bg-white/55 border-black/10' : 'bg-black/20 border-white/10'}`;
+
+  const copyDiagnostics = async () => {
+    const version = import.meta.env.VITE_APP_VERSION || 'unknown';
+    const [arch, osVersion] = await Promise.all([
+      window.electronAPI?.getArch?.().catch(() => 'unknown'),
+      window.electronAPI?.getOsVersion?.().catch(() => 'unknown'),
+    ]);
+    const { categorizeSttError } = await import('../lib/sttErrorMapper');
+    const userCat = sttUserError ? categorizeSttError(sttUserError) : null;
+    const interviewerCat = sttInterviewerError ? categorizeSttError(sttInterviewerError) : null;
+    const report = [
+      '## STT Diagnostic Report',
+      `App Version: ${version}`,
+      `Platform: ${osVersion} (${arch})`,
+      `---`,
+      `Microphone Provider: ${sttUserProvider}`,
+      `Microphone Status: ${sttUserStatus}`,
+      userCat ? `Microphone Category: ${userCat.title} [${userCat.category}]` : '',
+      `Microphone Error: ${sttUserError || 'N/A'}`,
+      `---`,
+      `System Audio Provider: ${sttInterviewerProvider}`,
+      `System Audio Status: ${sttInterviewerStatus}`,
+      interviewerCat
+        ? `System Audio Category: ${interviewerCat.title} [${interviewerCat.category}]`
+        : '',
+      `System Audio Error: ${sttInterviewerError || 'N/A'}`,
+      `Timestamp: ${new Date().toISOString()}`,
+    ]
+      .filter(Boolean)
+      .join('\n');
+    try {
+      await navigator.clipboard.writeText(report);
+    } catch {
+      const ta = document.createElement('textarea');
+      ta.value = report;
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+    }
+  };
+
+  return (
+    <div
+      ref={contentRef}
+      data-interface-theme={isGlassTheme ? 'liquid-glass' : undefined}
+      className="flex flex-col items-center w-fit mx-auto h-fit min-h-0 bg-transparent p-0 rounded-[24px] font-sans gap-2 overlay-text-primary"
+    >
+      <AnimatePresence>
+        {isExpanded && (
+          <motion.div
+            initial={{ opacity: 0, y: 20, scale: 0.95 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 20, scale: 0.95 }}
+            transition={{ duration: 0.3, ease: 'easeInOut' }}
+            className="flex flex-col items-center gap-2 w-full"
+          >
+            <TopPill
+              expanded={isExpanded}
+              onToggle={() => setIsExpanded(!isExpanded)}
+              onQuit={() => (onEndMeeting ? onEndMeeting() : window.electronAPI.quitApp())}
+              appearance={appearance}
+              onLogoClick={() => window.electronAPI?.setWindowMode?.('launcher')}
+            />
+            <motion.div
+              ref={shellRef}
+              className={`relative max-w-full backdrop-blur-2xl border rounded-[24px] overflow-hidden flex flex-col draggable-area overlay-shell-surface ${overlayPanelClass}`}
+              style={{
+                ...appearance.shellStyle,
+                width: shellWidth,
+                // Removed will-change: 'width' — Framer Motion animates shellWidth
+                // using transform (translateX), not CSS width, so this hint created
+                // a ghost compositor layer with stale dimensions from the first
+                // meeting's layout, blocking correct compositing on remount.
+              }}
+            >
+              {isGlassTheme && <GlassEffectLayer parentRef={shellRef} cornerRadius={24} />}
+
+              <div className="relative no-drag flex flex-wrap items-center justify-center gap-1.5 px-4 pt-3 pb-1">
+                <div
+                  className={`${statusPillBaseClass} overlay-text-primary`}
+                  title={
+                    activeModeLabel ? `Active mode: ${activeModeLabel}` : 'No active mode selected'
+                  }
+                >
+                  <LayoutGrid className="h-3 w-3 opacity-70" />
+                  <span>{activeModeLabel ? `Mode: ${activeModeLabel}` : 'General mode'}</span>
+                </div>
+                <div
+                  className={`${statusPillBaseClass} ${getStatusToneClass(sttSummary.tone)}`}
+                  title={sttSummary.detail}
+                >
+                  <Mic className="h-3 w-3 opacity-70" />
+                  <span>{sttSummary.label}</span>
+                </div>
+                {(() => {
+                  // Vision-first status chip. Order of preference for what to show:
+                  //   1. attached screenshots queued for this turn
+                  //   2. failure from the last vision call (reason-aware)
+                  //   3. success from the last vision call (provider/model surfaced)
+                  //   4. legacy ocr-available fallback (only fires if a legacy mode is re-enabled)
+                  //   5. nothing-yet placeholder
+                  const visionFailed =
+                    screenContextStatus === 'failed' || !!latestVisionFailureReason;
+                  const visionSucceeded =
+                    (latestUsedImageInput || screenContextStatus === 'available') && !visionFailed;
+                  const failureLabelMap: Record<string, string> = {
+                    no_vision_provider: 'No vision provider',
+                    all_vision_failed: 'Vision failed',
+                    privacy_blocked: 'Private mode blocked vision',
+                    scope_blocked: 'Screenshots disabled',
+                    provider_timeout: 'Vision timed out',
+                  };
+                  const failureLabel = latestVisionFailureReason
+                    ? failureLabelMap[latestVisionFailureReason] || 'Vision failed'
+                    : 'Vision failed';
+                  const failureTitleMap: Record<string, string> = {
+                    no_vision_provider:
+                      'No vision-capable provider is configured. Add a Natively, OpenAI, Claude, Gemini, or Groq key — or configure a local Ollama vision model.',
+                    all_vision_failed:
+                      'All configured vision providers failed for this turn. Check provider quotas and try again.',
+                    privacy_blocked:
+                      'Private vision mode blocked cloud vision providers; no local vision provider is configured.',
+                    scope_blocked:
+                      'Screenshots are disabled for the current provider. Enable the screenshots scope in Settings.',
+                    provider_timeout:
+                      'Vision provider exceeded its per-call timeout; the chain moved on to the next provider.',
+                  };
+                  const failureTitle = latestVisionFailureReason
+                    ? failureTitleMap[latestVisionFailureReason] ||
+                      'The vision provider failed for this turn.'
+                    : 'Screen vision did not return a result for this turn.';
+                  const providerLabel = latestVisionProviderUsed
+                    ? `Vision: ${latestVisionProviderUsed}`
+                    : 'Vision input used';
+                  const providerTitle =
+                    latestVisionProviderUsed && latestVisionModelUsed
+                      ? `Latest answer used ${latestVisionProviderUsed} (${latestVisionModelUsed}) vision on the screenshot`
+                      : latestVisionProviderUsed
+                        ? `Latest answer used ${latestVisionProviderUsed} vision on the screenshot`
+                        : 'The latest answer received direct image input from the attached screen';
+                  return (
+                    <div
+                      className={`${statusPillBaseClass} ${visionFailed ? getStatusToneClass('warn') : visionSucceeded ? getStatusToneClass('ok') : 'overlay-text-primary'}`}
+                      title={
+                        attachedContext.length > 0
+                          ? 'Attached screenshots will be sent to the vision provider when you send this turn'
+                          : visionFailed
+                            ? failureTitle
+                            : visionSucceeded
+                              ? providerTitle
+                              : 'No screen context attached'
+                      }
+                    >
+                      <Monitor className="h-3 w-3 opacity-70" />
+                      <span>
+                        {attachedContext.length > 0
+                          ? `${attachedContext.length} screen attached`
+                          : visionFailed
+                            ? failureLabel
+                            : visionSucceeded
+                              ? providerLabel
+                              : 'No screen context'}
+                      </span>
+                    </div>
+                  );
+                })()}
+                <div
+                  className={`${statusPillBaseClass} overlay-text-primary`}
+                  title={`${llmPrivacyLabel}: ${llmProviderLabel}`}
+                >
+                  <ShieldCheck className="h-3 w-3 opacity-70" />
+                  <span>{llmPrivacyLabel}</span>
+                </div>
+              </div>
+
+              {/* System Audio / Screen Recording Warning Banner */}
+              {systemAudioWarning && (
+                <div className="flex items-center justify-between mx-4 mt-3 mb-1 px-3.5 py-2.5 bg-yellow-500/10 border border-yellow-500/20 rounded-[12px] shadow-sm relative no-drag group/warning">
+                  <div className="flex flex-col gap-1 pr-3">
+                    <div className="flex items-center gap-2 text-[12.5px] text-yellow-600 dark:text-yellow-400/90 font-medium leading-tight">
+                      <div className="shrink-0 p-1 bg-yellow-500/20 rounded-full">
+                        <svg
+                          className="w-3.5 h-3.5 text-yellow-600 dark:text-yellow-400"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
                         >
-                            {isGlassTheme && <GlassEffectLayer parentRef={shellRef} cornerRadius={24} />}
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2.5}
+                            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                          />
+                        </svg>
+                      </div>
+                      <span>
+                        {systemAudioWarning.kind === 'screen-recording-permission'
+                          ? 'Screen Recording Permission Denied'
+                          : 'Audio Capture Issue'}
+                      </span>
+                    </div>
+                    <p className="text-[11px] text-yellow-600/70 dark:text-yellow-400/60 leading-snug pl-[26px]">
+                      {systemAudioWarning.message}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    {systemAudioWarning.kind === 'screen-recording-permission' ? (
+                      <button
+                        // Defense-in-depth: kind === 'screen-recording-permission'
+                        // is only ever set from a darwin-gated broadcast site
+                        // in main.ts (and the IPC allowlist rejects x-apple
+                        // URLs on non-darwin), but we still guard at call time
+                        // so a future regression in the broadcast layer can't
+                        // produce a no-op or worse on Windows.
+                        onClick={() => {
+                          if (isMac)
+                            window.electronAPI.openExternal(
+                              'x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture',
+                            );
+                        }}
+                        className="px-3 py-1.5 rounded-lg bg-yellow-500/15 hover:bg-yellow-500/25 text-yellow-700 dark:text-yellow-500 text-[11px] font-semibold transition-all active:scale-95 border border-yellow-500/20 shadow-sm"
+                      >
+                        Open Settings
+                      </button>
+                    ) : (
+                      <button
+                        onClick={() => {
+                          window.electronAPI?.toggleSettingsWindow?.();
+                        }}
+                        className="px-3 py-1.5 rounded-lg bg-yellow-500/15 hover:bg-yellow-500/25 text-yellow-700 dark:text-yellow-500 text-[11px] font-semibold transition-all active:scale-95 border border-yellow-500/20 shadow-sm"
+                      >
+                        Open Settings
+                      </button>
+                    )}
+                    <button
+                      onClick={() => setSystemAudioWarning(null)}
+                      className="p-1.5 rounded-full hover:bg-black/5 dark:hover:bg-white/10 text-yellow-600/50 hover:text-yellow-700 dark:text-yellow-500/50 dark:hover:text-yellow-400 transition-colors absolute top-1 right-1 opacity-0 group-hover/warning:opacity-100"
+                      title="Dismiss"
+                    >
+                      <X className="w-3 h-3" />
+                    </button>
+                  </div>
+                </div>
+              )}
 
-                            <div className="relative no-drag flex flex-wrap items-center justify-center gap-1.5 px-4 pt-3 pb-1">
-                                <div className={`${statusPillBaseClass} overlay-text-primary`} title={activeModeLabel ? `Active mode: ${activeModeLabel}` : 'No active mode selected'}>
-                                    <LayoutGrid className="h-3 w-3 opacity-70" />
-                                    <span>{activeModeLabel ? `Mode: ${activeModeLabel}` : 'General mode'}</span>
-                                </div>
-                                <div className={`${statusPillBaseClass} ${getStatusToneClass(sttSummary.tone)}`} title={sttSummary.detail}>
-                                    <Mic className="h-3 w-3 opacity-70" />
-                                    <span>{sttSummary.label}</span>
-                                </div>
-                                {(() => {
-                                    // Vision-first status chip. Order of preference for what to show:
-                                    //   1. attached screenshots queued for this turn
-                                    //   2. failure from the last vision call (reason-aware)
-                                    //   3. success from the last vision call (provider/model surfaced)
-                                    //   4. legacy ocr-available fallback (only fires if a legacy mode is re-enabled)
-                                    //   5. nothing-yet placeholder
-                                    const visionFailed = screenContextStatus === 'failed' || !!latestVisionFailureReason;
-                                    const visionSucceeded = (latestUsedImageInput || screenContextStatus === 'available') && !visionFailed;
-                                    const failureLabelMap: Record<string, string> = {
-                                        no_vision_provider: 'No vision provider',
-                                        all_vision_failed: 'Vision failed',
-                                        privacy_blocked: 'Private mode blocked vision',
-                                        scope_blocked: 'Screenshots disabled',
-                                        provider_timeout: 'Vision timed out',
-                                    };
-                                    const failureLabel = latestVisionFailureReason ? (failureLabelMap[latestVisionFailureReason] || 'Vision failed') : 'Vision failed';
-                                    const failureTitleMap: Record<string, string> = {
-                                        no_vision_provider: 'No vision-capable provider is configured. Add a Natively, OpenAI, Claude, Gemini, or Groq key — or configure a local Ollama vision model.',
-                                        all_vision_failed: 'All configured vision providers failed for this turn. Check provider quotas and try again.',
-                                        privacy_blocked: 'Private vision mode blocked cloud vision providers; no local vision provider is configured.',
-                                        scope_blocked: 'Screenshots are disabled for the current provider. Enable the screenshots scope in Settings.',
-                                        provider_timeout: 'Vision provider exceeded its per-call timeout; the chain moved on to the next provider.',
-                                    };
-                                    const failureTitle = latestVisionFailureReason ? (failureTitleMap[latestVisionFailureReason] || 'The vision provider failed for this turn.') : 'Screen vision did not return a result for this turn.';
-                                    const providerLabel = latestVisionProviderUsed
-                                        ? `Vision: ${latestVisionProviderUsed}`
-                                        : 'Vision input used';
-                                    const providerTitle = latestVisionProviderUsed && latestVisionModelUsed
-                                        ? `Latest answer used ${latestVisionProviderUsed} (${latestVisionModelUsed}) vision on the screenshot`
-                                        : latestVisionProviderUsed
-                                            ? `Latest answer used ${latestVisionProviderUsed} vision on the screenshot`
-                                            : 'The latest answer received direct image input from the attached screen';
-                                    return (
-                                        <div className={`${statusPillBaseClass} ${visionFailed ? getStatusToneClass('warn') : visionSucceeded ? getStatusToneClass('ok') : 'overlay-text-primary'}`} title={attachedContext.length > 0 ? 'Attached screenshots will be sent to the vision provider when you send this turn' : visionFailed ? failureTitle : visionSucceeded ? providerTitle : 'No screen context attached'}>
-                                            <Monitor className="h-3 w-3 opacity-70" />
-                                            <span>{attachedContext.length > 0 ? `${attachedContext.length} screen attached` : visionFailed ? failureLabel : visionSucceeded ? providerLabel : 'No screen context'}</span>
-                                        </div>
-                                    );
-                                })()}
-                                <div className={`${statusPillBaseClass} overlay-text-primary`} title={`${llmPrivacyLabel}: ${llmProviderLabel}`}>
-                                    <ShieldCheck className="h-3 w-3 opacity-70" />
-                                    <span>{llmPrivacyLabel}</span>
-                                </div>
-                            </div>
+              {/* PR #173: STT Not Configured Warning Banner */}
+              {sttNotConfigured && (
+                <div className="flex items-center justify-between mx-4 mt-3 mb-1 px-3.5 py-2.5 bg-orange-500/10 border border-orange-500/20 rounded-[12px] shadow-sm relative no-drag group/stt-warning">
+                  <div className="flex flex-col gap-1 pr-3">
+                    <div className="flex items-center gap-2 text-[12.5px] text-orange-600 dark:text-orange-400/90 font-medium leading-tight">
+                      <div className="shrink-0 p-1 bg-orange-500/20 rounded-full">
+                        <svg
+                          className="w-3.5 h-3.5 text-orange-600 dark:text-orange-400"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2.5}
+                            d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z"
+                          />
+                        </svg>
+                      </div>
+                      <span>Transcription Not Configured</span>
+                    </div>
+                    <p className="text-[11px] text-orange-600/70 dark:text-orange-400/60 leading-snug pl-[26px]">
+                      No STT provider selected. Open Settings → Audio to pick one.
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <button
+                      onClick={() => {
+                        window.electronAPI?.toggleSettingsWindow?.();
+                      }}
+                      className="px-3 py-1.5 rounded-lg bg-orange-500/15 hover:bg-orange-500/25 text-orange-700 dark:text-orange-500 text-[11px] font-semibold transition-all active:scale-95 border border-orange-500/20 shadow-sm"
+                    >
+                      Open Settings
+                    </button>
+                    <button
+                      onClick={() => setSttNotConfigured(false)}
+                      className="p-1.5 rounded-full hover:bg-black/5 dark:hover:bg-white/10 text-orange-600/50 hover:text-orange-700 dark:text-orange-500/50 dark:hover:text-orange-400 transition-colors absolute top-1 right-1 opacity-0 group-hover/stt-warning:opacity-100"
+                      title="Dismiss"
+                    >
+                      <X className="w-3 h-3" />
+                    </button>
+                  </div>
+                </div>
+              )}
 
-                            {/* System Audio / Screen Recording Warning Banner */}
-                            {systemAudioWarning && (
-                                <div className="flex items-center justify-between mx-4 mt-3 mb-1 px-3.5 py-2.5 bg-yellow-500/10 border border-yellow-500/20 rounded-[12px] shadow-sm relative no-drag group/warning">
-                                    <div className="flex flex-col gap-1 pr-3">
-                                        <div className="flex items-center gap-2 text-[12.5px] text-yellow-600 dark:text-yellow-400/90 font-medium leading-tight">
-                                            <div className="shrink-0 p-1 bg-yellow-500/20 rounded-full">
-                                                <svg className="w-3.5 h-3.5 text-yellow-600 dark:text-yellow-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-                                                </svg>
-                                            </div>
-                                            <span>
-                                                {systemAudioWarning.kind === 'screen-recording-permission'
-                                                    ? 'Screen Recording Permission Denied'
-                                                    : 'Audio Capture Issue'}
-                                            </span>
-                                        </div>
-                                        <p className="text-[11px] text-yellow-600/70 dark:text-yellow-400/60 leading-snug pl-[26px]">
-                                            {systemAudioWarning.message}
-                                        </p>
-                                    </div>
-                                    <div className="flex items-center gap-2 shrink-0">
-                                        {systemAudioWarning.kind === 'screen-recording-permission' ? (
-                                            <button
-                                                // Defense-in-depth: kind === 'screen-recording-permission'
-                                                // is only ever set from a darwin-gated broadcast site
-                                                // in main.ts (and the IPC allowlist rejects x-apple
-                                                // URLs on non-darwin), but we still guard at call time
-                                                // so a future regression in the broadcast layer can't
-                                                // produce a no-op or worse on Windows.
-                                                onClick={() => { if (isMac) window.electronAPI.openExternal('x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture'); }}
-                                                className="px-3 py-1.5 rounded-lg bg-yellow-500/15 hover:bg-yellow-500/25 text-yellow-700 dark:text-yellow-500 text-[11px] font-semibold transition-all active:scale-95 border border-yellow-500/20 shadow-sm"
-                                            >
-                                                Open Settings
-                                            </button>
-                                        ) : (
-                                            <button
-                                                onClick={() => { window.electronAPI?.toggleSettingsWindow?.(); }}
-                                                className="px-3 py-1.5 rounded-lg bg-yellow-500/15 hover:bg-yellow-500/25 text-yellow-700 dark:text-yellow-500 text-[11px] font-semibold transition-all active:scale-95 border border-yellow-500/20 shadow-sm"
-                                            >
-                                                Open Settings
-                                            </button>
-                                        )}
-                                        <button
-                                            onClick={() => setSystemAudioWarning(null)}
-                                            className="p-1.5 rounded-full hover:bg-black/5 dark:hover:bg-white/10 text-yellow-600/50 hover:text-yellow-700 dark:text-yellow-500/50 dark:hover:text-yellow-400 transition-colors absolute top-1 right-1 opacity-0 group-hover/warning:opacity-100"
-                                            title="Dismiss"
-                                        >
-                                            <X className="w-3 h-3" />
-                                        </button>
-                                    </div>
-                                </div>
-                            )}
-
-                            {/* PR #173: STT Not Configured Warning Banner */}
-                            {sttNotConfigured && (
-                                <div className="flex items-center justify-between mx-4 mt-3 mb-1 px-3.5 py-2.5 bg-orange-500/10 border border-orange-500/20 rounded-[12px] shadow-sm relative no-drag group/stt-warning">
-                                    <div className="flex flex-col gap-1 pr-3">
-                                        <div className="flex items-center gap-2 text-[12.5px] text-orange-600 dark:text-orange-400/90 font-medium leading-tight">
-                                            <div className="shrink-0 p-1 bg-orange-500/20 rounded-full">
-                                                <svg className="w-3.5 h-3.5 text-orange-600 dark:text-orange-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z" />
-                                                </svg>
-                                            </div>
-                                            <span>Transcription Not Configured</span>
-                                        </div>
-                                        <p className="text-[11px] text-orange-600/70 dark:text-orange-400/60 leading-snug pl-[26px]">
-                                            No STT provider selected. Open Settings → Audio to pick one.
-                                        </p>
-                                    </div>
-                                    <div className="flex items-center gap-2 shrink-0">
-                                        <button
-                                            onClick={() => { window.electronAPI?.toggleSettingsWindow?.(); }}
-                                            className="px-3 py-1.5 rounded-lg bg-orange-500/15 hover:bg-orange-500/25 text-orange-700 dark:text-orange-500 text-[11px] font-semibold transition-all active:scale-95 border border-orange-500/20 shadow-sm"
-                                        >
-                                            Open Settings
-                                        </button>
-                                        <button
-                                            onClick={() => setSttNotConfigured(false)}
-                                            className="p-1.5 rounded-full hover:bg-black/5 dark:hover:bg-white/10 text-orange-600/50 hover:text-orange-700 dark:text-orange-500/50 dark:hover:text-orange-400 transition-colors absolute top-1 right-1 opacity-0 group-hover/stt-warning:opacity-100"
-                                            title="Dismiss"
-                                        >
-                                            <X className="w-3 h-3" />
-                                        </button>
-                                    </div>
-                                </div>
-                            )}
-
-                            {/* Phase 3 — Dynamic action card row (Cluely-style live triggers).
+              {/* Phase 3 — Dynamic action card row (Cluely-style live triggers).
                                 Appears between status pills and rolling transcript so users see
                                 actionable suggestions in their primary scan path. Bar self-hides
                                 when no actions are present. */}
-                            <DynamicActionBar
-                                onAcceptAction={(action: DynamicActionPayload) => {
-                                    void handleWhatToSay(action.promptInstruction);
-                                }}
-                            />
+              <DynamicActionBar
+                onAcceptAction={(action: DynamicActionPayload) => {
+                  void handleWhatToSay(action.promptInstruction);
+                }}
+              />
 
-                            {/* Rolling Transcript Bar — includes STT status indicator inline */}
-                            {(showTranscript && rollingTranscript) || interviewerSttIndicatorStatus !== 'connected' || sttUserStatus !== 'connected' ? (
-                                <RollingTranscript
-                                    text={showTranscript ? rollingTranscript : ''}
-                                    isActive={isInterviewerSpeaking}
-                                    surfaceStyle={showTranscript ? appearance.transcriptStyle : undefined}
-                                    interviewerChannel={{
-                                        status: interviewerSttIndicatorStatus,
-                                        error: interviewerSttIndicatorError,
-                                        provider: sttInterviewerProvider,
-                                    }}
-                                    microphoneChannel={{
-                                        status: sttUserStatus,
-                                        error: sttUserError,
-                                        provider: sttUserProvider,
-                                    }}
-                                    onCopyDiagnostics={copyDiagnostics}
-                                />
-                            ) : null}
+              {/* Rolling Transcript Bar — includes STT status indicator inline */}
+              {(showTranscript && rollingTranscript) ||
+              interviewerSttIndicatorStatus !== 'connected' ||
+              sttUserStatus !== 'connected' ? (
+                <RollingTranscript
+                  text={showTranscript ? rollingTranscript : ''}
+                  isActive={isInterviewerSpeaking}
+                  surfaceStyle={showTranscript ? appearance.transcriptStyle : undefined}
+                  interviewerChannel={{
+                    status: interviewerSttIndicatorStatus,
+                    error: interviewerSttIndicatorError,
+                    provider: sttInterviewerProvider,
+                  }}
+                  microphoneChannel={{
+                    status: sttUserStatus,
+                    error: sttUserError,
+                    provider: sttUserProvider,
+                  }}
+                  onCopyDiagnostics={copyDiagnostics}
+                />
+              ) : null}
 
-                            {/* Chat History - Only show if there are messages OR active states */}
-                            {(messages.length > 0 || isManualRecording || isProcessing) && (
-                                <motion.div ref={scrollContainerRef} className="flex-1 overflow-y-auto p-4 space-y-3 no-drag" style={{ scrollbarWidth: 'none', maxHeight: scrollMaxH }}>
-                                    {/* Every row spans the full inner width of the scroll
+              {/* Chat History - Only show if there are messages OR active states */}
+              {(messages.length > 0 || isManualRecording || isProcessing) && (
+                <motion.div
+                  ref={scrollContainerRef}
+                  className="flex-1 overflow-y-auto p-4 space-y-3 no-drag"
+                  style={{ scrollbarWidth: 'none', maxHeight: scrollMaxH }}
+                >
+                  {/* Every row spans the full inner width of the scroll
                                         container, which itself rides the shell's animated
                                         width. Bubble max-widths are percentages so the text
                                         and code grow with the canvas — same as iMessage /
@@ -3315,183 +3854,252 @@ Provide only the answer, nothing else.`;
                                         so a setMessages on the streaming row does NOT
                                         re-render every prior message — bailout fires on
                                         identity equality (msg, theme, callbacks). */}
-                                    {messages.map((msg) => (
-                                        <MessageRow
-                                            key={msg.id}
-                                            msg={msg}
-                                            isLightTheme={isLightTheme}
-                                            appearance={appearance}
-                                            onCopy={handleCopy}
-                                            renderMessageText={renderMessageText}
-                                        />
-                                    ))}
+                  {messages.map((msg) => (
+                    <MessageRow
+                      key={msg.id}
+                      msg={msg}
+                      isLightTheme={isLightTheme}
+                      appearance={appearance}
+                      onCopy={handleCopy}
+                      renderMessageText={renderMessageText}
+                    />
+                  ))}
 
-                                    {/* Active Recording State with Live Transcription */}
-                                    {isManualRecording && (
-                                        <div className="flex flex-col items-end gap-1 animate-in fade-in slide-in-from-bottom-2 duration-300">
-                                            {/* Live transcription preview */}
-                                            {(manualTranscript || voiceInput) && (
-                                                <div className="max-w-[85%] px-3.5 py-2.5 bg-emerald-500/10 border border-emerald-500/20 rounded-[18px] rounded-tr-[4px]">
-                                                    <span className="text-[13px] text-emerald-300">
-                                                        {voiceInput}{voiceInput && manualTranscript ? ' ' : ''}{manualTranscript}
-                                                    </span>
-                                                </div>
-                                            )}
-                                            <div className="px-3 py-2 flex gap-1.5 items-center bg-emerald-500/10 border border-emerald-500/20 rounded-full">
-                                                <div className="w-2 h-2 bg-emerald-400 rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
-                                                <div className="w-2 h-2 bg-emerald-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
-                                                <div className="w-2 h-2 bg-emerald-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
-                                                <span className="text-[10px] text-emerald-400/70 ml-1">Listening...</span>
-                                            </div>
-                                        </div>
-                                    )}
+                  {/* Active Recording State with Live Transcription */}
+                  {isManualRecording && (
+                    <div className="flex flex-col items-end gap-1 animate-in fade-in slide-in-from-bottom-2 duration-300">
+                      {/* Live transcription preview */}
+                      {(manualTranscript || voiceInput) && (
+                        <div className="max-w-[85%] px-3.5 py-2.5 bg-emerald-500/10 border border-emerald-500/20 rounded-[18px] rounded-tr-[4px]">
+                          <span className="text-[13px] text-emerald-300">
+                            {voiceInput}
+                            {voiceInput && manualTranscript ? ' ' : ''}
+                            {manualTranscript}
+                          </span>
+                        </div>
+                      )}
+                      <div className="px-3 py-2 flex gap-1.5 items-center bg-emerald-500/10 border border-emerald-500/20 rounded-full">
+                        <div
+                          className="w-2 h-2 bg-emerald-400 rounded-full animate-bounce"
+                          style={{ animationDelay: '0ms' }}
+                        />
+                        <div
+                          className="w-2 h-2 bg-emerald-400 rounded-full animate-bounce"
+                          style={{ animationDelay: '150ms' }}
+                        />
+                        <div
+                          className="w-2 h-2 bg-emerald-400 rounded-full animate-bounce"
+                          style={{ animationDelay: '300ms' }}
+                        />
+                        <span className="text-[10px] text-emerald-400/70 ml-1">Listening...</span>
+                      </div>
+                    </div>
+                  )}
 
-                                    {isProcessing && (
-                                        <div className="flex justify-start">
-                                            <div className="px-3 py-2 flex gap-1.5 overlay-subtle-surface rounded-full border" style={appearance.subtleStyle}>
-                                                <div className="w-2 h-2 bg-slate-400 rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
-                                                <div className="w-2 h-2 bg-slate-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
-                                                <div className="w-2 h-2 bg-slate-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
-                                            </div>
-                                        </div>
-                                    )}
-                                    <div ref={messagesEndRef} />
-                                </motion.div>
-                            )}
+                  {isProcessing && (
+                    <div className="flex justify-start">
+                      <div
+                        className="px-3 py-2 flex gap-1.5 overlay-subtle-surface rounded-full border"
+                        style={appearance.subtleStyle}
+                      >
+                        <div
+                          className="w-2 h-2 bg-slate-400 rounded-full animate-bounce"
+                          style={{ animationDelay: '0ms' }}
+                        />
+                        <div
+                          className="w-2 h-2 bg-slate-400 rounded-full animate-bounce"
+                          style={{ animationDelay: '150ms' }}
+                        />
+                        <div
+                          className="w-2 h-2 bg-slate-400 rounded-full animate-bounce"
+                          style={{ animationDelay: '300ms' }}
+                        />
+                      </div>
+                    </div>
+                  )}
+                  <div ref={messagesEndRef} />
+                </motion.div>
+              )}
 
-                            {/* Quick Actions - Minimal & Clean */}
-                            <div className={`flex flex-nowrap justify-center items-center gap-1.5 px-4 pb-3 overflow-x-hidden ${rollingTranscript && showTranscript ? 'pt-1' : 'pt-3'}`}>
-                                <button onClick={handleWhatToSay} className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[11px] font-medium border transition-all active:scale-95 duration-200 interaction-base interaction-press whitespace-nowrap shrink-0 ${quickActionClass}`} style={appearance.chipStyle}>
-                                    <Pencil className="w-3 h-3 opacity-70" /> What to answer?
-                                </button>
-                                <button onClick={handleClarify} className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[11px] font-medium border transition-all active:scale-95 duration-200 interaction-base interaction-press whitespace-nowrap shrink-0 ${quickActionClass}`} style={appearance.chipStyle}>
-                                    <MessageSquare className="w-3 h-3 opacity-70" /> Clarify
-                                </button>
-                                <button onClick={actionButtonMode === 'brainstorm' ? handleBrainstorm : handleRecap} className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[11px] font-medium border transition-all active:scale-95 duration-200 interaction-base interaction-press whitespace-nowrap shrink-0 ${quickActionClass}`} style={appearance.chipStyle}>
-                                    {actionButtonMode === 'brainstorm'
-                                        ? <><Lightbulb className="w-3 h-3 opacity-70" /> Brainstorm</>
-                                        : <><RefreshCw className="w-3 h-3 opacity-70" /> Recap</>
-                                    }
-                                </button>
-                                <button onClick={handleFollowUpQuestions} className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[11px] font-medium border transition-all active:scale-95 duration-200 interaction-base interaction-press whitespace-nowrap shrink-0 ${quickActionClass}`} style={appearance.chipStyle}>
-                                    <HelpCircle className="w-3 h-3 opacity-70" /> Follow Up Question
-                                </button>
-                                <button
-                                    onClick={handleAnswerNow}
-                                    className={`flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-full text-[11px] font-medium transition-all active:scale-95 duration-200 interaction-base interaction-press min-w-[74px] whitespace-nowrap shrink-0 ${isManualRecording
-                                        ? 'bg-red-500/10 text-red-400 ring-1 ring-red-500/20'
-                                        : 'overlay-chip-surface overlay-text-interactive'
-                                        }`}
-                                    style={isManualRecording ? undefined : appearance.chipStyle}
-                                >
-                                    {isManualRecording ? (
-                                        <>
-                                            <div className="w-1.5 h-1.5 rounded-full bg-red-400 animate-pulse" />
-                                            Stop
-                                        </>
-                                    ) : (
-                                        <><Zap className="w-3 h-3 opacity-70" /> Answer</>
-                                    )}
-                                </button>
-                            </div>
+              {/* Quick Actions - Minimal & Clean */}
+              <div
+                className={`flex flex-nowrap justify-center items-center gap-1.5 px-4 pb-3 overflow-x-hidden ${rollingTranscript && showTranscript ? 'pt-1' : 'pt-3'}`}
+              >
+                <button
+                  onClick={handleWhatToSay}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[11px] font-medium border transition-all active:scale-95 duration-200 interaction-base interaction-press whitespace-nowrap shrink-0 ${quickActionClass}`}
+                  style={appearance.chipStyle}
+                >
+                  <Pencil className="w-3 h-3 opacity-70" /> What to answer?
+                </button>
+                <button
+                  onClick={handleClarify}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[11px] font-medium border transition-all active:scale-95 duration-200 interaction-base interaction-press whitespace-nowrap shrink-0 ${quickActionClass}`}
+                  style={appearance.chipStyle}
+                >
+                  <MessageSquare className="w-3 h-3 opacity-70" /> Clarify
+                </button>
+                <button
+                  onClick={actionButtonMode === 'brainstorm' ? handleBrainstorm : handleRecap}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[11px] font-medium border transition-all active:scale-95 duration-200 interaction-base interaction-press whitespace-nowrap shrink-0 ${quickActionClass}`}
+                  style={appearance.chipStyle}
+                >
+                  {actionButtonMode === 'brainstorm' ? (
+                    <>
+                      <Lightbulb className="w-3 h-3 opacity-70" /> Brainstorm
+                    </>
+                  ) : (
+                    <>
+                      <RefreshCw className="w-3 h-3 opacity-70" /> Recap
+                    </>
+                  )}
+                </button>
+                <button
+                  onClick={handleFollowUpQuestions}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[11px] font-medium border transition-all active:scale-95 duration-200 interaction-base interaction-press whitespace-nowrap shrink-0 ${quickActionClass}`}
+                  style={appearance.chipStyle}
+                >
+                  <HelpCircle className="w-3 h-3 opacity-70" /> Follow Up Question
+                </button>
+                <button
+                  onClick={handleAnswerNow}
+                  className={`flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-full text-[11px] font-medium transition-all active:scale-95 duration-200 interaction-base interaction-press min-w-[74px] whitespace-nowrap shrink-0 ${
+                    isManualRecording
+                      ? 'bg-red-500/10 text-red-400 ring-1 ring-red-500/20'
+                      : 'overlay-chip-surface overlay-text-interactive'
+                  }`}
+                  style={isManualRecording ? undefined : appearance.chipStyle}
+                >
+                  {isManualRecording ? (
+                    <>
+                      <div className="w-1.5 h-1.5 rounded-full bg-red-400 animate-pulse" />
+                      Stop
+                    </>
+                  ) : (
+                    <>
+                      <Zap className="w-3 h-3 opacity-70" /> Answer
+                    </>
+                  )}
+                </button>
+              </div>
 
-                            {/* Input Area */}
-                            <div className="p-3 pt-0">
-                                {/* Latent Context Preview (Attached Screenshot) */}
-                                {attachedContext.length > 0 && (
-                                    <div className={`mb-2 rounded-lg p-2 transition-all duration-200 border ${subtleSurfaceClass}`} style={appearance.subtleStyle}>
-                                        <div className="flex items-center justify-between mb-1.5">
-                                            <span className="text-[11px] font-medium overlay-text-primary">
-                                                {attachedContext.length} screenshot{attachedContext.length > 1 ? 's' : ''} attached
-                                            </span>
-                                            <button
-                                                onClick={() => setAttachedContext([])}
-                                                className="p-1 rounded-full transition-colors overlay-icon-surface overlay-icon-surface-hover overlay-text-interactive"
-                                                title="Remove all"
-                                                style={appearance.iconStyle}
-                                            >
-                                                <X className="w-3.5 h-3.5" />
-                                            </button>
-                                        </div>
-                                        <div className="flex gap-1.5 overflow-x-auto max-w-full pb-1">
-                                            {attachedContext.map((ctx, idx) => (
-                                                <div key={ctx.path} className="relative group/thumb flex-shrink-0">
-                                                    <img
-                                                        src={ctx.preview}
-                                                        alt={`Screenshot ${idx + 1}`}
-                                                        className={`h-10 w-auto rounded border ${isLightTheme ? 'border-black/15' : 'border-white/20'}`}
-                                                    />
-                                                    <button
-                                                        onClick={() => setAttachedContext(prev => prev.filter((_, i) => i !== idx))}
-                                                        className="absolute -top-1 -right-1 w-4 h-4 bg-red-500/80 hover:bg-red-500 rounded-full flex items-center justify-center opacity-0 group-hover/thumb:opacity-100 transition-opacity"
-                                                        title="Remove"
-                                                    >
-                                                        <X className="w-2.5 h-2.5 text-white" />
-                                                    </button>
-                                                </div>
-                                            ))}
-                                        </div>
-                                        <span className="text-[10px] overlay-text-muted">Ask a question or click Answer</span>
-                                    </div>
-                                )}
+              {/* Input Area */}
+              <div className="p-3 pt-0">
+                {/* Latent Context Preview (Attached Screenshot) */}
+                {attachedContext.length > 0 && (
+                  <div
+                    className={`mb-2 rounded-lg p-2 transition-all duration-200 border ${subtleSurfaceClass}`}
+                    style={appearance.subtleStyle}
+                  >
+                    <div className="flex items-center justify-between mb-1.5">
+                      <span className="text-[11px] font-medium overlay-text-primary">
+                        {attachedContext.length} screenshot{attachedContext.length > 1 ? 's' : ''}{' '}
+                        attached
+                      </span>
+                      <button
+                        onClick={() => setAttachedContext([])}
+                        className="p-1 rounded-full transition-colors overlay-icon-surface overlay-icon-surface-hover overlay-text-interactive"
+                        title="Remove all"
+                        style={appearance.iconStyle}
+                      >
+                        <X className="w-3.5 h-3.5" />
+                      </button>
+                    </div>
+                    <div className="flex gap-1.5 overflow-x-auto max-w-full pb-1">
+                      {attachedContext.map((ctx, idx) => (
+                        <div key={ctx.path} className="relative group/thumb flex-shrink-0">
+                          <img
+                            src={ctx.preview}
+                            alt={`Screenshot ${idx + 1}`}
+                            className={`h-10 w-auto rounded border ${isLightTheme ? 'border-black/15' : 'border-white/20'}`}
+                          />
+                          <button
+                            onClick={() =>
+                              setAttachedContext((prev) => prev.filter((_, i) => i !== idx))
+                            }
+                            className="absolute -top-1 -right-1 w-4 h-4 bg-red-500/80 hover:bg-red-500 rounded-full flex items-center justify-center opacity-0 group-hover/thumb:opacity-100 transition-opacity"
+                            title="Remove"
+                          >
+                            <X className="w-2.5 h-2.5 text-white" />
+                          </button>
+                        </div>
+                      ))}
+                    </div>
+                    <span className="text-[10px] overlay-text-muted">
+                      Ask a question or click Answer
+                    </span>
+                  </div>
+                )}
 
-                                {/* Stealth hotkey conflict banner — shown if globalShortcut.register()
+                {/* Stealth hotkey conflict banner — shown if globalShortcut.register()
                                     failed for chat:focusInput (typically because the configured
                                     activation hotkey is already claimed by another app or by the
                                     OS). Click-to-activate still works (mousedown listener is
                                     independent of the hotkey), but the user can rebind in Settings. */}
-                                {stealthHotkeyConflict && (
-                                    <div className="mb-2 px-3 py-2 rounded-xl border border-rose-400/40 bg-rose-500/10 text-[11px] flex items-center gap-2"
-                                         data-stealth-ignore="true">
-                                        <span className="overlay-text-primary flex-1">
-                                            Stealth typing hotkey <kbd className="px-1 py-0.5 rounded bg-white/10 font-mono text-[10px]">{stealthHotkeyConflict}</kbd> is already in use. Click the input to activate, or rebind in Settings.
-                                        </span>
-                                        <button
-                                            onClick={() => window.electronAPI.openSettingsTab('keybinds')}
-                                            className="px-2 py-1 rounded-md bg-rose-500/20 hover:bg-rose-500/30 transition-colors text-[11px] font-medium overlay-text-primary whitespace-nowrap"
-                                            data-stealth-ignore="true"
-                                        >
-                                            Rebind
-                                        </button>
-                                        <button
-                                            onClick={() => setStealthHotkeyConflict(null)}
-                                            className="px-1.5 py-1 rounded-md hover:bg-white/10 transition-colors text-[11px] overlay-text-muted"
-                                            aria-label="Dismiss"
-                                            data-stealth-ignore="true"
-                                        >×</button>
-                                    </div>
-                                )}
+                {stealthHotkeyConflict && (
+                  <div
+                    className="mb-2 px-3 py-2 rounded-xl border border-rose-400/40 bg-rose-500/10 text-[11px] flex items-center gap-2"
+                    data-stealth-ignore="true"
+                  >
+                    <span className="overlay-text-primary flex-1">
+                      Stealth typing hotkey{' '}
+                      <kbd className="px-1 py-0.5 rounded bg-white/10 font-mono text-[10px]">
+                        {stealthHotkeyConflict}
+                      </kbd>{' '}
+                      is already in use. Click the input to activate, or rebind in Settings.
+                    </span>
+                    <button
+                      onClick={() => window.electronAPI.openSettingsTab('keybinds')}
+                      className="px-2 py-1 rounded-md bg-rose-500/20 hover:bg-rose-500/30 transition-colors text-[11px] font-medium overlay-text-primary whitespace-nowrap"
+                      data-stealth-ignore="true"
+                    >
+                      Rebind
+                    </button>
+                    <button
+                      onClick={() => setStealthHotkeyConflict(null)}
+                      className="px-1.5 py-1 rounded-md hover:bg-white/10 transition-colors text-[11px] overlay-text-muted"
+                      aria-label="Dismiss"
+                      data-stealth-ignore="true"
+                    >
+                      ×
+                    </button>
+                  </div>
+                )}
 
-                                {/* Stealth tap permission banner — shown only when the user
+                {/* Stealth tap permission banner — shown only when the user
                                     pressed the activation hotkey but Accessibility wasn't
                                     granted. macOS-only: Accessibility is a TCC concept that
                                     doesn't exist on Windows, and the underlying CGEventTap
                                     Rust module ships only in the Darwin binary. Gating here
                                     is belt-and-suspenders on top of the native-side gate. */}
-                                {isMac && stealthPermissionMissing && (
-                                    <div className="mb-2 px-3 py-2 rounded-xl border border-amber-400/40 bg-amber-500/10 text-[11px] flex items-center gap-2"
-                                         data-stealth-ignore="true">
-                                        <span className="overlay-text-primary flex-1">
-                                            Stealth typing needs Accessibility access.
-                                            Grant it in System Settings, then restart Natively.
-                                        </span>
-                                        <button
-                                            onClick={() => window.electronAPI.stealthTapOpenSettings()}
-                                            className="px-2 py-1 rounded-md bg-amber-500/20 hover:bg-amber-500/30 transition-colors text-[11px] font-medium overlay-text-primary whitespace-nowrap"
-                                            data-stealth-ignore="true"
-                                        >
-                                            Open Settings
-                                        </button>
-                                        <button
-                                            onClick={() => setStealthPermissionMissing(false)}
-                                            className="px-1.5 py-1 rounded-md hover:bg-white/10 transition-colors text-[11px] overlay-text-muted"
-                                            aria-label="Dismiss"
-                                            data-stealth-ignore="true"
-                                        >×</button>
-                                    </div>
-                                )}
+                {isMac && stealthPermissionMissing && (
+                  <div
+                    className="mb-2 px-3 py-2 rounded-xl border border-amber-400/40 bg-amber-500/10 text-[11px] flex items-center gap-2"
+                    data-stealth-ignore="true"
+                  >
+                    <span className="overlay-text-primary flex-1">
+                      Stealth typing needs Accessibility access. Grant it in System Settings, then
+                      restart Natively.
+                    </span>
+                    <button
+                      onClick={() => window.electronAPI.stealthTapOpenSettings()}
+                      className="px-2 py-1 rounded-md bg-amber-500/20 hover:bg-amber-500/30 transition-colors text-[11px] font-medium overlay-text-primary whitespace-nowrap"
+                      data-stealth-ignore="true"
+                    >
+                      Open Settings
+                    </button>
+                    <button
+                      onClick={() => setStealthPermissionMissing(false)}
+                      className="px-1.5 py-1 rounded-md hover:bg-white/10 transition-colors text-[11px] overlay-text-muted"
+                      aria-label="Dismiss"
+                      data-stealth-ignore="true"
+                    >
+                      ×
+                    </button>
+                  </div>
+                )}
 
-                                {/* data-stealth-engage marks this subtree as
+                {/* data-stealth-engage marks this subtree as
                                     the ONLY clickable region that engages the
                                     CGEventTap. See the click-to-activate
                                     useEffect (~line 2840) for the opt-IN
@@ -3499,180 +4107,187 @@ Provide only the answer, nothing else.`;
                                     overlay no longer accidentally engage the
                                     tap and break inputs in Settings/Model
                                     Selector windows. */}
-                                <div className="relative group" data-stealth-engage="true">
-                                    <input
-                                        ref={textInputRef}
-                                        type="text"
-                                        value={inputValue}
-                                        onChange={(e) => setInputValue(e.target.value)}
-                                        onKeyDown={(e) => e.key === 'Enter' && handleManualSubmit()}
-                                        // Block native DOM focus on click — the panel becoming
-                                        // key window is exactly the signal coding-interview
-                                        // platforms watch for via window.onblur on the parent.
-                                        // mousedown listener (capture phase) already engaged
-                                        // the CGEventTap, so typing routes through that path.
-                                        onMouseDown={blockInputFocus}
-                                        readOnly={stealthTapActive}
-                                        className={`w-full border focus:ring-1 rounded-xl pl-3 pr-10 py-2.5 focus:outline-none transition-all duration-200 ease-sculpted text-[13px] leading-relaxed ${inputClass} ${stealthTapActive ? 'ring-2 ring-emerald-400/30 border-emerald-400/40 shadow-[0_0_12px_rgba(52,211,153,0.15)]' : ''}`}
-                                        style={appearance.inputStyle}
-                                    />
+                <div className="relative group" data-stealth-engage="true">
+                  <input
+                    ref={textInputRef}
+                    type="text"
+                    value={inputValue}
+                    onChange={(e) => setInputValue(e.target.value)}
+                    onKeyDown={(e) => e.key === 'Enter' && handleManualSubmit()}
+                    // Block native DOM focus on click — the panel becoming
+                    // key window is exactly the signal coding-interview
+                    // platforms watch for via window.onblur on the parent.
+                    // mousedown listener (capture phase) already engaged
+                    // the CGEventTap, so typing routes through that path.
+                    onMouseDown={blockInputFocus}
+                    readOnly={stealthTapActive}
+                    className={`w-full border focus:ring-1 rounded-xl pl-3 pr-10 py-2.5 focus:outline-none transition-all duration-200 ease-sculpted text-[13px] leading-relaxed ${inputClass} ${stealthTapActive ? 'ring-2 ring-emerald-400/30 border-emerald-400/40 shadow-[0_0_12px_rgba(52,211,153,0.15)]' : ''}`}
+                    style={appearance.inputStyle}
+                  />
 
-                                    {/* Custom Rich Placeholder */}
-                                    {!inputValue && (
-                                        <div className="absolute left-3 top-1/2 -translate-y-1/2 flex items-center gap-1.5 pointer-events-none text-[13px] overlay-text-muted">
-                                            <span>Ask anything on screen or conversation, or</span>
-                                            <div className="flex items-center gap-1 opacity-80">
-                                                {(shortcuts.selectiveScreenshot || [getModifierSymbol('cmd'), 'Shift', 'H']).map((key, i) => (
-                                                    <React.Fragment key={i}>
-                                                        {i > 0 && <span className="text-[10px]">+</span>}
-                                                        <kbd className="px-1.5 py-0.5 rounded border text-[10px] font-sans min-w-[20px] text-center overlay-control-surface overlay-text-secondary" style={appearance.controlStyle}>{key}</kbd>
-                                                    </React.Fragment>
-                                                ))}
-                                            </div>
-                                            <span>for selective screenshot</span>
-                                        </div>
-                                    )}
+                  {/* Custom Rich Placeholder */}
+                  {!inputValue && (
+                    <div className="absolute left-3 top-1/2 -translate-y-1/2 flex items-center gap-1.5 pointer-events-none text-[13px] overlay-text-muted">
+                      <span>Ask anything on screen or conversation, or</span>
+                      <div className="flex items-center gap-1 opacity-80">
+                        {(
+                          shortcuts.selectiveScreenshot || [getModifierSymbol('cmd'), 'Shift', 'H']
+                        ).map((key, i) => (
+                          <React.Fragment key={i}>
+                            {i > 0 && <span className="text-[10px]">+</span>}
+                            <kbd
+                              className="px-1.5 py-0.5 rounded border text-[10px] font-sans min-w-[20px] text-center overlay-control-surface overlay-text-secondary"
+                              style={appearance.controlStyle}
+                            >
+                              {key}
+                            </kbd>
+                          </React.Fragment>
+                        ))}
+                      </div>
+                      <span>for selective screenshot</span>
+                    </div>
+                  )}
 
-                                    {!inputValue && (
-                                        <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-1 pointer-events-none opacity-20">
-                                            <span className="text-[10px]">↵</span>
-                                        </div>
-                                    )}
-                                </div>
+                  {!inputValue && (
+                    <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-1 pointer-events-none opacity-20">
+                      <span className="text-[10px]">↵</span>
+                    </div>
+                  )}
+                </div>
 
-                                {/* Bottom Row */}
-                                <div className="flex items-center justify-between mt-3 px-0.5">
-                                    <div className="flex items-center gap-1.5">
-                                        <button
-                                            data-model-selector-toggle="true"
-                                            onClick={(e) => {
-                                                // Calculate position for detached window
-                                                if (!contentRef.current) return;
-                                                const contentRect = contentRef.current.getBoundingClientRect();
-                                                const buttonRect = e.currentTarget.getBoundingClientRect();
-                                                const GAP = 8;
+                {/* Bottom Row */}
+                <div className="flex items-center justify-between mt-3 px-0.5">
+                  <div className="flex items-center gap-1.5">
+                    <button
+                      data-model-selector-toggle="true"
+                      onClick={(e) => {
+                        // Calculate position for detached window
+                        if (!contentRef.current) return;
+                        const contentRect = contentRef.current.getBoundingClientRect();
+                        const buttonRect = e.currentTarget.getBoundingClientRect();
+                        const GAP = 8;
 
-                                                const x = window.screenX + buttonRect.left;
-                                                const y = window.screenY + contentRect.bottom + GAP;
+                        const x = window.screenX + buttonRect.left;
+                        const y = window.screenY + contentRect.bottom + GAP;
 
-                                                window.electronAPI.toggleModelSelector({ x, y });
-                                            }}
-                                            className={`
+                        window.electronAPI.toggleModelSelector({ x, y });
+                      }}
+                      className={`
                                                 flex items-center gap-2 px-3 py-1.5
                                                 border rounded-lg transition-colors
                                                 text-xs font-medium w-[140px]
                                                 interaction-base interaction-press
                                                 ${controlSurfaceClass}
                                             `}
-                                            style={appearance.controlStyle}
-                                        >
-                                            <span className="truncate min-w-0 flex-1">
-                                                {(() => {
-                                                    const m = currentModel;
-                                                    const codexCliName = getCodexCliModelDisplayName(m);
-                                                    if (codexCliName) return codexCliName;
-                                                    if (m.startsWith('ollama-')) return m.replace('ollama-', '');
-                                                    if (m === 'gemini-3.1-flash-lite-preview') return 'Gemini 3.1 Flash';
-                                                    if (m === 'gemini-3.1-pro-preview') return 'Gemini 3.1 Pro';
-                                                    if (m === 'llama-3.3-70b-versatile') return 'Groq Llama 3.3';
-                                                    if (m === 'gpt-5.4') return 'GPT 5.4';
-                                                    if (m === 'claude-sonnet-4-6') return 'Sonnet 4.6';
-                                                    return m;
-                                                })()}
-                                            </span>
-                                            <ChevronDown size={14} className="shrink-0 transition-transform" />
-                                        </button>
+                      style={appearance.controlStyle}
+                    >
+                      <span className="truncate min-w-0 flex-1">
+                        {(() => {
+                          const m = currentModel;
+                          const codexCliName = getCodexCliModelDisplayName(m);
+                          if (codexCliName) return codexCliName;
+                          if (m.startsWith('ollama-')) return m.replace('ollama-', '');
+                          if (m === 'gemini-3.1-flash-lite-preview') return 'Gemini 3.1 Flash';
+                          if (m === 'gemini-3.1-pro-preview') return 'Gemini 3.1 Pro';
+                          if (m === 'llama-3.3-70b-versatile') return 'Groq Llama 3.3';
+                          if (m === 'gpt-5.4') return 'GPT 5.4';
+                          if (m === 'claude-sonnet-4-6') return 'Sonnet 4.6';
+                          return m;
+                        })()}
+                      </span>
+                      <ChevronDown size={14} className="shrink-0 transition-transform" />
+                    </button>
 
-                                        <div className="w-px h-3 mx-1" style={appearance.dividerStyle} />
+                    <div className="w-px h-3 mx-1" style={appearance.dividerStyle} />
 
-                                        <div className="relative">
-                                            <button
-                                                onClick={(e) => {
-                                                    if (isSettingsOpen) {
-                                                        // If open, just close it (toggle will handle logic but we can be explicit or just toggle)
-                                                        // Actually toggle-settings-window handles hiding if visible, so logic is same.
-                                                        window.electronAPI.toggleSettingsWindow();
-                                                        return;
-                                                    }
+                    <div className="relative">
+                      <button
+                        onClick={(e) => {
+                          if (isSettingsOpen) {
+                            // If open, just close it (toggle will handle logic but we can be explicit or just toggle)
+                            // Actually toggle-settings-window handles hiding if visible, so logic is same.
+                            window.electronAPI.toggleSettingsWindow();
+                            return;
+                          }
 
-                                                    if (!contentRef.current) return;
+                          if (!contentRef.current) return;
 
-                                                    const contentRect = contentRef.current.getBoundingClientRect();
-                                                    const buttonRect = e.currentTarget.getBoundingClientRect();
-                                                    const POPUP_WIDTH = 270; // Matches SettingsWindowHelper actual width
-                                                    const GAP = 8; // Same gap as between TopPill and main body (gap-2 = 8px)
+                          const contentRect = contentRef.current.getBoundingClientRect();
+                          const buttonRect = e.currentTarget.getBoundingClientRect();
+                          const POPUP_WIDTH = 270; // Matches SettingsWindowHelper actual width
+                          const GAP = 8; // Same gap as between TopPill and main body (gap-2 = 8px)
 
-                                                    // X: Left-aligned relative to the Settings Button
-                                                    const x = window.screenX + buttonRect.left;
+                          // X: Left-aligned relative to the Settings Button
+                          const x = window.screenX + buttonRect.left;
 
-                                                    // Y: Below the main content + gap
-                                                    const y = window.screenY + contentRect.bottom + GAP;
+                          // Y: Below the main content + gap
+                          const y = window.screenY + contentRect.bottom + GAP;
 
-                                                    window.electronAPI.toggleSettingsWindow({ x, y });
-                                                }}
-                                                className={`
+                          window.electronAPI.toggleSettingsWindow({ x, y });
+                        }}
+                        className={`
                                             w-7 h-7 flex items-center justify-center rounded-lg
                                             interaction-base interaction-press
-                                            ${isSettingsOpen
-                                                        ? 'overlay-icon-surface overlay-icon-surface-hover overlay-text-primary'
-                                                        : 'overlay-icon-surface overlay-icon-surface-hover overlay-text-interactive'}
+                                            ${
+                                              isSettingsOpen
+                                                ? 'overlay-icon-surface overlay-icon-surface-hover overlay-text-primary'
+                                                : 'overlay-icon-surface overlay-icon-surface-hover overlay-text-interactive'
+                                            }
                                         `}
+                        style={appearance.iconStyle}
+                      >
+                        <SlidersHorizontal className="w-3.5 h-3.5" />
+                      </button>
+                    </div>
 
-                                                style={appearance.iconStyle}
-                                            >
-                                                <SlidersHorizontal className="w-3.5 h-3.5" />
-                                            </button>
-                                        </div>
-
-
-
-                                        {/* Mouse Passthrough Toggle */}
-                                        <div className="relative">
-                                            <button
-                                                onClick={() => {
-                                                    const newState = !isMousePassthrough;
-                                                    setIsMousePassthrough(newState);
-                                                    window.electronAPI?.setOverlayMousePassthrough?.(newState);
-                                                }}
-                                                className={`
+                    {/* Mouse Passthrough Toggle */}
+                    <div className="relative">
+                      <button
+                        onClick={() => {
+                          const newState = !isMousePassthrough;
+                          setIsMousePassthrough(newState);
+                          window.electronAPI?.setOverlayMousePassthrough?.(newState);
+                        }}
+                        className={`
                                                     w-7 h-7 flex items-center justify-center rounded-lg
                                                     interaction-base interaction-press
-                                                    ${isMousePassthrough
+                                                    ${
+                                                      isMousePassthrough
                                                         ? 'overlay-icon-surface overlay-icon-surface-hover text-sky-400 opacity-100'
-                                                        : 'overlay-icon-surface overlay-icon-surface-hover overlay-text-interactive'}
+                                                        : 'overlay-icon-surface overlay-icon-surface-hover overlay-text-interactive'
+                                                    }
                                                 `}
+                        style={appearance.iconStyle}
+                      >
+                        <PointerOff className="w-3.5 h-3.5" />
+                      </button>
+                    </div>
+                  </div>
 
-                                                style={appearance.iconStyle}
-                                            >
-                                                <PointerOff className="w-3.5 h-3.5" />
-                                            </button>
-                                        </div>
-
-                                    </div>
-
-                                    <button
-                                        onClick={handleManualSubmit}
-                                        disabled={!inputValue.trim()}
-                                        className={`
+                  <button
+                    onClick={handleManualSubmit}
+                    disabled={!inputValue.trim()}
+                    className={`
                                     w-7 h-7 rounded-full flex items-center justify-center
                                     interaction-base interaction-press
-                                    ${inputValue.trim()
-                                                ? 'bg-[#007AFF] text-white shadow-lg shadow-blue-500/20 hover:bg-[#0071E3]'
-                                                : 'overlay-icon-surface overlay-text-muted cursor-not-allowed'
-                                            }
+                                    ${
+                                      inputValue.trim()
+                                        ? 'bg-[#007AFF] text-white shadow-lg shadow-blue-500/20 hover:bg-[#0071E3]'
+                                        : 'overlay-icon-surface overlay-text-muted cursor-not-allowed'
+                                    }
                                 `}
-                                        style={inputValue.trim() ? undefined : appearance.iconStyle}
-                                    >
-                                        <ArrowRight className="w-3.5 h-3.5" />
-                                    </button>
-                                </div>
-                            </div>
-                        </motion.div>
-                    </motion.div>
-                )}
-            </AnimatePresence>
-        </div>
-    );
+                    style={inputValue.trim() ? undefined : appearance.iconStyle}
+                  >
+                    <ArrowRight className="w-3.5 h-3.5" />
+                  </button>
+                </div>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
 };
 
 export default NativelyInterface;

--- a/src/components/NativelyInterface.tsx
+++ b/src/components/NativelyInterface.tsx
@@ -2103,6 +2103,33 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
       }),
     );
 
+    // Phone-initiated chat: main process streams tokens via gemini-stream-*; this
+    // event adds the user turn + streaming placeholder before tokens arrive.
+    cleanups.push(
+      window.electronAPI.onPhoneMirrorIncomingChat(({ message }) => {
+        flushToken();
+        requestStartTimeRef.current = Date.now();
+        const userId = Date.now().toString();
+        const placeholderId = `${userId}-reply`;
+        setMessages((prev) => [
+          ...prev,
+          { id: userId, role: 'user', text: message },
+          {
+            id: placeholderId,
+            role: 'system',
+            text: '',
+            intent: 'chat',
+            isStreaming: true,
+          },
+        ]);
+        setIsExpanded(true);
+        setIsProcessing(true);
+        setTimeout(() => {
+          messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+        }, 50);
+      }),
+    );
+
     // JIT RAG Stream listeners (for live meeting RAG responses)
     if (window.electronAPI.onRAGStreamChunk) {
       cleanups.push(

--- a/src/components/dynamic-actions/DynamicActionBar.tsx
+++ b/src/components/dynamic-actions/DynamicActionBar.tsx
@@ -1,17 +1,17 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { AnimatePresence } from 'framer-motion'
-import { DynamicActionCard } from './DynamicActionCard'
-import type { DynamicActionPayload } from '@/types/electron'
+import type { DynamicActionPayload } from '@/types/electron';
+import { AnimatePresence } from 'framer-motion';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { DynamicActionCard } from './DynamicActionCard';
 
 interface Props {
   // Called when the user accepts (or hits Tab on the primary). Parent should
   // kick off the live answer stream using action.promptInstruction.
-  onAcceptAction: (action: DynamicActionPayload) => void
+  onAcceptAction: (action: DynamicActionPayload) => void;
   // Optional: max actions to keep visible. Cluely-style cap at 3.
-  maxVisible?: number
+  maxVisible?: number;
   // Optional: how long actions stay visible without user interaction (ms).
   // Server side already expires; this is the renderer-side cap.
-  staleAfterMs?: number
+  staleAfterMs?: number;
 }
 
 // DynamicActionBar — Cluely-style live action card row.
@@ -23,75 +23,95 @@ export const DynamicActionBar: React.FC<Props> = ({
   maxVisible = 3,
   staleAfterMs = 60_000,
 }) => {
-  const [actions, setActions] = useState<DynamicActionPayload[]>([])
-  const actionsRef = useRef(actions)
-  actionsRef.current = actions
+  const [actions, setActions] = useState<DynamicActionPayload[]>([]);
+  const actionsRef = useRef(actions);
+  actionsRef.current = actions;
 
-  const handleIncoming = useCallback((action: DynamicActionPayload) => {
-    setActions((prev) => {
-      // Dedupe by id (engine has already deduped at backend, but renderer
-      // may receive late-arriving duplicates after a window restore).
-      if (prev.some((a) => a.id === action.id)) return prev
-      // Sort by priority desc, then createdAt desc (newer first when tied).
-      const next = [...prev, action]
-        .filter((a) => Date.now() - a.createdAt < staleAfterMs)
-        .sort((a, b) => (b.priority - a.priority) || (b.createdAt - a.createdAt))
-      return next.slice(0, maxVisible * 2) // keep a small buffer past the visible cap
-    })
-  }, [staleAfterMs, maxVisible])
+  const handleIncoming = useCallback(
+    (action: DynamicActionPayload) => {
+      setActions((prev) => {
+        // Dedupe by id (engine has already deduped at backend, but renderer
+        // may receive late-arriving duplicates after a window restore).
+        if (prev.some((a) => a.id === action.id)) return prev;
+        // Sort by priority desc, then createdAt desc (newer first when tied).
+        const next = [...prev, action]
+          .filter((a) => Date.now() - a.createdAt < staleAfterMs)
+          .sort((a, b) => b.priority - a.priority || b.createdAt - a.createdAt);
+        return next.slice(0, maxVisible * 2); // keep a small buffer past the visible cap
+      });
+    },
+    [staleAfterMs, maxVisible],
+  );
 
   const dismiss = useCallback((id: string) => {
-    setActions((prev) => prev.filter((a) => a.id !== id))
-    window.electronAPI?.dismissDynamicAction?.(id).catch(() => { /* swallow */ })
-  }, [])
+    setActions((prev) => prev.filter((a) => a.id !== id));
+    window.electronAPI?.dismissDynamicAction?.(id).catch(() => {
+      /* swallow */
+    });
+  }, []);
 
-  const accept = useCallback(async (action: DynamicActionPayload) => {
-    // Optimistically remove from the bar so the user gets immediate feedback.
-    setActions((prev) => prev.filter((a) => a.id !== action.id))
-    try {
-      await window.electronAPI?.acceptDynamicAction?.(action.id)
-    } catch { /* swallow — the parent answer flow is the source of truth */ }
-    onAcceptAction(action)
-  }, [onAcceptAction])
+  const accept = useCallback(
+    async (action: DynamicActionPayload) => {
+      // Optimistically remove from the bar so the user gets immediate feedback.
+      setActions((prev) => prev.filter((a) => a.id !== action.id));
+      try {
+        await window.electronAPI?.acceptDynamicAction?.(action.id);
+      } catch {
+        /* swallow — the parent answer flow is the source of truth */
+      }
+      onAcceptAction(action);
+    },
+    [onAcceptAction],
+  );
 
   // Subscribe to push from main process
   useEffect(() => {
     const off = window.electronAPI?.onIntelligenceDynamicAction?.((data) => {
-      if (data?.action) handleIncoming(data.action)
-    })
-    return () => { try { off?.() } catch { /* ignore */ } }
-  }, [handleIncoming])
+      if (data?.action) handleIncoming(data.action);
+    });
+    return () => {
+      try {
+        off?.();
+      } catch {
+        /* ignore */
+      }
+    };
+  }, [handleIncoming]);
 
   // Keyboard: Tab accepts primary
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key !== 'Tab' || e.shiftKey || e.ctrlKey || e.metaKey || e.altKey) return
-      const visible = actionsRef.current.slice(0, maxVisible)
-      if (visible.length === 0) return
+      if (e.key !== 'Tab' || e.shiftKey || e.ctrlKey || e.metaKey || e.altKey) return;
+      const visible = actionsRef.current.slice(0, maxVisible);
+      if (visible.length === 0) return;
       // Don't hijack Tab if focus is in an editable element — the user is typing.
-      const target = e.target as HTMLElement | null
+      const target = e.target as HTMLElement | null;
       if (target) {
-        const tag = target.tagName?.toLowerCase()
-        if (tag === 'input' || tag === 'textarea' || target.isContentEditable) return
+        const tag = target.tagName?.toLowerCase();
+        if (tag === 'input' || tag === 'textarea' || target.isContentEditable) return;
       }
-      e.preventDefault()
-      void accept(visible[0])
-    }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [accept, maxVisible])
+      e.preventDefault();
+      void accept(visible[0]);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [accept, maxVisible]);
 
-  // Periodic stale prune (cheap)
+  // Periodic stale prune (cheap) — only run when actions exist
   useEffect(() => {
+    if (actions.length === 0) return;
     const t = setInterval(() => {
-      setActions((prev) => prev.filter((a) => Date.now() - a.createdAt < staleAfterMs))
-    }, 5_000)
-    return () => clearInterval(t)
-  }, [staleAfterMs])
+      setActions((prev) => {
+        if (prev.length === 0) return prev;
+        return prev.filter((a) => Date.now() - a.createdAt < staleAfterMs);
+      });
+    }, 5_000);
+    return () => clearInterval(t);
+  }, [staleAfterMs, actions.length]);
 
-  const visible = useMemo(() => actions.slice(0, maxVisible), [actions, maxVisible])
+  const visible = useMemo(() => actions.slice(0, maxVisible), [actions, maxVisible]);
 
-  if (visible.length === 0) return null
+  if (visible.length === 0) return null;
 
   return (
     <div
@@ -111,5 +131,5 @@ export const DynamicActionBar: React.FC<Props> = ({
         ))}
       </AnimatePresence>
     </div>
-  )
-}
+  );
+};

--- a/src/components/settings/AIProvidersSettings.tsx
+++ b/src/components/settings/AIProvidersSettings.tsx
@@ -1,964 +1,1093 @@
-import React, { useState, useEffect } from 'react';
-import { Plus, Trash2, Edit2, AlertCircle, CheckCircle, Save, ChevronDown, Check, RefreshCw, ExternalLink, Loader2 } from 'lucide-react';
-import { CODEX_CLI_MODEL, CODEX_CLI_MODEL_PRESETS, codexCliSelectorId, STANDARD_CLOUD_MODELS, prettifyModelId } from '../../utils/modelUtils';
+import {
+  AlertCircle,
+  Check,
+  CheckCircle,
+  ChevronDown,
+  Edit2,
+  Loader2,
+  Plus,
+  RefreshCw,
+  Save,
+  Trash2,
+} from 'lucide-react';
+import React, { useEffect, useRef, useState } from 'react';
 import { validateCurl } from '../../lib/curl-validator';
+import {
+  CODEX_CLI_MODEL,
+  CODEX_CLI_MODEL_PRESETS,
+  codexCliSelectorId,
+  prettifyModelId,
+  STANDARD_CLOUD_MODELS,
+} from '../../utils/modelUtils';
 import { ProviderCard } from './ProviderCard';
 
 interface CustomProvider {
-    id: string;
-    name: string;
-    curlCommand: string;
-    responsePath: string;
+  id: string;
+  name: string;
+  curlCommand: string;
+  responsePath: string;
 }
 
 interface ModelOption {
-    id: string;
-    name: string;
+  id: string;
+  name: string;
 }
 
 interface ModelSelectProps {
-    value: string;
-    options: ModelOption[];
-    onChange: (value: string) => void;
-    placeholder?: string;
+  value: string;
+  options: ModelOption[];
+  onChange: (value: string) => void;
+  placeholder?: string;
 }
 
-const ModelSelect: React.FC<ModelSelectProps> = ({ value, options, onChange, placeholder = "Select model" }) => {
-    const [isOpen, setIsOpen] = useState(false);
-    const containerRef = React.useRef<HTMLDivElement>(null);
+const ModelSelect: React.FC<ModelSelectProps> = ({
+  value,
+  options,
+  onChange,
+  placeholder = 'Select model',
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = React.useRef<HTMLDivElement>(null);
 
-    useEffect(() => {
-        const handleClickOutside = (event: MouseEvent) => {
-            if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
-                setIsOpen(false);
-            }
-        };
-        document.addEventListener('mousedown', handleClickOutside);
-        return () => document.removeEventListener('mousedown', handleClickOutside);
-    }, []);
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
 
-    const selectedOption = options.find(o => o.id === value);
+  const selectedOption = options.find((o) => o.id === value);
 
-    return (
-        <div className="relative" ref={containerRef}>
-            <button
-                onClick={() => setIsOpen(!isOpen)}
-                className="w-40 bg-bg-input border border-border-subtle rounded-lg px-3 py-1.5 text-xs text-text-primary focus:outline-none focus:border-accent-primary flex items-center justify-between hover:bg-bg-elevated transition-colors"
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-40 bg-bg-input border border-border-subtle rounded-lg px-3 py-1.5 text-xs text-text-primary focus:outline-none focus:border-accent-primary flex items-center justify-between hover:bg-bg-elevated transition-colors"
+        type="button"
+      >
+        <span className="truncate pr-2">{selectedOption ? selectedOption.name : placeholder}</span>
+        <ChevronDown
+          size={14}
+          className={`text-text-secondary transition-transform ${isOpen ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      {isOpen && (
+        <div className="absolute top-full right-0 mt-1 w-full bg-bg-elevated border border-border-subtle rounded-lg shadow-xl z-50 max-h-60 overflow-y-auto animated fadeIn">
+          <div className="p-1 space-y-0.5">
+            {options.map((option) => (
+              <button
+                key={option.id}
+                onClick={() => {
+                  onChange(option.id);
+                  setIsOpen(false);
+                }}
+                className={`w-full text-left px-3 py-2 text-xs rounded-md flex items-center justify-between group transition-colors ${value === option.id ? 'bg-bg-input hover:bg-bg-elevated text-text-primary' : 'text-text-secondary hover:bg-bg-input hover:text-text-primary'}`}
                 type="button"
-            >
-                <span className="truncate pr-2">{selectedOption ? selectedOption.name : placeholder}</span>
-                <ChevronDown size={14} className={`text-text-secondary transition-transform ${isOpen ? 'rotate-180' : ''}`} />
-            </button>
-
-            {isOpen && (
-                <div className="absolute top-full right-0 mt-1 w-full bg-bg-elevated border border-border-subtle rounded-lg shadow-xl z-50 max-h-60 overflow-y-auto animated fadeIn">
-                    <div className="p-1 space-y-0.5">
-                        {options.map((option) => (
-                            <button
-                                key={option.id}
-                                onClick={() => {
-                                    onChange(option.id);
-                                    setIsOpen(false);
-                                }}
-                                className={`w-full text-left px-3 py-2 text-xs rounded-md flex items-center justify-between group transition-colors ${value === option.id ? 'bg-bg-input hover:bg-bg-elevated text-text-primary' : 'text-text-secondary hover:bg-bg-input hover:text-text-primary'}`}
-                                type="button"
-                            >
-                                <span className="truncate">{option.name}</span>
-                                {value === option.id && <Check size={14} className="text-accent-primary shrink-0 ml-2" />}
-                            </button>
-                        ))}
-                        {options.length === 0 && (
-                            <div className="px-3 py-2 text-xs text-gray-500 italic">No models available</div>
-                        )}
-                    </div>
-                </div>
+              >
+                <span className="truncate">{option.name}</span>
+                {value === option.id && (
+                  <Check size={14} className="text-accent-primary shrink-0 ml-2" />
+                )}
+              </button>
+            ))}
+            {options.length === 0 && (
+              <div className="px-3 py-2 text-xs text-gray-500 italic">No models available</div>
             )}
+          </div>
         </div>
-    );
+      )}
+    </div>
+  );
 };
 
 const CodexCliModelField: React.FC<{
-    label: string;
-    value: string;
-    placeholder: string;
-    onChange: (value: string) => void;
-    onSelect: (value: string) => void;
-    onSave: () => void;
+  label: string;
+  value: string;
+  placeholder: string;
+  onChange: (value: string) => void;
+  onSelect: (value: string) => void;
+  onSave: () => void;
 }> = ({ label, value, placeholder, onChange, onSelect, onSave }) => (
-    <label className="space-y-1">
-        <span className="text-[10px] font-medium text-text-secondary uppercase tracking-wide">{label}</span>
-        <div className="flex gap-2">
-            <input
-                value={value}
-                onChange={e => onChange(e.target.value)}
-                onBlur={onSave}
-                className="min-w-0 flex-1 bg-bg-input border border-border-subtle rounded-lg px-3 py-2 text-xs text-text-primary font-mono focus:outline-none focus:border-accent-primary"
-                placeholder={placeholder}
-            />
-            <ModelSelect
-                value={value}
-                options={value && !CODEX_CLI_MODEL_PRESETS.some(option => option.id === value)
-                    ? [{ id: value, name: prettifyModelId(value) }, ...CODEX_CLI_MODEL_PRESETS]
-                    : CODEX_CLI_MODEL_PRESETS}
-                onChange={(modelId) => {
-                    onChange(modelId);
-                    onSelect(modelId);
-                }}
-                placeholder="Preset"
-            />
-        </div>
-    </label>
+  <label className="space-y-1">
+    <span className="text-[10px] font-medium text-text-secondary uppercase tracking-wide">
+      {label}
+    </span>
+    <div className="flex gap-2">
+      <input
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onBlur={onSave}
+        className="min-w-0 flex-1 bg-bg-input border border-border-subtle rounded-lg px-3 py-2 text-xs text-text-primary font-mono focus:outline-none focus:border-accent-primary"
+        placeholder={placeholder}
+      />
+      <ModelSelect
+        value={value}
+        options={
+          value && !CODEX_CLI_MODEL_PRESETS.some((option) => option.id === value)
+            ? [{ id: value, name: prettifyModelId(value) }, ...CODEX_CLI_MODEL_PRESETS]
+            : CODEX_CLI_MODEL_PRESETS
+        }
+        onChange={(modelId) => {
+          onChange(modelId);
+          onSelect(modelId);
+        }}
+        placeholder="Preset"
+      />
+    </div>
+  </label>
 );
 
 export const AIProvidersSettings: React.FC = () => {
-    // --- Standard Providers ---
-    const [apiKey, setApiKey] = useState('');
-    const [groqApiKey, setGroqApiKey] = useState('');
-    const [openaiApiKey, setOpenaiApiKey] = useState('');
-    const [claudeApiKey, setClaudeApiKey] = useState('');
+  // --- Standard Providers ---
+  const [apiKey, setApiKey] = useState('');
+  const [groqApiKey, setGroqApiKey] = useState('');
+  const [openaiApiKey, setOpenaiApiKey] = useState('');
+  const [claudeApiKey, setClaudeApiKey] = useState('');
 
-    // Status
-    const [savedStatus, setSavedStatus] = useState<Record<string, boolean>>({});
-    const [savingStatus, setSavingStatus] = useState<Record<string, boolean>>({});
-    const [hasStoredKey, setHasStoredKey] = useState<Record<string, boolean>>({});
-    const [testStatus, setTestStatus] = useState<Record<string, 'idle' | 'testing' | 'success' | 'error'>>({});
-    const [testError, setTestError] = useState<Record<string, string>>({});
+  // Status
+  const [savedStatus, setSavedStatus] = useState<Record<string, boolean>>({});
+  const [savingStatus, setSavingStatus] = useState<Record<string, boolean>>({});
+  const [hasStoredKey, setHasStoredKey] = useState<Record<string, boolean>>({});
+  const [testStatus, setTestStatus] = useState<
+    Record<string, 'idle' | 'testing' | 'success' | 'error'>
+  >({});
+  const [testError, setTestError] = useState<Record<string, string>>({});
 
-    // --- Custom Providers ---
-    const [customProviders, setCustomProviders] = useState<CustomProvider[]>([]);
-    const [isEditingCustom, setIsEditingCustom] = useState(false);
-    const [editingProvider, setEditingProvider] = useState<CustomProvider | null>(null);
-    const [customName, setCustomName] = useState('');
-    const [customCurl, setCustomCurl] = useState('');
-    const [customResponsePath, setCustomResponsePath] = useState('');
-    const [curlError, setCurlError] = useState<string | null>(null);
+  // --- Custom Providers ---
+  const [customProviders, setCustomProviders] = useState<CustomProvider[]>([]);
+  const [isEditingCustom, setIsEditingCustom] = useState(false);
+  const [editingProvider, setEditingProvider] = useState<CustomProvider | null>(null);
+  const [customName, setCustomName] = useState('');
+  const [customCurl, setCustomCurl] = useState('');
+  const [customResponsePath, setCustomResponsePath] = useState('');
+  const [curlError, setCurlError] = useState<string | null>(null);
 
-    // --- Local (Ollama) ---
-    const [ollamaModels, setOllamaModels] = useState<string[]>([]);
-    const [ollamaStatus, setOllamaStatus] = useState<'checking' | 'detected' | 'not-found' | 'fixing'>('checking');
-    const [ollamaRestarted, setOllamaRestarted] = useState(false);
-    const [isRefreshingOllama, setIsRefreshingOllama] = useState(false);
+  // --- Local (Ollama) ---
+  const [ollamaModels, setOllamaModels] = useState<string[]>([]);
+  const [ollamaStatus, setOllamaStatus] = useState<
+    'checking' | 'detected' | 'not-found' | 'fixing'
+  >('checking');
+  const [ollamaRestarted, setOllamaRestarted] = useState(false);
+  const [isRefreshingOllama, setIsRefreshingOllama] = useState(false);
+  const ollamaHealthyRef = useRef(false);
 
-    // --- Local (Codex CLI) ---
-    const [codexCliConfig, setCodexCliConfig] = useState({ enabled: false, path: 'codex', model: 'gpt-5.4', fastModel: 'gpt-5.3-codex-spark', timeoutMs: 60000 });
-    const [codexCliStatus, setCodexCliStatus] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
-    const [codexCliError, setCodexCliError] = useState('');
+  // --- Local (Codex CLI) ---
+  const [codexCliConfig, setCodexCliConfig] = useState({
+    enabled: false,
+    path: 'codex',
+    model: 'gpt-5.4',
+    fastModel: 'gpt-5.3-codex-spark',
+    timeoutMs: 60000,
+  });
+  const [codexCliStatus, setCodexCliStatus] = useState<'idle' | 'testing' | 'success' | 'error'>(
+    'idle',
+  );
+  const [codexCliError, setCodexCliError] = useState('');
 
-    // --- Default Model ---
-    const [defaultModel, setDefaultModel] = useState<string>('gemini-3.1-flash-lite-preview');
-    const [fastResponseMode, setFastResponseMode] = useState(false);
-    const [credentialsLoaded, setCredentialsLoaded] = useState(false);
-    const canUseFastMode = !!(hasStoredKey.groq || hasStoredKey.natively || codexCliConfig.enabled);
+  // --- Default Model ---
+  const [defaultModel, setDefaultModel] = useState<string>('gemini-3.1-flash-lite-preview');
+  const [fastResponseMode, setFastResponseMode] = useState(false);
+  const [credentialsLoaded, setCredentialsLoaded] = useState(false);
+  const canUseFastMode = !!(hasStoredKey.groq || hasStoredKey.natively || codexCliConfig.enabled);
 
-    // --- Dynamic Model Discovery ---
-    const [preferredModels, setPreferredModels] = useState<Record<string, string>>({});
+  // --- Dynamic Model Discovery ---
+  const [preferredModels, setPreferredModels] = useState<Record<string, string>>({});
 
-    // Load Initial Data
-    useEffect(() => {
-        const loadCredentials = async () => {
-            try {
-                // Load credentials FIRST so canUseFastMode is correct before we set fastResponseMode.
-                // If we set fastResponseMode before hasStoredKey is populated, the enforcement
-                // effect below fires with canUseFastMode=false and immediately resets fast mode
-                // to false — writing that reset back to SettingsManager on every startup.
-                // @ts-ignore
-                const creds = await window.electronAPI?.getStoredCredentials?.();
-                if (creds) {
-                    setHasStoredKey({
-                        gemini: creds.hasGeminiKey,
-                        groq: creds.hasGroqKey,
-                        openai: creds.hasOpenaiKey,
-                        claude: creds.hasClaudeKey,
-                        natively: creds.hasNativelyKey || false
-                    });
-                    // Load preferred models
-                    const pm: Record<string, string> = {};
-                    if (creds.geminiPreferredModel) pm.gemini = creds.geminiPreferredModel;
-                    if (creds.groqPreferredModel) pm.groq = creds.groqPreferredModel;
-                    if (creds.openaiPreferredModel) pm.openai = creds.openaiPreferredModel;
-                    if (creds.claudePreferredModel) pm.claude = creds.claudePreferredModel;
-                    setPreferredModels(pm);
-                }
-
-                // Now it's safe to read fast mode — hasStoredKey is already set so
-                // canUseFastMode will be correct when the enforcement effect runs.
-                // @ts-ignore
-                const cliConfig = await window.electronAPI?.getCodexCliConfig?.();
-                if (cliConfig) setCodexCliConfig(cliConfig);
-
-                const fastMode = await window.electronAPI?.getGroqFastTextMode();
-                if (fastMode) setFastResponseMode(fastMode.enabled);
-
-                // Mark credentials as fully loaded so the enforcement effect can fire
-                setCredentialsLoaded(true);
-
-                // @ts-ignore
-                const custom = await window.electronAPI?.getCustomProviders();
-                if (custom) {
-                    setCustomProviders(custom);
-                }
-
-                // Load persisted default model
-                // @ts-ignore
-                const result = await window.electronAPI?.getDefaultModel();
-                if (result && result.model) {
-                    setDefaultModel(result.model);
-                }
-
-                // Check Ollama
-                checkOllama();
-
-            } catch (e) {
-                console.error("Failed to load settings:", e);
-                setCredentialsLoaded(true); // Unblock even on error
-            }
-        };
-        loadCredentials();
-
-        // Listen for changes from other windows (2-way sync)
-        if (window.electronAPI?.onGroqFastTextChanged) {
-            // @ts-ignore
-            const unsubscribe = window.electronAPI.onGroqFastTextChanged((enabled: boolean) => {
-                setFastResponseMode(enabled);
-                localStorage.setItem('natively_groq_fast_text', String(enabled));
-            });
-            return () => unsubscribe();
-        }
-    }, []);
-
-    // Effect to enforce fast mode disabled if neither Groq key nor Natively API is configured.
-    // Guard with credentialsLoaded so this never fires during the initial async load phase
-    // (when hasStoredKey is still empty and canUseFastMode is incorrectly false).
-    useEffect(() => {
-        if (!credentialsLoaded) return;
-        if (!canUseFastMode && fastResponseMode) {
-            setFastResponseMode(false);
-            localStorage.setItem('natively_groq_fast_text', 'false');
-            // @ts-ignore
-            window.electronAPI?.setGroqFastTextMode(false);
-        }
-    }, [credentialsLoaded, canUseFastMode, fastResponseMode]);
-
-    // Poll for Ollama status every 3 seconds requesting smart start on mount
-    useEffect(() => {
-        // Immediate "Smart Start" check
-        ensureOllamaStartup();
-
-        // Background polling for maintenance
-        const interval = setInterval(() => {
-            checkOllama(false);
-        }, 3000);
-        return () => clearInterval(interval);
-    }, []);
-
-    const ensureOllamaStartup = async () => {
-        setOllamaStatus('checking');
-        try {
-            // @ts-ignore
-            const result = await window.electronAPI?.invoke?.('ensure-ollama-running');
-            if (result && result.success) {
-                // It's running (or just started), now fetch models
-                checkOllama(true);
-            } else {
-                setOllamaStatus('not-found');
-            }
-        } catch (e) {
-            console.warn("Ollama ensure startup failed:", e);
-            setOllamaStatus('not-found');
-        }
-    };
-
-    const checkOllama = async (_isInitial = true) => {
-        // Don't override 'checking' if we are already in smart-start mode
-        // if (isInitial) setOllamaStatus('checking'); 
-
-        try {
-            // @ts-ignore
-            const models = await window.electronAPI?.getAvailableOllamaModels?.();
-            if (models && models.length > 0) {
-                setOllamaModels(models);
-                setOllamaStatus('detected');
-            } else {
-                // Silent failure on background checks
-                // Only set not-found if we haven't detected it yet
-                if (ollamaStatus !== 'detected') {
-                    setOllamaStatus('not-found');
-                }
-            }
-        } catch (e) {
-            // console.warn(`Ollama check failed:`, e);
-            if (ollamaStatus !== 'detected') {
-                setOllamaStatus('not-found');
-            }
-        }
-    };
-
-    const handleFixOllama = async () => {
-        setOllamaStatus('fixing');
-        try {
-            // @ts-ignore
-            const result = await window.electronAPI?.invoke?.('force-restart-ollama');
-            if (result && result.success) {
-                setOllamaRestarted(true);
-                // Wait for server to be ready
-                setTimeout(() => checkOllama(false), 2000);
-            } else {
-                setOllamaStatus('not-found');
-            }
-        } catch (e) {
-            console.error("Fix failed", e);
-            setOllamaStatus('not-found');
-        }
-    };
-
-    const saveCodexCliConfig = async (next = codexCliConfig) => {
-        const normalized = { ...next, timeoutMs: Number(next.timeoutMs) || 60000 };
-        setCodexCliConfig(normalized);
-        const result = await window.electronAPI?.setCodexCliConfig?.(normalized);
-        if (result?.config) setCodexCliConfig(result.config);
-        return result;
-    };
-
-    const handleTestCodexCli = async () => {
-        setCodexCliStatus('testing');
-        setCodexCliError('');
-        try {
-            const saveResult = await saveCodexCliConfig();
-            const configToTest = saveResult?.config || codexCliConfig;
-            const result = await window.electronAPI?.testCodexCli?.(configToTest);
-            if (result?.success) {
-                // If the main process auto-detected an install, reflect the
-                // resolved path in the form so the user sees what got picked.
-                if (result.config) setCodexCliConfig(result.config);
-                setCodexCliStatus('success');
-                setTimeout(() => setCodexCliStatus('idle'), 3000);
-            } else {
-                setCodexCliStatus('error');
-                setCodexCliError(result?.error || 'Codex CLI test failed');
-            }
-        } catch (e: any) {
-            setCodexCliStatus('error');
-            setCodexCliError(e.message || 'Codex CLI test failed');
-        }
-    };
-
-    const handleSaveKey = async (provider: string, key: string, setter: (val: string) => void) => {
-        if (!key.trim()) return;
-        setSavingStatus(prev => ({ ...prev, [provider]: true }));
-        try {
-            let result;
-            // @ts-ignore
-            if (provider === 'gemini') result = await window.electronAPI.setGeminiApiKey(key);
-            // @ts-ignore
-            if (provider === 'groq') result = await window.electronAPI.setGroqApiKey(key);
-            // @ts-ignore
-            if (provider === 'openai') result = await window.electronAPI.setOpenaiApiKey(key);
-            // @ts-ignore
-            if (provider === 'claude') result = await window.electronAPI.setClaudeApiKey(key);
-
-            if (result && result.success) {
-                setSavedStatus(prev => ({ ...prev, [provider]: true }));
-                setHasStoredKey(prev => ({ ...prev, [provider]: true }));
-                setter('');
-                setTimeout(() => setSavedStatus(prev => ({ ...prev, [provider]: false })), 2000);
-            }
-        } catch (e) {
-            console.error(`Failed to save ${provider} key:`, e);
-        } finally {
-            setSavingStatus(prev => ({ ...prev, [provider]: false }));
-        }
-    };
-
-    const handleRemoveKey = async (provider: string, setter: (val: string) => void) => {
-        if (!confirm(`Are you sure you want to remove the ${provider} API key?`)) return;
-        try {
-            let result;
-            // @ts-ignore
-            if (provider === 'gemini') result = await window.electronAPI.setGeminiApiKey('');
-            // @ts-ignore
-            if (provider === 'groq') result = await window.electronAPI.setGroqApiKey('');
-            // @ts-ignore
-            if (provider === 'openai') result = await window.electronAPI.setOpenaiApiKey('');
-            // @ts-ignore
-            if (provider === 'claude') result = await window.electronAPI.setClaudeApiKey('');
-
-            if (result && result.success) {
-                setHasStoredKey(prev => ({ ...prev, [provider]: false }));
-                setter('');
-            }
-        } catch (e) {
-            console.error(`Failed to remove ${provider} key:`, e);
-        }
-    };
-
-    const handleTestConnection = async (provider: string, key: string) => {
-        // Allow testing if key is provided OR if we have a stored key
-        if (!key.trim() && !hasStoredKey[provider]) {
-            return;
-        }
-        setTestStatus(prev => ({ ...prev, [provider]: 'testing' }));
-        setTestError(prev => ({ ...prev, [provider]: '' }));
-
-        try {
-            // @ts-ignore
-            const result = await window.electronAPI.testLlmConnection(provider, key);
-            if (result.success) {
-                setTestStatus(prev => ({ ...prev, [provider]: 'success' }));
-                setTimeout(() => setTestStatus(prev => ({ ...prev, [provider]: 'idle' })), 3000);
-            } else {
-                setTestStatus(prev => ({ ...prev, [provider]: 'error' }));
-                setTestError(prev => ({ ...prev, [provider]: result.error || 'Connection failed' }));
-            }
-        } catch (e: any) {
-            setTestStatus(prev => ({ ...prev, [provider]: 'error' }));
-            setTestError(prev => ({ ...prev, [provider]: e.message || 'Connection failed' }));
-        }
-    };
-
-    const openKeyUrl = (provider: string) => {
-        const urls: Record<string, string> = {
-            gemini: 'https://aistudio.google.com/app/apikey',
-            groq: 'https://console.groq.com/keys',
-            openai: 'https://platform.openai.com/api-keys',
-            claude: 'https://console.anthropic.com/settings/keys'
-        };
+  // Load Initial Data
+  useEffect(() => {
+    const loadCredentials = async () => {
+      try {
+        // Load credentials FIRST so canUseFastMode is correct before we set fastResponseMode.
+        // If we set fastResponseMode before hasStoredKey is populated, the enforcement
+        // effect below fires with canUseFastMode=false and immediately resets fast mode
+        // to false — writing that reset back to SettingsManager on every startup.
         // @ts-ignore
-        window.electronAPI?.openExternal(urls[provider]);
-    };
-
-
-    // --- Custom Provider Handlers ---
-
-    const handleEditProvider = (provider: CustomProvider) => {
-        setEditingProvider(provider);
-        setCustomName(provider.name);
-        setCustomCurl(provider.curlCommand);
-        setCustomResponsePath(provider.responsePath || '');
-        setIsEditingCustom(true);
-        setCurlError(null);
-    };
-
-    const handleNewProvider = () => {
-        setEditingProvider(null);
-        setCustomName('');
-        setCustomCurl('');
-        setCustomResponsePath('');
-        setIsEditingCustom(true);
-        setCurlError(null);
-    };
-
-    const handleSaveCustom = async () => {
-        setCurlError(null);
-        if (!customName.trim()) {
-            setCurlError("Provider Name is required.");
-            return;
+        const creds = await window.electronAPI?.getStoredCredentials?.();
+        if (creds) {
+          setHasStoredKey({
+            gemini: creds.hasGeminiKey,
+            groq: creds.hasGroqKey,
+            openai: creds.hasOpenaiKey,
+            claude: creds.hasClaudeKey,
+            natively: creds.hasNativelyKey || false,
+          });
+          // Load preferred models
+          const pm: Record<string, string> = {};
+          if (creds.geminiPreferredModel) pm.gemini = creds.geminiPreferredModel;
+          if (creds.groqPreferredModel) pm.groq = creds.groqPreferredModel;
+          if (creds.openaiPreferredModel) pm.openai = creds.openaiPreferredModel;
+          if (creds.claudePreferredModel) pm.claude = creds.claudePreferredModel;
+          setPreferredModels(pm);
         }
 
-        const validation = validateCurl(customCurl);
-        if (!validation.isValid) {
-            setCurlError(validation.message || "Invalid cURL command.");
-            return;
+        // Now it's safe to read fast mode — hasStoredKey is already set so
+        // canUseFastMode will be correct when the enforcement effect runs.
+        // @ts-ignore
+        const cliConfig = await window.electronAPI?.getCodexCliConfig?.();
+        if (cliConfig) setCodexCliConfig(cliConfig);
+
+        const fastMode = await window.electronAPI?.getGroqFastTextMode();
+        if (fastMode) setFastResponseMode(fastMode.enabled);
+
+        // Mark credentials as fully loaded so the enforcement effect can fire
+        setCredentialsLoaded(true);
+
+        // @ts-ignore
+        const custom = await window.electronAPI?.getCustomProviders();
+        if (custom) {
+          setCustomProviders(custom);
         }
 
-        const newProvider: CustomProvider = {
-            id: editingProvider ? editingProvider.id : crypto.randomUUID(),
-            name: customName,
-            curlCommand: customCurl,
-            responsePath: customResponsePath
-        };
+        // Load persisted default model
+        // @ts-ignore
+        const result = await window.electronAPI?.getDefaultModel();
+        if (result && result.model) {
+          setDefaultModel(result.model);
+        }
 
-        try {
-            // @ts-ignore
-            const result = await window.electronAPI.saveCustomProvider(newProvider);
-            if (result.success) {
-                // Refresh list
-                // @ts-ignore
-                const updated = await window.electronAPI.getCustomProviders();
-                setCustomProviders(updated);
-                setIsEditingCustom(false);
-            } else {
-                setCurlError(result.error ?? null);
+        // Check Ollama
+        checkOllama();
+      } catch (e) {
+        console.error('Failed to load settings:', e);
+        setCredentialsLoaded(true); // Unblock even on error
+      }
+    };
+    loadCredentials();
+
+    // Listen for changes from other windows (2-way sync)
+    if (window.electronAPI?.onGroqFastTextChanged) {
+      // @ts-ignore
+      const unsubscribe = window.electronAPI.onGroqFastTextChanged((enabled: boolean) => {
+        setFastResponseMode(enabled);
+        localStorage.setItem('natively_groq_fast_text', String(enabled));
+      });
+      return () => unsubscribe();
+    }
+  }, []);
+
+  // Effect to enforce fast mode disabled if neither Groq key nor Natively API is configured.
+  // Guard with credentialsLoaded so this never fires during the initial async load phase
+  // (when hasStoredKey is still empty and canUseFastMode is incorrectly false).
+  useEffect(() => {
+    if (!credentialsLoaded) return;
+    if (!canUseFastMode && fastResponseMode) {
+      setFastResponseMode(false);
+      localStorage.setItem('natively_groq_fast_text', 'false');
+      // @ts-ignore
+      window.electronAPI?.setGroqFastTextMode(false);
+    }
+  }, [credentialsLoaded, canUseFastMode, fastResponseMode]);
+
+  // Poll for Ollama status every 3 seconds requesting smart start on mount
+  useEffect(() => {
+    // Immediate "Smart Start" check
+    ensureOllamaStartup();
+
+    // Background polling for maintenance — stop once Ollama is detected healthy
+    const interval = setInterval(() => {
+      if (ollamaHealthyRef.current) return;
+      checkOllama(false);
+    }, 3000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const ensureOllamaStartup = async () => {
+    setOllamaStatus('checking');
+    try {
+      // @ts-ignore
+      const result = await window.electronAPI?.invoke?.('ensure-ollama-running');
+      if (result && result.success) {
+        // It's running (or just started), now fetch models
+        checkOllama(true);
+      } else {
+        setOllamaStatus('not-found');
+      }
+    } catch (e) {
+      console.warn('Ollama ensure startup failed:', e);
+      setOllamaStatus('not-found');
+    }
+  };
+
+  const checkOllama = async (_isInitial = true) => {
+    // Don't override 'checking' if we are already in smart-start mode
+    // if (isInitial) setOllamaStatus('checking');
+
+    try {
+      // @ts-ignore
+      const models = await window.electronAPI?.getAvailableOllamaModels?.();
+      if (models && models.length > 0) {
+        setOllamaModels(models);
+        setOllamaStatus('detected');
+        ollamaHealthyRef.current = true;
+      } else {
+        // Silent failure on background checks
+        // Only set not-found if we haven't detected it yet
+        if (ollamaStatus !== 'detected') {
+          setOllamaStatus('not-found');
+        }
+      }
+    } catch (e) {
+      // console.warn(`Ollama check failed:`, e);
+      if (ollamaStatus !== 'detected') {
+        setOllamaStatus('not-found');
+      }
+    }
+  };
+
+  const handleFixOllama = async () => {
+    setOllamaStatus('fixing');
+    ollamaHealthyRef.current = false;
+    try {
+      // @ts-ignore
+      const result = await window.electronAPI?.invoke?.('force-restart-ollama');
+      if (result && result.success) {
+        setOllamaRestarted(true);
+        // Wait for server to be ready
+        setTimeout(() => checkOllama(false), 2000);
+      } else {
+        setOllamaStatus('not-found');
+      }
+    } catch (e) {
+      console.error('Fix failed', e);
+      setOllamaStatus('not-found');
+    }
+  };
+
+  const saveCodexCliConfig = async (next = codexCliConfig) => {
+    const normalized = { ...next, timeoutMs: Number(next.timeoutMs) || 60000 };
+    setCodexCliConfig(normalized);
+    const result = await window.electronAPI?.setCodexCliConfig?.(normalized);
+    if (result?.config) setCodexCliConfig(result.config);
+    return result;
+  };
+
+  const handleTestCodexCli = async () => {
+    setCodexCliStatus('testing');
+    setCodexCliError('');
+    try {
+      const saveResult = await saveCodexCliConfig();
+      const configToTest = saveResult?.config || codexCliConfig;
+      const result = await window.electronAPI?.testCodexCli?.(configToTest);
+      if (result?.success) {
+        // If the main process auto-detected an install, reflect the
+        // resolved path in the form so the user sees what got picked.
+        if (result.config) setCodexCliConfig(result.config);
+        setCodexCliStatus('success');
+        setTimeout(() => setCodexCliStatus('idle'), 3000);
+      } else {
+        setCodexCliStatus('error');
+        setCodexCliError(result?.error || 'Codex CLI test failed');
+      }
+    } catch (e: any) {
+      setCodexCliStatus('error');
+      setCodexCliError(e.message || 'Codex CLI test failed');
+    }
+  };
+
+  const handleSaveKey = async (provider: string, key: string, setter: (val: string) => void) => {
+    if (!key.trim()) return;
+    setSavingStatus((prev) => ({ ...prev, [provider]: true }));
+    try {
+      let result;
+      // @ts-ignore
+      if (provider === 'gemini') result = await window.electronAPI.setGeminiApiKey(key);
+      // @ts-ignore
+      if (provider === 'groq') result = await window.electronAPI.setGroqApiKey(key);
+      // @ts-ignore
+      if (provider === 'openai') result = await window.electronAPI.setOpenaiApiKey(key);
+      // @ts-ignore
+      if (provider === 'claude') result = await window.electronAPI.setClaudeApiKey(key);
+
+      if (result && result.success) {
+        setSavedStatus((prev) => ({ ...prev, [provider]: true }));
+        setHasStoredKey((prev) => ({ ...prev, [provider]: true }));
+        setter('');
+        setTimeout(() => setSavedStatus((prev) => ({ ...prev, [provider]: false })), 2000);
+      }
+    } catch (e) {
+      console.error(`Failed to save ${provider} key:`, e);
+    } finally {
+      setSavingStatus((prev) => ({ ...prev, [provider]: false }));
+    }
+  };
+
+  const handleRemoveKey = async (provider: string, setter: (val: string) => void) => {
+    if (!confirm(`Are you sure you want to remove the ${provider} API key?`)) return;
+    try {
+      let result;
+      // @ts-ignore
+      if (provider === 'gemini') result = await window.electronAPI.setGeminiApiKey('');
+      // @ts-ignore
+      if (provider === 'groq') result = await window.electronAPI.setGroqApiKey('');
+      // @ts-ignore
+      if (provider === 'openai') result = await window.electronAPI.setOpenaiApiKey('');
+      // @ts-ignore
+      if (provider === 'claude') result = await window.electronAPI.setClaudeApiKey('');
+
+      if (result && result.success) {
+        setHasStoredKey((prev) => ({ ...prev, [provider]: false }));
+        setter('');
+      }
+    } catch (e) {
+      console.error(`Failed to remove ${provider} key:`, e);
+    }
+  };
+
+  const handleTestConnection = async (provider: string, key: string) => {
+    // Allow testing if key is provided OR if we have a stored key
+    if (!key.trim() && !hasStoredKey[provider]) {
+      return;
+    }
+    setTestStatus((prev) => ({ ...prev, [provider]: 'testing' }));
+    setTestError((prev) => ({ ...prev, [provider]: '' }));
+
+    try {
+      // @ts-ignore
+      const result = await window.electronAPI.testLlmConnection(provider, key);
+      if (result.success) {
+        setTestStatus((prev) => ({ ...prev, [provider]: 'success' }));
+        setTimeout(() => setTestStatus((prev) => ({ ...prev, [provider]: 'idle' })), 3000);
+      } else {
+        setTestStatus((prev) => ({ ...prev, [provider]: 'error' }));
+        setTestError((prev) => ({ ...prev, [provider]: result.error || 'Connection failed' }));
+      }
+    } catch (e: any) {
+      setTestStatus((prev) => ({ ...prev, [provider]: 'error' }));
+      setTestError((prev) => ({ ...prev, [provider]: e.message || 'Connection failed' }));
+    }
+  };
+
+  const openKeyUrl = (provider: string) => {
+    const urls: Record<string, string> = {
+      gemini: 'https://aistudio.google.com/app/apikey',
+      groq: 'https://console.groq.com/keys',
+      openai: 'https://platform.openai.com/api-keys',
+      claude: 'https://console.anthropic.com/settings/keys',
+    };
+    // @ts-ignore
+    window.electronAPI?.openExternal(urls[provider]);
+  };
+
+  // --- Custom Provider Handlers ---
+
+  const handleEditProvider = (provider: CustomProvider) => {
+    setEditingProvider(provider);
+    setCustomName(provider.name);
+    setCustomCurl(provider.curlCommand);
+    setCustomResponsePath(provider.responsePath || '');
+    setIsEditingCustom(true);
+    setCurlError(null);
+  };
+
+  const handleNewProvider = () => {
+    setEditingProvider(null);
+    setCustomName('');
+    setCustomCurl('');
+    setCustomResponsePath('');
+    setIsEditingCustom(true);
+    setCurlError(null);
+  };
+
+  const handleSaveCustom = async () => {
+    setCurlError(null);
+    if (!customName.trim()) {
+      setCurlError('Provider Name is required.');
+      return;
+    }
+
+    const validation = validateCurl(customCurl);
+    if (!validation.isValid) {
+      setCurlError(validation.message || 'Invalid cURL command.');
+      return;
+    }
+
+    const newProvider: CustomProvider = {
+      id: editingProvider ? editingProvider.id : crypto.randomUUID(),
+      name: customName,
+      curlCommand: customCurl,
+      responsePath: customResponsePath,
+    };
+
+    try {
+      // @ts-ignore
+      const result = await window.electronAPI.saveCustomProvider(newProvider);
+      if (result.success) {
+        // Refresh list
+        // @ts-ignore
+        const updated = await window.electronAPI.getCustomProviders();
+        setCustomProviders(updated);
+        setIsEditingCustom(false);
+      } else {
+        setCurlError(result.error ?? null);
+      }
+    } catch (e: any) {
+      setCurlError(e.message);
+    }
+  };
+
+  const handleDeleteCustom = async (id: string) => {
+    if (!confirm('Are you sure you want to delete this provider?')) return;
+    try {
+      // @ts-ignore
+      const result = await window.electronAPI.deleteCustomProvider(id);
+      if (result.success) {
+        // @ts-ignore
+        const updated = await window.electronAPI.getCustomProviders();
+        setCustomProviders(updated);
+      }
+    } catch (e) {
+      console.error('Failed to delete provider:', e);
+    }
+  };
+
+  return (
+    <div className="space-y-5 animated fadeIn pb-10">
+      {/* Default Model for Chat */}
+      <div className="space-y-5">
+        <div>
+          <h3 className="text-sm font-bold text-text-primary mb-1">Default Model for Chat</h3>
+          <p className="text-xs text-text-secondary mb-2">
+            Primary model for new chats. Other configured models act as fallbacks.
+          </p>
+        </div>
+
+        <div className="bg-bg-item-surface rounded-xl p-5 border border-border-subtle flex items-center justify-between">
+          <div>
+            <label className="block text-xs font-medium text-text-primary uppercase tracking-wide mb-0">
+              Active Model
+            </label>
+            <p className="text-[10px] text-text-secondary">Applies to new chats instantly.</p>
+          </div>
+          <ModelSelect
+            value={defaultModel}
+            options={(() => {
+              const opts: { id: string; name: string }[] = [];
+
+              if (hasStoredKey.natively) {
+                opts.push({ id: 'natively', name: 'Natively API' });
+              }
+
+              for (const [prov, cfg] of Object.entries(STANDARD_CLOUD_MODELS)) {
+                if (!hasStoredKey[prov as keyof typeof hasStoredKey]) continue;
+                cfg.ids.forEach((id, i) => opts.push({ id, name: cfg.names[i] }));
+                const pm = preferredModels[prov as keyof typeof preferredModels];
+                if (pm && !cfg.ids.includes(pm)) {
+                  opts.push({ id: pm, name: prettifyModelId(pm) });
+                }
+              }
+              if (codexCliConfig.enabled) {
+                opts.push({
+                  id: CODEX_CLI_MODEL.id,
+                  name: `${CODEX_CLI_MODEL.name} (${prettifyModelId(codexCliConfig.model)})`,
+                });
+                CODEX_CLI_MODEL_PRESETS.forEach((model) => {
+                  const id = codexCliSelectorId(model.id);
+                  if (!opts.find((o) => o.id === id)) {
+                    opts.push({ id, name: `${CODEX_CLI_MODEL.name}: ${model.name}` });
+                  }
+                });
+              }
+              customProviders.forEach((p) => opts.push({ id: p.id, name: p.name }));
+              ollamaModels.forEach((m) => opts.push({ id: `ollama-${m}`, name: `${m} (Local)` }));
+
+              if (defaultModel && !opts.find((o) => o.id === defaultModel)) {
+                opts.unshift({ id: defaultModel, name: prettifyModelId(defaultModel) });
+              }
+              return opts;
+            })()}
+            onChange={(val) => {
+              setDefaultModel(val);
+              // @ts-ignore - persist as default + update runtime + broadcast
+              window.electronAPI?.setDefaultModel(val).catch(console.error);
+            }}
+          />
+        </div>
+
+        {/* Fast Response Mode */}
+        <div
+          className={`bg-bg-item-surface rounded-xl p-5 border border-border-subtle flex items-center justify-between gap-4 ${!canUseFastMode ? 'opacity-50 grayscale' : ''}`}
+          title={
+            !canUseFastMode ? 'Requires Groq, Natively API, or Codex CLI to be configured' : ''
+          }
+        >
+          <div className="flex-1">
+            <div className="flex items-center gap-2">
+              <label className="block text-xs font-medium text-text-primary uppercase tracking-wide mb-0">
+                Fast Response Mode
+              </label>
+              <span className="bg-orange-500/10 text-orange-500 text-[9px] font-bold px-1.5 py-0.5 rounded border border-orange-500/20">
+                NEW
+              </span>
+            </div>
+            <p className="text-[10px] text-text-secondary mt-0.5">
+              Super fast responses using the Codex CLI fast model, Groq, or Natively. Turn this off
+              to use the selected normal model.
+            </p>
+            {!canUseFastMode && (
+              <p className="text-[10px] text-orange-500 mt-0.5 font-medium">
+                Requires Groq, Natively API, or Codex CLI to be configured.
+              </p>
+            )}
+          </div>
+          <div
+            onClick={async () => {
+              if (!canUseFastMode) {
+                alert(
+                  'Please configure Groq, Natively API, or Codex CLI first to enable Fast Response Mode.',
+                );
+                return;
+              }
+              const newState = !fastResponseMode;
+              setFastResponseMode(newState);
+              localStorage.setItem('natively_groq_fast_text', String(newState));
+              // @ts-ignore
+              await window.electronAPI?.setGroqFastTextMode(newState);
+            }}
+            className={`shrink-0 w-11 h-6 rounded-full relative cursor-pointer transition-colors ${!canUseFastMode ? 'cursor-not-allowed bg-bg-toggle-switch' : fastResponseMode ? 'bg-orange-500' : 'bg-bg-toggle-switch border border-border-muted'}`}
+          >
+            <div
+              className={`absolute top-1 left-1 w-4 h-4 rounded-full bg-white shadow-sm transition-transform ${fastResponseMode ? 'translate-x-5' : 'translate-x-0'}`}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Cloud Providers */}
+      <div className="space-y-5">
+        <div>
+          <h3 className="text-sm font-bold text-text-primary mb-1">Cloud Providers</h3>
+          <p className="text-xs text-text-secondary mb-2">
+            Add API keys to unlock cloud AI models.
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          {/* Gemini */}
+          <ProviderCard
+            providerId="gemini"
+            providerName="Gemini"
+            apiKey={apiKey}
+            preferredModel={preferredModels.gemini}
+            hasStoredKey={!!hasStoredKey.gemini}
+            onKeyChange={setApiKey}
+            onSaveKey={async () => {
+              await handleSaveKey('gemini', apiKey, setApiKey);
+            }}
+            onRemoveKey={() => handleRemoveKey('gemini', setApiKey)}
+            onTestConnection={() => handleTestConnection('gemini', apiKey)}
+            testStatus={testStatus.gemini || 'idle'}
+            testError={testError.gemini}
+            savingStatus={!!savingStatus.gemini}
+            savedStatus={!!savedStatus.gemini}
+            keyPlaceholder="AIzaSy..."
+            keyUrl="https://aistudio.google.com/app/apikey"
+            onPreferredModelChange={(model) =>
+              setPreferredModels((prev) => ({ ...prev, gemini: model }))
             }
-        } catch (e: any) {
-            setCurlError(e.message);
-        }
-    };
+          />
 
-    const handleDeleteCustom = async (id: string) => {
-        if (!confirm("Are you sure you want to delete this provider?")) return;
-        try {
-            // @ts-ignore
-            const result = await window.electronAPI.deleteCustomProvider(id);
-            if (result.success) {
-                // @ts-ignore
-                const updated = await window.electronAPI.getCustomProviders();
-                setCustomProviders(updated);
+          {/* Groq */}
+          <ProviderCard
+            providerId="groq"
+            providerName="Groq"
+            apiKey={groqApiKey}
+            preferredModel={preferredModels.groq}
+            hasStoredKey={!!hasStoredKey.groq}
+            onKeyChange={setGroqApiKey}
+            onSaveKey={async () => {
+              await handleSaveKey('groq', groqApiKey, setGroqApiKey);
+            }}
+            onRemoveKey={() => handleRemoveKey('groq', setGroqApiKey)}
+            onTestConnection={() => handleTestConnection('groq', groqApiKey)}
+            testStatus={testStatus.groq || 'idle'}
+            testError={testError.groq}
+            savingStatus={!!savingStatus.groq}
+            savedStatus={!!savedStatus.groq}
+            keyPlaceholder="gsk_..."
+            keyUrl="https://console.groq.com/keys"
+            onPreferredModelChange={(model) =>
+              setPreferredModels((prev) => ({ ...prev, groq: model }))
             }
-        } catch (e) {
-            console.error("Failed to delete provider:", e);
-        }
-    };
+          />
 
-    return (
-        <div className="space-y-5 animated fadeIn pb-10">
-            {/* Default Model for Chat */}
-            <div className="space-y-5">
-                <div>
-                    <h3 className="text-sm font-bold text-text-primary mb-1">Default Model for Chat</h3>
-                    <p className="text-xs text-text-secondary mb-2">Primary model for new chats. Other configured models act as fallbacks.</p>
+          {/* OpenAI */}
+          <ProviderCard
+            providerId="openai"
+            providerName="OpenAI"
+            apiKey={openaiApiKey}
+            preferredModel={preferredModels.openai}
+            hasStoredKey={!!hasStoredKey.openai}
+            onKeyChange={setOpenaiApiKey}
+            onSaveKey={async () => {
+              await handleSaveKey('openai', openaiApiKey, setOpenaiApiKey);
+            }}
+            onRemoveKey={() => handleRemoveKey('openai', setOpenaiApiKey)}
+            onTestConnection={() => handleTestConnection('openai', openaiApiKey)}
+            testStatus={testStatus.openai || 'idle'}
+            testError={testError.openai}
+            savingStatus={!!savingStatus.openai}
+            savedStatus={!!savedStatus.openai}
+            keyPlaceholder="sk-..."
+            keyUrl="https://platform.openai.com/api-keys"
+            onPreferredModelChange={(model) =>
+              setPreferredModels((prev) => ({ ...prev, openai: model }))
+            }
+          />
+
+          {/* Claude */}
+          <ProviderCard
+            providerId="claude"
+            providerName="Claude"
+            apiKey={claudeApiKey}
+            preferredModel={preferredModels.claude}
+            hasStoredKey={!!hasStoredKey.claude}
+            onKeyChange={setClaudeApiKey}
+            onSaveKey={async () => {
+              await handleSaveKey('claude', claudeApiKey, setClaudeApiKey);
+            }}
+            onRemoveKey={() => handleRemoveKey('claude', setClaudeApiKey)}
+            onTestConnection={() => handleTestConnection('claude', claudeApiKey)}
+            testStatus={testStatus.claude || 'idle'}
+            testError={testError.claude}
+            savingStatus={!!savingStatus.claude}
+            savedStatus={!!savedStatus.claude}
+            keyPlaceholder="sk-ant-..."
+            keyUrl="https://console.anthropic.com/settings/keys"
+            onPreferredModelChange={(model) =>
+              setPreferredModels((prev) => ({ ...prev, claude: model }))
+            }
+          />
+        </div>
+      </div>
+
+      {/* Local (Codex CLI) Provider */}
+      <div className="space-y-5">
+        <div>
+          <h3 className="text-sm font-bold text-text-primary mb-1">Local Provider (Codex CLI)</h3>
+          <p className="text-xs text-text-secondary">
+            Route text and screenshot responses through a locally authenticated Codex CLI.
+          </p>
+        </div>
+
+        <div className="bg-bg-item-surface rounded-xl p-5 border border-border-subtle space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <label className="block text-xs font-medium text-text-primary uppercase tracking-wide mb-0">
+                Enable Codex CLI
+              </label>
+              <p className="text-[10px] text-text-secondary">
+                Adds Codex CLI as a selectable local backend and fallback.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={async () => {
+                const next = { ...codexCliConfig, enabled: !codexCliConfig.enabled };
+                await saveCodexCliConfig(next);
+              }}
+              className={`w-11 h-6 rounded-full relative transition-colors ${codexCliConfig.enabled ? 'bg-accent-primary' : 'bg-bg-toggle-switch border border-border-muted'}`}
+            >
+              <span
+                className={`absolute top-1 left-1 w-4 h-4 rounded-full bg-white shadow-sm transition-transform ${codexCliConfig.enabled ? 'translate-x-5' : 'translate-x-0'}`}
+              />
+            </button>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <label className="space-y-1">
+              <span className="text-[10px] font-medium text-text-secondary uppercase tracking-wide">
+                Executable
+              </span>
+              <input
+                value={codexCliConfig.path}
+                onChange={(e) => setCodexCliConfig((prev) => ({ ...prev, path: e.target.value }))}
+                onBlur={() => saveCodexCliConfig()}
+                className="w-full bg-bg-input border border-border-subtle rounded-lg px-3 py-2 text-xs text-text-primary font-mono focus:outline-none focus:border-accent-primary"
+                placeholder="codex"
+              />
+            </label>
+            <label className="space-y-1">
+              <span className="text-[10px] font-medium text-text-secondary uppercase tracking-wide">
+                Timeout (ms)
+              </span>
+              <input
+                type="number"
+                value={codexCliConfig.timeoutMs}
+                onChange={(e) =>
+                  setCodexCliConfig((prev) => ({ ...prev, timeoutMs: Number(e.target.value) }))
+                }
+                onBlur={() => saveCodexCliConfig()}
+                className="w-full bg-bg-input border border-border-subtle rounded-lg px-3 py-2 text-xs text-text-primary font-mono focus:outline-none focus:border-accent-primary"
+                min={1000}
+              />
+            </label>
+            <CodexCliModelField
+              label="Normal Model"
+              value={codexCliConfig.model}
+              placeholder="gpt-5.5"
+              onChange={(model) => setCodexCliConfig((prev) => ({ ...prev, model }))}
+              onSelect={(model) => saveCodexCliConfig({ ...codexCliConfig, model })}
+              onSave={() => saveCodexCliConfig()}
+            />
+            <CodexCliModelField
+              label="Fast Model"
+              value={codexCliConfig.fastModel}
+              placeholder="gpt-5.3-codex-spark"
+              onChange={(fastModel) => setCodexCliConfig((prev) => ({ ...prev, fastModel }))}
+              onSelect={(fastModel) => saveCodexCliConfig({ ...codexCliConfig, fastModel })}
+              onSave={() => saveCodexCliConfig()}
+            />
+          </div>
+
+          <div className="flex items-center justify-between gap-3">
+            <div className="min-h-5">
+              {codexCliStatus === 'success' && (
+                <div className="flex items-center gap-2 text-xs text-green-400">
+                  <CheckCircle size={14} />
+                  <span>Codex CLI detected</span>
                 </div>
-
-                <div className="bg-bg-item-surface rounded-xl p-5 border border-border-subtle flex items-center justify-between">
-                    <div>
-                        <label className="block text-xs font-medium text-text-primary uppercase tracking-wide mb-0">Active Model</label>
-                        <p className="text-[10px] text-text-secondary">Applies to new chats instantly.</p>
-                    </div>
-                    <ModelSelect
-                        value={defaultModel}
-                        options={(() => {
-                            const opts: { id: string; name: string }[] = [];
-
-                            if (hasStoredKey.natively) {
-                                opts.push({ id: 'natively', name: 'Natively API' });
-                            }
-
-                            for (const [prov, cfg] of Object.entries(STANDARD_CLOUD_MODELS)) {
-                                if (!hasStoredKey[prov as keyof typeof hasStoredKey]) continue;
-                                cfg.ids.forEach((id, i) => opts.push({ id, name: cfg.names[i] }));
-                                const pm = preferredModels[prov as keyof typeof preferredModels];
-                                if (pm && !cfg.ids.includes(pm)) {
-                                    opts.push({ id: pm, name: prettifyModelId(pm) });
-                                }
-                            }
-                            if (codexCliConfig.enabled) {
-                                opts.push({ id: CODEX_CLI_MODEL.id, name: `${CODEX_CLI_MODEL.name} (${prettifyModelId(codexCliConfig.model)})` });
-                                CODEX_CLI_MODEL_PRESETS.forEach(model => {
-                                    const id = codexCliSelectorId(model.id);
-                                    if (!opts.find(o => o.id === id)) {
-                                        opts.push({ id, name: `${CODEX_CLI_MODEL.name}: ${model.name}` });
-                                    }
-                                });
-                            }
-                            customProviders.forEach(p => opts.push({ id: p.id, name: p.name }));
-                            ollamaModels.forEach(m => opts.push({ id: `ollama-${m}`, name: `${m} (Local)` }));
-
-                            if (defaultModel && !opts.find(o => o.id === defaultModel)) {
-                                opts.unshift({ id: defaultModel, name: prettifyModelId(defaultModel) });
-                            }
-                            return opts;
-                        })()}
-                        onChange={(val) => {
-                            setDefaultModel(val);
-                            // @ts-ignore - persist as default + update runtime + broadcast
-                            window.electronAPI?.setDefaultModel(val).catch(console.error);
-                        }}
-                    />
+              )}
+              {codexCliStatus === 'error' && (
+                <div className="flex items-center gap-2 text-xs text-red-400">
+                  <AlertCircle size={14} />
+                  <span>{codexCliError}</span>
                 </div>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={handleTestCodexCli}
+              disabled={codexCliStatus === 'testing'}
+              className="flex items-center gap-2 px-3 py-1.5 bg-bg-input hover:bg-bg-elevated border border-border-subtle rounded-lg text-xs font-medium text-text-primary transition-colors disabled:opacity-60"
+            >
+              {codexCliStatus === 'testing' ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <CheckCircle size={14} />
+              )}
+              Test CLI
+            </button>
+          </div>
+        </div>
+      </div>
 
-                {/* Fast Response Mode */}
-                <div
-                    className={`bg-bg-item-surface rounded-xl p-5 border border-border-subtle flex items-center justify-between gap-4 ${!canUseFastMode ? 'opacity-50 grayscale' : ''}`}
-                    title={!canUseFastMode ? "Requires Groq, Natively API, or Codex CLI to be configured" : ""}
+      {/* Local (Ollama) Providers */}
+      <div className="space-y-5">
+        <div className="flex items-center justify-between mb-2">
+          <div>
+            <h3 className="text-sm font-bold text-text-primary mb-1">Local Models (Ollama)</h3>
+            <p className="text-xs text-text-secondary">Run open-source models locally.</p>
+          </div>
+          <button
+            onClick={async () => {
+              setIsRefreshingOllama(true);
+              await checkOllama(false);
+              // Add a small delay for visual feedback if the check is too fast
+              setTimeout(() => setIsRefreshingOllama(false), 500);
+            }}
+            className="p-2 rounded-lg text-text-secondary hover:text-text-primary hover:bg-bg-input transition-colors"
+            title="Refresh Ollama"
+            disabled={isRefreshingOllama}
+          >
+            <RefreshCw size={18} className={isRefreshingOllama ? 'animate-spin' : ''} />
+          </button>
+        </div>
+
+        <div className="bg-bg-item-surface rounded-xl p-5 border border-border-subtle">
+          {ollamaStatus === 'checking' && (
+            <div className="flex items-center gap-2 text-xs text-text-secondary">
+              <span className="animate-spin">⏳</span> Checking for Ollama...
+            </div>
+          )}
+
+          {ollamaStatus === 'fixing' && (
+            <div className="flex items-center gap-2 text-xs text-text-secondary">
+              <span className="animate-spin">🔧</span> Attempting to auto-fix connection...
+            </div>
+          )}
+
+          {ollamaStatus === 'not-found' && (
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center gap-2 text-xs text-red-400">
+                <AlertCircle size={14} />
+                <span>Ollama not detected</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <p className="text-xs text-text-secondary">
+                  Ensure Ollama is running (`ollama serve`).
+                </p>
+                <button
+                  onClick={handleFixOllama}
+                  className="text-[10px] bg-bg-elevated hover:bg-bg-input px-2 py-1 rounded border border-border-subtle"
                 >
-                    <div className="flex-1">
-                        <div className="flex items-center gap-2">
-                            <label className="block text-xs font-medium text-text-primary uppercase tracking-wide mb-0">Fast Response Mode</label>
-                            <span className="bg-orange-500/10 text-orange-500 text-[9px] font-bold px-1.5 py-0.5 rounded border border-orange-500/20">NEW</span>
-                        </div>
-                        <p className="text-[10px] text-text-secondary mt-0.5">Super fast responses using the Codex CLI fast model, Groq, or Natively. Turn this off to use the selected normal model.</p>
-                        {!canUseFastMode && (
-                            <p className="text-[10px] text-orange-500 mt-0.5 font-medium">Requires Groq, Natively API, or Codex CLI to be configured.</p>
-                        )}
-                    </div>
-                    <div
-                        onClick={async () => {
-                            if (!canUseFastMode) {
-                                alert("Please configure Groq, Natively API, or Codex CLI first to enable Fast Response Mode.");
-                                return;
-                            }
-                            const newState = !fastResponseMode;
-                            setFastResponseMode(newState);
-                            localStorage.setItem('natively_groq_fast_text', String(newState));
-                            // @ts-ignore
-                            await window.electronAPI?.setGroqFastTextMode(newState);
-                        }}
-                        className={`shrink-0 w-11 h-6 rounded-full relative cursor-pointer transition-colors ${!canUseFastMode ? 'cursor-not-allowed bg-bg-toggle-switch' : fastResponseMode ? 'bg-orange-500' : 'bg-bg-toggle-switch border border-border-muted'}`}
-                    >
-                        <div className={`absolute top-1 left-1 w-4 h-4 rounded-full bg-white shadow-sm transition-transform ${fastResponseMode ? 'translate-x-5' : 'translate-x-0'}`} />
-                    </div>
-                </div>
+                  Auto-Fix Connection
+                </button>
+              </div>
             </div>
+          )}
 
-            {/* Cloud Providers */}
-            <div className="space-y-5">
-                <div>
-                    <h3 className="text-sm font-bold text-text-primary mb-1">Cloud Providers</h3>
-                    <p className="text-xs text-text-secondary mb-2">Add API keys to unlock cloud AI models.</p>
-                </div>
+          {ollamaStatus === 'detected' && ollamaModels.length > 0 && (
+            <div className="space-y-3">
+              <div className="flex items-center gap-2 text-xs text-green-400 mb-3">
+                <CheckCircle size={14} />
+                <span>Ollama connected</span>
+              </div>
 
-                <div className="space-y-4">
-
-                    {/* Gemini */}
-                    <ProviderCard
-                        providerId="gemini"
-                        providerName="Gemini"
-                        apiKey={apiKey}
-                        preferredModel={preferredModels.gemini}
-                        hasStoredKey={!!hasStoredKey.gemini}
-                        onKeyChange={setApiKey}
-                        onSaveKey={async () => { await handleSaveKey('gemini', apiKey, setApiKey); }}
-                        onRemoveKey={() => handleRemoveKey('gemini', setApiKey)}
-                        onTestConnection={() => handleTestConnection('gemini', apiKey)}
-                        testStatus={testStatus.gemini || 'idle'}
-                        testError={testError.gemini}
-                        savingStatus={!!savingStatus.gemini}
-                        savedStatus={!!savedStatus.gemini}
-                        keyPlaceholder="AIzaSy..."
-                        keyUrl="https://aistudio.google.com/app/apikey"
-                        onPreferredModelChange={(model) => setPreferredModels(prev => ({ ...prev, gemini: model }))}
-                    />
-
-                    {/* Groq */}
-                    <ProviderCard
-                        providerId="groq"
-                        providerName="Groq"
-                        apiKey={groqApiKey}
-                        preferredModel={preferredModels.groq}
-                        hasStoredKey={!!hasStoredKey.groq}
-                        onKeyChange={setGroqApiKey}
-                        onSaveKey={async () => { await handleSaveKey('groq', groqApiKey, setGroqApiKey); }}
-                        onRemoveKey={() => handleRemoveKey('groq', setGroqApiKey)}
-                        onTestConnection={() => handleTestConnection('groq', groqApiKey)}
-                        testStatus={testStatus.groq || 'idle'}
-                        testError={testError.groq}
-                        savingStatus={!!savingStatus.groq}
-                        savedStatus={!!savedStatus.groq}
-                        keyPlaceholder="gsk_..."
-                        keyUrl="https://console.groq.com/keys"
-                        onPreferredModelChange={(model) => setPreferredModels(prev => ({ ...prev, groq: model }))}
-                    />
-
-                    {/* OpenAI */}
-                    <ProviderCard
-                        providerId="openai"
-                        providerName="OpenAI"
-                        apiKey={openaiApiKey}
-                        preferredModel={preferredModels.openai}
-                        hasStoredKey={!!hasStoredKey.openai}
-                        onKeyChange={setOpenaiApiKey}
-                        onSaveKey={async () => { await handleSaveKey('openai', openaiApiKey, setOpenaiApiKey); }}
-                        onRemoveKey={() => handleRemoveKey('openai', setOpenaiApiKey)}
-                        onTestConnection={() => handleTestConnection('openai', openaiApiKey)}
-                        testStatus={testStatus.openai || 'idle'}
-                        testError={testError.openai}
-                        savingStatus={!!savingStatus.openai}
-                        savedStatus={!!savedStatus.openai}
-                        keyPlaceholder="sk-..."
-                        keyUrl="https://platform.openai.com/api-keys"
-                        onPreferredModelChange={(model) => setPreferredModels(prev => ({ ...prev, openai: model }))}
-                    />
-
-                    {/* Claude */}
-                    <ProviderCard
-                        providerId="claude"
-                        providerName="Claude"
-                        apiKey={claudeApiKey}
-                        preferredModel={preferredModels.claude}
-                        hasStoredKey={!!hasStoredKey.claude}
-                        onKeyChange={setClaudeApiKey}
-                        onSaveKey={async () => { await handleSaveKey('claude', claudeApiKey, setClaudeApiKey); }}
-                        onRemoveKey={() => handleRemoveKey('claude', setClaudeApiKey)}
-                        onTestConnection={() => handleTestConnection('claude', claudeApiKey)}
-                        testStatus={testStatus.claude || 'idle'}
-                        testError={testError.claude}
-                        savingStatus={!!savingStatus.claude}
-                        savedStatus={!!savedStatus.claude}
-                        keyPlaceholder="sk-ant-..."
-                        keyUrl="https://console.anthropic.com/settings/keys"
-                        onPreferredModelChange={(model) => setPreferredModels(prev => ({ ...prev, claude: model }))}
-                    />
-
-                </div>
+              <div className="grid grid-cols-1 gap-2">
+                {ollamaModels.map((model) => (
+                  <div
+                    key={model}
+                    className="flex items-center justify-between p-2 bg-bg-input rounded-lg border border-border-subtle"
+                  >
+                    <span className="text-xs text-text-primary font-mono">{model}</span>
+                    <span className="text-[10px] text-bg-elevated bg-text-secondary px-1.5 py-0.5 rounded-full font-bold">
+                      LOCAL
+                    </span>
+                  </div>
+                ))}
+              </div>
             </div>
-
-            {/* Local (Codex CLI) Provider */}
-            <div className="space-y-5">
-                <div>
-                    <h3 className="text-sm font-bold text-text-primary mb-1">Local Provider (Codex CLI)</h3>
-                    <p className="text-xs text-text-secondary">Route text and screenshot responses through a locally authenticated Codex CLI.</p>
-                </div>
-
-                <div className="bg-bg-item-surface rounded-xl p-5 border border-border-subtle space-y-4">
-                    <div className="flex items-center justify-between">
-                        <div>
-                            <label className="block text-xs font-medium text-text-primary uppercase tracking-wide mb-0">Enable Codex CLI</label>
-                            <p className="text-[10px] text-text-secondary">Adds Codex CLI as a selectable local backend and fallback.</p>
-                        </div>
-                        <button
-                            type="button"
-                            onClick={async () => {
-                                const next = { ...codexCliConfig, enabled: !codexCliConfig.enabled };
-                                await saveCodexCliConfig(next);
-                            }}
-                            className={`w-11 h-6 rounded-full relative transition-colors ${codexCliConfig.enabled ? 'bg-accent-primary' : 'bg-bg-toggle-switch border border-border-muted'}`}
-                        >
-                            <span className={`absolute top-1 left-1 w-4 h-4 rounded-full bg-white shadow-sm transition-transform ${codexCliConfig.enabled ? 'translate-x-5' : 'translate-x-0'}`} />
-                        </button>
-                    </div>
-
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                        <label className="space-y-1">
-                            <span className="text-[10px] font-medium text-text-secondary uppercase tracking-wide">Executable</span>
-                            <input
-                                value={codexCliConfig.path}
-                                onChange={e => setCodexCliConfig(prev => ({ ...prev, path: e.target.value }))}
-                                onBlur={() => saveCodexCliConfig()}
-                                className="w-full bg-bg-input border border-border-subtle rounded-lg px-3 py-2 text-xs text-text-primary font-mono focus:outline-none focus:border-accent-primary"
-                                placeholder="codex"
-                            />
-                        </label>
-                        <label className="space-y-1">
-                            <span className="text-[10px] font-medium text-text-secondary uppercase tracking-wide">Timeout (ms)</span>
-                            <input
-                                type="number"
-                                value={codexCliConfig.timeoutMs}
-                                onChange={e => setCodexCliConfig(prev => ({ ...prev, timeoutMs: Number(e.target.value) }))}
-                                onBlur={() => saveCodexCliConfig()}
-                                className="w-full bg-bg-input border border-border-subtle rounded-lg px-3 py-2 text-xs text-text-primary font-mono focus:outline-none focus:border-accent-primary"
-                                min={1000}
-                            />
-                        </label>
-                        <CodexCliModelField
-                            label="Normal Model"
-                            value={codexCliConfig.model}
-                            placeholder="gpt-5.5"
-                            onChange={(model) => setCodexCliConfig(prev => ({ ...prev, model }))}
-                            onSelect={(model) => saveCodexCliConfig({ ...codexCliConfig, model })}
-                            onSave={() => saveCodexCliConfig()}
-                        />
-                        <CodexCliModelField
-                            label="Fast Model"
-                            value={codexCliConfig.fastModel}
-                            placeholder="gpt-5.3-codex-spark"
-                            onChange={(fastModel) => setCodexCliConfig(prev => ({ ...prev, fastModel }))}
-                            onSelect={(fastModel) => saveCodexCliConfig({ ...codexCliConfig, fastModel })}
-                            onSave={() => saveCodexCliConfig()}
-                        />
-                    </div>
-
-                    <div className="flex items-center justify-between gap-3">
-                        <div className="min-h-5">
-                            {codexCliStatus === 'success' && (
-                                <div className="flex items-center gap-2 text-xs text-green-400">
-                                    <CheckCircle size={14} />
-                                    <span>Codex CLI detected</span>
-                                </div>
-                            )}
-                            {codexCliStatus === 'error' && (
-                                <div className="flex items-center gap-2 text-xs text-red-400">
-                                    <AlertCircle size={14} />
-                                    <span>{codexCliError}</span>
-                                </div>
-                            )}
-                        </div>
-                        <button
-                            type="button"
-                            onClick={handleTestCodexCli}
-                            disabled={codexCliStatus === 'testing'}
-                            className="flex items-center gap-2 px-3 py-1.5 bg-bg-input hover:bg-bg-elevated border border-border-subtle rounded-lg text-xs font-medium text-text-primary transition-colors disabled:opacity-60"
-                        >
-                            {codexCliStatus === 'testing' ? <Loader2 size={14} className="animate-spin" /> : <CheckCircle size={14} />}
-                            Test CLI
-                        </button>
-                    </div>
-                </div>
+          )}
+          {ollamaStatus === 'detected' && ollamaModels.length === 0 && (
+            <div className="text-xs text-text-secondary">
+              Ollama is running but no models found. Run `ollama pull llama3` to get started.
             </div>
+          )}
+        </div>
+      </div>
 
-            {/* Local (Ollama) Providers */}
-            <div className="space-y-5">
-                <div className="flex items-center justify-between mb-2">
-                    <div>
-                        <h3 className="text-sm font-bold text-text-primary mb-1">Local Models (Ollama)</h3>
-                        <p className="text-xs text-text-secondary">Run open-source models locally.</p>
-                    </div>
-                    <button
-                        onClick={async () => {
-                            setIsRefreshingOllama(true);
-                            await checkOllama(false);
-                            // Add a small delay for visual feedback if the check is too fast
-                            setTimeout(() => setIsRefreshingOllama(false), 500);
-                        }}
-                        className="p-2 rounded-lg text-text-secondary hover:text-text-primary hover:bg-bg-input transition-colors"
-                        title="Refresh Ollama"
-                        disabled={isRefreshingOllama}
-                    >
-                        <RefreshCw size={18} className={isRefreshingOllama ? "animate-spin" : ""} />
-                    </button>
-                </div>
-
-                <div className="bg-bg-item-surface rounded-xl p-5 border border-border-subtle">
-                    {ollamaStatus === 'checking' && (
-                        <div className="flex items-center gap-2 text-xs text-text-secondary">
-                            <span className="animate-spin">⏳</span> Checking for Ollama...
-                        </div>
-                    )}
-
-                    {ollamaStatus === 'fixing' && (
-                        <div className="flex items-center gap-2 text-xs text-text-secondary">
-                            <span className="animate-spin">🔧</span> Attempting to auto-fix connection...
-                        </div>
-                    )}
-
-                    {ollamaStatus === 'not-found' && (
-                        <div className="flex flex-col gap-2">
-                            <div className="flex items-center gap-2 text-xs text-red-400">
-                                <AlertCircle size={14} />
-                                <span>Ollama not detected</span>
-                            </div>
-                            <div className="flex items-center gap-2">
-                                <p className="text-xs text-text-secondary">
-                                    Ensure Ollama is running (`ollama serve`).
-                                </p>
-                                <button
-                                    onClick={handleFixOllama}
-                                    className="text-[10px] bg-bg-elevated hover:bg-bg-input px-2 py-1 rounded border border-border-subtle"
-                                >
-                                    Auto-Fix Connection
-                                </button>
-                            </div>
-                        </div>
-                    )}
-
-                    {ollamaStatus === 'detected' && ollamaModels.length > 0 && (
-                        <div className="space-y-3">
-                            <div className="flex items-center gap-2 text-xs text-green-400 mb-3">
-                                <CheckCircle size={14} />
-                                <span>Ollama connected</span>
-                            </div>
-
-                            <div className="grid grid-cols-1 gap-2">
-                                {ollamaModels.map(model => (
-                                    <div key={model} className="flex items-center justify-between p-2 bg-bg-input rounded-lg border border-border-subtle">
-                                        <span className="text-xs text-text-primary font-mono">{model}</span>
-                                        <span className="text-[10px] text-bg-elevated bg-text-secondary px-1.5 py-0.5 rounded-full font-bold">LOCAL</span>
-                                    </div>
-                                ))}
-                            </div>
-                        </div>
-                    )}
-                    {ollamaStatus === 'detected' && ollamaModels.length === 0 && (
-                        <div className="text-xs text-text-secondary">
-                            Ollama is running but no models found. Run `ollama pull llama3` to get started.
-                        </div>
-                    )}
-                </div>
+      {/* Custom Providers */}
+      <div className="space-y-5">
+        <div className="flex items-center justify-between mb-2">
+          <div>
+            <div className="flex items-center gap-2 mb-1">
+              <h3 className="text-sm font-bold text-text-primary">Custom Providers</h3>
+              <span className="px-1.5 py-0 rounded-full text-[7px] font-bold bg-yellow-500/10 text-yellow-500 uppercase tracking-widest border border-yellow-500/20 leading-loose mt-0.5">
+                Experimental
+              </span>
             </div>
+            <p className="text-xs text-text-secondary">Add your own AI endpoints via cURL.</p>
+          </div>
+          {!isEditingCustom && (
+            <button
+              onClick={handleNewProvider}
+              className="flex items-center gap-2 px-3 py-1.5 bg-bg-input hover:bg-bg-elevated border border-border-subtle rounded-lg text-xs font-medium text-text-primary transition-colors"
+            >
+              <Plus size={14} /> Add Provider
+            </button>
+          )}
+        </div>
 
-            {/* Custom Providers */}
-            <div className="space-y-5">
-                <div className="flex items-center justify-between mb-2">
-                    <div>
-                        <div className="flex items-center gap-2 mb-1">
-                            <h3 className="text-sm font-bold text-text-primary">Custom Providers</h3>
-                            <span className="px-1.5 py-0 rounded-full text-[7px] font-bold bg-yellow-500/10 text-yellow-500 uppercase tracking-widest border border-yellow-500/20 leading-loose mt-0.5">Experimental</span>
-                        </div>
-                        <p className="text-xs text-text-secondary">Add your own AI endpoints via cURL.</p>
-                    </div>
-                    {!isEditingCustom && (
-                        <button
-                            onClick={handleNewProvider}
-                            className="flex items-center gap-2 px-3 py-1.5 bg-bg-input hover:bg-bg-elevated border border-border-subtle rounded-lg text-xs font-medium text-text-primary transition-colors"
-                        >
-                            <Plus size={14} /> Add Provider
-                        </button>
-                    )}
+        {isEditingCustom ? (
+          <div className="bg-bg-item-surface rounded-xl p-5 border border-border-subtle animated fadeIn">
+            <h4 className="text-sm font-bold text-text-primary mb-4">
+              {editingProvider ? 'Edit Provider' : 'New Provider'}
+            </h4>
+
+            <div className="space-y-4">
+              <div>
+                <label className="block text-xs font-medium text-text-primary uppercase tracking-wide mb-1">
+                  Provider Name
+                </label>
+                <input
+                  type="text"
+                  value={customName}
+                  onChange={(e) => setCustomName(e.target.value)}
+                  placeholder="My Custom LLM"
+                  className="w-full bg-bg-input border border-border-subtle rounded-lg px-4 py-2.5 text-xs text-text-primary focus:outline-none focus:border-accent-primary transition-colors"
+                />
+              </div>
+
+              <div>
+                <label className="block text-xs font-medium text-text-primary uppercase tracking-wide mb-1">
+                  cURL Command
+                </label>
+                <div className="relative">
+                  <textarea
+                    value={customCurl}
+                    onChange={(e) => setCustomCurl(e.target.value)}
+                    placeholder={`curl https://api.openai.com/v1/chat/completions ... "content": "{{TEXT}}"`}
+                    className="w-full h-32 bg-bg-input border border-border-subtle rounded-lg p-4 text-xs font-mono text-text-primary focus:outline-none focus:border-accent-primary transition-colors resize-none leading-relaxed"
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label className="block text-xs font-medium text-text-primary uppercase tracking-wide mb-1">
+                  Response JSON Path{' '}
+                  <span className="text-text-tertiary normal-case font-normal">(Optional)</span>
+                </label>
+                <input
+                  type="text"
+                  value={customResponsePath}
+                  onChange={(e) => setCustomResponsePath(e.target.value)}
+                  placeholder="e.g. choices[0].message.content"
+                  className="w-full bg-bg-input border border-border-subtle rounded-lg px-4 py-2.5 text-xs text-text-primary focus:outline-none focus:border-accent-primary transition-colors font-mono"
+                />
+                <p className="text-[10px] text-text-secondary mt-1">
+                  Dot notation path to the answer text in the JSON response. If empty, the full JSON
+                  is returned.
+                </p>
+              </div>
+
+              <div className="bg-bg-elevated/30 rounded-lg overflow-hidden border border-border-subtle mt-4">
+                <div className="px-4 py-3 bg-bg-elevated/50 border-b border-border-subtle flex items-center justify-between">
+                  <h5 className="block text-xs font-medium text-text-primary uppercase tracking-wide">
+                    Configuration Guide
+                  </h5>
                 </div>
 
-                {isEditingCustom ? (
-                    <div className="bg-bg-item-surface rounded-xl p-5 border border-border-subtle animated fadeIn">
-                        <h4 className="text-sm font-bold text-text-primary mb-4">{editingProvider ? 'Edit Provider' : 'New Provider'}</h4>
+                <div className="p-4 space-y-4">
+                  <div>
+                    <p className="text-xs text-text-secondary mb-2 font-medium">
+                      Available Variables
+                    </p>
+                    <div className="grid grid-cols-1 gap-2">
+                      <div className="flex items-center gap-2 text-xs">
+                        <code className="bg-bg-input px-1.5 py-0.5 rounded text-text-primary font-mono border border-border-subtle">
+                          {'{{TEXT}}'}
+                        </code>
+                        <span className="text-text-tertiary">
+                          Combined System + Context + Message (Recommended)
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-2 text-xs">
+                        <code className="bg-bg-input px-1.5 py-0.5 rounded text-text-primary font-mono border border-border-subtle">
+                          {'{{IMAGE_BASE64}}'}
+                        </code>
+                        <span className="text-text-tertiary">Screenshot data (if available)</span>
+                      </div>
+                    </div>
+                  </div>
 
-                        <div className="space-y-4">
-                            <div>
-                                <label className="block text-xs font-medium text-text-primary uppercase tracking-wide mb-1">Provider Name</label>
-                                <input
-                                    type="text"
-                                    value={customName}
-                                    onChange={(e) => setCustomName(e.target.value)}
-                                    placeholder="My Custom LLM"
-                                    className="w-full bg-bg-input border border-border-subtle rounded-lg px-4 py-2.5 text-xs text-text-primary focus:outline-none focus:border-accent-primary transition-colors"
-                                />
-                            </div>
+                  <div>
+                    <p className="text-xs text-text-secondary mb-2 font-medium">Examples</p>
+                    <div className="space-y-3">
+                      {/* Ollama Example */}
+                      <div>
+                        <div className="text-[10px] uppercase tracking-wider text-text-tertiary mb-1.5">
+                          Local (Ollama)
+                        </div>
+                        <div className="bg-bg-input p-2.5 rounded-lg border border-border-subtle overflow-x-auto group relative">
+                          <code className="font-mono text-[10px] text-text-primary whitespace-pre block">
+                            curl http://localhost:11434/api/generate -d '{'{'}"model": "llama3",
+                            "prompt": "{`{{TEXT}}`}"{'}'}'
+                          </code>
+                        </div>
+                      </div>
 
-                            <div>
-                                <label className="block text-xs font-medium text-text-primary uppercase tracking-wide mb-1">cURL Command</label>
-                                <div className="relative">
-                                    <textarea
-                                        value={customCurl}
-                                        onChange={(e) => setCustomCurl(e.target.value)}
-                                        placeholder={`curl https://api.openai.com/v1/chat/completions ... "content": "{{TEXT}}"`}
-                                        className="w-full h-32 bg-bg-input border border-border-subtle rounded-lg p-4 text-xs font-mono text-text-primary focus:outline-none focus:border-accent-primary transition-colors resize-none leading-relaxed"
-                                    />
-                                </div>
-                            </div>
-
-                            <div>
-                                <label className="block text-xs font-medium text-text-primary uppercase tracking-wide mb-1">
-                                    Response JSON Path <span className="text-text-tertiary normal-case font-normal">(Optional)</span>
-                                </label>
-                                <input
-                                    type="text"
-                                    value={customResponsePath}
-                                    onChange={(e) => setCustomResponsePath(e.target.value)}
-                                    placeholder="e.g. choices[0].message.content"
-                                    className="w-full bg-bg-input border border-border-subtle rounded-lg px-4 py-2.5 text-xs text-text-primary focus:outline-none focus:border-accent-primary transition-colors font-mono"
-                                />
-                                <p className="text-[10px] text-text-secondary mt-1">
-                                    Dot notation path to the answer text in the JSON response. If empty, the full JSON is returned.
-                                </p>
-                            </div>
-
-                            <div className="bg-bg-elevated/30 rounded-lg overflow-hidden border border-border-subtle mt-4">
-                                <div className="px-4 py-3 bg-bg-elevated/50 border-b border-border-subtle flex items-center justify-between">
-                                    <h5 className="block text-xs font-medium text-text-primary uppercase tracking-wide">
-                                        Configuration Guide
-                                    </h5>
-                                </div>
-
-                                <div className="p-4 space-y-4">
-                                    <div>
-                                        <p className="text-xs text-text-secondary mb-2 font-medium">Available Variables</p>
-                                        <div className="grid grid-cols-1 gap-2">
-                                            <div className="flex items-center gap-2 text-xs">
-                                                <code className="bg-bg-input px-1.5 py-0.5 rounded text-text-primary font-mono border border-border-subtle">{"{{TEXT}}"}</code>
-                                                <span className="text-text-tertiary">Combined System + Context + Message (Recommended)</span>
-                                            </div>
-                                            <div className="flex items-center gap-2 text-xs">
-                                                <code className="bg-bg-input px-1.5 py-0.5 rounded text-text-primary font-mono border border-border-subtle">{"{{IMAGE_BASE64}}"}</code>
-                                                <span className="text-text-tertiary">Screenshot data (if available)</span>
-                                            </div>
-                                        </div>
-                                    </div>
-
-                                    <div>
-                                        <p className="text-xs text-text-secondary mb-2 font-medium">Examples</p>
-                                        <div className="space-y-3">
-                                            {/* Ollama Example */}
-                                            <div>
-                                                <div className="text-[10px] uppercase tracking-wider text-text-tertiary mb-1.5">Local (Ollama)</div>
-                                                <div className="bg-bg-input p-2.5 rounded-lg border border-border-subtle overflow-x-auto group relative">
-                                                    <code className="font-mono text-[10px] text-text-primary whitespace-pre block">
-                                                        curl http://localhost:11434/api/generate -d '{"{"}"model": "llama3", "prompt": "{`{{TEXT}}`}"{"}"}'
-                                                    </code>
-                                                </div>
-                                            </div>
-
-                                            {/* OpenAI Example */}
-                                            <div>
-                                                <div className="text-[10px] uppercase tracking-wider text-text-tertiary mb-1.5">OpenAI Compatible</div>
-                                                <div className="bg-bg-input p-2.5 rounded-lg border border-border-subtle overflow-x-auto">
-                                                    <code className="font-mono text-[10px] text-text-primary whitespace-pre block">
-                                                        {`curl https://api.openai.com/v1/chat/completions \\
+                      {/* OpenAI Example */}
+                      <div>
+                        <div className="text-[10px] uppercase tracking-wider text-text-tertiary mb-1.5">
+                          OpenAI Compatible
+                        </div>
+                        <div className="bg-bg-input p-2.5 rounded-lg border border-border-subtle overflow-x-auto">
+                          <code className="font-mono text-[10px] text-text-primary whitespace-pre block">
+                            {`curl https://api.openai.com/v1/chat/completions \\
   -H "Content-Type: application/json" \\
   -H "Authorization: Bearer YOUR_API_KEY" \\
   -d '{
@@ -969,84 +1098,87 @@ export const AIProvidersSettings: React.FC = () => {
     ],
     "temperature": 0.7
   }'`}
-                                                    </code>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-
-                            {curlError && (
-                                <div className="flex items-start gap-2 p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400 text-xs">
-                                    <AlertCircle size={14} className="shrink-0 mt-0.5" />
-                                    <span>{curlError}</span>
-                                </div>
-                            )}
-
-                            <div className="flex justify-end gap-3 pt-2">
-                                <button
-                                    onClick={() => setIsEditingCustom(false)}
-                                    className="px-4 py-2 rounded-lg text-xs font-medium text-text-secondary hover:text-text-primary hover:bg-bg-input transition-colors"
-                                >
-                                    Cancel
-                                </button>
-                                <button
-                                    onClick={handleSaveCustom}
-                                    className="px-4 py-2 rounded-lg text-xs font-medium bg-accent-primary text-white hover:bg-accent-secondary transition-colors flex items-center gap-2"
-                                >
-                                    <Save size={14} /> Save Provider
-                                </button>
-                            </div>
+                          </code>
                         </div>
+                      </div>
                     </div>
-                ) : (
-                    <div className="space-y-3">
-                        {customProviders.length === 0 ? (
-                            <div className="text-center py-8 bg-bg-item-surface rounded-xl border border-border-subtle border-dashed">
-                                <p className="text-xs text-text-tertiary">No custom providers added yet.</p>
-                            </div>
-                        ) : (
-                            customProviders.map((provider) => (
-                                <div key={provider.id} className="bg-bg-item-surface rounded-xl p-4 border border-border-subtle flex items-center justify-between group">
-                                    <div className="flex items-center gap-3">
-                                        <div className="w-8 h-8 rounded-lg bg-bg-input flex items-center justify-center text-text-secondary font-mono text-xs font-bold">
-                                            {provider.name.substring(0, 2).toUpperCase()}
-                                        </div>
-                                        <div>
-                                            <h4 className="text-sm font-medium text-text-primary">{provider.name}</h4>
-                                            <p className="text-[10px] text-text-tertiary font-mono truncate max-w-[200px] opacity-60">
-                                                {provider.curlCommand.substring(0, 30)}...
-                                            </p>
-                                            {provider.responsePath && (
-                                                <p className="text-[9px] text-text-tertiary font-mono opacity-40 mt-0.5">
-                                                    path: {provider.responsePath}
-                                                </p>
-                                            )}
-                                        </div>
-                                    </div>
-                                    <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
-                                        <button
-                                            onClick={() => handleEditProvider(provider)}
-                                            className="p-1.5 rounded-lg text-text-secondary hover:text-text-primary hover:bg-bg-elevated transition-colors"
-                                            title="Edit"
-                                        >
-                                            <Edit2 size={14} />
-                                        </button>
-                                        <button
-                                            onClick={() => handleDeleteCustom(provider.id)}
-                                            className="p-1.5 rounded-lg text-text-secondary hover:text-red-400 hover:bg-red-500/10 transition-colors"
-                                            title="Delete"
-                                        >
-                                            <Trash2 size={14} />
-                                        </button>
-                                    </div>
-                                </div>
-                            ))
-                        )}
-                    </div>
-                )}
+                  </div>
+                </div>
+              </div>
+
+              {curlError && (
+                <div className="flex items-start gap-2 p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400 text-xs">
+                  <AlertCircle size={14} className="shrink-0 mt-0.5" />
+                  <span>{curlError}</span>
+                </div>
+              )}
+
+              <div className="flex justify-end gap-3 pt-2">
+                <button
+                  onClick={() => setIsEditingCustom(false)}
+                  className="px-4 py-2 rounded-lg text-xs font-medium text-text-secondary hover:text-text-primary hover:bg-bg-input transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleSaveCustom}
+                  className="px-4 py-2 rounded-lg text-xs font-medium bg-accent-primary text-white hover:bg-accent-secondary transition-colors flex items-center gap-2"
+                >
+                  <Save size={14} /> Save Provider
+                </button>
+              </div>
             </div>
-        </div>
-    );
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {customProviders.length === 0 ? (
+              <div className="text-center py-8 bg-bg-item-surface rounded-xl border border-border-subtle border-dashed">
+                <p className="text-xs text-text-tertiary">No custom providers added yet.</p>
+              </div>
+            ) : (
+              customProviders.map((provider) => (
+                <div
+                  key={provider.id}
+                  className="bg-bg-item-surface rounded-xl p-4 border border-border-subtle flex items-center justify-between group"
+                >
+                  <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 rounded-lg bg-bg-input flex items-center justify-center text-text-secondary font-mono text-xs font-bold">
+                      {provider.name.substring(0, 2).toUpperCase()}
+                    </div>
+                    <div>
+                      <h4 className="text-sm font-medium text-text-primary">{provider.name}</h4>
+                      <p className="text-[10px] text-text-tertiary font-mono truncate max-w-[200px] opacity-60">
+                        {provider.curlCommand.substring(0, 30)}...
+                      </p>
+                      {provider.responsePath && (
+                        <p className="text-[9px] text-text-tertiary font-mono opacity-40 mt-0.5">
+                          path: {provider.responsePath}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <button
+                      onClick={() => handleEditProvider(provider)}
+                      className="p-1.5 rounded-lg text-text-secondary hover:text-text-primary hover:bg-bg-elevated transition-colors"
+                      title="Edit"
+                    >
+                      <Edit2 size={14} />
+                    </button>
+                    <button
+                      onClick={() => handleDeleteCustom(provider.id)}
+                      className="p-1.5 rounded-lg text-text-secondary hover:text-red-400 hover:bg-red-500/10 transition-colors"
+                      title="Delete"
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
 };

--- a/src/components/settings/NativelyApiSettings.tsx
+++ b/src/components/settings/NativelyApiSettings.tsx
@@ -1,857 +1,1095 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
 import {
-    CheckCircle, AlertCircle,
-    Mic, Brain, Search, Shield, Loader2,
-    RefreshCw, CalendarClock, Trash2, ArrowUpRight, Info,
-    Zap, Clock, Sparkles
+  AlertCircle,
+  ArrowUpRight,
+  Brain,
+  CalendarClock,
+  CheckCircle,
+  Clock,
+  Info,
+  Loader2,
+  Mic,
+  RefreshCw,
+  Search,
+  Shield,
+  Trash2,
+  Zap,
 } from 'lucide-react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { NativelyLogoMark } from '../NativelyLogoMark';
 import { FreeTrialModal } from '../trial/FreeTrialModal';
 
 // ─── Types ───────────────────────────────────────────────────
-interface QuotaBucket { used: number; limit: number; remaining: number; }
+interface QuotaBucket {
+  used: number;
+  limit: number;
+  remaining: number;
+}
 interface UsageData {
-    plan: string;
-    member_since: string;
-    quota: {
-        transcription: QuotaBucket;
-        ai:            QuotaBucket;
-        search:        QuotaBucket;
-        resets_at:     string;
-    };
+  plan: string;
+  member_since: string;
+  quota: {
+    transcription: QuotaBucket;
+    ai: QuotaBucket;
+    search: QuotaBucket;
+    resets_at: string;
+  };
 }
 
 const PLAN_STANDARD_URL = 'https://checkout.dodopayments.com/buy/pdt_0NbFixGmD8CSeawb5qvVl';
-const PLAN_PRO_URL      = 'https://checkout.dodopayments.com/buy/pdt_0NcM6Aw0IWdspbsgUeCLA';
-const PLAN_MAX_URL      = 'https://checkout.dodopayments.com/buy/pdt_0NcM7JElX4Af6LNVFS1Yf';
-const PLAN_ULTRA_URL    = 'https://checkout.dodopayments.com/buy/pdt_0NcM7rC2kAb69TFKsZnUU';
+const PLAN_PRO_URL = 'https://checkout.dodopayments.com/buy/pdt_0NcM6Aw0IWdspbsgUeCLA';
+const PLAN_MAX_URL = 'https://checkout.dodopayments.com/buy/pdt_0NcM7JElX4Af6LNVFS1Yf';
+const PLAN_ULTRA_URL = 'https://checkout.dodopayments.com/buy/pdt_0NcM7rC2kAb69TFKsZnUU';
 
 // ─── Quota bar ───────────────────────────────────────────────
-function QuotaBar({ label, icon: Icon, bucket, barColor }: {
-    label:    string;
-    icon:     React.ElementType;
-    bucket:   QuotaBucket;
-    barColor: string;
+function QuotaBar({
+  label,
+  icon: Icon,
+  bucket,
+  barColor,
+}: {
+  label: string;
+  icon: React.ElementType;
+  bucket: QuotaBucket;
+  barColor: string;
 }) {
-    const pct    = bucket.limit > 0 ? Math.min(100, (bucket.used / bucket.limit) * 100) : 0;
-    const isHigh = pct >= 80;
-    return (
-        <div className="space-y-2">
-            <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                    <Icon size={12} className={isHigh ? 'text-amber-400' : 'text-text-tertiary'} strokeWidth={1.75} />
-                    <span className="text-[12px] text-text-secondary">{label}</span>
-                </div>
-                <span className={`text-[12px] tabular-nums font-medium ${isHigh ? 'text-amber-400' : 'text-text-tertiary'}`}>
-                    {bucket.used.toLocaleString()}<span className="font-normal text-text-tertiary/60"> / {bucket.limit.toLocaleString()}</span>
-                </span>
-            </div>
-            <div className="h-[5px] w-full bg-bg-input rounded-full overflow-hidden">
-                <div
-                    className={`h-full rounded-full transition-all duration-700 ease-out ${isHigh ? 'bg-amber-400' : barColor}`}
-                    style={{ width: `${pct}%` }}
-                />
-            </div>
+  const pct = bucket.limit > 0 ? Math.min(100, (bucket.used / bucket.limit) * 100) : 0;
+  const isHigh = pct >= 80;
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Icon
+            size={12}
+            className={isHigh ? 'text-amber-400' : 'text-text-tertiary'}
+            strokeWidth={1.75}
+          />
+          <span className="text-[12px] text-text-secondary">{label}</span>
         </div>
-    );
+        <span
+          className={`text-[12px] tabular-nums font-medium ${isHigh ? 'text-amber-400' : 'text-text-tertiary'}`}
+        >
+          {bucket.used.toLocaleString()}
+          <span className="font-normal text-text-tertiary/60">
+            {' '}
+            / {bucket.limit.toLocaleString()}
+          </span>
+        </span>
+      </div>
+      <div className="h-[5px] w-full bg-bg-input rounded-full overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all duration-700 ease-out ${isHigh ? 'bg-amber-400' : barColor}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
 }
 
 // ─── Trial countdown (live, ticks every 500ms) ───────────────
 function TrialCountdown({ expiresAt }: { expiresAt: string }) {
-    const [remaining, setRemaining] = useState(() =>
-        Math.max(0, new Date(expiresAt).getTime() - Date.now())
-    );
-    useEffect(() => {
-        const id = setInterval(() => {
-            setRemaining(Math.max(0, new Date(expiresAt).getTime() - Date.now()));
-        }, 500);
-        return () => clearInterval(id);
-    }, [expiresAt]);
-    const totalSec = Math.ceil(remaining / 1000);
-    const m = Math.floor(totalSec / 60);
-    const s = totalSec % 60;
-    const isWarning = remaining < 2 * 60 * 1000;
-    return (
-        <div className={`flex items-center gap-1 ${isWarning ? 'text-amber-400' : 'text-text-tertiary'}`}>
-            <Clock size={11} strokeWidth={2} />
-            <span className="text-[11px] font-mono font-semibold tabular-nums">
-                {remaining === 0 ? 'Ended' : `${m}:${s.toString().padStart(2, '0')}`}
-            </span>
-        </div>
-    );
+  const [remaining, setRemaining] = useState(() =>
+    Math.max(0, new Date(expiresAt).getTime() - Date.now()),
+  );
+  useEffect(() => {
+    const id = setInterval(() => {
+      setRemaining(Math.max(0, new Date(expiresAt).getTime() - Date.now()));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [expiresAt]);
+  const totalSec = Math.ceil(remaining / 1000);
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  const isWarning = remaining < 2 * 60 * 1000;
+  return (
+    <div
+      className={`flex items-center gap-1 ${isWarning ? 'text-amber-400' : 'text-text-tertiary'}`}
+    >
+      <Clock size={11} strokeWidth={2} />
+      <span className="text-[11px] font-mono font-semibold tabular-nums">
+        {remaining === 0 ? 'Ended' : `${m}:${s.toString().padStart(2, '0')}`}
+      </span>
+    </div>
+  );
 }
 
 // ─── Trial usage pill ─────────────────────────────────────────
 function TrialUsagePill({
-    icon: Icon, used, limit, label, unit,
-}: { icon: React.ElementType; used: number; limit: number; label: string; unit: string }) {
-    const pct    = Math.min(100, (used / limit) * 100);
-    const isHigh = pct >= 80;
-    return (
-        <div className="bg-bg-input rounded-[10px] px-3 py-2.5 space-y-2 border border-border-subtle">
-            <div className="flex items-center justify-between">
-                <div className="flex items-center gap-1.5">
-                    <Icon size={12} strokeWidth={2} className={isHigh ? 'text-amber-400' : 'text-text-tertiary'} />
-                    <span className="text-[10.5px] text-text-secondary font-medium">{label}</span>
-                </div>
-                <span className={`text-[12px] tabular-nums font-bold ${isHigh ? 'text-amber-400' : 'text-text-primary'}`}>
-                    {used}<span className="text-[10px] font-medium text-text-tertiary">/{limit}{unit}</span>
-                </span>
-            </div>
-            <div className="h-[4px] w-full bg-bg-surface rounded-full overflow-hidden">
-                <div
-                    className={`h-full rounded-full transition-all duration-500 ${isHigh ? 'bg-amber-400' : 'bg-violet-500/70'}`}
-                    style={{ width: `${pct}%` }}
-                />
-            </div>
+  icon: Icon,
+  used,
+  limit,
+  label,
+  unit,
+}: {
+  icon: React.ElementType;
+  used: number;
+  limit: number;
+  label: string;
+  unit: string;
+}) {
+  const pct = Math.min(100, (used / limit) * 100);
+  const isHigh = pct >= 80;
+  return (
+    <div className="bg-bg-input rounded-[10px] px-3 py-2.5 space-y-2 border border-border-subtle">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1.5">
+          <Icon
+            size={12}
+            strokeWidth={2}
+            className={isHigh ? 'text-amber-400' : 'text-text-tertiary'}
+          />
+          <span className="text-[10.5px] text-text-secondary font-medium">{label}</span>
         </div>
-    );
+        <span
+          className={`text-[12px] tabular-nums font-bold ${isHigh ? 'text-amber-400' : 'text-text-primary'}`}
+        >
+          {used}
+          <span className="text-[10px] font-medium text-text-tertiary">
+            /{limit}
+            {unit}
+          </span>
+        </span>
+      </div>
+      <div className="h-[4px] w-full bg-bg-surface rounded-full overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all duration-500 ${isHigh ? 'bg-amber-400' : 'bg-violet-500/70'}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
 }
 
 // ─── Card wrapper ────────────────────────────────────────────
 function Card({ children, className = '' }: { children: React.ReactNode; className?: string }) {
-    return (
-        <div className={`bg-bg-item-surface rounded-2xl border border-border-subtle overflow-hidden ${className}`}>
-            {children}
-        </div>
-    );
+  return (
+    <div
+      className={`bg-bg-item-surface rounded-2xl border border-border-subtle overflow-hidden ${className}`}
+    >
+      {children}
+    </div>
+  );
 }
 
 // ─── Component ───────────────────────────────────────────────
 export const NativelyApiSettings: React.FC = () => {
-    const [apiKey,         setApiKey]         = useState('');
-    const [isSaved,        setIsSaved]        = useState(false);
-    const [isLoading,      setIsLoading]      = useState(true);
-    const [isSaving,       setIsSaving]       = useState(false);
-    const [error,          setError]          = useState<string | null>(null);
-    const [justSaved,      setJustSaved]      = useState(false);
-    const [usageData,      setUsageData]      = useState<UsageData | null>(null);
-    const [usageError,     setUsageError]     = useState<string | null>(null);
-    const [isLoadingUsage, setIsLoadingUsage] = useState(false);
+  const [apiKey, setApiKey] = useState('');
+  const [isSaved, setIsSaved] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [justSaved, setJustSaved] = useState(false);
+  const [usageData, setUsageData] = useState<UsageData | null>(null);
+  const [usageError, setUsageError] = useState<string | null>(null);
+  const [isLoadingUsage, setIsLoadingUsage] = useState(false);
 
-    // ── Free Trial state ──────────────────────────────────────
-    const [trialState, setTrialState] = useState<{
-        active:    boolean;
-        expired:   boolean;
-        expiresAt: string;
-        startedAt: string;
-        usage:     { ai: number; stt_seconds: number; search: number };
-    } | null>(null);
-    // True while getLocalTrial is in flight — prevents the "start trial" card
-    // from flashing before we know whether a trial token exists.
-    const [isCheckingTrial, setIsCheckingTrial] = useState(true);
-    const [trialLoading,    setTrialLoading]    = useState(false);
-    const [trialError,      setTrialError]      = useState<string | null>(null);
-    const [showTrialModal,  setShowTrialModal]  = useState(false);
-    const trialPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // ── Free Trial state ──────────────────────────────────────
+  const [trialState, setTrialState] = useState<{
+    active: boolean;
+    expired: boolean;
+    expiresAt: string;
+    startedAt: string;
+    usage: { ai: number; stt_seconds: number; search: number };
+  } | null>(null);
+  // True while getLocalTrial is in flight — prevents the "start trial" card
+  // from flashing before we know whether a trial token exists.
+  const [isCheckingTrial, setIsCheckingTrial] = useState(true);
+  const [trialLoading, setTrialLoading] = useState(false);
+  const [trialError, setTrialError] = useState<string | null>(null);
+  const [showTrialModal, setShowTrialModal] = useState(false);
+  const trialPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-    useEffect(() => {
-        (async () => {
-            try {
-                const creds = await window.electronAPI.getStoredCredentials();
-                if (creds.hasNativelyKey) { setApiKey('•'.repeat(24)); setIsSaved(true); }
-            } catch (e) { console.error('[NativelyApi]', e); }
-            finally { setIsLoading(false); }
-        })();
-    }, []);
+  useEffect(() => {
+    (async () => {
+      try {
+        const creds = await window.electronAPI.getStoredCredentials();
+        if (creds.hasNativelyKey) {
+          setApiKey('•'.repeat(24));
+          setIsSaved(true);
+        }
+      } catch (e) {
+        console.error('[NativelyApi]', e);
+      } finally {
+        setIsLoading(false);
+      }
+    })();
+  }, []);
 
-    const fetchUsage = useCallback(async () => {
-        setIsLoadingUsage(true);
-        setUsageError(null);
-        try {
-            const r = await window.electronAPI.getNativelyUsage();
-            if (r.ok && r.quota) {
-                setUsageData(r as UsageData);
-            } else {
-                setUsageError(
-                    r.error === 'subscription_inactive' ? 'Subscription inactive — renew to restore access.'
-                    : r.error === 'key_not_found'       ? 'Key not recognised by server.'
-                    : r.error === 'invalid_key_format'  ? 'Invalid key format.'
-                    : r.error === 'network_error' || r.error?.includes('fetch')
-                                                        ? 'Could not reach server.'
-                    : `Server error: ${r.error ?? 'unknown'}`
-                );
-            }
-        } catch { setUsageError('Failed to load usage.'); }
-        finally  { setIsLoadingUsage(false); }
-    }, []);
+  const fetchUsage = useCallback(async () => {
+    setIsLoadingUsage(true);
+    setUsageError(null);
+    try {
+      const r = await window.electronAPI.getNativelyUsage();
+      if (r.ok && r.quota) {
+        setUsageData(r as UsageData);
+      } else {
+        setUsageError(
+          r.error === 'subscription_inactive'
+            ? 'Subscription inactive — renew to restore access.'
+            : r.error === 'key_not_found'
+              ? 'Key not recognised by server.'
+              : r.error === 'invalid_key_format'
+                ? 'Invalid key format.'
+                : r.error === 'network_error' || r.error?.includes('fetch')
+                  ? 'Could not reach server.'
+                  : `Server error: ${r.error ?? 'unknown'}`,
+        );
+      }
+    } catch {
+      setUsageError('Failed to load usage.');
+    } finally {
+      setIsLoadingUsage(false);
+    }
+  }, []);
 
-    useEffect(() => { if (isSaved && !isLoading) fetchUsage(); }, [isSaved, isLoading, fetchUsage]);
+  useEffect(() => {
+    if (isSaved && !isLoading) fetchUsage();
+  }, [isSaved, isLoading, fetchUsage]);
 
-    // ── Trial init + polling ──────────────────────────────────
-    const refreshTrial = useCallback(async () => {
-        const res = await window.electronAPI?.getTrialStatus?.();
-        if (!res?.ok) return;
+  // ── Trial init + polling ──────────────────────────────────
+  const refreshTrial = useCallback(async () => {
+    const res = await window.electronAPI?.getTrialStatus?.();
+    if (!res?.ok) return;
+
+    localStorage.setItem('natively_trial_claimed', 'true');
+
+    setTrialState({
+      active: !(res.expired ?? false),
+      expired: res.expired ?? false,
+      expiresAt: res.expires_at ?? '',
+      startedAt: res.started_at ?? '',
+      usage: res.usage ?? { ai: 0, stt_seconds: 0, search: 0 },
+    });
+    if (res.expired) {
+      setShowTrialModal(true);
+      if (trialPollRef.current) {
+        clearInterval(trialPollRef.current);
+        trialPollRef.current = null;
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    // On mount: read local trial token (no network) to determine initial render state,
+    // then fetch live usage from server. Setting trialState from local data first
+    // prevents the "start trial" card from flashing while the server call is in flight.
+    (async () => {
+      try {
+        const local = await window.electronAPI?.getLocalTrial?.();
+        if (!local?.hasToken) {
+          if (local?.trialClaimed) localStorage.setItem('natively_trial_claimed', 'true');
+          return;
+        }
 
         localStorage.setItem('natively_trial_claimed', 'true');
 
+        if (local.expired) {
+          // Token exists but expired locally — show modal immediately, confirm via server
+          setTrialState({
+            active: false,
+            expired: true,
+            expiresAt: local.expiresAt ?? '',
+            startedAt: local.startedAt ?? '',
+            usage: { ai: 0, stt_seconds: 0, search: 0 },
+          });
+          setShowTrialModal(true);
+          refreshTrial(); // updates usage counters in the modal
+          return;
+        }
+
+        // Set optimistic active state immediately from local data so the correct
+        // card renders before the server responds (prevents start-card flash).
+        // Usage counters start at 0 and are replaced by refreshTrial below.
         setTrialState({
-            active:    !(res.expired ?? false),
-            expired:   res.expired   ?? false,
-            expiresAt: res.expires_at ?? '',
-            startedAt: res.started_at ?? '',
-            usage:     res.usage      ?? { ai: 0, stt_seconds: 0, search: 0 },
+          active: true,
+          expired: false,
+          expiresAt: local.expiresAt ?? '',
+          startedAt: local.startedAt ?? '',
+          usage: { ai: 0, stt_seconds: 0, search: 0 },
         });
-        if (res.expired) {
-            setShowTrialModal(true);
-            if (trialPollRef.current) { clearInterval(trialPollRef.current); trialPollRef.current = null; }
+
+        // Fetch live usage + start 15s polling (was 30s — halved so counters
+        // feel more responsive during an active session).
+        refreshTrial();
+        trialPollRef.current = setInterval(refreshTrial, 15_000);
+      } finally {
+        setIsCheckingTrial(false);
+      }
+    })();
+    return () => {
+      if (trialPollRef.current) clearInterval(trialPollRef.current);
+    };
+  }, [refreshTrial]);
+
+  const handleStartTrial = async () => {
+    setTrialLoading(true);
+    setTrialError(null);
+    try {
+      const res = await window.electronAPI?.startTrial?.();
+      if (!res?.ok) {
+        if (res?.error === 'trial_ip_limit' || res?.error === 'trial_start_rate_limited') {
+          localStorage.setItem('natively_trial_claimed', 'true');
+          setTrialState({
+            active: false,
+            expired: true,
+            expiresAt: '',
+            startedAt: '',
+            usage: { ai: 0, stt_seconds: 0, search: 0 },
+          });
+          return;
         }
-    }, []);
+        const msg =
+          res?.error === 'invalid_hwid'
+            ? 'Could not read device ID. Restart the app and try again.'
+            : res?.error || 'Could not start trial. Try again.';
+        setTrialError(msg);
+        return;
+      }
 
-    useEffect(() => {
-        // On mount: read local trial token (no network) to determine initial render state,
-        // then fetch live usage from server. Setting trialState from local data first
-        // prevents the "start trial" card from flashing while the server call is in flight.
-        (async () => {
-            try {
-                const local = await window.electronAPI?.getLocalTrial?.();
-                if (!local?.hasToken) {
-                    if (local?.trialClaimed) localStorage.setItem('natively_trial_claimed', 'true');
-                    return;
-                }
+      localStorage.setItem('natively_trial_claimed', 'true');
 
-                localStorage.setItem('natively_trial_claimed', 'true');
+      if (res.already_used && res.expired) {
+        setTrialState({
+          active: false,
+          expired: true,
+          expiresAt: '',
+          startedAt: '',
+          usage: { ai: 0, stt_seconds: 0, search: 0 },
+        });
+        return;
+      }
+      setTrialState({
+        active: !(res.expired ?? false),
+        expired: res.expired ?? false,
+        expiresAt: res.expires_at ?? '',
+        startedAt: res.started_at ?? '',
+        usage: res.usage ?? { ai: 0, stt_seconds: 0, search: 0 },
+      });
+      if (!res.expired) {
+        trialPollRef.current = setInterval(refreshTrial, 30_000);
+      }
+    } catch (e: any) {
+      setTrialError(e.message || 'Network error');
+    } finally {
+      setTrialLoading(false);
+    }
+  };
 
-                if (local.expired) {
-                    // Token exists but expired locally — show modal immediately, confirm via server
-                    setTrialState({ active: false, expired: true, expiresAt: local.expiresAt ?? '', startedAt: local.startedAt ?? '', usage: { ai: 0, stt_seconds: 0, search: 0 } });
-                    setShowTrialModal(true);
-                    refreshTrial(); // updates usage counters in the modal
-                    return;
-                }
+  const handleByok = async () => {
+    // Only wipe — modal transitions to DoneState, then onDone closes it
+    await window.electronAPI?.endTrialByok?.();
+  };
 
-                // Set optimistic active state immediately from local data so the correct
-                // card renders before the server responds (prevents start-card flash).
-                // Usage counters start at 0 and are replaced by refreshTrial below.
-                setTrialState({ active: true, expired: false, expiresAt: local.expiresAt ?? '', startedAt: local.startedAt ?? '', usage: { ai: 0, stt_seconds: 0, search: 0 } });
+  const handleTrialDone = () => {
+    setTrialState(null);
+    setShowTrialModal(false);
+  };
 
-                // Fetch live usage + start 15s polling (was 30s — halved so counters
-                // feel more responsive during an active session).
-                refreshTrial();
-                trialPollRef.current = setInterval(refreshTrial, 15_000);
-            } finally {
-                setIsCheckingTrial(false);
-            }
-        })();
-        return () => { if (trialPollRef.current) clearInterval(trialPollRef.current); };
-    }, [refreshTrial]);
+  const handleSave = async () => {
+    if (!apiKey.trim() || apiKey.includes('•')) return;
+    setIsSaving(true);
+    setError(null);
+    try {
+      const r = await window.electronAPI.setNativelyApiKey(apiKey.trim());
+      if (r.success) {
+        setApiKey('•'.repeat(24));
+        setIsSaved(true);
+        setJustSaved(true);
+        setTimeout(() => setJustSaved(false), 2500);
+        // @ts-ignore
+        window.electronAPI?.setDefaultModel?.('natively').catch(console.error);
+        // @ts-ignore
+        window.electronAPI?.setSttProvider?.('natively').catch(console.error);
+      } else {
+        setError(r.error || 'Failed to save API key');
+      }
+    } catch (e: any) {
+      setError(e.message || 'Unexpected error');
+    } finally {
+      setIsSaving(false);
+    }
+  };
 
-    const handleStartTrial = async () => {
-        setTrialLoading(true);
-        setTrialError(null);
-        try {
-            const res = await window.electronAPI?.startTrial?.();
-            if (!res?.ok) {
-                if (res?.error === 'trial_ip_limit' || res?.error === 'trial_start_rate_limited') {
-                    localStorage.setItem('natively_trial_claimed', 'true');
-                    setTrialState({ active: false, expired: true, expiresAt: '', startedAt: '', usage: { ai: 0, stt_seconds: 0, search: 0 } });
-                    return;
-                }
-                const msg = res?.error === 'invalid_hwid'
-                    ? 'Could not read device ID. Restart the app and try again.'
-                    : res?.error || 'Could not start trial. Try again.';
-                setTrialError(msg);
-                return;
-            }
+  const handleClear = () => {
+    setApiKey('');
+    setIsSaved(false);
+    setError(null);
+    setUsageData(null);
+    setUsageError(null);
+    window.electronAPI.setNativelyApiKey('').catch(() => {});
+  };
 
-            localStorage.setItem('natively_trial_claimed', 'true');
+  const openExternal = (url: string) => {
+    (window.electronAPI as any)?.openExternal?.(url);
+  };
 
-            if (res.already_used && res.expired) {
-                setTrialState({ active: false, expired: true, expiresAt: '', startedAt: '', usage: { ai: 0, stt_seconds: 0, search: 0 } });
-                return;
-            }
-            setTrialState({
-                active:    !(res.expired ?? false),
-                expired:   res.expired   ?? false,
-                expiresAt: res.expires_at ?? '',
-                startedAt: res.started_at ?? '',
-                usage:     res.usage      ?? { ai: 0, stt_seconds: 0, search: 0 },
-            });
-            if (!res.expired) {
-                trialPollRef.current = setInterval(refreshTrial, 30_000);
-            }
-        } catch (e: any) {
-            setTrialError(e.message || 'Network error');
-        } finally {
-            setTrialLoading(false);
-        }
-    };
+  const isDirty = apiKey.length > 0 && !apiKey.includes('•') && !isSaved;
+  const planLabel = usageData?.plan
+    ? usageData.plan.charAt(0).toUpperCase() + usageData.plan.slice(1)
+    : null;
+  const fmtDate = (iso: string) => {
+    try {
+      return new Date(iso).toLocaleDateString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      });
+    } catch {
+      return iso;
+    }
+  };
 
-    const handleByok = async () => {
-        // Only wipe — modal transitions to DoneState, then onDone closes it
-        await window.electronAPI?.endTrialByok?.();
-    };
+  const PlansCard = (
+    <Card>
+      <div className="px-5 pt-5 pb-2">
+        <div className="flex flex-col gap-2.5 mb-4">
+          <div className="flex items-center justify-between">
+            <p className="text-[10px] font-semibold text-text-tertiary uppercase tracking-widest">
+              Choose a Plan
+            </p>
+            <span className="text-[10px] text-text-tertiary">
+              Pro, Max &amp; Ultra include Natively Pro app
+            </span>
+          </div>
+          <div className="w-full flex items-center justify-center py-2 bg-violet-500/10 border border-violet-500/20 rounded-[10px]">
+            <span className="text-[11.5px] font-medium text-violet-400/90">
+              Use code <span className="font-bold text-violet-400">INSIDER25</span> for 25% off
+            </span>
+          </div>
+        </div>
 
-    const handleTrialDone = () => {
-        setTrialState(null);
-        setShowTrialModal(false);
-    };
-
-    const handleSave = async () => {
-        if (!apiKey.trim() || apiKey.includes('•')) return;
-        setIsSaving(true); setError(null);
-        try {
-            const r = await window.electronAPI.setNativelyApiKey(apiKey.trim());
-            if (r.success) {
-                setApiKey('•'.repeat(24)); setIsSaved(true); setJustSaved(true);
-                setTimeout(() => setJustSaved(false), 2500);
-                // @ts-ignore
-                window.electronAPI?.setDefaultModel?.('natively').catch(console.error);
-                // @ts-ignore
-                window.electronAPI?.setSttProvider?.('natively').catch(console.error);
-            } else { setError(r.error || 'Failed to save API key'); }
-        } catch (e: any) { setError(e.message || 'Unexpected error'); }
-        finally { setIsSaving(false); }
-    };
-
-    const handleClear = () => {
-        setApiKey(''); setIsSaved(false); setError(null); setUsageData(null); setUsageError(null);
-        window.electronAPI.setNativelyApiKey('').catch(() => {});
-    };
-
-    const openExternal = (url: string) => { (window.electronAPI as any)?.openExternal?.(url); };
-
-    const isDirty   = apiKey.length > 0 && !apiKey.includes('•') && !isSaved;
-    const planLabel = usageData?.plan ? usageData.plan.charAt(0).toUpperCase() + usageData.plan.slice(1) : null;
-    const fmtDate   = (iso: string) => { try { return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' }); } catch { return iso; } };
-
-    const PlansCard = (
-        <Card>
-            <div className="px-5 pt-5 pb-2">
-                <div className="flex flex-col gap-2.5 mb-4">
-                    <div className="flex items-center justify-between">
-                        <p className="text-[10px] font-semibold text-text-tertiary uppercase tracking-widest">Choose a Plan</p>
-                        <span className="text-[10px] text-text-tertiary">Pro, Max &amp; Ultra include Natively Pro app</span>
+        {/* Plan rows */}
+        <div className="space-y-2 pb-3">
+          {(
+            [
+              {
+                name: 'Standard',
+                price: '$8',
+                url: PLAN_STANDARD_URL,
+                color: 'text-slate-400',
+                bg: 'bg-slate-500/10',
+                border: 'border-slate-500/20',
+                btnBg: 'bg-slate-700 hover:bg-slate-600',
+                includesPro: false,
+                features: ['500 AI req / mo', '200 min STT', '20 searches'],
+              },
+              {
+                name: 'Pro',
+                price: '$15',
+                url: PLAN_PRO_URL,
+                color: 'text-violet-400',
+                bg: 'bg-violet-500/10',
+                border: 'border-violet-500/20',
+                btnBg: 'bg-violet-600 hover:bg-violet-500',
+                includesPro: true,
+                features: ['1,000 AI req / mo', '500 min STT', '100 searches'],
+              },
+              {
+                name: 'Max',
+                price: '$25',
+                url: PLAN_MAX_URL,
+                color: 'text-blue-400',
+                bg: 'bg-blue-500/10',
+                border: 'border-blue-500/20',
+                btnBg: 'bg-blue-600 hover:bg-blue-500',
+                includesPro: true,
+                features: ['2,000 AI req / mo', '1,000 min STT', '200 searches'],
+              },
+              {
+                name: 'Ultra',
+                price: '$35',
+                url: PLAN_ULTRA_URL,
+                color: 'text-orange-400',
+                bg: 'bg-orange-500/10',
+                border: 'border-orange-500/20',
+                btnBg: 'bg-orange-600 hover:bg-orange-500',
+                includesPro: true,
+                features: ['3,000 AI req / mo', '2,000 min STT', '300 searches'],
+              },
+            ] as const
+          ).map((plan) => (
+            <div
+              key={plan.name}
+              className={`flex items-center gap-3 px-3.5 py-3 rounded-xl border ${plan.bg} ${plan.border}`}
+            >
+              {/* Name + features */}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 mb-1">
+                  <span className={`text-[13px] font-semibold ${plan.color}`}>{plan.name}</span>
+                  {plan.includesPro && (
+                    <span className="text-[9px] font-semibold px-1.5 py-0.5 rounded-full bg-emerald-500/15 border border-emerald-500/20 text-emerald-400 tracking-wide">
+                      + Pro App
+                    </span>
+                  )}
+                </div>
+                <p className="text-[10px] text-text-tertiary leading-relaxed">
+                  {plan.features.join(' · ')}
+                </p>
+              </div>
+              {/* Price + button */}
+              <div className="flex items-center gap-2.5 shrink-0">
+                <span className="text-[13px] font-semibold text-text-primary tabular-nums">
+                  {plan.price}
+                  <span className="text-[10px] font-normal text-text-tertiary">/mo</span>
+                </span>
+                {(() => {
+                  const currentPlan = usageData?.plan?.toLowerCase();
+                  const rowPlan = plan.name.toLowerCase();
+                  // 'starter' is the legacy name for the $8 Standard plan
+                  const isActive =
+                    currentPlan === rowPlan ||
+                    (rowPlan === 'standard' && currentPlan === 'starter');
+                  return isActive ? (
+                    <div className="px-3 py-1.5 rounded-lg text-[11px] font-semibold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20">
+                      Active
                     </div>
-                    <div className="w-full flex items-center justify-center py-2 bg-violet-500/10 border border-violet-500/20 rounded-[10px]">
-                        <span className="text-[11.5px] font-medium text-violet-400/90">
-                            Use code <span className="font-bold text-violet-400">INSIDER25</span> for 25% off
-                        </span>
-                    </div>
-                </div>
-
-                {/* Plan rows */}
-                <div className="space-y-2 pb-3">
-                    {([
-                        {
-                            name: 'Standard',
-                            price: '$8',
-                            url: PLAN_STANDARD_URL,
-                            color: 'text-slate-400',
-                            bg: 'bg-slate-500/10',
-                            border: 'border-slate-500/20',
-                            btnBg: 'bg-slate-700 hover:bg-slate-600',
-                            includesPro: false,
-                            features: ['500 AI req / mo', '200 min STT', '20 searches'],
-                        },
-                        {
-                            name: 'Pro',
-                            price: '$15',
-                            url: PLAN_PRO_URL,
-                            color: 'text-violet-400',
-                            bg: 'bg-violet-500/10',
-                            border: 'border-violet-500/20',
-                            btnBg: 'bg-violet-600 hover:bg-violet-500',
-                            includesPro: true,
-                            features: ['1,000 AI req / mo', '500 min STT', '100 searches'],
-                        },
-                        {
-                            name: 'Max',
-                            price: '$25',
-                            url: PLAN_MAX_URL,
-                            color: 'text-blue-400',
-                            bg: 'bg-blue-500/10',
-                            border: 'border-blue-500/20',
-                            btnBg: 'bg-blue-600 hover:bg-blue-500',
-                            includesPro: true,
-                            features: ['2,000 AI req / mo', '1,000 min STT', '200 searches'],
-                        },
-                        {
-                            name: 'Ultra',
-                            price: '$35',
-                            url: PLAN_ULTRA_URL,
-                            color: 'text-orange-400',
-                            bg: 'bg-orange-500/10',
-                            border: 'border-orange-500/20',
-                            btnBg: 'bg-orange-600 hover:bg-orange-500',
-                            includesPro: true,
-                            features: ['3,000 AI req / mo', '2,000 min STT', '300 searches'],
-                        },
-                    ] as const).map((plan) => (
-                        <div
-                            key={plan.name}
-                            className={`flex items-center gap-3 px-3.5 py-3 rounded-xl border ${plan.bg} ${plan.border}`}
-                        >
-                            {/* Name + features */}
-                            <div className="flex-1 min-w-0">
-                                <div className="flex items-center gap-2 mb-1">
-                                    <span className={`text-[13px] font-semibold ${plan.color}`}>{plan.name}</span>
-                                    {plan.includesPro && (
-                                        <span className="text-[9px] font-semibold px-1.5 py-0.5 rounded-full bg-emerald-500/15 border border-emerald-500/20 text-emerald-400 tracking-wide">
-                                            + Pro App
-                                        </span>
-                                    )}
-                                </div>
-                                <p className="text-[10px] text-text-tertiary leading-relaxed">
-                                    {plan.features.join(' · ')}
-                                </p>
-                            </div>
-                            {/* Price + button */}
-                            <div className="flex items-center gap-2.5 shrink-0">
-                                <span className="text-[13px] font-semibold text-text-primary tabular-nums">{plan.price}<span className="text-[10px] font-normal text-text-tertiary">/mo</span></span>
-                                {(() => {
-                                    const currentPlan = usageData?.plan?.toLowerCase();
-                                    const rowPlan     = plan.name.toLowerCase();
-                                    // 'starter' is the legacy name for the $8 Standard plan
-                                    const isActive =
-                                        currentPlan === rowPlan ||
-                                        (rowPlan === 'standard' && currentPlan === 'starter');
-                                    return isActive ? (
-                                    <div className="px-3 py-1.5 rounded-lg text-[11px] font-semibold text-emerald-400 bg-emerald-500/10 border border-emerald-500/20">
-                                        Active
-                                    </div>
-                                ) : (
-                                    <button
-                                        onClick={() => openExternal(plan.url)}
-                                        className={`px-3 py-1.5 rounded-lg text-[11px] font-semibold text-white ${plan.btnBg} transition-all duration-150 flex items-center gap-1 cursor-pointer active:scale-[0.98]`}
-                                    >
-                                        Get <ArrowUpRight size={10} strokeWidth={2.5} />
-                                    </button>
-                                );
-                                })()}
-                            </div>
-                        </div>
-                    ))}
-                </div>
-
-                {/* AI quota note */}
-                <div className="flex items-start gap-2 mb-4 px-3 py-2.5 bg-bg-input rounded-xl border border-border-subtle">
-                    <Info size={11} className="text-text-tertiary shrink-0 mt-[1px]" strokeWidth={2} />
-                    <p className="text-[11px] text-text-tertiary leading-relaxed">
-                        AI requests include chat replies, meeting title &amp; summary generation, and embeddings — not just manual messages.
-                    </p>
-                </div>
+                  ) : (
+                    <button
+                      onClick={() => openExternal(plan.url)}
+                      className={`px-3 py-1.5 rounded-lg text-[11px] font-semibold text-white ${plan.btnBg} transition-all duration-150 flex items-center gap-1 cursor-pointer active:scale-[0.98]`}
+                    >
+                      Get <ArrowUpRight size={10} strokeWidth={2.5} />
+                    </button>
+                  );
+                })()}
+              </div>
             </div>
-        </Card>
-    );
+          ))}
+        </div>
 
+        {/* AI quota note */}
+        <div className="flex items-start gap-2 mb-4 px-3 py-2.5 bg-bg-input rounded-xl border border-border-subtle">
+          <Info size={11} className="text-text-tertiary shrink-0 mt-[1px]" strokeWidth={2} />
+          <p className="text-[11px] text-text-tertiary leading-relaxed">
+            AI requests include chat replies, meeting title &amp; summary generation, and embeddings
+            — not just manual messages.
+          </p>
+        </div>
+      </div>
+    </Card>
+  );
 
-    return (
-        <div className="space-y-4 animated fadeIn">
+  return (
+    <div className="space-y-4 animated fadeIn">
+      {/* ── Page title ───────────────────────────────────── */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-[15px] font-semibold text-text-primary tracking-[-0.01em]">
+            Natively API
+          </h3>
+          <p className="text-[12px] text-text-tertiary mt-0.5 leading-snug">
+            Managed transcription, AI &amp; search
+          </p>
+        </div>
+        {!isLoading && isSaved && (
+          <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-emerald-500/10 border border-emerald-500/20">
+            <div className="w-1.5 h-1.5 rounded-full bg-emerald-500 shadow-[0_0_6px_rgba(16,185,129,0.6)]" />
+            <span className="text-[10px] font-semibold text-emerald-500 tracking-wide">
+              {planLabel ?? 'Connected'}
+            </span>
+          </div>
+        )}
+      </div>
 
-            {/* ── Page title ───────────────────────────────────── */}
-            <div className="flex items-center justify-between">
-                <div>
-                    <h3 className="text-[15px] font-semibold text-text-primary tracking-[-0.01em]">Natively API</h3>
-                    <p className="text-[12px] text-text-tertiary mt-0.5 leading-snug">
-                        Managed transcription, AI &amp; search
-                    </p>
-                </div>
-                {!isLoading && isSaved && (
-                    <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-emerald-500/10 border border-emerald-500/20">
-                        <div className="w-1.5 h-1.5 rounded-full bg-emerald-500 shadow-[0_0_6px_rgba(16,185,129,0.6)]" />
-                        <span className="text-[10px] font-semibold text-emerald-500 tracking-wide">
-                            {planLabel ?? 'Connected'}
-                        </span>
+      {/* ── Free Trial Modal (post-trial) ─────────────── */}
+      {showTrialModal && trialState && (
+        <FreeTrialModal usage={trialState.usage} onByok={handleByok} onDone={handleTrialDone} />
+      )}
+
+      {/* ── Active trial status card ──────────────────── */}
+      {trialState?.active &&
+        (() => {
+          const sttMin = (trialState.usage.stt_seconds / 60).toFixed(1);
+          return (
+            <Card className="shadow-sm border-violet-500/25">
+              <div className="px-5 pt-5 pb-5 space-y-4">
+                {/* Header — same layout as "Try Natively API free" start card */}
+                <div className="flex items-start gap-3.5">
+                  <div className="w-10 h-10 rounded-[11px] bg-violet-500/10 border border-violet-500/20 flex items-center justify-center shrink-0">
+                    <NativelyLogoMark size={18} className="text-violet-400" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center justify-between">
+                      <p className="text-[13.5px] font-semibold text-text-primary tracking-tight">
+                        Free Trial Active
+                      </p>
+                      <TrialCountdown expiresAt={trialState.expiresAt} />
                     </div>
+                    <p className="text-[10.5px] text-text-tertiary mt-1">
+                      {trialState.usage.ai} AI · {sttMin} min STT · {trialState.usage.search}{' '}
+                      searches used
+                    </p>
+                  </div>
+                </div>
+
+                {/* Usage pills */}
+                <div className="grid grid-cols-3 gap-2">
+                  <TrialUsagePill
+                    icon={Zap}
+                    used={trialState.usage.ai}
+                    limit={10}
+                    label="AI"
+                    unit=""
+                  />
+                  <TrialUsagePill
+                    icon={Mic}
+                    used={Math.round(trialState.usage.stt_seconds / 60)}
+                    limit={10}
+                    label="STT"
+                    unit="m"
+                  />
+                  <TrialUsagePill
+                    icon={Search}
+                    used={trialState.usage.search}
+                    limit={2}
+                    label="Search"
+                    unit=""
+                  />
+                </div>
+
+                {/* CTA */}
+                <button
+                  onClick={() => setShowTrialModal(true)}
+                  className="w-full flex items-center justify-center gap-2 py-2.5 rounded-[9px] text-[12.5px] font-semibold bg-violet-600 hover:bg-violet-500 text-white shadow-[0_1px_3px_rgba(0,0,0,0.1)] transition-all active:scale-[0.98] cursor-pointer"
+                >
+                  <ArrowUpRight size={13} strokeWidth={2.3} />
+                  Keep the momentum going
+                </button>
+              </div>
+            </Card>
+          );
+        })()}
+
+      {/* ── Free trial start card (no key, no active trial) ── */}
+      {!isLoading &&
+        !isSaved &&
+        !isCheckingTrial &&
+        (!trialState || (trialState.expired && !trialState.active)) &&
+        (() => {
+          const isClaimed =
+            trialState?.expired === true ||
+            localStorage.getItem('natively_trial_claimed') === 'true';
+
+          if (isClaimed) {
+            return null;
+          }
+
+          return (
+            <Card className="shadow-sm">
+              <div className="px-5 pt-5 pb-4 flex flex-col items-center justify-center text-center">
+                {/* Apple Promo Icon */}
+                <div className="w-[42px] h-[42px] mb-3 rounded-[12px] bg-bg-input border border-border-subtle shadow-[inset_0_1px_rgba(255,255,255,0.06),0_2px_8px_rgba(0,0,0,0.04)] flex items-center justify-center relative overflow-hidden">
+                  <NativelyLogoMark
+                    size={20}
+                    className={
+                      isClaimed ? 'text-text-tertiary' : 'text-text-primary drop-shadow-sm'
+                    }
+                  />
+                </div>
+
+                <h3 className="text-[14.5px] font-bold text-text-primary tracking-tight mb-1">
+                  Natively API. Try it free.
+                </h3>
+                <p className="text-[12px] text-text-secondary leading-snug px-4 mb-4">
+                  Experience managed text-to-speech, AI models, and real-time research without a
+                  subscription.
+                </p>
+
+                {/* Clean limits grid container */}
+                <div className="flex items-center justify-center gap-3.5 mb-5 text-[11.5px] font-medium text-text-primary bg-bg-input px-3.5 py-2 rounded-[8px] border border-border-subtle shadow-[inset_0_1px_rgba(255,255,255,0.02)]">
+                  <div className="flex flex-col items-center gap-1">
+                    <Clock size={14} strokeWidth={2} className="text-blue-500" />
+                    <span>30 min</span>
+                  </div>
+                  <div className="w-px h-5 bg-border-subtle/80" />
+                  <div className="flex flex-col items-center gap-1">
+                    <Brain size={14} strokeWidth={2} className="text-violet-500" />
+                    <span>10 reqs</span>
+                  </div>
+                  <div className="w-px h-5 bg-border-subtle/80" />
+                  <div className="flex flex-col items-center gap-1">
+                    <Mic size={14} strokeWidth={2} className="text-emerald-500" />
+                    <span>10m STT</span>
+                  </div>
+                  <div className="w-px h-5 bg-border-subtle/80" />
+                  <div className="flex flex-col items-center gap-1">
+                    <Search size={14} strokeWidth={2} className="text-orange-500" />
+                    <span>2 searches</span>
+                  </div>
+                </div>
+
+                <button
+                  onClick={handleStartTrial}
+                  disabled={trialLoading || isClaimed}
+                  className={`w-full max-w-[240px] flex items-center justify-center gap-2 py-2 rounded-full text-[13px] font-bold shadow-[0_1px_3px_rgba(0,0,0,0.1)] transition-all ${
+                    isClaimed
+                      ? 'bg-bg-input text-text-tertiary border border-border-subtle cursor-not-allowed'
+                      : 'bg-text-primary hover:bg-text-primary/90 text-bg-primary active:scale-[0.98]'
+                  }`}
+                >
+                  {trialLoading ? (
+                    <>
+                      <Loader2 size={13} className="animate-spin" /> Starting trial…
+                    </>
+                  ) : isClaimed ? (
+                    'Trial Already Claimed'
+                  ) : (
+                    'Start 10-Minute Free Trial'
+                  )}
+                </button>
+
+                {/* Error Handling */}
+                {trialError && !isClaimed && (
+                  <div className="flex items-center gap-1.5 px-3 py-2 mt-3 bg-red-500/10 border border-red-500/20 rounded-[8px]">
+                    <AlertCircle size={13} className="text-red-500 shrink-0" strokeWidth={2} />
+                    <p className="text-[11.5px] text-red-500 font-medium">{trialError}</p>
+                  </div>
                 )}
-            </div>
 
-            {/* ── Free Trial Modal (post-trial) ─────────────── */}
-            {showTrialModal && trialState && (
-                <FreeTrialModal
-                    usage={trialState.usage}
-                    onByok={handleByok}
-                    onDone={handleTrialDone}
-                />
+                <p className="text-[10.5px] text-text-tertiary font-medium mt-3">
+                  No account needed — bound to this device.
+                </p>
+
+                <div className="w-[30px] h-px bg-border-subtle my-3" />
+
+                <p className="text-[11px] text-text-secondary font-medium">
+                  Already have an API key? Enter it below.
+                </p>
+              </div>
+            </Card>
+          );
+        })()}
+
+      {/* ── Plans ────────────────────────────────────────── */}
+      {!isSaved && PlansCard}
+
+      {/* ── API Key card ─────────────────────────────────── */}
+      <Card>
+        {/* Card header */}
+        <div className="flex items-center gap-3 px-5 pt-5 pb-4">
+          {/* Tinted icon well — Apple style */}
+          <div className="w-9 h-9 rounded-xl bg-blue-500/15 border border-blue-500/20 flex items-center justify-center shrink-0">
+            <NativelyLogoMark size={18} className="text-blue-400" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-[13px] font-semibold text-text-primary">API Key</p>
+            <p className="text-[11px] text-text-tertiary leading-snug mt-0.5">
+              Your Natively API key from your subscription email
+            </p>
+          </div>
+        </div>
+
+        {/* Hairline divider */}
+        <div className="h-px bg-border-subtle mx-5" />
+
+        {/* Body */}
+        <div className="px-5 pt-4 pb-5 space-y-3">
+          {/* Label row */}
+          <div className="flex items-center justify-between">
+            <span className="text-[10px] font-semibold text-text-tertiary uppercase tracking-widest">
+              Secret key
+            </span>
+            {isSaved && (
+              <button
+                onClick={handleClear}
+                className="flex items-center gap-1 text-[11px] text-red-400/80 hover:text-red-400 transition-colors duration-150 cursor-pointer"
+              >
+                <Trash2 size={11} strokeWidth={2} />
+                Remove
+              </button>
             )}
+          </div>
 
-            {/* ── Active trial status card ──────────────────── */}
-            {trialState?.active && (() => {
-                const sttMin = (trialState.usage.stt_seconds / 60).toFixed(1);
-                return (
-                    <Card className="shadow-sm border-violet-500/25">
-                        <div className="px-5 pt-5 pb-5 space-y-4">
-                            {/* Header — same layout as "Try Natively API free" start card */}
-                            <div className="flex items-start gap-3.5">
-                                <div className="w-10 h-10 rounded-[11px] bg-violet-500/10 border border-violet-500/20 flex items-center justify-center shrink-0">
-                                    <NativelyLogoMark size={18} className="text-violet-400" />
-                                </div>
-                                <div className="flex-1 min-w-0">
-                                    <div className="flex items-center justify-between">
-                                        <p className="text-[13.5px] font-semibold text-text-primary tracking-tight">Free Trial Active</p>
-                                        <TrialCountdown expiresAt={trialState.expiresAt} />
-                                    </div>
-                                    <p className="text-[10.5px] text-text-tertiary mt-1">
-                                        {trialState.usage.ai} AI · {sttMin} min STT · {trialState.usage.search} searches used
-                                    </p>
-                                </div>
-                            </div>
-
-                            {/* Usage pills */}
-                            <div className="grid grid-cols-3 gap-2">
-                                <TrialUsagePill icon={Zap}    used={trialState.usage.ai}  limit={10}  label="AI"     unit="" />
-                                <TrialUsagePill icon={Mic}    used={Math.round(trialState.usage.stt_seconds / 60)} limit={10} label="STT"    unit="m" />
-                                <TrialUsagePill icon={Search} used={trialState.usage.search} limit={2}  label="Search" unit="" />
-                            </div>
-
-                            {/* CTA */}
-                            <button
-                                onClick={() => setShowTrialModal(true)}
-                                className="w-full flex items-center justify-center gap-2 py-2.5 rounded-[9px] text-[12.5px] font-semibold bg-violet-600 hover:bg-violet-500 text-white shadow-[0_1px_3px_rgba(0,0,0,0.1)] transition-all active:scale-[0.98] cursor-pointer"
-                            >
-                                <ArrowUpRight size={13} strokeWidth={2.3} />
-                                Keep the momentum going
-                            </button>
-                        </div>
-                    </Card>
-                );
-            })()}
-
-            {/* ── Free trial start card (no key, no active trial) ── */}
-            {!isLoading && !isSaved && !isCheckingTrial && (!trialState || (trialState.expired && !trialState.active)) && (() => {
-                const isClaimed = trialState?.expired === true || localStorage.getItem('natively_trial_claimed') === 'true';
-                
-                if (isClaimed) {
-                    return null;
-                }
-
-                return (
-                    <Card className="shadow-sm">
-                        <div className="px-5 pt-5 pb-4 flex flex-col items-center justify-center text-center">
-                            {/* Apple Promo Icon */}
-                            <div className="w-[42px] h-[42px] mb-3 rounded-[12px] bg-bg-input border border-border-subtle shadow-[inset_0_1px_rgba(255,255,255,0.06),0_2px_8px_rgba(0,0,0,0.04)] flex items-center justify-center relative overflow-hidden">
-                                <NativelyLogoMark size={20} className={isClaimed ? "text-text-tertiary" : "text-text-primary drop-shadow-sm"} />
-                            </div>
-                            
-                            <h3 className="text-[14.5px] font-bold text-text-primary tracking-tight mb-1">Natively API. Try it free.</h3>
-                            <p className="text-[12px] text-text-secondary leading-snug px-4 mb-4">
-                                Experience managed text-to-speech, AI models, and real-time research without a subscription.
-                            </p>
-
-                            {/* Clean limits grid container */}
-                            <div className="flex items-center justify-center gap-3.5 mb-5 text-[11.5px] font-medium text-text-primary bg-bg-input px-3.5 py-2 rounded-[8px] border border-border-subtle shadow-[inset_0_1px_rgba(255,255,255,0.02)]">
-                                <div className="flex flex-col items-center gap-1">
-                                    <Clock size={14} strokeWidth={2} className="text-blue-500" />
-                                    <span>30 min</span>
-                                </div>
-                                <div className="w-px h-5 bg-border-subtle/80" />
-                                <div className="flex flex-col items-center gap-1">
-                                    <Brain size={14} strokeWidth={2} className="text-violet-500" />
-                                    <span>10 reqs</span>
-                                </div>
-                                <div className="w-px h-5 bg-border-subtle/80" />
-                                <div className="flex flex-col items-center gap-1">
-                                    <Mic size={14} strokeWidth={2} className="text-emerald-500" />
-                                    <span>10m STT</span>
-                                </div>
-                                <div className="w-px h-5 bg-border-subtle/80" />
-                                <div className="flex flex-col items-center gap-1">
-                                    <Search size={14} strokeWidth={2} className="text-orange-500" />
-                                    <span>2 searches</span>
-                                </div>
-                            </div>
-
-                            <button
-                                onClick={handleStartTrial}
-                                disabled={trialLoading || isClaimed}
-                                className={`w-full max-w-[240px] flex items-center justify-center gap-2 py-2 rounded-full text-[13px] font-bold shadow-[0_1px_3px_rgba(0,0,0,0.1)] transition-all ${
-                                    isClaimed 
-                                    ? 'bg-bg-input text-text-tertiary border border-border-subtle cursor-not-allowed'
-                                    : 'bg-text-primary hover:bg-text-primary/90 text-bg-primary active:scale-[0.98]'
-                                }`}
-                            >
-                                {trialLoading ? <><Loader2 size={13} className="animate-spin" /> Starting trial…</>
-                                : isClaimed ? 'Trial Already Claimed'
-                                : 'Start 10-Minute Free Trial'}
-                            </button>
-
-                            {/* Error Handling */}
-                            {trialError && !isClaimed && (
-                                <div className="flex items-center gap-1.5 px-3 py-2 mt-3 bg-red-500/10 border border-red-500/20 rounded-[8px]">
-                                    <AlertCircle size={13} className="text-red-500 shrink-0" strokeWidth={2} />
-                                    <p className="text-[11.5px] text-red-500 font-medium">{trialError}</p>
-                                </div>
-                            )}
-
-                            <p className="text-[10.5px] text-text-tertiary font-medium mt-3">
-                                No account needed — bound to this device.
-                            </p>
-                            
-                            <div className="w-[30px] h-px bg-border-subtle my-3" />
-                            
-                            <p className="text-[11px] text-text-secondary font-medium">
-                                Already have an API key? Enter it below.
-                            </p>
-                        </div>
-                    </Card>
-                );
-            })()}
-
-            {/* ── Plans ────────────────────────────────────────── */}
-            {!isSaved && PlansCard}
-
-            {/* ── API Key card ─────────────────────────────────── */}
-            <Card>
-                {/* Card header */}
-                <div className="flex items-center gap-3 px-5 pt-5 pb-4">
-                    {/* Tinted icon well — Apple style */}
-                    <div className="w-9 h-9 rounded-xl bg-blue-500/15 border border-blue-500/20 flex items-center justify-center shrink-0">
-                        <NativelyLogoMark size={18} className="text-blue-400" />
-                    </div>
-                    <div className="min-w-0">
-                        <p className="text-[13px] font-semibold text-text-primary">API Key</p>
-                        <p className="text-[11px] text-text-tertiary leading-snug mt-0.5">
-                            Your Natively API key from your subscription email
-                        </p>
-                    </div>
-                </div>
-
-                {/* Hairline divider */}
-                <div className="h-px bg-border-subtle mx-5" />
-
-                {/* Body */}
-                <div className="px-5 pt-4 pb-5 space-y-3">
-                    {/* Label row */}
-                    <div className="flex items-center justify-between">
-                        <span className="text-[10px] font-semibold text-text-tertiary uppercase tracking-widest">Secret key</span>
-                        {isSaved && (
-                            <button
-                                onClick={handleClear}
-                                className="flex items-center gap-1 text-[11px] text-red-400/80 hover:text-red-400 transition-colors duration-150 cursor-pointer"
-                            >
-                                <Trash2 size={11} strokeWidth={2} />
-                                Remove
-                            </button>
-                        )}
-                    </div>
-
-                    {/* Input — with inset shadow for Apple depth */}
-                    <input
-                        type="text"
-                        value={apiKey}
-                        onChange={e => { setApiKey(e.target.value); setIsSaved(false); setError(null); }}
-                        onKeyDown={e => e.key === 'Enter' && handleSave()}
-                        placeholder="natively_api_..."
-                        spellCheck={false}
-                        autoComplete="off"
-                        className={`w-full bg-bg-input border rounded-xl px-3.5 py-2.5 text-[13px] font-mono text-text-primary
+          {/* Input — with inset shadow for Apple depth */}
+          <input
+            type="text"
+            value={apiKey}
+            onChange={(e) => {
+              setApiKey(e.target.value);
+              setIsSaved(false);
+              setError(null);
+            }}
+            onKeyDown={(e) => e.key === 'Enter' && handleSave()}
+            placeholder="natively_api_..."
+            spellCheck={false}
+            autoComplete="off"
+            className={`w-full bg-bg-input border rounded-xl px-3.5 py-2.5 text-[13px] font-mono text-text-primary
                             placeholder:text-text-tertiary/50 placeholder:font-sans placeholder:text-[13px]
                             shadow-[inset_0_1px_2px_rgba(0,0,0,0.25)]
                             focus:outline-none transition-all duration-150
-                            ${error
+                            ${
+                              error
                                 ? 'border-red-500/40 focus:border-red-500/60 focus:ring-1 focus:ring-red-500/20'
                                 : 'border-border-subtle focus:border-blue-500/50 focus:ring-1 focus:ring-blue-500/15'
                             }`}
-                    />
+          />
 
-                    {/* Error */}
-                    {error && (
-                        <div className="flex items-center gap-2 px-3 py-2.5 bg-red-500/8 border border-red-500/15 rounded-xl text-[12px] text-red-400">
-                            <AlertCircle size={13} className="shrink-0" />
-                            {error}
-                        </div>
-                    )}
+          {/* Error */}
+          {error && (
+            <div className="flex items-center gap-2 px-3 py-2.5 bg-red-500/8 border border-red-500/15 rounded-xl text-[12px] text-red-400">
+              <AlertCircle size={13} className="shrink-0" />
+              {error}
+            </div>
+          )}
 
-                    {/* Save button */}
-                    <button
-                        onClick={handleSave}
-                        disabled={isSaving || !isDirty}
-                        className={`w-full py-2.5 rounded-xl text-[13px] font-medium transition-all duration-150 select-none
-                            ${isSaving         ? 'bg-button-primary-disabled-bg border border-button-primary-disabled-border text-button-primary-disabled-text cursor-wait'
-                            : justSaved        ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 cursor-pointer'
-                            : !isDirty         ? 'bg-button-primary-disabled-bg border border-button-primary-disabled-border text-button-primary-disabled-text cursor-default'
-                            :                   'bg-button-primary-bg hover:bg-button-primary-hover text-white shadow-sm active:scale-[0.99] cursor-pointer'
+          {/* Save button */}
+          <button
+            onClick={handleSave}
+            disabled={isSaving || !isDirty}
+            className={`w-full py-2.5 rounded-xl text-[13px] font-medium transition-all duration-150 select-none
+                            ${
+                              isSaving
+                                ? 'bg-button-primary-disabled-bg border border-button-primary-disabled-border text-button-primary-disabled-text cursor-wait'
+                                : justSaved
+                                  ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 cursor-pointer'
+                                  : !isDirty
+                                    ? 'bg-button-primary-disabled-bg border border-button-primary-disabled-border text-button-primary-disabled-text cursor-default'
+                                    : 'bg-button-primary-bg hover:bg-button-primary-hover text-white shadow-sm active:scale-[0.99] cursor-pointer'
                             }`}
-                    >
-                        {isSaving   ? <span className="flex items-center justify-center gap-2"><Loader2 size={13} className="animate-spin" />Saving…</span>
-                        : justSaved ? <span className="flex items-center justify-center gap-2"><CheckCircle size={13} />Saved</span>
-                        :             'Save key'}
-                    </button>
+          >
+            {isSaving ? (
+              <span className="flex items-center justify-center gap-2">
+                <Loader2 size={13} className="animate-spin" />
+                Saving…
+              </span>
+            ) : justSaved ? (
+              <span className="flex items-center justify-center gap-2">
+                <CheckCircle size={13} />
+                Saved
+              </span>
+            ) : (
+              'Save key'
+            )}
+          </button>
 
-                    {/* Hint */}
-                    <p className="text-[11px] text-text-secondary leading-relaxed text-center">
-                        Don't have a key?{' '}
-                        <span
-                            onClick={() => openExternal(PLAN_STANDARD_URL)}
-                            className="text-blue-400 hover:text-blue-300 cursor-pointer transition-colors duration-150"
-                        >
-                            Subscribe to get one
-                        </span>
-                    </p>
+          {/* Hint */}
+          <p className="text-[11px] text-text-secondary leading-relaxed text-center">
+            Don't have a key?{' '}
+            <span
+              onClick={() => openExternal(PLAN_STANDARD_URL)}
+              className="text-blue-400 hover:text-blue-300 cursor-pointer transition-colors duration-150"
+            >
+              Subscribe to get one
+            </span>
+          </p>
 
-                    {/* T&C consent */}
-                    <p className="text-[10.5px] text-text-tertiary leading-relaxed text-center">
-                        By saving your key, you agree to our{' '}
-                        <span
-                            onClick={() => openExternal('https://natively.software/nativelyapi/t&c')}
-                            className="text-text-secondary hover:text-text-primary underline decoration-border-subtle underline-offset-[3px] cursor-pointer transition-colors"
-                        >
-                            Terms &amp; Conditions
-                        </span>
-                        .
-                    </p>
-                </div>
-            </Card>
+          {/* T&C consent */}
+          <p className="text-[10.5px] text-text-tertiary leading-relaxed text-center">
+            By saving your key, you agree to our{' '}
+            <span
+              onClick={() => openExternal('https://natively.software/nativelyapi/t&c')}
+              className="text-text-secondary hover:text-text-primary underline decoration-border-subtle underline-offset-[3px] cursor-pointer transition-colors"
+            >
+              Terms &amp; Conditions
+            </span>
+            .
+          </p>
+        </div>
+      </Card>
 
-            {/* ── Usage card (connected state) ─────────────────── */}
-            {isSaved && (
-                <Card>
-                    {/* Header */}
-                    <div className="flex items-center justify-between px-5 pt-5 pb-4">
-                        <div className="flex items-center gap-3">
-                            <div className="w-9 h-9 rounded-xl bg-violet-500/15 border border-violet-500/20 flex items-center justify-center shrink-0">
-                                {isLoadingUsage && !usageData
-                                    ? <Loader2 size={15} className="animate-spin text-violet-400" />
-                                    : <CalendarClock size={15} className="text-violet-400" strokeWidth={1.75} />
-                                }
-                            </div>
-                            <div>
-                                <p className="text-[13px] font-semibold text-text-primary">Usage this month</p>
-                                {usageData && (
-                                    <p className="text-[11px] text-text-tertiary mt-0.5">
-                                        Resets {fmtDate(usageData.quota.resets_at)}
-                                    </p>
-                                )}
-                            </div>
-                        </div>
-                        <button
-                            onClick={fetchUsage}
-                            disabled={isLoadingUsage}
-                            className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-[11px] text-text-tertiary
+      {/* ── Usage card (connected state) ─────────────────── */}
+      {isSaved && (
+        <Card>
+          {/* Header */}
+          <div className="flex items-center justify-between px-5 pt-5 pb-4">
+            <div className="flex items-center gap-3">
+              <div className="w-9 h-9 rounded-xl bg-violet-500/15 border border-violet-500/20 flex items-center justify-center shrink-0">
+                {isLoadingUsage && !usageData ? (
+                  <Loader2 size={15} className="animate-spin text-violet-400" />
+                ) : (
+                  <CalendarClock size={15} className="text-violet-400" strokeWidth={1.75} />
+                )}
+              </div>
+              <div>
+                <p className="text-[13px] font-semibold text-text-primary">Usage this month</p>
+                {usageData && (
+                  <p className="text-[11px] text-text-tertiary mt-0.5">
+                    Resets {fmtDate(usageData.quota.resets_at)}
+                  </p>
+                )}
+              </div>
+            </div>
+            <button
+              onClick={fetchUsage}
+              disabled={isLoadingUsage}
+              className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-[11px] text-text-tertiary
                                 hover:text-text-secondary hover:bg-bg-input transition-all duration-150
                                 disabled:opacity-40 cursor-pointer"
-                        >
-                            <RefreshCw size={11} className={isLoadingUsage ? 'animate-spin' : ''} strokeWidth={2} />
-                            Refresh
-                        </button>
-                    </div>
+            >
+              <RefreshCw
+                size={11}
+                className={isLoadingUsage ? 'animate-spin' : ''}
+                strokeWidth={2}
+              />
+              Refresh
+            </button>
+          </div>
 
-                    {usageError && !usageData && (
-                        <div className="mx-5 mb-5 flex items-center gap-2 px-3 py-2.5 bg-red-500/8 border border-red-500/15 rounded-xl text-[12px] text-red-400">
-                            <AlertCircle size={13} className="shrink-0" /> {usageError}
-                        </div>
-                    )}
+          {usageError && !usageData && (
+            <div className="mx-5 mb-5 flex items-center gap-2 px-3 py-2.5 bg-red-500/8 border border-red-500/15 rounded-xl text-[12px] text-red-400">
+              <AlertCircle size={13} className="shrink-0" /> {usageError}
+            </div>
+          )}
 
-                    {usageData && (
-                        <>
-                            {/* Stat strip */}
-                            <div className="mx-5 mb-4 grid grid-cols-3 bg-bg-input border border-border-subtle rounded-2xl overflow-hidden divide-x divide-border-subtle">
-                                {[
-                                    { label: 'STT mins',   value: usageData.quota.transcription.used, color: 'text-blue-400',    glow: 'rgba(59,130,246,0.5)'   },
-                                    { label: 'AI calls',   value: usageData.quota.ai.used,            color: 'text-violet-400',  glow: 'rgba(139,92,246,0.5)'   },
-                                    { label: 'Searches',   value: usageData.quota.search.used,        color: 'text-emerald-400', glow: 'rgba(16,185,129,0.5)'   },
-                                ].map(({ label, value, color }) => (
-                                    <div key={label} className="flex flex-col items-center py-4 px-3 gap-1">
-                                        <span className={`text-[22px] font-semibold tabular-nums tracking-tight leading-none ${color}`}>
-                                            {value.toLocaleString()}
-                                        </span>
-                                        <span className="text-[10px] text-text-tertiary font-medium tracking-wide">
-                                            {label}
-                                        </span>
-                                    </div>
-                                ))}
-                            </div>
+          {usageData && (
+            <>
+              {/* Stat strip */}
+              <div className="mx-5 mb-4 grid grid-cols-3 bg-bg-input border border-border-subtle rounded-2xl overflow-hidden divide-x divide-border-subtle">
+                {[
+                  {
+                    label: 'STT mins',
+                    value: usageData.quota.transcription.used,
+                    color: 'text-blue-400',
+                    glow: 'rgba(59,130,246,0.5)',
+                  },
+                  {
+                    label: 'AI calls',
+                    value: usageData.quota.ai.used,
+                    color: 'text-violet-400',
+                    glow: 'rgba(139,92,246,0.5)',
+                  },
+                  {
+                    label: 'Searches',
+                    value: usageData.quota.search.used,
+                    color: 'text-emerald-400',
+                    glow: 'rgba(16,185,129,0.5)',
+                  },
+                ].map(({ label, value, color }) => (
+                  <div key={label} className="flex flex-col items-center py-4 px-3 gap-1">
+                    <span
+                      className={`text-[22px] font-semibold tabular-nums tracking-tight leading-none ${color}`}
+                    >
+                      {value.toLocaleString()}
+                    </span>
+                    <span className="text-[10px] text-text-tertiary font-medium tracking-wide">
+                      {label}
+                    </span>
+                  </div>
+                ))}
+              </div>
 
-                            {/* Progress bars */}
-                            <div className="px-5 pb-5 space-y-3.5">
-                                <QuotaBar label="Transcription" icon={Mic}    bucket={usageData.quota.transcription} barColor="bg-blue-500"    />
-                                <QuotaBar label="AI requests"   icon={Brain}  bucket={usageData.quota.ai}            barColor="bg-violet-500"  />
-                                <QuotaBar label="Web searches"  icon={Search} bucket={usageData.quota.search}        barColor="bg-emerald-500" />
-                            </div>
-                        </>
-                    )}
-                </Card>
-            )}
+              {/* Progress bars */}
+              <div className="px-5 pb-5 space-y-3.5">
+                <QuotaBar
+                  label="Transcription"
+                  icon={Mic}
+                  bucket={usageData.quota.transcription}
+                  barColor="bg-blue-500"
+                />
+                <QuotaBar
+                  label="AI requests"
+                  icon={Brain}
+                  bucket={usageData.quota.ai}
+                  barColor="bg-violet-500"
+                />
+                <QuotaBar
+                  label="Web searches"
+                  icon={Search}
+                  bucket={usageData.quota.search}
+                  barColor="bg-emerald-500"
+                />
+              </div>
+            </>
+          )}
+        </Card>
+      )}
 
-            {/* ── Plans ────────────────────────────────────────── */}
-            {isSaved && PlansCard}
+      {/* ── Plans ────────────────────────────────────────── */}
+      {isSaved && PlansCard}
 
-            {/* ── How it works ─────────────────────────────────── */}
-            <Card>
-                <div className="px-5 py-4">
-                    <div className="flex items-center justify-between mb-3.5">
-                        <p className="text-[10px] font-semibold text-text-tertiary uppercase tracking-widest">
-                            How it works
-                        </p>
-                        <button
-                            onClick={() => openExternal('https://natively.software/pro')}
-                            className="flex items-center gap-1 text-[10px] font-semibold text-blue-400 hover:text-blue-300 uppercase tracking-widest transition-colors cursor-pointer"
-                        >
-                            Watch Demo <ArrowUpRight size={10} strokeWidth={2} />
-                        </button>
-                    </div>
-                    <div className="space-y-3">
-                        {[
-                            { step: '1', text: 'Subscribe above and complete checkout on Dodo Payments.' },
-                            { step: '2', text: 'Your API key is emailed instantly to your inbox.'        },
-                            { step: '3', text: 'Paste it here — Natively handles the rest automatically.' },
-                        ].map(({ step, text }) => (
-                            <div key={step} className="flex items-start gap-3">
-                                <div className="w-5 h-5 rounded-full bg-bg-input border border-border-subtle flex items-center justify-center text-[10px] font-bold text-text-tertiary shrink-0 mt-[1px]">
-                                    {step}
-                                </div>
-                                <p className="text-[12px] text-text-secondary leading-relaxed">{text}</p>
-                            </div>
-                        ))}
-                    </div>
+      {/* ── How it works ─────────────────────────────────── */}
+      <Card>
+        <div className="px-5 py-4">
+          <div className="flex items-center justify-between mb-3.5">
+            <p className="text-[10px] font-semibold text-text-tertiary uppercase tracking-widest">
+              How it works
+            </p>
+            <button
+              onClick={() => openExternal('https://natively.software/pro')}
+              className="flex items-center gap-1 text-[10px] font-semibold text-blue-400 hover:text-blue-300 uppercase tracking-widest transition-colors cursor-pointer"
+            >
+              Watch Demo <ArrowUpRight size={10} strokeWidth={2} />
+            </button>
+          </div>
+          <div className="space-y-3">
+            {[
+              { step: '1', text: 'Subscribe above and complete checkout on Dodo Payments.' },
+              { step: '2', text: 'Your API key is emailed instantly to your inbox.' },
+              { step: '3', text: 'Paste it here — Natively handles the rest automatically.' },
+            ].map(({ step, text }) => (
+              <div key={step} className="flex items-start gap-3">
+                <div className="w-5 h-5 rounded-full bg-bg-input border border-border-subtle flex items-center justify-center text-[10px] font-bold text-text-tertiary shrink-0 mt-[1px]">
+                  {step}
                 </div>
-            </Card>
-
-            {/* ── Refund Policy ────────────────────────────────── */}
-            <Card>
-                <div className="flex items-center gap-3 px-5 pt-5 pb-4">
-                    <div className="w-9 h-9 rounded-xl bg-emerald-500/15 border border-emerald-500/20 flex items-center justify-center shrink-0">
-                        <Shield size={18} className="text-emerald-400" />
-                    </div>
-                    <div className="min-w-0">
-                        <p className="text-[13px] font-semibold text-text-primary">Refund Policy</p>
-                        <p className="text-[11px] text-text-tertiary leading-snug mt-0.5">
-                            24-hour refund window — voucher purchases are final sale
-                        </p>
-                    </div>
-                </div>
-
-                <div className="h-px bg-border-subtle mx-5" />
-
-                <div className="px-5 pt-4 pb-4">
-                    <div className="space-y-3">
-                        <div className="rounded-xl bg-bg-input/50 border border-border-subtle px-3.5 py-3">
-                            <p className="text-[11.5px] text-text-secondary leading-relaxed">
-                                <strong className="text-text-primary font-semibold">A quick heads-up:</strong> Natively is built and maintained by a single developer and integrates a lot of third-party services — AI providers, transcription engines, search APIs, payments, OS-level audio &amp; screen capture. That gives the app a lot of capability, but the surface area is wider than a typical closed-source product, and once in a while something may not behave exactly as expected. If you run into something like that, please <em>report it</em> rather than disputing the charge — we read every report and fixes typically land in the next update.
-                            </p>
-                        </div>
-
-                        <div className="flex items-start gap-3">
-                            <div className="w-1.5 h-1.5 rounded-full bg-text-tertiary/40 shrink-0 mt-[6px]" />
-                            <p className="text-[11.5px] text-text-secondary leading-relaxed">
-                                Purchases made with a coupon, voucher, referral credit, or limited-time offer are <strong className="text-text-primary font-semibold">final sale</strong> and not eligible for refund.
-                            </p>
-                        </div>
-
-                        <div className="h-px bg-border-subtle mt-4 mb-3" />
-
-                        <p className="text-[11.5px] text-text-secondary leading-relaxed">
-                            For everything else — the 24-hour refund window, subscription handling, taxes &amp; fees, and your local consumer rights — please see our full{' '}
-                            <span
-                                onClick={() => openExternal('https://natively.software/refundpolicy')}
-                                className="text-text-primary hover:text-text-secondary underline decoration-border-subtle underline-offset-[3px] cursor-pointer transition-colors"
-                            >
-                                Refund Policy
-                            </span>
-                            . To request a refund or ask a question, email{' '}
-                            <span
-                                onClick={() => openExternal('mailto:natively.contact@gmail.com')}
-                                className="text-text-primary hover:text-text-secondary underline decoration-border-subtle underline-offset-[3px] cursor-pointer transition-colors"
-                            >
-                                natively.contact@gmail.com
-                            </span>
-                            .
-                        </p>
-                    </div>
-                </div>
-            </Card>
-
+                <p className="text-[12px] text-text-secondary leading-relaxed">{text}</p>
+              </div>
+            ))}
+          </div>
         </div>
-    );
+      </Card>
+
+      {/* ── Refund Policy ────────────────────────────────── */}
+      <Card>
+        <div className="flex items-center gap-3 px-5 pt-5 pb-4">
+          <div className="w-9 h-9 rounded-xl bg-emerald-500/15 border border-emerald-500/20 flex items-center justify-center shrink-0">
+            <Shield size={18} className="text-emerald-400" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-[13px] font-semibold text-text-primary">Refund Policy</p>
+            <p className="text-[11px] text-text-tertiary leading-snug mt-0.5">
+              24-hour refund window — voucher purchases are final sale
+            </p>
+          </div>
+        </div>
+
+        <div className="h-px bg-border-subtle mx-5" />
+
+        <div className="px-5 pt-4 pb-4">
+          <div className="space-y-3">
+            <div className="rounded-xl bg-bg-input/50 border border-border-subtle px-3.5 py-3">
+              <p className="text-[11.5px] text-text-secondary leading-relaxed">
+                <strong className="text-text-primary font-semibold">A quick heads-up:</strong>{' '}
+                Natively is built and maintained by a single developer and integrates a lot of
+                third-party services — AI providers, transcription engines, search APIs, payments,
+                OS-level audio &amp; screen capture. That gives the app a lot of capability, but the
+                surface area is wider than a typical closed-source product, and once in a while
+                something may not behave exactly as expected. If you run into something like that,
+                please <em>report it</em> rather than disputing the charge — we read every report
+                and fixes typically land in the next update.
+              </p>
+            </div>
+
+            <div className="flex items-start gap-3">
+              <div className="w-1.5 h-1.5 rounded-full bg-text-tertiary/40 shrink-0 mt-[6px]" />
+              <p className="text-[11.5px] text-text-secondary leading-relaxed">
+                Purchases made with a coupon, voucher, referral credit, or limited-time offer are{' '}
+                <strong className="text-text-primary font-semibold">final sale</strong> and not
+                eligible for refund.
+              </p>
+            </div>
+
+            <div className="h-px bg-border-subtle mt-4 mb-3" />
+
+            <p className="text-[11.5px] text-text-secondary leading-relaxed">
+              For everything else — the 24-hour refund window, subscription handling, taxes &amp;
+              fees, and your local consumer rights — please see our full{' '}
+              <span
+                onClick={() => openExternal('https://natively.software/refundpolicy')}
+                className="text-text-primary hover:text-text-secondary underline decoration-border-subtle underline-offset-[3px] cursor-pointer transition-colors"
+              >
+                Refund Policy
+              </span>
+              . To request a refund or ask a question, email{' '}
+              <span
+                onClick={() => openExternal('mailto:natively.contact@gmail.com')}
+                className="text-text-primary hover:text-text-secondary underline decoration-border-subtle underline-offset-[3px] cursor-pointer transition-colors"
+              >
+                natively.contact@gmail.com
+              </span>
+              .
+            </p>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
 };

--- a/src/components/settings/PhoneMirrorSettings.tsx
+++ b/src/components/settings/PhoneMirrorSettings.tsx
@@ -1,267 +1,318 @@
+import { Check, Copy, Lock, RefreshCw, ShieldAlert, Smartphone, Wifi } from 'lucide-react';
 import React, { useCallback, useEffect, useState } from 'react';
-import { Smartphone, Wifi, Lock, RefreshCw, Copy, Check, ShieldAlert } from 'lucide-react';
 import type { PhoneMirrorInfo } from '../../types/electron';
 import { isMac } from '../../utils/platformUtils';
 
 const EMPTY_INFO: PhoneMirrorInfo = {
-    running: false,
-    enabled: false,
-    exposeOnLan: false,
-    port: 0,
-    loopbackUrl: null,
-    primaryUrl: null,
-    lanUrls: [],
-    token: null,
-    qrDataUrl: null,
-    clients: 0,
+  running: false,
+  enabled: false,
+  exposeOnLan: false,
+  port: 0,
+  loopbackUrl: null,
+  primaryUrl: null,
+  lanUrls: [],
+  token: null,
+  qrDataUrl: null,
+  clients: 0,
 };
 
 export const PhoneMirrorSettings: React.FC = () => {
-    const [info, setInfo] = useState<PhoneMirrorInfo>(EMPTY_INFO);
-    const [busy, setBusy] = useState<null | 'enable' | 'disable' | 'lan' | 'rotate'>(null);
-    const [error, setError] = useState<string | null>(null);
-    const [copied, setCopied] = useState(false);
+  const [info, setInfo] = useState<PhoneMirrorInfo>(EMPTY_INFO);
+  const [busy, setBusy] = useState<null | 'enable' | 'disable' | 'lan' | 'rotate'>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
 
-    const refresh = useCallback(async () => {
-        try {
-            const next = await window.electronAPI.phoneMirrorGetInfo();
-            if (next && typeof next === 'object') setInfo(next as PhoneMirrorInfo);
-        } catch (e: any) {
-            setError(e?.message || 'Failed to load phone mirror status');
+  const refresh = useCallback(async () => {
+    try {
+      const next = await window.electronAPI.phoneMirrorGetInfo();
+      if (next && typeof next === 'object') setInfo(next as PhoneMirrorInfo);
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load phone mirror status');
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    const off = window.electronAPI.onPhoneMirrorStatus((next) => {
+      if (!next || typeof next !== 'object') return;
+      setInfo((prev) => {
+        const n = next as PhoneMirrorInfo;
+        if (
+          prev &&
+          prev.qrDataUrl === n.qrDataUrl &&
+          prev.primaryUrl === n.primaryUrl &&
+          prev.token === n.token &&
+          prev.running === n.running &&
+          prev.clients === n.clients
+        ) {
+          return prev;
         }
-    }, []);
+        return n;
+      });
+    });
+    return () => {
+      off?.();
+    };
+  }, [refresh]);
 
-    useEffect(() => {
-        refresh();
-        const off = window.electronAPI.onPhoneMirrorStatus((next) => {
-            if (next && typeof next === 'object') setInfo(next as PhoneMirrorInfo);
-        });
-        return () => { off?.(); };
-    }, [refresh]);
-
-    const apply = useCallback(async (key: 'enable' | 'disable' | 'lan' | 'rotate', fn: () => Promise<any>) => {
-        setBusy(key);
-        setError(null);
-        try {
-            const result = await fn();
-            if (result && typeof result === 'object' && 'error' in result && result.error) {
-                setError(String(result.error));
-            } else if (result && typeof result === 'object' && 'running' in result) {
-                setInfo(result as PhoneMirrorInfo);
-            } else {
-                await refresh();
-            }
-        } catch (e: any) {
-            setError(e?.message || 'Action failed');
-        } finally {
-            setBusy(null);
-        }
-    }, [refresh]);
-
-    const onToggleEnable = useCallback(async () => {
-        if (info.running) {
-            await apply('disable', () => window.electronAPI.phoneMirrorDisable());
+  const apply = useCallback(
+    async (key: 'enable' | 'disable' | 'lan' | 'rotate', fn: () => Promise<any>) => {
+      setBusy(key);
+      setError(null);
+      try {
+        const result = await fn();
+        if (result && typeof result === 'object' && 'error' in result && result.error) {
+          setError(String(result.error));
+        } else if (result && typeof result === 'object' && 'running' in result) {
+          setInfo(result as PhoneMirrorInfo);
         } else {
-            await apply('enable', () => window.electronAPI.phoneMirrorEnable(info.exposeOnLan));
+          await refresh();
         }
-    }, [apply, info.running, info.exposeOnLan]);
+      } catch (e: any) {
+        setError(e?.message || 'Action failed');
+      } finally {
+        setBusy(null);
+      }
+    },
+    [refresh],
+  );
 
-    const onToggleLan = useCallback(async () => {
-        await apply('lan', () => window.electronAPI.phoneMirrorSetLan(!info.exposeOnLan));
-    }, [apply, info.exposeOnLan]);
+  const onToggleEnable = useCallback(async () => {
+    if (info.running) {
+      await apply('disable', () => window.electronAPI.phoneMirrorDisable());
+    } else {
+      await apply('enable', () => window.electronAPI.phoneMirrorEnable(info.exposeOnLan));
+    }
+  }, [apply, info.running, info.exposeOnLan]);
 
-    const onRotate = useCallback(async () => {
-        await apply('rotate', () => window.electronAPI.phoneMirrorRotateToken());
-    }, [apply]);
+  const onToggleLan = useCallback(async () => {
+    await apply('lan', () => window.electronAPI.phoneMirrorSetLan(!info.exposeOnLan));
+  }, [apply, info.exposeOnLan]);
 
-    const onCopy = useCallback(async () => {
-        if (!info.primaryUrl) return;
-        try {
-            await navigator.clipboard.writeText(info.primaryUrl);
-            setCopied(true);
-            setTimeout(() => setCopied(false), 1200);
-        } catch (_) { /* noop */ }
-    }, [info.primaryUrl]);
+  const onRotate = useCallback(async () => {
+    await apply('rotate', () => window.electronAPI.phoneMirrorRotateToken());
+  }, [apply]);
 
-    const lanWarning = info.running && info.exposeOnLan;
-    const showQr = info.running && info.qrDataUrl;
-    const lanRequestedButMissing = info.running && info.exposeOnLan && info.lanUrls.length === 0;
+  const onCopy = useCallback(async () => {
+    if (!info.primaryUrl) return;
+    try {
+      await navigator.clipboard.writeText(info.primaryUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch (_) {
+      /* noop */
+    }
+  }, [info.primaryUrl]);
 
-    return (
-        <div className="space-y-6 animated fadeIn">
-            <header className="flex items-start gap-3">
-                <div className="rounded-xl bg-bg-item-surface p-2.5 border border-border-subtle">
-                    <Smartphone size={20} className="text-text-primary" />
-                </div>
-                <div className="flex-1">
-                    <div className="flex items-center gap-2">
-                        <h3 className="text-text-primary text-lg font-semibold tracking-tight">Phone Mirror</h3>
-                        <span className="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-[0.08em] bg-amber-500/15 text-amber-400 border border-amber-500/30">
-                            Beta
-                        </span>
-                    </div>
-                    <p className="text-text-secondary text-sm mt-1 leading-relaxed">
-                        Stream live AI responses from your desktop to a phone browser on the same network.
-                        Useful when you're sharing your screen and want the AI output kept off the shared display.
-                    </p>
-                </div>
-            </header>
+  const lanWarning = info.running && info.exposeOnLan;
+  const showQr = info.running && info.qrDataUrl;
+  const lanRequestedButMissing = info.running && info.exposeOnLan && info.lanUrls.length === 0;
 
-            {/* Master toggle */}
-            <div className="bg-bg-item-surface rounded-xl border border-border-subtle p-5 flex items-center justify-between gap-4">
-                <div className="min-w-0">
-                    <div className="text-text-primary font-medium text-sm">Enable Phone Mirror</div>
-                    <div className="text-text-secondary text-xs mt-1">
-                        {info.running
-                            ? `Running on port ${info.port} · ${info.clients} ${info.clients === 1 ? 'phone' : 'phones'} connected`
-                            : 'Off — no listener, no exposure.'}
-                    </div>
-                </div>
-                <button
-                    type="button"
-                    role="switch"
-                    aria-checked={info.running}
-                    disabled={busy !== null}
-                    onClick={onToggleEnable}
-                    className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500/40 ${info.running ? 'bg-blue-500' : 'bg-bg-item-active'} ${busy !== null ? 'opacity-60 cursor-wait' : ''}`}
-                >
-                    <span className={`inline-block h-5 w-5 transform rounded-full bg-white transition-transform ${info.running ? 'translate-x-5' : 'translate-x-1'}`} />
-                </button>
-            </div>
-
-            {/* LAN switch */}
-            <div className={`bg-bg-item-surface rounded-xl border ${lanWarning ? 'border-amber-500/30' : 'border-border-subtle'} p-5 transition-colors`}>
-                <div className="flex items-center justify-between gap-4">
-                    <div className="min-w-0">
-                        <div className="text-text-primary font-medium text-sm flex items-center gap-2">
-                            <Wifi size={14} className="text-text-secondary" /> Allow LAN access
-                        </div>
-                        <div className="text-text-secondary text-xs mt-1">
-                            {info.exposeOnLan
-                                ? 'Phones on the same WiFi can connect with the pairing token.'
-                                : 'Loopback only — only this computer can connect (use SSH tunnel for remote access).'}
-                        </div>
-                    </div>
-                    <button
-                        type="button"
-                        role="switch"
-                        aria-checked={info.exposeOnLan}
-                        disabled={busy !== null}
-                        onClick={onToggleLan}
-                        className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500/40 ${info.exposeOnLan ? 'bg-amber-500' : 'bg-bg-item-active'} ${busy !== null ? 'opacity-60 cursor-wait' : ''}`}
-                    >
-                        <span className={`inline-block h-5 w-5 transform rounded-full bg-white transition-transform ${info.exposeOnLan ? 'translate-x-5' : 'translate-x-1'}`} />
-                    </button>
-                </div>
-                {lanWarning && (
-                    <div className="mt-3 flex items-start gap-2 text-amber-400/90 text-xs leading-relaxed">
-                        <ShieldAlert size={14} className="mt-0.5 flex-shrink-0" />
-                        <span>
-                            Anyone on this network with the pairing URL can read your AI responses. Use only on trusted networks.
-                            Rotate the token below if you suspect the URL was shared.
-                        </span>
-                    </div>
-                )}
-            </div>
-
-            {/* No-LAN-IP warning */}
-            {lanRequestedButMissing && (
-                <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-4 text-amber-300 text-xs leading-relaxed flex items-start gap-2">
-                    <ShieldAlert size={14} className="mt-0.5 flex-shrink-0" />
-                    <span>
-                        LAN access is on, but no Wi-Fi or Ethernet IP was detected. Connect this {isMac ? 'Mac' : 'PC'} to the same Wi-Fi as your phone (VPN tunnels and virtual interfaces don't count). If you've connected, also confirm {isMac ? <strong>System Settings → Network → Firewall</strong> : <strong>Windows Defender Firewall → Allowed apps</strong>} is allowing incoming connections for this app.
-                    </span>
-                </div>
-            )}
-
-            {/* Pairing card */}
-            {info.running ? (
-                <div className="bg-bg-item-surface rounded-xl border border-border-subtle p-5 space-y-4">
-                    <div className="flex items-start gap-5">
-                        {showQr ? (
-                            <div className="flex-shrink-0 rounded-lg bg-white p-2 shadow-sm">
-                                <img
-                                    src={info.qrDataUrl!}
-                                    alt="Pairing QR code"
-                                    className="block w-36 h-36"
-                                    draggable={false}
-                                />
-                            </div>
-                        ) : (
-                            <div className="flex-shrink-0 w-36 h-36 rounded-lg border border-dashed border-border-subtle grid place-items-center text-text-secondary text-xs">
-                                generating QR…
-                            </div>
-                        )}
-                        <div className="flex-1 min-w-0 space-y-3">
-                            <div>
-                                <div className="text-text-secondary text-xs uppercase tracking-wider mb-1.5">Scan with your phone</div>
-                                <div className="text-text-primary text-sm font-medium">
-                                    {info.exposeOnLan
-                                        ? 'Open the camera app and point at the code.'
-                                        : 'LAN access is off. Turn it on, or open the URL on this computer.'}
-                                </div>
-                            </div>
-                            <div>
-                                <div className="text-text-secondary text-xs uppercase tracking-wider mb-1.5">Pairing URL</div>
-                                <div className="flex items-center gap-2">
-                                    <code className="flex-1 min-w-0 truncate font-mono text-xs px-2.5 py-2 rounded-md bg-bg-main border border-border-subtle text-text-primary">
-                                        {info.primaryUrl || '—'}
-                                    </code>
-                                    <button
-                                        type="button"
-                                        onClick={onCopy}
-                                        disabled={!info.primaryUrl}
-                                        className="flex-shrink-0 inline-flex items-center gap-1.5 px-3 py-2 rounded-md text-xs font-medium bg-bg-item-active text-text-primary hover:bg-bg-item-active/70 disabled:opacity-50 transition-colors"
-                                    >
-                                        {copied ? <><Check size={13} /> Copied</> : <><Copy size={13} /> Copy</>}
-                                    </button>
-                                </div>
-                            </div>
-                            {info.exposeOnLan && info.lanUrls.length > 1 && (
-                                <details className="text-xs">
-                                    <summary className="text-text-secondary cursor-pointer hover:text-text-primary">
-                                        Other LAN addresses ({info.lanUrls.length - 1})
-                                    </summary>
-                                    <ul className="mt-2 space-y-1 font-mono text-text-secondary">
-                                        {info.lanUrls.slice(1).map((u) => (
-                                            <li key={u} className="truncate">{u}</li>
-                                        ))}
-                                    </ul>
-                                </details>
-                            )}
-                        </div>
-                    </div>
-                    <div className="flex items-center justify-between pt-3 border-t border-border-subtle">
-                        <div className="flex items-center gap-2 text-text-secondary text-xs">
-                            <Lock size={12} /> Pairing token gates every connection.
-                        </div>
-                        <button
-                            type="button"
-                            onClick={onRotate}
-                            disabled={busy !== null}
-                            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium text-text-secondary hover:text-text-primary hover:bg-bg-item-active/60 transition-colors disabled:opacity-50"
-                        >
-                            <RefreshCw size={12} className={busy === 'rotate' ? 'animate-spin' : ''} />
-                            Rotate token
-                        </button>
-                    </div>
-                </div>
-            ) : (
-                <div className="bg-bg-item-surface/50 rounded-xl border border-dashed border-border-subtle p-6 text-center text-text-secondary text-sm">
-                    Turn on Phone Mirror to generate a pairing URL and QR code.
-                </div>
-            )}
-
-            {error && (
-                <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">
-                    {error}
-                </div>
-            )}
-
-            <div className="text-text-secondary text-xs leading-relaxed">
-                Phone Mirror runs entirely on your local network. No traffic leaves your machine — the bridge serves
-                an HTML page and a WebSocket directly to your phone, gated by a per-session pairing token.
-            </div>
+  return (
+    <div className="space-y-6 animated fadeIn">
+      <header className="flex items-start gap-3">
+        <div className="rounded-xl bg-bg-item-surface p-2.5 border border-border-subtle">
+          <Smartphone size={20} className="text-text-primary" />
         </div>
-    );
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            <h3 className="text-text-primary text-lg font-semibold tracking-tight">Phone Mirror</h3>
+            <span className="inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-[0.08em] bg-amber-500/15 text-amber-400 border border-amber-500/30">
+              Beta
+            </span>
+          </div>
+          <p className="text-text-secondary text-sm mt-1 leading-relaxed">
+            Stream live AI responses from your desktop to a phone browser on the same network.
+            Useful when you're sharing your screen and want the AI output kept off the shared
+            display.
+          </p>
+        </div>
+      </header>
+
+      {/* Master toggle */}
+      <div className="bg-bg-item-surface rounded-xl border border-border-subtle p-5 flex items-center justify-between gap-4">
+        <div className="min-w-0">
+          <div className="text-text-primary font-medium text-sm">Enable Phone Mirror</div>
+          <div className="text-text-secondary text-xs mt-1">
+            {info.running
+              ? `Running on port ${info.port} · ${info.clients} ${info.clients === 1 ? 'phone' : 'phones'} connected`
+              : 'Off — no listener, no exposure.'}
+          </div>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={info.running}
+          disabled={busy !== null}
+          onClick={onToggleEnable}
+          className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500/40 ${info.running ? 'bg-blue-500' : 'bg-bg-item-active'} ${busy !== null ? 'opacity-60 cursor-wait' : ''}`}
+        >
+          <span
+            className={`inline-block h-5 w-5 transform rounded-full bg-white transition-transform ${info.running ? 'translate-x-5' : 'translate-x-1'}`}
+          />
+        </button>
+      </div>
+
+      {/* LAN switch */}
+      <div
+        className={`bg-bg-item-surface rounded-xl border ${lanWarning ? 'border-amber-500/30' : 'border-border-subtle'} p-5 transition-colors`}
+      >
+        <div className="flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <div className="text-text-primary font-medium text-sm flex items-center gap-2">
+              <Wifi size={14} className="text-text-secondary" /> Allow LAN access
+            </div>
+            <div className="text-text-secondary text-xs mt-1">
+              {info.exposeOnLan
+                ? 'Phones on the same WiFi can connect with the pairing token.'
+                : 'Loopback only — only this computer can connect (use SSH tunnel for remote access).'}
+            </div>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={info.exposeOnLan}
+            disabled={busy !== null}
+            onClick={onToggleLan}
+            className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500/40 ${info.exposeOnLan ? 'bg-amber-500' : 'bg-bg-item-active'} ${busy !== null ? 'opacity-60 cursor-wait' : ''}`}
+          >
+            <span
+              className={`inline-block h-5 w-5 transform rounded-full bg-white transition-transform ${info.exposeOnLan ? 'translate-x-5' : 'translate-x-1'}`}
+            />
+          </button>
+        </div>
+        {lanWarning && (
+          <div className="mt-3 flex items-start gap-2 text-amber-400/90 text-xs leading-relaxed">
+            <ShieldAlert size={14} className="mt-0.5 flex-shrink-0" />
+            <span>
+              Anyone on this network with the pairing URL can read your AI responses. Use only on
+              trusted networks. Rotate the token below if you suspect the URL was shared.
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* No-LAN-IP warning */}
+      {lanRequestedButMissing && (
+        <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-4 text-amber-300 text-xs leading-relaxed flex items-start gap-2">
+          <ShieldAlert size={14} className="mt-0.5 flex-shrink-0" />
+          <span>
+            LAN access is on, but no Wi-Fi or Ethernet IP was detected. Connect this{' '}
+            {isMac ? 'Mac' : 'PC'} to the same Wi-Fi as your phone (VPN tunnels and virtual
+            interfaces don't count). If you've connected, also confirm{' '}
+            {isMac ? (
+              <strong>System Settings → Network → Firewall</strong>
+            ) : (
+              <strong>Windows Defender Firewall → Allowed apps</strong>
+            )}{' '}
+            is allowing incoming connections for this app.
+          </span>
+        </div>
+      )}
+
+      {/* Pairing card */}
+      {info.running ? (
+        <div className="bg-bg-item-surface rounded-xl border border-border-subtle p-5 space-y-4">
+          <div className="flex items-start gap-5">
+            {showQr ? (
+              <div className="flex-shrink-0 rounded-lg bg-white p-2 shadow-sm">
+                <img
+                  src={info.qrDataUrl!}
+                  alt="Pairing QR code"
+                  className="block w-36 h-36"
+                  draggable={false}
+                />
+              </div>
+            ) : (
+              <div className="flex-shrink-0 w-36 h-36 rounded-lg border border-dashed border-border-subtle grid place-items-center text-text-secondary text-xs">
+                generating QR…
+              </div>
+            )}
+            <div className="flex-1 min-w-0 space-y-3">
+              <div>
+                <div className="text-text-secondary text-xs uppercase tracking-wider mb-1.5">
+                  Scan with your phone
+                </div>
+                <div className="text-text-primary text-sm font-medium">
+                  {info.exposeOnLan
+                    ? 'Open the camera app and point at the code.'
+                    : 'LAN access is off. Turn it on, or open the URL on this computer.'}
+                </div>
+              </div>
+              <div>
+                <div className="text-text-secondary text-xs uppercase tracking-wider mb-1.5">
+                  Pairing URL
+                </div>
+                <div className="flex items-center gap-2">
+                  <code className="flex-1 min-w-0 truncate font-mono text-xs px-2.5 py-2 rounded-md bg-bg-main border border-border-subtle text-text-primary">
+                    {info.primaryUrl || '—'}
+                  </code>
+                  <button
+                    type="button"
+                    onClick={onCopy}
+                    disabled={!info.primaryUrl}
+                    className="flex-shrink-0 inline-flex items-center gap-1.5 px-3 py-2 rounded-md text-xs font-medium bg-bg-item-active text-text-primary hover:bg-bg-item-active/70 disabled:opacity-50 transition-colors"
+                  >
+                    {copied ? (
+                      <>
+                        <Check size={13} /> Copied
+                      </>
+                    ) : (
+                      <>
+                        <Copy size={13} /> Copy
+                      </>
+                    )}
+                  </button>
+                </div>
+              </div>
+              {info.exposeOnLan && info.lanUrls.length > 1 && (
+                <details className="text-xs">
+                  <summary className="text-text-secondary cursor-pointer hover:text-text-primary">
+                    Other LAN addresses ({info.lanUrls.length - 1})
+                  </summary>
+                  <ul className="mt-2 space-y-1 font-mono text-text-secondary">
+                    {info.lanUrls.slice(1).map((u) => (
+                      <li key={u} className="truncate">
+                        {u}
+                      </li>
+                    ))}
+                  </ul>
+                </details>
+              )}
+            </div>
+          </div>
+          <div className="flex items-center justify-between pt-3 border-t border-border-subtle">
+            <div className="flex items-center gap-2 text-text-secondary text-xs">
+              <Lock size={12} /> Pairing token gates every connection.
+            </div>
+            <button
+              type="button"
+              onClick={onRotate}
+              disabled={busy !== null}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium text-text-secondary hover:text-text-primary hover:bg-bg-item-active/60 transition-colors disabled:opacity-50"
+            >
+              <RefreshCw size={12} className={busy === 'rotate' ? 'animate-spin' : ''} />
+              Rotate token
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="bg-bg-item-surface/50 rounded-xl border border-dashed border-border-subtle p-6 text-center text-text-secondary text-sm">
+          Turn on Phone Mirror to generate a pairing URL and QR code.
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      <div className="text-text-secondary text-xs leading-relaxed">
+        Phone Mirror runs entirely on your local network. No traffic leaves your machine — the
+        bridge serves an HTML page and a WebSocket directly to your phone, gated by a per-session
+        pairing token.
+      </div>
+    </div>
+  );
 };

--- a/src/components/trial/FreeTrialBanner.tsx
+++ b/src/components/trial/FreeTrialBanner.tsx
@@ -2,135 +2,139 @@
 // Persistent countdown banner shown during an active free trial.
 // Stays visible across the whole session; not dismissible while trial is running.
 
+import { AnimatePresence, motion } from 'framer-motion';
+import { ArrowUpRight, Clock, Mic, Search, Zap } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
-import { Clock, Zap, Mic, Search, ArrowUpRight } from 'lucide-react';
 
 const PLAN_PRO_URL = 'https://checkout.dodopayments.com/buy/pdt_0NcM6Aw0IWdspbsgUeCLA';
 
 interface TrialBannerProps {
-    expiresAt:   string;            // ISO timestamp
-    usage:       { ai: number; stt_seconds: number; search: number };
-    onUpgrade:   () => void;        // opens FreeTrialModal
+  expiresAt: string; // ISO timestamp
+  usage: { ai: number; stt_seconds: number; search: number };
+  onUpgrade: () => void; // opens FreeTrialModal
 }
 
 function fmt(ms: number): string {
-    if (ms <= 0) return '0:00';
-    const totalSec = Math.ceil(ms / 1000);
-    const m = Math.floor(totalSec / 60);
-    const s = totalSec % 60;
-    return `${m}:${s.toString().padStart(2, '0')}`;
+  if (ms <= 0) return '0:00';
+  const totalSec = Math.ceil(ms / 1000);
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
 }
 
 export const FreeTrialBanner: React.FC<TrialBannerProps> = ({ expiresAt, usage, onUpgrade }) => {
-    const [remaining, setRemaining] = useState(() =>
-        Math.max(0, new Date(expiresAt).getTime() - Date.now())
-    );
-    const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [remaining, setRemaining] = useState(() =>
+    Math.max(0, new Date(expiresAt).getTime() - Date.now()),
+  );
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-    useEffect(() => {
-        const tick = () => {
-            const left = Math.max(0, new Date(expiresAt).getTime() - Date.now());
-            setRemaining(left);
-            if (left === 0 && intervalRef.current) {
-                clearInterval(intervalRef.current);
-                intervalRef.current = null;
-            }
-        };
-        intervalRef.current = setInterval(tick, 500);
-        tick();
-        return () => {
-            if (intervalRef.current) clearInterval(intervalRef.current);
-        };
-    }, [expiresAt]);
+  useEffect(() => {
+    const tick = () => {
+      const left = Math.max(0, new Date(expiresAt).getTime() - Date.now());
+      setRemaining(left);
+      if (left === 0 && intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+    intervalRef.current = setInterval(tick, 1000);
+    tick();
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [expiresAt]);
 
-    const isWarning = remaining > 0 && remaining < 2 * 60 * 1000;
-    const expired   = remaining === 0;
+  const isWarning = remaining > 0 && remaining < 2 * 60 * 1000;
+  const expired = remaining === 0;
 
-    const aiPct     = Math.min(100, (usage.ai / 10) * 100);
-    const sttPct    = Math.min(100, ((usage.stt_seconds / 60) / 10) * 100);
-    const searchPct = Math.min(100, (usage.search / 2) * 100);
+  const aiPct = Math.min(100, (usage.ai / 10) * 100);
+  const sttPct = Math.min(100, (usage.stt_seconds / 60 / 10) * 100);
+  const searchPct = Math.min(100, (usage.search / 2) * 100);
 
-    return (
-        <AnimatePresence>
-            <motion.div
-                initial={{ opacity: 0, y: -8 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: -8 }}
-                transition={{ duration: 0.25 }}
-                className={`
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0, y: -8 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: -8 }}
+        transition={{ duration: 0.25 }}
+        className={`
                     mx-3 mb-2 rounded-xl border px-3 py-2
-                    ${isWarning || expired
+                    ${
+                      isWarning || expired
                         ? 'bg-amber-500/10 border-amber-500/30'
-                        : 'bg-bg-item-surface border-border-subtle'}
+                        : 'bg-bg-item-surface border-border-subtle'
+                    }
                 `}
+      >
+        <div className="flex items-center justify-between gap-3">
+          {/* Timer */}
+          <div className="flex items-center gap-1.5 shrink-0">
+            <Clock
+              size={12}
+              strokeWidth={2}
+              className={isWarning || expired ? 'text-amber-400' : 'text-text-tertiary'}
+            />
+            <span
+              className={`text-[12px] font-mono font-semibold tabular-nums ${
+                isWarning || expired ? 'text-amber-400' : 'text-text-secondary'
+              }`}
             >
-                <div className="flex items-center justify-between gap-3">
-                    {/* Timer */}
-                    <div className="flex items-center gap-1.5 shrink-0">
-                        <Clock
-                            size={12}
-                            strokeWidth={2}
-                            className={isWarning || expired ? 'text-amber-400' : 'text-text-tertiary'}
-                        />
-                        <span
-                            className={`text-[12px] font-mono font-semibold tabular-nums ${
-                                isWarning || expired ? 'text-amber-400' : 'text-text-secondary'
-                            }`}
-                        >
-                            {expired ? 'Trial ended' : fmt(remaining)}
-                        </span>
-                        <span className="text-[10px] text-text-tertiary/70 font-medium">
-                            free trial
-                        </span>
-                    </div>
+              {expired ? 'Trial ended' : fmt(remaining)}
+            </span>
+            <span className="text-[10px] text-text-tertiary/70 font-medium">free trial</span>
+          </div>
 
-                    {/* Usage mini-bars */}
-                    <div className="flex items-center gap-3 flex-1 min-w-0">
-                        <UsagePip icon={Zap}    pct={aiPct}     label={`${usage.ai}/10 AI`}          />
-                        <UsagePip icon={Mic}    pct={sttPct}    label={`${(usage.stt_seconds/60).toFixed(1)}/10m STT`} />
-                        <UsagePip icon={Search} pct={searchPct} label={`${usage.search}/2 search`}    />
-                    </div>
+          {/* Usage mini-bars */}
+          <div className="flex items-center gap-3 flex-1 min-w-0">
+            <UsagePip icon={Zap} pct={aiPct} label={`${usage.ai}/10 AI`} />
+            <UsagePip
+              icon={Mic}
+              pct={sttPct}
+              label={`${(usage.stt_seconds / 60).toFixed(1)}/10m STT`}
+            />
+            <UsagePip icon={Search} pct={searchPct} label={`${usage.search}/2 search`} />
+          </div>
 
-                    {/* Upgrade CTA */}
-                    <button
-                        onClick={onUpgrade}
-                        className="flex items-center gap-1 px-2.5 py-1 rounded-lg text-[11px] font-semibold bg-violet-500/15 text-violet-400 hover:bg-violet-500/25 border border-violet-500/30 transition-colors shrink-0"
-                    >
-                        Upgrade
-                        <ArrowUpRight size={10} strokeWidth={2.5} />
-                    </button>
-                </div>
-            </motion.div>
-        </AnimatePresence>
-    );
+          {/* Upgrade CTA */}
+          <button
+            onClick={onUpgrade}
+            className="flex items-center gap-1 px-2.5 py-1 rounded-lg text-[11px] font-semibold bg-violet-500/15 text-violet-400 hover:bg-violet-500/25 border border-violet-500/30 transition-colors shrink-0"
+          >
+            Upgrade
+            <ArrowUpRight size={10} strokeWidth={2.5} />
+          </button>
+        </div>
+      </motion.div>
+    </AnimatePresence>
+  );
 };
 
 function UsagePip({
-    icon: Icon,
-    pct,
-    label,
+  icon: Icon,
+  pct,
+  label,
 }: {
-    icon:  React.ElementType;
-    pct:   number;
-    label: string;
+  icon: React.ElementType;
+  pct: number;
+  label: string;
 }) {
-    const isHigh = pct >= 80;
-    return (
-        <div className="flex items-center gap-1.5 min-w-0" title={label}>
-            <Icon
-                size={10}
-                strokeWidth={2}
-                className={isHigh ? 'text-amber-400 shrink-0' : 'text-text-tertiary/60 shrink-0'}
-            />
-            <div className="h-[3px] w-12 bg-bg-input rounded-full overflow-hidden shrink-0">
-                <div
-                    className={`h-full rounded-full transition-all duration-700 ${
-                        isHigh ? 'bg-amber-400' : 'bg-violet-500/60'
-                    }`}
-                    style={{ width: `${pct}%` }}
-                />
-            </div>
-        </div>
-    );
+  const isHigh = pct >= 80;
+  return (
+    <div className="flex items-center gap-1.5 min-w-0" title={label}>
+      <Icon
+        size={10}
+        strokeWidth={2}
+        className={isHigh ? 'text-amber-400 shrink-0' : 'text-text-tertiary/60 shrink-0'}
+      />
+      <div className="h-[3px] w-12 bg-bg-input rounded-full overflow-hidden shrink-0">
+        <div
+          className={`h-full rounded-full transition-all duration-700 ${
+            isHigh ? 'bg-amber-400' : 'bg-violet-500/60'
+          }`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
 }

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -474,6 +474,9 @@ export interface ElectronAPI {
   phoneMirrorSetLan: (exposeOnLan: boolean) => Promise<PhoneMirrorInfo | { error: string }>;
   phoneMirrorRotateToken: () => Promise<PhoneMirrorInfo | { error: string }>;
   onPhoneMirrorStatus: (callback: (info: PhoneMirrorInfo) => void) => () => void;
+  onPhoneMirrorIncomingChat: (
+    callback: (data: { message: string; streamId: string }) => void,
+  ) => () => void;
 }
 
 export interface PhoneMirrorInfo {


### PR DESCRIPTION
Fixes #248 — Phone Link buttons unresponsive / no desktop sync  
Fixes #261 — Hotkey / IntelligenceEngine answers not mirrored to phone

## Summary

This PR completes bidirectional phone mirroring and hardens the hot path for production use. Desktop shortcut actions, chat streams, and phone-initiated commands stay in sync across both surfaces. Stealth behavior is preserved as a hard constraint: no focus steals, no macOS opacity hacks, and screenshot capture remains a desktop-only remote shutter.

## What changed

### Phone mirroring (#248, #261)

- **WebSocket command routing** — Phone `chat`, `action`, and `screenshot` commands are validated and routed (previously dropped silently).
- **Full shortcut mirroring** — All `generate-*` handlers publish labelled assistant cards to the phone feed.
- **Phone-initiated chat** — Streams through the same LLM path as `gemini-chat-stream`, with shared monotonic stream IDs to prevent cross-stream UI bleed.
- **Desktop overlay sync** — Renderer now subscribes to `onPhoneMirrorIncomingChat` so phone-typed turns appear in the overlay before `gemini-stream-*` tokens arrive.
- **Screenshot semantics** — Phone acts as a remote shutter; desktop captures stealthily and queues for AI. No image bytes over WebSocket.

### Greptile review fixes

- **Concurrent stream guard** — Phone chat uses the shared `_chatStreamId` counter; superseded streams stop emitting without corrupting the active stream.
- **IntelligenceManager parity** — Phone chat snapshots pre-turn context, records transcript/assistant turns, and logs usage like desktop chat.
- **Dead code removal** — Removed unused `publishScreenshot` path; screenshot flow uses `publishAck('screenshot', …)` only.

### Stealth regressions (must not break)

- **macOS hide** — Removed `setOpacity(0)` regression from `hideMainWindow()` (Windows-only opacity path retained).
- **Settings focus** — When undetectable, `settings:open-tab` uses `showInactive()` without stealing focus.
- **Overlay show** — `centerAndShowWindow()` passes `inactive=true` when undetectable.

### Performance

| Area | Change |
|------|--------|
| `PhoneMirrorService` | Skip broadcast when no clients; QR cache by URL; debounced status; O(1) history trim |
| `WindowHelper` | Skip no-op overlay `setBounds()`; removed hot-path logging |
| `NativelyInterface` | Gemini tokens coalesced via rAF `queueToken('chat')`; `isCode` computed once on stream done |
| Settings UI | QR shallow-compare; Ollama poll stops once healthy; trial timers 500ms → 1000ms |
| `DynamicActionBar` | Stale-prune interval only when actions exist |

### Test infrastructure

- Added `electron/services/__tests__/ipcTestUtils.mjs` for quote-agnostic `safeHandle` matching in static IPC tests.
- Updated IPC static tests for multiline handler patterns.

## Test results

```
499 / 530 passing
```

One pre-existing failure remains: `KnowledgeOrchestratorIngest.test.mjs` requires a premium module build (`dist-electron/premium/.../KnowledgeDatabaseManager.js`) not present in this environment. Not introduced by this PR.

## Test plan

- [ ] Connect phone via QR; trigger Ctrl+1–Ctrl+7 on desktop — labelled responses appear on phone
- [ ] Type chat on phone — user turn + streaming reply appear on both phone feed and desktop overlay
- [ ] Tap quick-action buttons on phone — corresponding desktop actions fire
- [ ] Tap Capture on phone — ack toast on phone; screenshot queued on desktop for next AI prompt; no image sent to phone
- [ ] Rapid phone reconnect — status updates cleanly without QR flicker
- [ ] Join mid-stream — late joiner receives consolidated in-flight content
- [ ] With undetectable mode enabled — screenshot/settings flows do not steal focus or flash overlay

## Notes for reviewers

- Large diffs in `ipcHandlers.ts`, `preload.ts`, and several UI files include quote/style normalization from the phone-mirror workstream. Functional changes are scoped to phone mirror, stealth guards, and perf hot paths listed above.
- Superseded chat streams (phone or desktop) stop emitting without sending `done`/`error`, matching existing desktop `gemini-chat-stream` cancellation semantics.