### PR TITLE
Improved (UI) : Dragable area

### DIFF
--- a/src/components/ui/TopPill.tsx
+++ b/src/components/ui/TopPill.tsx
@@ -22,11 +22,11 @@ export default function TopPill({
             <div
                 className="
           draggable-area
-          flex items-center gap-2
+          flex items-center gap-5
           rounded-full
           overlay-pill-surface
           backdrop-blur-md
-          pl-1.5 pr-1.5 py-1.5
+          pl-2.5 pr-2.5 py-1.5
           transition-all duration-300 ease-sculpted
         "
                 style={appearance.pillStyle}


### PR DESCRIPTION
## Summary
This PR increases drag area for header, as natively icon button was clickable and draging does not work on it.  Having low drag area affects experience and becomes very irritating when user is trying to move but it does nothing 

Fixes #

Issue:

https://github.com/user-attachments/assets/fbcb5b6c-defe-4063-8f9a-bfa465bcf383



Fixes:

https://github.com/user-attachments/assets/4f378591-d599-4983-aa69-fef741762e7a





## Type of Change
- 🐛 Bug Fix
- ✨ New Feature
- 🎨 Refactor / Style Update
- 📝 Documentation

## Testing & Environment
- [ ] Manual test performed on: **[e.g. Windows 11]**
<!-- Describe how to verify the changes below -->

## Visuals (Optional)
<!-- Drag and drop screenshots or videos here. -->
