### PR TITLE
fix(macos): dual dock icons + recoverable permission denials

### DIFF
--- a/electron/audio/__tests__/ActivationPolicyOrdering.test.mjs
+++ b/electron/audio/__tests__/ActivationPolicyOrdering.test.mjs
@@ -79,3 +79,39 @@ test('non-stealth cold launch stays on accessory until the disguised window is p
     'BUG: post-window promotion must be gated on darwin && !undetectable so stealth mode never promotes to regular.',
   );
 });
+
+test('runtime setDisguise brackets the rename in accessory→regular and restores focus', () => {
+  // The runtime disguise switch performs the SAME app.setName()/setProcessDisplayName()
+  // LaunchServices re-registration as startup; on the already-foregrounded app it must
+  // (a) drop to accessory before the rename and promote back to regular after (no 2nd
+  // dock tile), and (b) restore key-window focus, because the activation-policy churn
+  // deactivates the app and AppKit does not auto-restore focus on the way back to
+  // regular — without the restore, a live disguise switch hands control to the app
+  // behind Natively.
+  const body = extractIfElseBlock('public setDisguise(');
+
+  // Ordering: accessory ... _applyDisguise(mode) ... regular
+  const accIdx = body.search(/setActivationPolicy\s*\(\s*['"]accessory['"]\s*\)/);
+  const applyIdx = body.indexOf('_applyDisguise(mode)');
+  const regIdx = body.search(/setActivationPolicy\s*\(\s*['"]regular['"]\s*\)/);
+  assert.ok(accIdx >= 0, 'BUG: runtime setDisguise must drop to accessory before the rename.');
+  assert.ok(applyIdx >= 0, 'sanity: setDisguise must call _applyDisguise(mode).');
+  assert.ok(regIdx >= 0, 'BUG: runtime setDisguise must promote back to regular after the rename.');
+  assert.ok(accIdx < applyIdx, 'BUG: accessory clamp must precede _applyDisguise().');
+  assert.ok(applyIdx < regIdx, 'BUG: regular promotion must follow _applyDisguise().');
+
+  // The bracket must be gated so stealth (undetectable) never promotes to regular.
+  assert.ok(
+    /!\s*this\.isUndetectable/.test(body),
+    'BUG: runtime bracket must be gated on !this.isUndetectable so stealth stays dock-hidden.',
+  );
+
+  // Focus restore: a .focus() call must exist AFTER the regular promotion so the
+  // live disguise switch does not drop Natively behind the previously-active app.
+  const afterPromotion = body.slice(regIdx);
+  assert.ok(
+    /\.focus\s*\(\s*\)/.test(afterPromotion),
+    'BUG: runtime setDisguise must restore window focus after promoting back to regular, ' +
+    'otherwise the activation-policy churn hands key-window to the app behind Natively.',
+  );
+});

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -3564,7 +3564,10 @@ export function initializeIpcHandlers(appState: AppState): void {
       return { success: true };
     } catch (error: any) {
       console.error('Error starting meeting:', error);
-      return { success: false, error: error.message };
+      // Forward the structured error code (e.g. 'mic-permission-denied') so the
+      // renderer can surface a recoverable permissions prompt rather than a
+      // silent failure. Falls back to undefined for plain errors.
+      return { success: false, error: error?.message, code: error?.code };
     }
   });
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -3705,7 +3705,16 @@ export class AppState {
     if (!(await ensureMacMicrophoneAccess('meeting start'))) {
       const message = formatPermissionMessage('mic-denied');
       this.broadcast('meeting-audio-error', message);
-      throw new Error(message);
+      // Tag the thrown error so the renderer's start-meeting caller (still on
+      // the launcher — the overlay/meeting surface hasn't been shown yet, so
+      // the in-overlay audio banner would not be visible) can recognise this
+      // as a recoverable mic-permission denial and re-open the permissions
+      // card instead of failing silently with only a console.error. Pre-fix,
+      // a denied/revoked mic grant made "Start Natively" do nothing on screen.
+      const err = new Error(message) as Error & { code?: string; channel?: string };
+      err.code = 'mic-permission-denied';
+      err.channel = 'mic';
+      throw err;
     }
 
     // Check Screen Recording permission required for system audio capture
@@ -5180,10 +5189,47 @@ export class AppState {
     this.disguiseMode = mode;
     SettingsManager.getInstance().set('disguiseMode', mode);
 
+    // DUAL-DOCK-ICON FIX (runtime half): _applyDisguise() performs the same
+    // app.setName() + setProcessDisplayName() LaunchServices re-registration that
+    // duplicates the dock tile at startup. At runtime the app is on 'regular'
+    // with a tile already showing, so a live disguise change can paint a second
+    // tile too. Bracket the rename in accessory→regular (no visible tile during
+    // re-registration) exactly like the startup path. macOS-only; skipped in
+    // stealth (the dock is already hidden and must stay hidden — never promote).
+    const bracketDock =
+      process.platform === 'darwin' && !this.isUndetectable;
+
+    // Capture which Natively window currently holds focus BEFORE the bracket.
+    // The accessory→regular activation-policy churn deactivates the app and
+    // resigns key-window status (AppKit does not auto-restore it on the way
+    // back to 'regular'), which would silently hand control to the app behind
+    // Natively — the same hazard the stealth dock-hide path guards against via
+    // win.focus() (see _enforceDockState). setDisguise runs while the user is
+    // foregrounded in Settings, so we restore focus to the same surface after.
+    const focusWin = bracketDock
+      ? (this.settingsWindowHelper.getSettingsWindow()
+          ?? this.windowHelper.getMainWindow())
+      : null;
+    const nativelyWasFocused =
+      !!focusWin && !focusWin.isDestroyed() && focusWin.isFocused();
+
+    if (bracketDock) {
+      app.setActivationPolicy('accessory');
+    }
+
     // Apply the disguise regardless of undetectable state
     // (disguise affects Activity Monitor name via process.title,
     //  dock icon only updates when NOT in stealth)
     this._applyDisguise(mode);
+
+    if (bracketDock) {
+      app.setActivationPolicy('regular');
+      // Restore key-window so the live disguise switch doesn't drop Natively
+      // behind the previously-active app. win.focus(), not app.focus().
+      if (nativelyWasFocused && focusWin && !focusWin.isDestroyed()) {
+        focusWin.focus();
+      }
+    }
   }
 
   public applyInitialDisguise(): void {
@@ -5391,8 +5437,20 @@ async function initializeApp() {
   // 2. Wait for app to be ready
   await app.whenReady()
 
-  // 2a. PRE-EMPTIVE dock hide: must happen before ANY operation that causes macOS to
-  // register a dock entry (app.setName, BrowserWindow creation, etc.).
+  // 2a. PRE-EMPTIVE dock hide / activation-policy clamp: must happen before ANY
+  // operation that causes macOS to register a dock entry (app.setName, the
+  // LaunchServices live-rename in _applyDisguise, BrowserWindow creation, etc.).
+  //
+  // DUAL-DOCK-ICON FIX: even in NORMAL (non-stealth) mode, applyInitialDisguise()
+  // → app.setName() + the native setProcessDisplayName() LaunchServices rename
+  // re-register the running app's LS identity. Doing that while the app is on the
+  // default 'regular' activation policy makes macOS paint a SECOND dock tile (the
+  // old identity's tile lingers while the renamed one registers) — the duplicate
+  // "Natively" icon multiple users reported. We therefore drop to 'accessory'
+  // (no dock tile) for the whole rename+window-creation window, then promote back
+  // to 'regular' exactly once AFTER createWindow() so a single, correctly-named
+  // tile appears together with the window. Stealth mode stays hidden via dock.hide()
+  // and is never promoted.
   // We read isUndetectable directly from settings here — AppState singleton isn't
   // constructed yet, so we cannot call appState.getUndetectable().
   if (process.platform === 'darwin') {
@@ -5400,6 +5458,11 @@ async function initializeApp() {
     const isUndetectableOnStartup = SettingsManager.getInstance().get('isUndetectable') ?? false;
     if (isUndetectableOnStartup) {
       app.dock.hide();
+    } else {
+      // Non-stealth: clamp to accessory (dock-tile-less) until the disguised
+      // name/icon is painted and the window exists. Do NOT promote to 'regular'
+      // here — that happens once after createWindow() below.
+      app.setActivationPolicy('accessory');
     }
   }
 
@@ -5534,6 +5597,17 @@ if (process.env.THINKING_MATRIX === '1') {
   }
 
   appState.createWindow()
+
+  // DUAL-DOCK-ICON FIX (promotion half): now that the disguised name/icon are
+  // applied and the window exists, promote back to 'regular' so a SINGLE dock
+  // tile appears together with the window. Gated on darwin && !undetectable so
+  // stealth mode is never promoted (it must stay dock-tile-less). This pairs
+  // with the 'accessory' clamp in step 2a above — together they ensure the LS
+  // re-registration from app.setName()/setProcessDisplayName() happens while no
+  // tile is visible, so macOS never paints a second "Natively" icon.
+  if (process.platform === 'darwin' && !appState.getUndetectable()) {
+    app.setActivationPolicy('regular');
+  }
 
   // Apply initial stealth state based on isUndetectable setting.
   if (!appState.getUndetectable()) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -352,10 +352,41 @@ const App: React.FC = () => {
         // First ever launch — show permissions toaster
         setShowPermissionsToaster(true);
       } else {
-        // Subsequent launches — trial promo will self-gate via TrialPromoToaster
-        const trialShown = localStorage.getItem('natively_trial_promo_ts');
-        if (!trialShown) {
-          setShowTrialPromo(true);
+        // Returning launch: re-check live TCC status. A macOS permission grant
+        // can be DROPPED out from under a returning user — most commonly after
+        // an app update changes the code signature (macOS may re-evaluate /
+        // invalidate the Screen Recording or Microphone grant for the new
+        // binary), or if the user revoked it in System Settings. In that state
+        // askForMediaAccess() returns denied WITHOUT a prompt (macOS only
+        // prompts from 'not-determined'), so the app would silently fail to
+        // capture with nothing on screen. Surface the recoverable permissions
+        // card (it deep-links to the exact System Settings pane) instead of the
+        // trial promo when mic/screen is denied or restricted. The main process
+        // also broadcasts a denied banner at startup, but that targets the
+        // in-overlay meeting surface — at launch the user is on the launcher,
+        // so this launcher-side check is what they actually see.
+        const showTrialPromoFallback = () => {
+          // Subsequent launches — trial promo will self-gate via TrialPromoToaster
+          const trialShown = localStorage.getItem('natively_trial_promo_ts');
+          if (!trialShown) {
+            setShowTrialPromo(true);
+          }
+        };
+        const maybeSurfacePermissions = window.electronAPI?.checkPermissions;
+        if (maybeSurfacePermissions) {
+          maybeSurfacePermissions()
+            .then((p) => {
+              const blocked = (s?: string) => s === 'denied' || s === 'restricted';
+              if (p?.platform === 'darwin' && (blocked(p.microphone) || blocked(p.screen))) {
+                setShowPermissionsToaster(true);
+              } else {
+                showTrialPromoFallback();
+              }
+            })
+            .catch(showTrialPromoFallback);
+        } else {
+          // Non-macOS or API unavailable — preserve the original behaviour.
+          showTrialPromoFallback();
         }
       }
     }
@@ -525,9 +556,26 @@ const App: React.FC = () => {
         // launcher. No follow-up setWindowMode IPC needed here.
       } else {
         console.error("Failed to start meeting:", result.error);
+        // A mic-permission denial aborts the meeting before the overlay (which
+        // hosts the in-meeting audio banner) is ever shown — so the user is
+        // left on the launcher with nothing actionable. Re-open the permissions
+        // card, which checks live mic/screen status, re-requests the mic, and
+        // deep-links to System Settings. This is the recoverable surface for
+        // the "I press Start Natively and nothing happens" report.
+        if (result.code === 'mic-permission-denied') {
+          setShowPermissionsToaster(true);
+        }
       }
     } catch (err) {
       console.error("Failed to start meeting:", err);
+      // Defense-in-depth: today the start-meeting IPC handler catches and
+      // resolves {success:false, code}, so a mic denial lands in the else
+      // branch above. If the call ever rejects instead, Electron preserves the
+      // serialized error .code across ipcRenderer.invoke — keep the recovery
+      // working so the denial never regresses to a silent failure.
+      if ((err as { code?: string })?.code === 'mic-permission-denied') {
+        setShowPermissionsToaster(true);
+      }
     }
   };
 

--- a/src/components/onboarding/PermissionsToaster.tsx
+++ b/src/components/onboarding/PermissionsToaster.tsx
@@ -257,6 +257,7 @@ export const PermissionsToaster: React.FC<Props> = ({ isOpen, onDismiss }) => {
                       onToggle={handleScrToggle}
                       reduced={reduced}
                       isLight={isLight}
+                      relaunchHintWhenDenied
                     />
                   )}
                   <PermItem
@@ -494,6 +495,7 @@ export const PermissionsToaster: React.FC<Props> = ({ isOpen, onDismiss }) => {
 // ─── Single permission item with toggle ───────────────────────
 function PermItem({
   icon: Icon, label, description, status, platform, onToggle, reduced, isLight,
+  relaunchHintWhenDenied,
 }: {
   icon:        React.ElementType;
   label:       string;
@@ -503,10 +505,17 @@ function PermItem({
   onToggle?:   () => void;
   reduced:     boolean;
   isLight:     boolean;
+  relaunchHintWhenDenied?: boolean;
 }) {
   const isGranted = status === 'granted';
   const isDenied  = status === 'denied' || status === 'restricted';
   const isLoading = status === 'loading' || status === 'not-determined';
+  // macOS reads the Screen Recording grant at process launch: re-enabling it in
+  // System Settings does NOT apply to the running app, so a previously-denied
+  // user must relaunch. The mic grant DOES take effect live, so no hint there.
+  const deniedHint = relaunchHintWhenDenied
+    ? 'Re-enable in Settings, then restart'
+    : 'Re-enable in Settings';
 
   const t1 = isLight ? '#1C1C1E' : '#FFFFFF';
   const t3 = isLight ? 'rgba(28, 28, 30, 0.48)' : 'rgba(255, 255, 255, 0.44)';
@@ -542,7 +551,7 @@ function PermItem({
       <div style={{ flex: 1, minWidth: 0 }}>
         <div style={{ fontSize: '13.5px', fontWeight: 580, color: t1, letterSpacing: '-0.01em' }}>{label}</div>
         <div style={{ fontSize: '11.5px', color: t3, marginTop: '2px' }}>
-          {platform !== 'darwin' ? description : isGranted ? 'Access granted' : isDenied ? 'Re-enable in Settings' : description}
+          {platform !== 'darwin' ? description : isGranted ? 'Access granted' : isDenied ? deniedHint : description}
         </div>
       </div>
 

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -240,7 +240,7 @@ export interface ElectronAPI {
   modesRemoveAllNoteSections: (modeId: string) => Promise<{ success: boolean; error?: string }>
 
   // Meeting Lifecycle
-  startMeeting: (metadata?: any) => Promise<{ success: boolean; error?: string }>
+  startMeeting: (metadata?: any) => Promise<{ success: boolean; error?: string; code?: string }>
   endMeeting: () => Promise<{ success: boolean; error?: string }>
   finalizeMicSTT: () => Promise<void>
   getRecentMeetings: () => Promise<Array<{ id: string; title: string; date: string; duration: string; summary: string }>>


### PR DESCRIPTION
## Summary

Fixes three macOS issues from a user report (reproduced on **signed** builds, normal/non-stealth mode).

### 1. Dual dock icons (multiple users)
The startup `app.setName()` + native `setProcessDisplayName()` LaunchServices re-registration ran while the app was on the default `regular` activation policy with a dock tile visible, so macOS painted a **second** tile. A pre-existing test (`ActivationPolicyOrdering.test.mjs`) specified the fix but it had **never been implemented** (zero `setActivationPolicy` calls in `main.ts`; the test was failing).

- Startup: clamp to `accessory` (no tile) before the disguise rename + `createWindow()`, promote back to `regular` once after the window exists.
- Runtime: `setDisguise()` brackets the same rename in `accessory→regular` (a live disguise switch hit the identical re-registration), and **restores key-window focus** afterwards so it doesn't hand control to the app behind Natively.
- Stealth/undetectable is never promoted (stays dock-tile-less).

### 2. Silent "Start Natively" failure on mic denial
`startMeeting()` threw + broadcast `meeting-audio-error`, which has **no renderer listener**, and the in-overlay recovery banner is never shown (denial aborts before the overlay swap) — the user saw nothing. Now the error is tagged `code: 'mic-permission-denied'`, forwarded through the `start-meeting` IPC result, and `App.tsx` re-opens the recoverable `PermissionsToaster` from the launcher.

### 3. Returning-user dropped TCC grant (no prompt)
A signed-build **update can change the code signature and drop the prior Screen Recording / Microphone grant**; macOS then never prompts (`askForMediaAccess` only prompts from `not-determined`). The launcher now re-checks live permission status on a returning launch and surfaces the recoverable `PermissionsToaster` (deep-links to the exact System Settings pane) when mic/screen is denied or restricted. Added a **"re-enable in Settings, then restart"** hint on the Screen Recording row (that grant only applies on relaunch).

## Tests
- Extends `ActivationPolicyOrdering.test.mjs` with a runtime-bracket + focus-restore regression guard (**2/2 pass**).
- Dock/stealth/permission suites relevant to the change pass; failures in the local sweep were pre-existing (require a compiled `dist-electron`), unrelated to this change.
- Electron + renderer typecheck clean (0 errors).

## Files
`electron/main.ts`, `electron/ipcHandlers.ts`, `src/App.tsx`, `src/types/electron.d.ts`, `src/components/onboarding/PermissionsToaster.tsx`, `electron/audio/__tests__/ActivationPolicyOrdering.test.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)