### PR TITLE
feat(linux): add native Linux support (Wayland and X11 support)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -370,3 +370,6 @@ CORE_PIPELINE_AUDIT_REPORT.md
 reportforgpt.md
 testengineer.prompt
 cluely/
+
+# relay-patch draft
+.relay-patch-draft.md

--- a/electron/ScreenshotHelper.ts
+++ b/electron/ScreenshotHelper.ts
@@ -609,6 +609,35 @@ export class ScreenshotHelper {
     throw new Error(`Unsupported platform for screenshots: ${platform}`);
   }
 
+  /**
+   * Linux screenshot backend selector.
+   *
+   * On Wayland, `desktopCapturer` (enabled via `WebRTCPipeWireCapturer` feature
+   * flag in main.ts) pops up the xdg-desktop-portal dialog and returns the
+   * screen content. This is the only correct screenshot path for non-GNOME
+   * Wayland compositors (KDE, Sway, Hyprland, COSMIC, etc.) — shell tools like
+   * `gnome-screenshot`/`scrot`/`import` fail silently or return black frames.
+   *
+   * On X11, shell tools (`gnome-screenshot -f`/`scrot`/`import`) are preferred
+   * because they're faster (no dialog) and produce clean full-screen captures.
+   *
+   * Users can override the auto-detection via NATIVELY_SCREENSHOT_TOOL env var:
+   *   - `desktopCapturer` — force Electron desktopCapturer (Wayland style)
+   *   - `shell`           — force gnome-screenshot/scrot/import
+   *   - `auto` (default)  — desktopCapturer on Wayland, shell on X11
+   */
+  private shouldUseDesktopCapturerOnLinux(): boolean {
+    if (process.platform !== "linux") return false;
+    const override = (process.env.NATIVELY_SCREENSHOT_TOOL ?? "auto").toLowerCase();
+    if (override === "desktopcapturer" || override === "capturer") return true;
+    if (override === "shell") return false;
+    // Auto: desktopCapturer on Wayland, shell on X11
+    return (
+      process.env.XDG_SESSION_TYPE === "wayland" ||
+      (!!process.env.WAYLAND_DISPLAY && !process.env.DISPLAY)
+    );
+  }
+
   public async takeScreenshot(preferredDisplay?: Electron.Display): Promise<string> {
     try {
       console.log('[ScreenshotHelper] Taking screenshot...');
@@ -622,7 +651,12 @@ export class ScreenshotHelper {
           await this.captureWithDesktopCapturer(screenshotPath, undefined, preferredDisplay);
         } else if (process.platform === 'win32') {
           await this.captureWithDesktopCapturer(screenshotPath);
+        } else if (this.shouldUseDesktopCapturerOnLinux()) {
+          // Wayland: desktopCapturer uses PipeWire (enabled via WebRTCPipeWireCapturer
+          // feature flag in main.ts). Pops up the portal dialog for screen selection.
+          await this.captureWithDesktopCapturer(screenshotPath, undefined, preferredDisplay);
         } else {
+          // X11: shell tools are faster (no dialog, direct X11 capture)
           await shellExecAsync(this.getScreenshotCommand(screenshotPath, false))
         }
 
@@ -690,13 +724,22 @@ export class ScreenshotHelper {
           await this.captureWithDesktopCapturer(screenshotPath, captureArea);
         }
       } else if (process.platform === 'linux') {
-        // Linux: use interactive selection command
+        // Linux: prefer desktopCapturer on Wayland (uses PipeWire portal for
+        // interactive screen selection), shell tools on X11 (gnome-screenshot
+        // -a gives interactive crop selection directly).
         console.log('[ScreenshotHelper] Using interactive selection');
-        try {
-          await shellExecAsync(this.getScreenshotCommand(screenshotPath, true))
-        } catch (e: any) {
-          console.warn('[ScreenshotHelper] User cancelled selection or error occurred:', e);
-          throw new Error("Selection cancelled")
+        if (this.shouldUseDesktopCapturerOnLinux()) {
+          // Wayland: desktopCapturer via PipeWire. User picks a screen in the
+          // portal dialog; we capture the full screen and let the cropper
+          // window handle the selection.
+          await this.captureWithDesktopCapturer(screenshotPath);
+        } else {
+          try {
+            await shellExecAsync(this.getScreenshotCommand(screenshotPath, true))
+          } catch (e: any) {
+            console.warn('[ScreenshotHelper] User cancelled selection or error occurred:', e);
+            throw new Error("Selection cancelled")
+          }
         }
       } else {
         throw new Error('Selection bounds are required for this platform');

--- a/electron/WindowHelper.ts
+++ b/electron/WindowHelper.ts
@@ -421,7 +421,39 @@ export class WindowHelper {
       // stays "in front." Required for the chat:focusInput stealth-typing path.
       // Windows/Linux fall back to a regular focusable window.
       ...(isMac ? { type: 'panel' as const } : {}),
+      // Wayland uses layer-shell for "above fullscreen" overlay rendering. Electron's
+      // built-in alwaysOnTop on Wayland does NOT raise above a fullscreen Zoom/Teams
+      // window because of the compositor's security model (one client cannot raise
+      // above another). Users on Wayland who want the "stays-on-top-of-Zoom" UX must
+      // either:
+      //   1) run with --ozone-platform=x11 (XWayland) — full alwaysOnTop works
+      //   2) use a WM with layer-shell protocol + custom Electron build (out of scope)
+      // On X11/XWayland, alwaysOnTop: 'screen-saver' level (used below) raises
+      // above fullscreen apps including screen-share surface.
+      // transparent: true works on both Wayland (with WaylandWindowDecorations
+      // feature flag) and X11 — the Electron renderer uses an RGBA surface in
+      // both cases. backgroundColor: '#00000000' is required for true transparency.
     };
+
+    // Linux-specific overlay adjustments.
+    // - Wayland: ALWAYS-ON-TOP IS A LIE — the compositor ignores cross-client
+    //   raise requests above another app's surface. We accept this
+    //   gracefully; the overlay still works for the "floating toolbar" UX
+    //   even when it doesn't cover Zoom's share surface.
+    // - X11 / XWayland: 'screen-saver' is the highest TOPMOST level Chromium
+    //   supports. It raises above fullscreen apps including screen-share.
+    // - Both: skipTaskbar has no effect on Wayland's wm-aware surfaces;
+    //   that's fine, Wayland compositors don't show a per-window taskbar entry
+    //   for skipTaskbar windows anyway.
+    const isLinux = process.platform === 'linux';
+    if (isLinux) {
+      // Use screen-saver level on X11 to ensure overlay stays above Zoom/Teams
+      // fullscreen share surfaces. On Wayland this is ignored by the compositor
+      // anyway, so no harm done.
+      overlaySettings.alwaysOnTop = true;
+      // We could add `screen-saver` level via setAlwaysOnTop() in the call below
+      // since BrowserWindowConstructorOptions doesn't accept the level param.
+    }
 
     this.overlayWindow = new BrowserWindow(overlaySettings);
     this.overlayWindow.setContentProtection(this.contentProtection);
@@ -489,6 +521,53 @@ export class WindowHelper {
       // visibleOnFullScreen above; Windows has no equivalent flag, so the level
       // itself is what controls fullscreen visibility. See issue #167.
       this.overlayWindow.setAlwaysOnTop(true, 'screen-saver');
+    } else if (process.platform === 'linux') {
+      // Linux: X11 vs Wayland behave very differently here. On X11 we use
+      // 'screen-saver' level (the highest TOPMOST) to raise above fullscreen
+      // Zoom/Teams share surfaces — same reasoning as Windows. On Wayland,
+      // setAlwaysOnTop is essentially a hint — the compositor (GNOME, KDE,
+      // Sway, Hyprland) decides whether to honor it. In practice Wayland
+      // honors it for "above non-fullscreen" but NOT for "above another
+      // client's fullscreen surface" (security model). Users wanting the
+      // full "stays-above-Zoom" UX on Linux should run with
+      // --ozone-platform=x11 (forces XWayland). We still call this so X11
+      // users get correct behavior.
+      this.overlayWindow.setAlwaysOnTop(true, 'screen-saver');
+
+      // Wayland-only: try to surface a brief dialog if we detect that the
+      // overlay is on Wayland and won't stay above fullscreen. We DON'T
+      // auto-fall-back to XWayland — that would surprise users who chose
+      // Wayland — but we tell them how to opt in.
+      if (process.env.XDG_SESSION_TYPE === 'wayland') {
+        // Fire-and-forget one-time notice at overlay creation; we only show
+        // it if the user hasn't dismissed it before (checked via simple env).
+        if (!process.env.NATIVELY_WAYLAND_NOTICE_DISMISSED) {
+          setTimeout(() => {
+            try {
+              const { dialog } = require('electron');
+              dialog.showMessageBoxSync(this.launcherWindow!, {
+                type: 'info',
+                buttons: ['Got it', "Don't show again"],
+                defaultId: 0,
+                cancelId: 1,
+                title: 'Running on Wayland',
+                message: 'Natively is running under Wayland.',
+                detail:
+                  'The overlay stays above other apps in normal use, but on Wayland ' +
+                  'it cannot raise above a fullscreen Zoom/Teams/meeting share surface ' +
+                  '(a compositor security policy, not a Natively limitation). ' +
+                  'For the full "stays-above-Zoom" UX, relaunch with ' +
+                  '--ozone-platform=x11 or set NATIVELY_USE_XWAYLAND=1 in your environment.',
+              });
+              // We can't easily persist the "don't show again" state here without
+              // touching SettingsManager; the env-var read at next launch is
+              // sufficient for now (cheap heuristic).
+            } catch (_e) {
+              // dialog may not be available; swallow.
+            }
+          }, 4000);
+        }
+      }
     }
 
     this.overlayWindow.loadURL(`${startUrl}?window=overlay`).catch((e) => {

--- a/electron/WindowHelper.ts
+++ b/electron/WindowHelper.ts
@@ -539,13 +539,27 @@ export class WindowHelper {
       // auto-fall-back to XWayland — that would surprise users who chose
       // Wayland — but we tell them how to opt in.
       if (process.env.XDG_SESSION_TYPE === 'wayland') {
-        // Fire-and-forget one-time notice at overlay creation; we only show
-        // it if the user hasn't dismissed it before (checked via simple env).
-        if (!process.env.NATIVELY_WAYLAND_NOTICE_DISMISSED) {
+        // Fire-and-forget one-time notice at overlay creation. We only show
+        // it if the user hasn't dismissed it before. The "Don't show again"
+        // choice is persisted via SettingsManager so it survives restarts.
+        // We also respect the env var for headless/CI environments that want
+        // to skip the dialog entirely.
+        const envDismissed = !!process.env.NATIVELY_WAYLAND_NOTICE_DISMISSED;
+        let settingsDismissed = false;
+        try {
+          // SettingsManager requires app.whenReady(); the overlay is created
+          // post-ready so this is safe.
+          const { SettingsManager } = require('./services/SettingsManager');
+          settingsDismissed = !!SettingsManager.getInstance().get('waylandNoticeDismissed');
+        } catch (_e) {
+          // SettingsManager unavailable (very early init) — fall through and
+          // show the dialog.
+        }
+        if (!envDismissed && !settingsDismissed) {
           setTimeout(() => {
             try {
               const { dialog } = require('electron');
-              dialog.showMessageBoxSync(this.launcherWindow!, {
+              const choice = dialog.showMessageBoxSync(this.launcherWindow!, {
                 type: 'info',
                 buttons: ['Got it', "Don't show again"],
                 defaultId: 0,
@@ -559,9 +573,17 @@ export class WindowHelper {
                   'For the full "stays-above-Zoom" UX, relaunch with ' +
                   '--ozone-platform=x11 or set NATIVELY_USE_XWAYLAND=1 in your environment.',
               });
-              // We can't easily persist the "don't show again" state here without
-              // touching SettingsManager; the env-var read at next launch is
-              // sufficient for now (cheap heuristic).
+              // choice === 1 → "Don't show again" button. Persist via
+              // SettingsManager so the user isn't re-prompted on every launch.
+              if (choice === 1) {
+                try {
+                  const { SettingsManager } = require('./services/SettingsManager');
+                  SettingsManager.getInstance().set('waylandNoticeDismissed', true);
+                } catch (_e) {
+                  // Best-effort. If SettingsManager fails, the user will
+                  // see the dialog again next launch.
+                }
+              }
             } catch (_e) {
               // dialog may not be available; swallow.
             }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -11,11 +11,24 @@ import { autoUpdater } from "electron-updater"
 // honored if they're set before the underlying platform integration is
 // initialized. See https://www.electronjs.org/docs/latest/api/command-line-switches
 if (process.platform === "linux") {
+  // XWayland auto-fallback: if the user wants the "above fullscreen Zoom" UX
+  // (which Wayland cannot provide because of the compositor security model),
+  // they can set NATIVELY_USE_XWAYLAND=1 in their environment. This forces
+  // Electron to run under XWayland, which fully supports alwaysOnTop. The
+  // same flag can be passed via CLI: `./natively --ozone-platform=x11`.
+  const forceXWayland =
+    process.env.NATIVELY_USE_XWAYLAND === "1" ||
+    process.env.NATIVELY_USE_XWAYLAND === "true";
+
   // Use Ozone (Chromium's Linux platform abstraction). With ozone-platform-hint
   // set to "auto", Electron picks Wayland when WAYLAND_DISPLAY is set and X11
-  // otherwise. Setting ozone-platform explicitly would override this.
+  // otherwise. Setting ozone-platform explicitly overrides this.
+  if (forceXWayland) {
+    app.commandLine.appendSwitch("ozone-platform", "x11")
+  } else {
+    app.commandLine.appendSwitch("ozone-platform-hint", "auto")
+  }
   app.commandLine.appendSwitch("enable-features", "UseOzonePlatform,WaylandWindowDecorations,WebRTCPipeWireCapturer")
-  app.commandLine.appendSwitch("ozone-platform-hint", "auto")
   // PipeWire screen capture is required for getDisplayMedia on Wayland. The
   // WebRTCPipeWireCapturer feature flag enables that path. Without it,
   // desktopCapturer returns nothing on Wayland sessions.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -6,6 +6,27 @@ import dns from "dns"
 import { SystemAudioHealthClassifier } from "./audio/systemAudioHealthClassifier.mjs"
 import { autoUpdater } from "electron-updater"
 
+// Linux / Wayland runtime configuration.
+// These MUST run before app.whenReady() — command-line switches are only
+// honored if they're set before the underlying platform integration is
+// initialized. See https://www.electronjs.org/docs/latest/api/command-line-switches
+if (process.platform === "linux") {
+  // Use Ozone (Chromium's Linux platform abstraction). With ozone-platform-hint
+  // set to "auto", Electron picks Wayland when WAYLAND_DISPLAY is set and X11
+  // otherwise. Setting ozone-platform explicitly would override this.
+  app.commandLine.appendSwitch("enable-features", "UseOzonePlatform,WaylandWindowDecorations,WebRTCPipeWireCapturer")
+  app.commandLine.appendSwitch("ozone-platform-hint", "auto")
+  // PipeWire screen capture is required for getDisplayMedia on Wayland. The
+  // WebRTCPipeWireCapturer feature flag enables that path. Without it,
+  // desktopCapturer returns nothing on Wayland sessions.
+  // Keep GPU acceleration on but disable the GPU sandbox under XWayland —
+  // it's flaky in some nested setups (X11-in-Wayland) and adds 200ms latency
+  // for the first window paint.
+  if (process.env.NATIVELY_DISABLE_GPU_SANDBOX === "1") {
+    app.commandLine.appendSwitch("disable-gpu-sandbox")
+  }
+}
+
 // Override global dns.lookup to resolve macOS system resolver issues with api.natively.software
 const originalLookup = dns.lookup;
 dns.lookup = function(hostname: any, options: any, callback: any) {
@@ -516,6 +537,26 @@ export class AppState {
   private isMeetingActive: boolean = false; // Guard for session state leaks
   private _meetingGeneration = 0;
   private _audioInitPromise: Promise<void> | null = null;
+
+  // Platform info (Linux session detection — see SessionTypeResolver below).
+  // Exposed as readonly so consumers can branch on isLinux/isWayland without
+  // re-querying the env on every frame.
+  public readonly platform: NodeJS.Platform = process.platform;
+  public readonly isLinux: boolean = process.platform === "linux";
+  public readonly sessionType: "wayland" | "x11" | "unsupported" = (() => {
+    if (process.platform !== "linux") return "unsupported" as const;
+    const t = (process.env.XDG_SESSION_TYPE ?? "").toLowerCase();
+    if (t === "wayland") return "wayland" as const;
+    if (t === "x11") return "x11" as const;
+    // No XDG_SESSION_TYPE (rare: e.g. TTY-only Linux session) — fall back to
+    // checking WAYLAND_DISPLAY/DISPLAY env vars as a last resort.
+    if (process.env.WAYLAND_DISPLAY) return "wayland" as const;
+    if (process.env.DISPLAY) return "x11" as const;
+    return "unsupported" as const;
+  })();
+  public readonly isWayland: boolean = this.sessionType === "wayland";
+  public readonly isX11: boolean = this.sessionType === "x11";
+
   // AbortController handle for the in-flight startMeeting() audio init, so endMeeting()
   // can cancel it (signal.aborted short-circuits the init's isCurrentMeeting() guards)
   // and await its completion before tearing down captures — preventing a fresh capture

--- a/electron/services/SettingsManager.ts
+++ b/electron/services/SettingsManager.ts
@@ -28,6 +28,11 @@ export interface AppSettings {
     hindsightAutoStart?: boolean;
     hindsightServerCommand?: string;
     hindsightLlmProvider?: string;
+    // Linux-only: set when the user dismisses the "Running on Wayland"
+    // notice dialog (selecting "Don't show again"). Persisted across
+    // launches so we don't pester users who've already acknowledged the
+    // Wayland limitation.
+    waylandNoticeDismissed?: boolean;
     knowledgeMode?: boolean;
     phoneMirrorEnabled?: boolean;
     phoneMirrorExposeOnLan?: boolean;

--- a/native-module/Cargo.lock
+++ b/native-module/Cargo.lock
@@ -979,6 +979,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "libpulse-binding"
+version = "2.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909eb3049e16e373680fe65afe6e2a722ace06b671250cc4849557bc57d6a397"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+ "libpulse-sys",
+ "num-derive",
+ "num-traits",
+ "winapi",
+]
+
+[[package]]
+name = "libpulse-sys"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d74371848b22e989f829cc1621d2ebd74960711557d8b45cfe740f60d0a05e61"
+dependencies = [
+ "libc",
+ "num-derive",
+ "num-traits",
+ "pkg-config",
+ "winapi",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,6 +1165,7 @@ dependencies = [
  "core-foundation 0.10.1",
  "core-graphics",
  "cpal",
+ "libpulse-binding",
  "machine-uid",
  "napi",
  "napi-derive",
@@ -2438,6 +2466,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2445,6 +2489,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"

--- a/native-module/Cargo.toml
+++ b/native-module/Cargo.toml
@@ -47,3 +47,13 @@ core-foundation = "0.10"
 wasapi = "0.13.0"
 windows = { version = "0.52.0", features = ["Win32_Media_Audio", "Win32_System_Com", "Win32_System_Threading"] }
 tracing = "0.1.44"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+# PulseAudio bindings (libpulse-sys is pulled in transitively for the FFI).
+# Works with both native PulseAudio and PipeWire's pipewire-pulse compatibility
+# layer, so the same code covers Ubuntu 22.04+, Fedora Workstation, and any
+# legacy PulseAudio install. System audio is captured via a monitor source
+# stream on the default sink (the same trick WASAPI uses with loopback on
+# Windows). Requires libpulse-dev (libpulse.so + headers) at build time.
+libpulse-binding = "2.30"
+tracing = "0.1.44"

--- a/native-module/Cargo.toml
+++ b/native-module/Cargo.toml
@@ -24,6 +24,10 @@ webrtc-vad = "0.4"
 # Zero-copy reinterpret of &[i16] as &[u8] for napi Buffer hand-off.
 # Replaces a per-chunk per-sample to_le_bytes loop in the DSP hot path.
 bytemuck = "1"
+# tracing is used by all platforms (macos, windows, linux) for structured
+# logging of capture thread lifecycle events. Was previously scoped to the
+# Windows target cfg, which silently broke when linux.rs was added.
+tracing = "0.1.44"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cidre = { version = "0.11.10", features = ["ca", "cm", "av", "cat", "dispatch", "ns", "sc", "cf", "blocks", "objc"] }
@@ -46,7 +50,6 @@ core-foundation = "0.10"
 [target.'cfg(target_os = "windows")'.dependencies]
 wasapi = "0.13.0"
 windows = { version = "0.52.0", features = ["Win32_Media_Audio", "Win32_System_Com", "Win32_System_Threading"] }
-tracing = "0.1.44"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # PulseAudio bindings (libpulse-sys is pulled in transitively for the FFI).
@@ -56,4 +59,3 @@ tracing = "0.1.44"
 # stream on the default sink (the same trick WASAPI uses with loopback on
 # Windows). Requires libpulse-dev (libpulse.so + headers) at build time.
 libpulse-binding = "2.30"
-tracing = "0.1.44"

--- a/native-module/src/speaker/linux.rs
+++ b/native-module/src/speaker/linux.rs
@@ -330,16 +330,22 @@ context
                     }
                 };
 
-                // Reinterpret F32le bytes as f32 frames. The slice length
-                // should always be a multiple of 4 (frame_size) because
-                // we declared channels=2 and Format::F32le. We slice to the
-                // largest multiple to be safe.
+                // Decode F32le bytes into f32 frames. We do NOT cast via
+                // `slice.as_ptr() as *const f32` because the underlying
+                // PA buffer has alignment 1 (it's a u8 slice), and casting
+                // an unaligned pointer to *const f32 is UB even though it
+                // works in practice on x86_64. Instead, copy via
+                // `f32::from_le_bytes` for each 4-byte chunk. PA gives us
+                // F32le format so this is a straight byte-to-f32 decode.
                 let frame_size = std::mem::size_of::<f32>();
-                let n_full_frames = slice.len() / frame_size;
-                let bytes_to_use = n_full_frames * frame_size;
-                let frames = unsafe {
-                    std::slice::from_raw_parts(slice.as_ptr() as *const f32, n_full_frames)
-                };
+                let usable_len = (slice.len() / frame_size) * frame_size;
+                let mut frames: Vec<f32> = Vec::with_capacity(usable_len / frame_size);
+                let mut i = 0;
+                while i + frame_size <= usable_len {
+                    let b = &slice[i..i + frame_size];
+                    frames.push(f32::from_le_bytes([b[0], b[1], b[2], b[3]]));
+                    i += frame_size;
+                }
 
                 // Push into the ringbuf. If the ringbuf is full we drop
                 // remaining samples (better than blocking the capture thread).
@@ -353,7 +359,6 @@ context
                 }
 
                 // Advance PA's read pointer.
-                let _ = bytes_to_use;
                 if let Err(e) = stream.discard() {
                     error!("[LinuxSpeaker] discard error: {}", e);
                     return Ok(());
@@ -433,7 +438,7 @@ fn wait_for_op<C: ?Sized>(
     op: &pulse::operation::Operation<C>,
 ) {
     let mut tries = 0;
-    while !matches!(op.get_state(), OpState::Done) {
+    while !matches!(op.get_state(), OpState::Done | OpState::Cancelled) {
         mainloop.iterate(false);
         tries += 1;
         if tries > 1000 {

--- a/native-module/src/speaker/linux.rs
+++ b/native-module/src/speaker/linux.rs
@@ -1,0 +1,444 @@
+// Linux speaker (system audio) capture via PulseAudio monitor-source loopback.
+//
+// Works on both X11 and Wayland via:
+//   - native PulseAudio (legacy Linux audio servers)
+//   - pipewire-pulse (PulseAudio compatibility layer that PipeWire ships with
+//     by default on Ubuntu 22.04+, Fedora Workstation, etc.)
+//
+// Strategy: open a recording stream on the monitor source of the default sink.
+// PulseAudio mirrors every audio output to the corresponding "monitor" source,
+// which is exactly what WASAPI loopback does on Windows.
+//
+// Threading model: PulseAudio streams MUST be driven by a mainloop on the
+// same thread that created them. We therefore dedicate a capture thread to
+// owning the mainloop + stream. On the capture thread, we iterate the
+// mainloop in a `loop { iterate(); read_some(); }` pattern:
+//   - iterate() runs PA callbacks (including the read callback)
+//   - read_some() drains the stream's internal buffer into our ringbuf
+// This is simpler than driving the read callback to push directly, because
+// peek/discard require &mut Stream, and the callback also takes &mut Stream
+// — keeping the actual buffer drain in the main loop avoids aliasing.
+//
+// Build requirement: libpulse-dev (libpulse.so + headers). The
+// libpulse-binding crate's build script invokes pkg-config to find the
+// headers; on Debian/Ubuntu install libpulse-dev, on Fedora install
+// pulseaudio-libs-devel.
+use crate::audio_config::RING_BUFFER_SAMPLES;
+use anyhow::{anyhow, Result};
+use libpulse_binding as pulse;
+use pulse::context::{Context, FlagSet as ContextFlagSet, State as ContextState};
+use pulse::mainloop::standard::Mainloop as StandardMainLoop;
+use pulse::operation::State as OpState;
+use pulse::sample::{Format, Spec};
+use pulse::stream::{FlagSet as StreamFlagSet, Stream};
+use ringbuf::traits::{Producer, Split};
+use ringbuf::{HeapCons, HeapProd, HeapRb};
+use std::sync::mpsc;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+use tracing::error;
+use tracing::warn;
+
+struct CaptureState {
+    shutdown: bool,
+}
+
+pub struct SpeakerInput {
+    device_id: Option<String>,
+}
+
+pub struct SpeakerStream {
+    consumer: Option<HeapCons<f32>>,
+    capture_state: Arc<Mutex<CaptureState>>,
+    capture_thread: Option<thread::JoinHandle<()>>,
+    actual_sample_rate: u32,
+}
+
+impl SpeakerStream {
+    pub fn sample_rate(&self) -> u32 {
+        self.actual_sample_rate
+    }
+
+    pub fn take_consumer(&mut self) -> Option<HeapCons<f32>> {
+        self.consumer.take()
+    }
+}
+
+impl Drop for SpeakerStream {
+    fn drop(&mut self) {
+        if let Ok(mut s) = self.capture_state.lock() {
+            s.shutdown = true;
+        }
+        if let Some(t) = self.capture_thread.take() {
+            let _ = t.join();
+        }
+    }
+}
+
+/// Enumerate output sinks. (uid, description) pairs. UID is the sink name
+/// (which doubles as the prefix for its monitor source: `<name>.monitor`).
+pub fn list_output_devices() -> Result<Vec<(String, String)>> {
+    let mut mainloop = StandardMainLoop::new().ok_or_else(|| anyhow!("PA mainloop"))?;
+    let mut context = Context::new(&mainloop, "natively-list")
+        .ok_or_else(|| anyhow!("PA context"))?;
+    context
+        .connect(None, ContextFlagSet::NOFAIL, None)
+        .map_err(|_| anyhow!("PA connect"))?;
+
+    let mut tries = 0;
+    while !matches!(context.get_state(), ContextState::Ready) {
+        mainloop.iterate(false);
+        tries += 1;
+        if tries > 200 {
+            return Err(anyhow!("PA context ready timeout"));
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    let results: Arc<Mutex<Vec<(String, String)>>> = Arc::new(Mutex::new(Vec::new()));
+    let results_cb = results.clone();
+    let op = context.introspect().get_sink_info_list(move |result| {
+        if let pulse::callbacks::ListResult::Item(info) = result {
+            let name = info.name.as_ref().map(|n| n.to_string()).unwrap_or_default();
+            let desc = info
+                .description
+                .as_ref()
+                .map(|d| d.to_string())
+                .unwrap_or_else(|| name.clone());
+            if !name.is_empty() {
+                results_cb.lock().unwrap().push((name, desc));
+            }
+        }
+    });
+    wait_for_op(&mut mainloop, &op);
+
+    let mut list = results.lock().unwrap().clone();
+    list.sort();
+    list.dedup();
+    Ok(list)
+}
+
+/// Returns the sink name of the current default sink, or empty string on failure.
+pub fn default_output_device_uid() -> String {
+    let Some(mut mainloop) = StandardMainLoop::new() else {
+        return String::new();
+    };
+    let Some(mut context) = Context::new(&mainloop, "natively-default") else {
+        return String::new();
+    };
+    if context.connect(None, ContextFlagSet::NOFAIL, None).is_err() {
+        return String::new();
+    }
+    let mut tries = 0;
+    while !matches!(context.get_state(), ContextState::Ready) {
+        mainloop.iterate(false);
+        tries += 1;
+        if tries > 200 {
+            return String::new();
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    let result: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let result_cb = result.clone();
+    let op = context.introspect().get_server_info(move |info| {
+        if let Some(name) = info.default_sink_name.as_ref() {
+            *result_cb.lock().unwrap() = Some(name.to_string());
+        }
+    });
+    wait_for_op(&mut mainloop, &op);
+
+    let result_str = result.lock().unwrap().clone().unwrap_or_default();
+    drop(result); // Release the MutexGuard before returning
+    result_str
+}
+
+impl SpeakerInput {
+    pub fn new(device_id: Option<String>) -> Result<Self> {
+        let device_id = device_id.filter(|id| !id.is_empty() && id != "default");
+        Ok(Self { device_id })
+    }
+
+    /// Spawn the PulseAudio capture thread. Returns the negotiated sample rate.
+    pub fn stream(self) -> Result<SpeakerStream> {
+        let rb = HeapRb::<f32>::new(RING_BUFFER_SAMPLES);
+        let (producer, consumer) = rb.split();
+
+        let capture_state = Arc::new(Mutex::new(CaptureState {
+            shutdown: false,
+        }));
+        let (init_tx, init_rx) = mpsc::channel::<Result<u32>>();
+
+        let state_clone = capture_state.clone();
+        let device_id = self.device_id;
+
+        let capture_thread = thread::spawn(move || {
+            if let Err(e) = Self::capture_audio_loop(producer, state_clone, init_tx, device_id) {
+                error!("[LinuxSpeaker] capture loop exited: {}", e);
+            }
+        });
+
+        let actual_sample_rate = match init_rx.recv_timeout(Duration::from_secs(5)) {
+            Ok(Ok(rate)) => rate,
+            Ok(Err(e)) => {
+                if let Ok(mut s) = capture_state.lock() {
+                    s.shutdown = true;
+                }
+                return Err(anyhow!("PulseAudio init failed: {}", e));
+            }
+            Err(_) => {
+                if let Ok(mut s) = capture_state.lock() {
+                    s.shutdown = true;
+                }
+                return Err(anyhow!(
+                    "PulseAudio init timed out after 5s (no server, or sink busy)"
+                ));
+            }
+        };
+
+        Ok(SpeakerStream {
+            consumer: Some(consumer),
+            capture_state,
+            capture_thread: Some(capture_thread),
+            actual_sample_rate,
+        })
+    }
+
+    fn capture_audio_loop(
+        mut producer: HeapProd<f32>,
+        capture_state: Arc<Mutex<CaptureState>>,
+        init_tx: mpsc::Sender<Result<u32>>,
+        device_id: Option<String>,
+    ) -> Result<()> {
+        let mut mainloop = StandardMainLoop::new()
+            .ok_or_else(|| anyhow!("creating PulseAudio mainloop"))?;
+        let mut context = Context::new(&mainloop, "natively-speaker")
+            .ok_or_else(|| anyhow!("creating PulseAudio context"))?;
+context
+        .connect(None, ContextFlagSet::NOFAIL, None)
+        .map_err(|e| anyhow!("PA connect: {}", e))?;
+
+        // Wait for context ready (2s budget).
+        let mut tries = 0;
+        while !matches!(context.get_state(), ContextState::Ready) {
+            mainloop.iterate(false);
+            tries += 1;
+            if tries > 200 {
+                let _ = init_tx.send(Err(anyhow!("PA context ready timeout")));
+                return Err(anyhow!("PA context ready timeout"));
+            }
+            thread::sleep(Duration::from_millis(10));
+            if matches!(context.get_state(), ContextState::Failed | ContextState::Terminated) {
+                let _ = init_tx.send(Err(anyhow!("PA context failed/terminated")));
+                return Err(anyhow!("PA context failed/terminated"));
+            }
+        }
+
+        // Resolve monitor source.
+        let monitor_source = match Self::resolve_monitor_source(&mut mainloop, &context, device_id) {
+            Ok(s) => s,
+            Err(e) => {
+                let _ = init_tx.send(Err(anyhow!("{}", e)));
+                return Err(anyhow!("{}", e));
+            }
+        };
+
+        // Build spec: F32le stereo at 48kHz. PA resamples from the hardware
+        // rate if needed.
+        let spec = Spec {
+            format: Format::F32le,
+            rate: 48000,
+            channels: 2,
+        };
+        if !spec.is_valid() {
+            let _ = init_tx.send(Err(anyhow!("invalid PulseAudio sample spec")));
+            return Err(anyhow!("invalid PulseAudio sample spec"));
+        }
+
+        // Stream attributes:
+        //   ADJUST_LATENCY: let PA pick a sensible buffer size
+        //   DONT_MOVE: don't migrate the stream if the default sink changes
+        //     mid-meeting — we'd lose the monitor otherwise
+        // (DAUDIOCAPTURE / PA_STREAM_RECORD is the implicit default for
+        // connect_record and isn't exposed as a stream flag in libpulse-binding.)
+        let mut attrs = StreamFlagSet::empty();
+        attrs.insert(StreamFlagSet::ADJUST_LATENCY);
+        attrs.insert(StreamFlagSet::DONT_MOVE);
+
+        // Build the stream object. We need a unique name to avoid conflicts
+        // with other PA clients. Stream::new requires &mut Context.
+        let mut stream = Stream::new(&mut context, "natively-capture", &spec, None)
+            .ok_or_else(|| anyhow!("creating PA stream"))?;
+
+        // Connect to the monitor source. The stream moves to "ready" state
+        // when PA has finished setup. We don't need to wait for a callback
+        // here — the connect_record call returns synchronously, and the
+        // stream is usable immediately (calls to peek/iterate will block
+        // until data arrives).
+        stream
+            .connect_record(Some(&monitor_source), None, attrs)
+            .map_err(|e| anyhow!("PA connect_record failed: {}", e))?;
+
+        // Read back the actual sample rate PA negotiated (PA may resample
+        // from the hardware rate).
+        let actual_rate = stream.get_sample_spec().map(|s| s.rate).unwrap_or(48000);
+
+        // Signal init complete.
+        let _ = init_tx.send(Ok(actual_rate));
+
+        // Main capture loop: iterate the mainloop + drain the stream's
+        // internal buffer into our ringbuf. The mainloop processes PA
+        // callbacks; we drain via peek/discard which require &mut Stream
+        // (not usable from inside a callback, so we do it here).
+        loop {
+            // Shutdown check.
+            {
+                let shutdown = capture_state
+                    .lock()
+                    .map(|s| s.shutdown)
+                    .unwrap_or(true);
+                if shutdown {
+                    break;
+                }
+            }
+
+            // Process PA callbacks (including any read callbacks).
+            mainloop.iterate(false);
+
+            // Drain the stream's buffer. We do this in a loop because
+            // peek+discard can be called repeatedly until the buffer is
+            // empty (each call returns at most one "fragment" of audio).
+            //
+            // SAFETY: peek returns a `&[u8]` borrowed from PA's internal
+            // buffer. We immediately copy into f32 frames (PA gave us F32le)
+            // and then discard. The peek/discard pair must be called with no
+            // other PA API calls in between on the same stream.
+            loop {
+                let slice = match stream.peek() {
+                    Ok(pulse::stream::PeekResult::Data(s)) => s,
+                    Ok(pulse::stream::PeekResult::Empty) => break,
+                    Ok(pulse::stream::PeekResult::Hole(_)) => {
+                        // Hole = PA detected a gap in the stream (e.g. sink
+                        // disconnected). Skip it; PA advances the read pointer.
+                        stream.discard().ok();
+                        continue;
+                    }
+                    Err(e) => {
+                        error!("[LinuxSpeaker] peek error: {}", e);
+                        return Ok(());
+                    }
+                };
+
+                // Reinterpret F32le bytes as f32 frames. The slice length
+                // should always be a multiple of 4 (frame_size) because
+                // we declared channels=2 and Format::F32le. We slice to the
+                // largest multiple to be safe.
+                let frame_size = std::mem::size_of::<f32>();
+                let n_full_frames = slice.len() / frame_size;
+                let bytes_to_use = n_full_frames * frame_size;
+                let frames = unsafe {
+                    std::slice::from_raw_parts(slice.as_ptr() as *const f32, n_full_frames)
+                };
+
+                // Push into the ringbuf. If the ringbuf is full we drop
+                // remaining samples (better than blocking the capture thread).
+                let mut idx = 0;
+                while idx < frames.len() {
+                    let pushed = producer.push_slice(&frames[idx..]);
+                    if pushed == 0 {
+                        break;
+                    }
+                    idx += pushed;
+                }
+
+                // Advance PA's read pointer.
+                let _ = bytes_to_use;
+                if let Err(e) = stream.discard() {
+                    error!("[LinuxSpeaker] discard error: {}", e);
+                    return Ok(());
+                }
+            }
+
+            // Don't busy-spin. 5ms = ~200 wakeups/sec which is plenty for
+            // 48kHz audio (a 10ms buffer at 48kHz is 480 frames; 5ms gives
+            // us ~1 wakeup per buffer).
+            thread::sleep(Duration::from_millis(5));
+        }
+
+        Ok(())
+    }
+
+    fn resolve_monitor_source(
+        mainloop: &mut StandardMainLoop,
+        context: &Context,
+        device_id: Option<String>,
+    ) -> Result<String> {
+        match device_id {
+            Some(ref id) => {
+                let candidate = format!("{}.monitor", id);
+                let exists: Arc<Mutex<bool>> = Arc::new(Mutex::new(false));
+                let exists_cb = exists.clone();
+                let op =
+                    context
+                        .introspect()
+                        .get_source_info_by_name(&candidate, move |result| {
+                            if matches!(
+                                result,
+                                pulse::callbacks::ListResult::Item(_)
+                            ) {
+                                *exists_cb.lock().unwrap() = true;
+                            }
+                        });
+                wait_for_op(mainloop, &op);
+
+                if *exists.lock().unwrap() {
+                    Ok(candidate)
+                } else {
+                    warn!(
+                        "[LinuxSpeaker] sink '{}' not found or has no monitor; falling back to default",
+                        id
+                    );
+                    Self::default_monitor_source(mainloop, context)
+                }
+            }
+            None => Self::default_monitor_source(mainloop, context),
+        }
+    }
+
+    fn default_monitor_source(
+        mainloop: &mut StandardMainLoop,
+        context: &Context,
+    ) -> Result<String> {
+        let result: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let result_cb = result.clone();
+        let op = context.introspect().get_server_info(move |info| {
+            if let Some(name) = info.default_sink_name.as_ref() {
+                *result_cb.lock().unwrap() = Some(name.to_string());
+            }
+        });
+        wait_for_op(mainloop, &op);
+
+        let sink = result
+            .lock()
+            .unwrap()
+            .clone()
+            .ok_or_else(|| anyhow!("no default sink in PulseAudio"))?;
+        Ok(format!("{}.monitor", sink))
+    }
+}
+
+fn wait_for_op<C: ?Sized>(
+    mainloop: &mut StandardMainLoop,
+    op: &pulse::operation::Operation<C>,
+) {
+    let mut tries = 0;
+    while !matches!(op.get_state(), OpState::Done) {
+        mainloop.iterate(false);
+        tries += 1;
+        if tries > 1000 {
+            break; // Don't hang forever; return whatever PA gave us.
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+}

--- a/native-module/src/speaker/mod.rs
+++ b/native-module/src/speaker/mod.rs
@@ -26,7 +26,18 @@ pub use windows::SpeakerStream;
 #[cfg(target_os = "windows")]
 pub use windows::default_output_device_uid;
 
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+#[cfg(target_os = "linux")]
+pub mod linux;
+#[cfg(target_os = "linux")]
+pub use linux::list_output_devices;
+#[cfg(target_os = "linux")]
+pub use linux::SpeakerInput;
+#[cfg(target_os = "linux")]
+pub use linux::SpeakerStream;
+#[cfg(target_os = "linux")]
+pub use linux::default_output_device_uid;
+
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
 pub mod fallback {
     // Stub implementation for Linux (and any other unsupported platform).
     // The system-audio capture pipeline is macOS/Windows only — `new()` always
@@ -78,11 +89,11 @@ pub mod fallback {
         String::new()
     }
 }
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
 pub use fallback::list_output_devices;
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
 pub use fallback::SpeakerInput;
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
 pub use fallback::SpeakerStream;
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
 pub use fallback::default_output_device_uid;


### PR DESCRIPTION
## Summary

Adds native Linux support to natively-cluely-ai-assistant:

- **System audio capture** via PipeWire/PulseAudio monitor-source loopback (works on both Wayland via pipewire-pulse and native PulseAudio on X11)
- **Electron Ozone Wayland auto-detection** via `XDG_SESSION_TYPE` (uses `UseOzonePlatform,WaylandWindowDecorations,WebRTCPipeWireCapturer` features + `ozone-platform-hint=auto`)
- **Wayland screenshots** via Electron's `desktopCapturer` + PipeWire portal (works on ALL Wayland compositors — GNOME, KDE, Sway, Hyprland, COSMIC)
- **X11 screenshots** via existing shell tools (`gnome-screenshot`/`scrot`/`import`) — faster, no dialog
- **Linux-aware overlay window** with `screen-saver` z-order level on X11/XWayland
- **XWayland-launch helper**: `NATIVELY_USE_XWAYLAND=1` forces XWayland mode for "above fullscreen Zoom" UX
- **Native module** (`libpulse-binding` gated on Linux) — builds clean for `x86_64-unknown-linux-gnu`

Closes #326.

## Files Changed

| File | Change |
|---|---|
| `native-module/src/speaker/linux.rs` (**NEW**) | PulseAudio monitor-source loopback capture |
| `native-module/src/speaker/mod.rs` | Wires in linux module; removes fallback gate for Linux |
| `native-module/Cargo.toml` | Adds `libpulse-binding` Linux-only dep; moves `tracing` to global deps |
| `electron/main.ts` | Ozone command-line switches + `NATIVELY_USE_XWAYLAND` flag + `AppState` session-type fields |
| `electron/WindowHelper.ts` | Linux overlay z-order + Wayland notice dialog (persists via SettingsManager) |
| `electron/ScreenshotHelper.ts` | Wayland: `desktopCapturer` via PipeWire; X11: shell tools; override via `NATIVELY_SCREENSHOT_TOOL` |
| `electron/services/SettingsManager.ts` | Adds `waylandNoticeDismissed` for persistent notice dismissal |

No changes to macOS or Windows code paths.

## How to try on Linux

```bash
# 1. Install build dependency
sudo apt install libpulse-dev   # Debian/Ubuntu
# sudo dnf install pulseaudio-libs-devel   # Fedora

# 2. Clone the fork and switch to this branch
git clone https://github.com/ImBIOS/natively-cluely-ai-assistant.git
cd natively-cluely-ai-assistant
git checkout add-native-linux-support-with-wayland-primary-and-

# 3. Install deps + build
npm install
npm run build:native    # compiles the Rust native module
npm run build:electron  # compiles the Electron main process
npm run build           # compiles the renderer

# 4. Run in dev mode
npm run electron:dev

# 5. (Optional) Force XWayland for "above fullscreen Zoom" UX
NATIVELY_USE_XWAYLAND=1 npm run electron:dev
# OR:
npm run electron:dev -- --ozone-platform=x11
```

### Environment variables

| Variable | Default | Effect |
|---|---|---|
| `NATIVELY_USE_XWAYLAND` | unset | Set to `1` to force XWayland mode (restores above-fullscreen overlay) |
| `NATIVELY_SCREENSHOT_TOOL` | `auto` | `auto` = desktopCapturer on Wayland, shell on X11; `desktopCapturer` = force Electron API; `shell` = force gnome-screenshot/scrot |

## Feature parity vs macOS

| Feature | macOS | Linux (this PR) | Notes |
|---|---|---|---|
| Microphone capture | ✅ CoreAudio | ✅ ALSA (cpal) | Already worked, no change |
| System audio | ✅ CoreAudio Tap/SCK | ✅ PulseAudio monitor | New `speaker/linux.rs` |
| Screenshot | ✅ native | ✅ desktopCapturer (Wayland) / shell (X11) | PipeWire portal on Wayland |
| Overlay window | ✅ NSPanel stealth | ⚠️ frameless transparent | `screen-saver` level on X11; Wayland limitation documented |
| Above fullscreen Zoom | ✅ | ⚠️ X11/XWayland only | Use `NATIVELY_USE_XWAYLAND=1` |
| Stealth keyboard tap | ✅ CGEventTap | ❌ out of scope | libei immature; use normal DOM input |
| App disguise | ✅ LaunchServices | ❌ N/A | macOS identity model |

## Testing

```bash
# Build the native module
sudo apt install libpulse-dev
cd native-module
cargo build --release --target x86_64-unknown-linux-gnu

# Verify it links against libpulse
ldd target/x86_64-unknown-linux-gnu/release/libnatively_audio.so | grep pulse
```

Tested on Ubuntu 24.04 Wayland (GNOME) with `libpulse-dev 16.1`.

## References

- Closes #326
- PR #278 (X11-only port by @DeusMos) — built upon, added Wayland + PipeWire support
- #219 (closed build issue) — original `stream()` method-not-found error

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>