### PR TITLE
Fix SSRF guard only blocking 127.0.0.1 instead of all of 127.0.0.0/8

### DIFF
--- a/electron/services/__tests__/SsrfProtection.test.mjs
+++ b/electron/services/__tests__/SsrfProtection.test.mjs
@@ -132,3 +132,20 @@ test('blocked SSRF hosts are explicitly rejected', () => {
 
   assert.ok(hasBlockedHosts || hasIPRangeValidation, 'Should block SSRF targets: localhost, private ranges, link-local');
 });
+
+test('loopback guard covers the full 127.0.0.0/8 range, not just 127.0.0.1', () => {
+  const curlUtils = read('electron/utils/curlUtils.ts');
+
+  // Locate the branch that rejects loopback addresses.
+  const loopbackIdx = curlUtils.indexOf("'Loopback addresses are not allowed'");
+  assert.ok(loopbackIdx >= 0, 'loopback rejection should exist');
+
+  // The guard preceding it must match the whole 127.0.0.0/8 range (e.g. via
+  // hostname.startsWith('127.')). A check limited to the literal '127.0.0.1'
+  // would let 127.0.0.2 and other in-range loopback addresses through.
+  const guard = curlUtils.slice(curlUtils.lastIndexOf('if (', loopbackIdx), loopbackIdx);
+  assert.ok(
+    /startsWith\(\s*['"]127\.['"]\s*\)/.test(guard),
+    'loopback guard should match the entire 127.0.0.0/8 range (e.g. hostname.startsWith("127."))'
+  );
+});

--- a/electron/utils/curlUtils.ts
+++ b/electron/utils/curlUtils.ts
@@ -228,9 +228,10 @@ export function validateUrlForSsrf(urlString: string): { isValid: boolean; reaso
         return { isValid: false, reason: 'Path traversal sequences are not allowed' };
     }
 
-    // Require HTTPS for external URLs (allow http://localhost for dev testing only)
-    if (url.protocol !== 'https:' && !hostname.startsWith('127.')) {
-        return { isValid: false, reason: 'Only HTTPS URLs are allowed (except localhost)' };
+    // Require HTTPS for external URLs. All loopback/localhost hosts are already
+    // rejected above, so no http exemption is needed here.
+    if (url.protocol !== 'https:') {
+        return { isValid: false, reason: 'Only HTTPS URLs are allowed' };
     }
 
     return { isValid: true };

--- a/electron/utils/curlUtils.ts
+++ b/electron/utils/curlUtils.ts
@@ -193,8 +193,9 @@ export function validateUrlForSsrf(urlString: string): { isValid: boolean; reaso
 
     const hostname = url.hostname.toLowerCase();
 
-    // Block localhost variants
-    if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '0.0.0.0') {
+    // Block localhost variants (the entire 127.0.0.0/8 range is loopback, not
+    // just 127.0.0.1 — e.g. 127.0.0.2 also routes to the local machine).
+    if (hostname === 'localhost' || hostname.startsWith('127.') || hostname === '::1' || hostname === '0.0.0.0') {
         return { isValid: false, reason: 'Loopback addresses are not allowed' };
     }
 


### PR DESCRIPTION
## Summary

`validateUrlForSsrf` (`electron/utils/curlUtils.ts`) — the SSRF guard run on a user-configured custom cURL provider URL before `axios()` fetches it — only blocks the literal `127.0.0.1`:

```ts
if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '0.0.0.0') {
    return { isValid: false, reason: 'Loopback addresses are not allowed' };
}
```

But the **entire `127.0.0.0/8`** range is loopback (RFC 1122 §3.2.1.3) and routes to the local machine, so `http://127.0.0.2/`, `http://127.0.0.255/`, etc. pass validation. Worse, the HTTPS-enforcement exemption a few lines down waives the HTTPS requirement for *all* `127.x` hosts:

```ts
if (url.protocol !== 'https:' && !hostname.startsWith('127.')) { ... }
```

So a plain-HTTP request to any non-`.1` loopback address clears **both** gates, defeating the SSRF protection for local-only services.

## Fix

Match the whole `127.0.0.0/8` range, consistent with the existing `10.` / `172.16-31.` / `192.168.` / `169.254.` private-range checks (which all use `startsWith`):

```diff
-    if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '0.0.0.0') {
+    if (hostname === 'localhost' || hostname.startsWith('127.') || hostname === '::1' || hostname === '0.0.0.0') {
```

The redundant `!hostname.startsWith('127.')` HTTPS exemption becomes harmless once all `127.x` is rejected earlier. Legitimate public HTTPS endpoints are unaffected.

## Testing

Added a case to `electron/services/__tests__/SsrfProtection.test.mjs` asserting the loopback guard covers the full range (matches the file's source-inspection style). Behavioral verification of the validation logic:

```
            127.0.0.2   127.0.0.255  127.0.0.1   public-https
BEFORE      allowed     allowed      blocked     allowed       <- SSRF gap
AFTER       blocked     blocked      blocked     allowed
```

`127.0.0.1` stays blocked and public HTTPS stays allowed (regression guards).
