### PR TITLE
Fix screenshot context routing for screen-backed answers

### DIFF
--- a/electron/services/__tests__/DynamicActionEngine.test.mjs
+++ b/electron/services/__tests__/DynamicActionEngine.test.mjs
@@ -296,6 +296,7 @@ test('screen coding actions carry screen evidence so renderer captures a fresh s
 
   const screenAction = actions.find(action => action.type === 'screen_coding_problem');
   assert.ok(screenAction, 'Expected a screen_coding_problem dynamic action');
+  assert.equal(screenAction.requiresScreen, true);
   assert.equal(screenAction.evidenceRefs[0].source, 'screen');
 });
 

--- a/electron/services/__tests__/DynamicActionEngine.test.mjs
+++ b/electron/services/__tests__/DynamicActionEngine.test.mjs
@@ -282,6 +282,23 @@ test('Evidence refs contain transcript snippet and timestamp', async () => {
   assert.ok(evidence.timestamp, 'Expected timestamp in evidence');
 });
 
+test('screen coding actions carry screen evidence so renderer captures a fresh screenshot', async () => {
+  const { DynamicActionEngine } = await loadModules();
+  const engine = new DynamicActionEngine();
+
+  const actions = engine.detectActions({
+    transcript: 'The coding problem is visible on screen.',
+    speaker: 'Interviewer',
+    modeTemplateType: 'technical_interview',
+    modeId: 'mode_technical',
+    sessionId: 'session_screen_action',
+  });
+
+  const screenAction = actions.find(action => action.type === 'screen_coding_problem');
+  assert.ok(screenAction, 'Expected a screen_coding_problem dynamic action');
+  assert.equal(screenAction.evidenceRefs[0].source, 'screen');
+});
+
 test('dynamic actions are isolated by session and mode to prevent bleeding', async () => {
   const { DynamicActionEngine } = await loadModules();
   const engine = new DynamicActionEngine();

--- a/electron/services/__tests__/DynamicActionPromptInstructionWiring.test.mjs
+++ b/electron/services/__tests__/DynamicActionPromptInstructionWiring.test.mjs
@@ -15,9 +15,44 @@ test('dynamic action accept uses promptInstruction instead of display label/manu
   assert.ok(mountStart >= 0, 'DynamicActionBar should be mounted');
   const mountSource = source.slice(mountStart, source.indexOf('/>', mountStart) + 2);
 
-  assert.match(mountSource, /handleWhatToSay\(action\.promptInstruction\)/);
+  assert.match(mountSource, /handleDynamicActionAccept\(action\)/);
+  assert.match(source, /await handleWhatToSay\(action\.promptInstruction\)/);
   assert.doesNotMatch(mountSource, /setInputValue\(action\.label\)/);
   assert.doesNotMatch(mountSource, /handleManualSubmitRef\.current/);
+});
+
+test('screen-backed dynamic action captures and stages a screenshot before asking', () => {
+  const source = read('src/components/NativelyInterface.tsx');
+  const handlerStart = source.indexOf('const handleDynamicActionAccept');
+  assert.ok(handlerStart >= 0, 'handleDynamicActionAccept should exist');
+  const handlerSource = source.slice(handlerStart, source.indexOf('const handleFollowUp', handlerStart));
+
+  assert.match(handlerSource, /actionNeedsScreenCapture\(action\)/);
+  assert.match(handlerSource, /captureScreenshotForDynamicAction\(\)/);
+  assert.match(handlerSource, /await handleWhatToSay\(action\.promptInstruction\)/);
+
+  const captureStart = source.indexOf('const captureScreenshotForDynamicAction');
+  assert.ok(captureStart >= 0, 'captureScreenshotForDynamicAction should exist');
+  const captureSource = source.slice(captureStart, handlerStart);
+  assert.match(captureSource, /window\.electronAPI\.takeScreenshot\(\)/);
+  assert.match(captureSource, /handleScreenshotAttach\(data as \{ path: string; preview: string \}\)/);
+});
+
+test('screenshot attach stages pending ref so immediate What To Say forwards image paths', () => {
+  const source = read('src/components/NativelyInterface.tsx');
+  const attachStart = source.indexOf('const handleScreenshotAttach');
+  assert.ok(attachStart >= 0, 'handleScreenshotAttach should exist');
+  const attachSource = source.slice(attachStart, source.indexOf('// STT Status listener', attachStart));
+  assert.match(attachSource, /pendingCaptureRef\.current = data/);
+  assert.match(attachSource, /appendScreenshotAttachment\(prev, data\)/);
+
+  const wtaStart = source.indexOf('const handleWhatToSay');
+  assert.ok(wtaStart >= 0, 'handleWhatToSay should exist');
+  const wtaSource = source.slice(wtaStart, source.indexOf('const captureScreenshotForDynamicAction', wtaStart));
+  assert.match(wtaSource, /const pending = pendingCaptureRef\.current/);
+  assert.match(wtaSource, /mergePendingScreenshotAttachment\(attachedContext, pending\)/);
+  assert.match(wtaSource, /if \(pending\) pendingCaptureRef\.current = null/);
+  assert.match(wtaSource, /currentAttachments\.map\(\(s\) => s\.path\)/);
 });
 
 test('generate-what-to-say IPC forwards promptInstruction option to IntelligenceManager', () => {
@@ -25,16 +60,17 @@ test('generate-what-to-say IPC forwards promptInstruction option to Intelligence
   const handlerSource = sliceSafeHandleBlock(source, 'generate-what-to-say');
   assert.ok(findSafeHandle(source, 'generate-what-to-say') >= 0, 'generate-what-to-say handler should exist');
 
-  assert.match(handlerSource, /options\?: \{ promptInstruction\?: string; domContext\?: string \}/);
+  assert.match(handlerSource, /options\?: \{ promptInstruction\?: string; domContext\?: string; domContextEnvelope\?: unknown \}/);
   assert.match(handlerSource, /promptInstruction:[\s\S]{0,120}typeof options\?\.promptInstruction === 'string'[\s\S]{0,80}options\.promptInstruction[\s\S]{0,40}: undefined/);
-  assert.match(handlerSource, /domContext:[\s\S]{0,120}typeof options\?\.domContext === 'string'[\s\S]{0,80}options\.domContext\.substring\(0, DOM_CONTEXT_MAX_CHARS\)[\s\S]{0,40}: undefined/);
+  assert.match(handlerSource, /let effectiveDomContext =[\s\S]{0,120}typeof options\?\.domContext === 'string'[\s\S]{0,80}options\.domContext\.substring\(0, DOM_CONTEXT_MAX_CHARS\)[\s\S]{0,40}: undefined/);
+  assert.match(handlerSource, /domContext: effectiveDomContext/);
 });
 
 test('preload and renderer type expose promptInstruction option on generateWhatToSay', () => {
   const preload = read('electron/preload.ts');
   const types = read('src/types/electron.d.ts');
 
-  assert.match(preload, /generateWhatToSay:[\s\S]{0,200}options\?: \{ promptInstruction\?: string; domContext\?: string \}/);
+  assert.match(preload, /generateWhatToSay:[\s\S]{0,220}options\?: \{ promptInstruction\?: string; domContext\?: string; domContextEnvelope\?: unknown \}/);
   assert.match(preload, /ipcRenderer\.invoke\(['"]generate-what-to-say['"], question, imagePaths, options\)/);
-  assert.match(types, /generateWhatToSay:[\s\S]{0,200}options\?: \{ promptInstruction\?: string; domContext\?: string \}/);
+  assert.match(types, /generateWhatToSay:[\s\S]{0,220}options\?: \{ promptInstruction\?: string; domContext\?: string; domContextEnvelope\?: ContextEnvelope \}/);
 });

--- a/electron/services/__tests__/DynamicActionPromptInstructionWiring.test.mjs
+++ b/electron/services/__tests__/DynamicActionPromptInstructionWiring.test.mjs
@@ -16,7 +16,7 @@ test('dynamic action accept uses promptInstruction instead of display label/manu
   const mountSource = source.slice(mountStart, source.indexOf('/>', mountStart) + 2);
 
   assert.match(mountSource, /handleDynamicActionAccept\(action\)/);
-  assert.match(source, /await handleWhatToSay\(action\.promptInstruction\)/);
+  assert.match(source, /await runWhatToSay\(action\.promptInstruction\)/);
   assert.doesNotMatch(mountSource, /setInputValue\(action\.label\)/);
   assert.doesNotMatch(mountSource, /handleManualSubmitRef\.current/);
 });
@@ -33,7 +33,15 @@ test('screen-backed dynamic action captures and stages a screenshot before askin
   assert.match(handlerSource, /dynamicActionAcceptInFlightRef\.current = false/);
   assert.match(handlerSource, /actionNeedsScreenCapture\(action\)/);
   assert.match(handlerSource, /captureScreenshotForDynamicAction\(\)/);
-  assert.match(handlerSource, /await handleWhatToSay\(action\.promptInstruction\)/);
+  assert.match(handlerSource, /let shouldReleaseWhatToSay = false/);
+  assert.match(handlerSource, /tryBeginOverlayAction\('what_to_say'\)/);
+  assert.match(handlerSource, /if \(shouldReleaseWhatToSay\) endOverlayAction\('what_to_say'\)/);
+  assert.match(handlerSource, /await runWhatToSay\(action\.promptInstruction\)/);
+
+  const slotStart = handlerSource.indexOf("tryBeginOverlayAction('what_to_say')");
+  const captureCall = handlerSource.indexOf('captureScreenshotForDynamicAction()');
+  assert.ok(slotStart >= 0, 'dynamic action should claim the what_to_say slot');
+  assert.ok(captureCall > slotStart, 'screen capture should run only after the what_to_say slot is claimed');
 
   const captureStart = source.indexOf('const captureScreenshotForDynamicAction');
   assert.ok(captureStart >= 0, 'captureScreenshotForDynamicAction should exist');
@@ -50,13 +58,19 @@ test('screenshot attach stages pending ref so immediate What To Say forwards ima
   assert.match(attachSource, /pendingCaptureRef\.current = data/);
   assert.match(attachSource, /appendScreenshotAttachment\(prev, data\)/);
 
-  const wtaStart = source.indexOf('const handleWhatToSay');
-  assert.ok(wtaStart >= 0, 'handleWhatToSay should exist');
-  const wtaSource = source.slice(wtaStart, source.indexOf('const captureScreenshotForDynamicAction', wtaStart));
+  const runStart = source.indexOf('const runWhatToSay');
+  assert.ok(runStart >= 0, 'runWhatToSay should exist');
+  const wtaSource = source.slice(runStart, source.indexOf('const handleWhatToSay', runStart));
   assert.match(wtaSource, /const pending = pendingCaptureRef\.current/);
   assert.match(wtaSource, /mergePendingScreenshotAttachment\(attachedContext, pending\)/);
   assert.match(wtaSource, /if \(pending\) pendingCaptureRef\.current = null/);
   assert.match(wtaSource, /currentAttachments\.map\(\(s\) => s\.path\)/);
+
+  const handleStart = source.indexOf('const handleWhatToSay');
+  assert.ok(handleStart >= 0, 'handleWhatToSay should exist');
+  const handleSource = source.slice(handleStart, source.indexOf('const captureScreenshotForDynamicAction', handleStart));
+  assert.match(handleSource, /tryBeginOverlayAction\('what_to_say'\)/);
+  assert.match(handleSource, /await runWhatToSay\(promptInstruction\)/);
 
   const captureShortcutStart = source.indexOf('window.electronAPI.onCaptureAndProcess');
   assert.ok(captureShortcutStart >= 0, 'Capture & Process handler should exist');

--- a/electron/services/__tests__/DynamicActionPromptInstructionWiring.test.mjs
+++ b/electron/services/__tests__/DynamicActionPromptInstructionWiring.test.mjs
@@ -27,6 +27,10 @@ test('screen-backed dynamic action captures and stages a screenshot before askin
   assert.ok(handlerStart >= 0, 'handleDynamicActionAccept should exist');
   const handlerSource = source.slice(handlerStart, source.indexOf('const handleFollowUp', handlerStart));
 
+  assert.match(source, /const dynamicActionAcceptInFlightRef = useRef\(false\)/);
+  assert.match(handlerSource, /if \(dynamicActionAcceptInFlightRef\.current\) return/);
+  assert.match(handlerSource, /dynamicActionAcceptInFlightRef\.current = true/);
+  assert.match(handlerSource, /dynamicActionAcceptInFlightRef\.current = false/);
   assert.match(handlerSource, /actionNeedsScreenCapture\(action\)/);
   assert.match(handlerSource, /captureScreenshotForDynamicAction\(\)/);
   assert.match(handlerSource, /await handleWhatToSay\(action\.promptInstruction\)/);
@@ -53,6 +57,34 @@ test('screenshot attach stages pending ref so immediate What To Say forwards ima
   assert.match(wtaSource, /mergePendingScreenshotAttachment\(attachedContext, pending\)/);
   assert.match(wtaSource, /if \(pending\) pendingCaptureRef\.current = null/);
   assert.match(wtaSource, /currentAttachments\.map\(\(s\) => s\.path\)/);
+
+  const captureShortcutStart = source.indexOf('window.electronAPI.onCaptureAndProcess');
+  assert.ok(captureShortcutStart >= 0, 'Capture & Process handler should exist');
+  const captureShortcutSource = source.slice(captureShortcutStart, source.indexOf('// Inertial-scroll engine', captureShortcutStart));
+  assert.match(captureShortcutSource, /pendingCaptureRef\.current = data/);
+  assert.match(captureShortcutSource, /appendScreenshotAttachment\(prev, data\)/);
+  assert.doesNotMatch(captureShortcutSource, /prev\.some\(\(s\) => s\.path === data\.path\)/);
+});
+
+test('screen-backed action routing uses trigger requiresScreen instead of hardcoded type checks', () => {
+  const detector = read('electron/services/dynamic-actions/DynamicActionDetector.ts');
+  const engine = read('electron/services/dynamic-actions/DynamicActionEngine.ts');
+  const helper = read('src/lib/screenshotAttachment.mjs');
+  const actionTypes = read('electron/services/dynamic-actions/DynamicAction.ts');
+  const rendererTypes = read('src/types/electron.d.ts');
+
+  const screenTriggerStart = detector.indexOf("type: 'screen_coding_problem'");
+  assert.ok(screenTriggerStart >= 0, 'screen coding trigger should exist');
+  const screenTriggerSource = detector.slice(screenTriggerStart, detector.indexOf('},', screenTriggerStart) + 2);
+  assert.match(screenTriggerSource, /requiresScreen: true/);
+
+  assert.match(engine, /const requiresScreen = Boolean\(trigger\.requiresScreen\)/);
+  assert.match(engine, /source: requiresScreen \? 'screen' : 'transcript'/);
+  assert.doesNotMatch(engine, /screen_coding_problem/);
+  assert.match(helper, /action\.requiresScreen === true/);
+  assert.doesNotMatch(helper, /screen_coding_problem/);
+  assert.match(actionTypes, /requiresScreen\?: boolean/);
+  assert.match(rendererTypes, /requiresScreen\?: boolean/);
 });
 
 test('generate-what-to-say IPC forwards promptInstruction option to IntelligenceManager', () => {

--- a/electron/services/dynamic-actions/DynamicAction.ts
+++ b/electron/services/dynamic-actions/DynamicAction.ts
@@ -19,6 +19,7 @@ export interface DynamicAction {
     description?: string;
     confidence: number;
     priority: number;
+    requiresScreen?: boolean;
     evidenceRefs: EvidenceRef[];
     status: ActionStatus;
     createdAt: number;

--- a/electron/services/dynamic-actions/DynamicActionDetector.ts
+++ b/electron/services/dynamic-actions/DynamicActionDetector.ts
@@ -4,6 +4,7 @@ export interface ActionTrigger {
     priority: number;
     label: string;
     promptInstruction: string;
+    requiresScreen?: boolean;
     answerStyle?: {
         maxWords: number;
         format: 'bullets' | 'short_script' | 'code' | 'checklist' | 'summary';
@@ -274,6 +275,7 @@ const TECHNICAL_TRIGGERS: ActionTrigger[] = [
         patterns: [/\b(screen|visible|shown|popup|error message|output|on screen)\b/i],
         priority: 0.92,
         label: 'Answer from screen',
+        requiresScreen: true,
         promptInstruction:
             'You are in Technical Interview mode. A coding problem is visible on the screen. Read the visible problem carefully and provide a solution.',
     },

--- a/electron/services/dynamic-actions/DynamicActionEngine.ts
+++ b/electron/services/dynamic-actions/DynamicActionEngine.ts
@@ -30,9 +30,10 @@ export class DynamicActionEngine {
         const matchedTriggers = this.detector.detectTriggers({ transcript, modeTemplateType });
 
         for (const { trigger, match, index } of matchedTriggers) {
-            // Build evidence ref from transcript
+            // Screen-triggered actions are detected from transcript text, but
+            // their answer path must include a fresh screenshot.
             const evidenceRef: EvidenceRef = {
-                source: 'transcript',
+                source: trigger.type === 'screen_coding_problem' ? 'screen' : 'transcript',
                 text: transcript,
                 timestamp: now,
                 speaker,

--- a/electron/services/dynamic-actions/DynamicActionEngine.ts
+++ b/electron/services/dynamic-actions/DynamicActionEngine.ts
@@ -30,10 +30,9 @@ export class DynamicActionEngine {
         const matchedTriggers = this.detector.detectTriggers({ transcript, modeTemplateType });
 
         for (const { trigger, match, index } of matchedTriggers) {
-            // Screen-triggered actions are detected from transcript text, but
-            // their answer path must include a fresh screenshot.
+            const requiresScreen = Boolean(trigger.requiresScreen);
             const evidenceRef: EvidenceRef = {
-                source: trigger.type === 'screen_coding_problem' ? 'screen' : 'transcript',
+                source: requiresScreen ? 'screen' : 'transcript',
                 text: transcript,
                 timestamp: now,
                 speaker,
@@ -54,6 +53,7 @@ export class DynamicActionEngine {
                 description: `Triggered by: "${match}"`,
                 confidence: trigger.priority,
                 priority: trigger.priority,
+                requiresScreen: requiresScreen || undefined,
                 evidenceRefs: [evidenceRef],
                 status: 'candidate',
                 createdAt: now,

--- a/src/components/NativelyInterface.tsx
+++ b/src/components/NativelyInterface.tsx
@@ -3340,17 +3340,17 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
     // Optional: Trigger a small toast or state change for visual feedback
   }, []);
 
-  const handleWhatToSay = async (promptInstruction?: string | React.MouseEvent) => {
-    if (!tryBeginOverlayAction('what_to_say')) {
-      // The press was blocked because a prior 'what_to_say' is still streaming.
-      // Surface a brief hint instead of silently doing nothing, so a blocked
-      // press is never indistinguishable from a crash / dead hotkey.
-      setMessages((prev) => [
-        ...prev,
-        { id: genMessageId(), role: 'system', text: 'Still finishing the previous answer — one moment…' },
-      ]);
-      return;
-    }
+  const showWhatToSayBusyMessage = () => {
+    // The press was blocked because a prior 'what_to_say' is still streaming.
+    // Surface a brief hint instead of silently doing nothing, so a blocked
+    // press is never indistinguishable from a crash / dead hotkey.
+    setMessages((prev) => [
+      ...prev,
+      { id: genMessageId(), role: 'system', text: 'Still finishing the previous answer — one moment…' },
+    ]);
+  };
+
+  const runWhatToSay = async (promptInstruction?: string | React.MouseEvent) => {
     const dynamicPromptInstruction =
       typeof promptInstruction === 'string' ? promptInstruction : undefined;
     setIsExpanded(true);
@@ -3506,6 +3506,14 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
     }
   };
 
+  const handleWhatToSay = async (promptInstruction?: string | React.MouseEvent) => {
+    if (!tryBeginOverlayAction('what_to_say')) {
+      showWhatToSayBusyMessage();
+      return;
+    }
+    await runWhatToSay(promptInstruction);
+  };
+
   const captureScreenshotForDynamicAction = async (): Promise<boolean> => {
     const data = await window.electronAPI.takeScreenshot();
     if (!data?.path) return false;
@@ -3516,8 +3524,15 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
   const handleDynamicActionAccept = async (action: DynamicActionPayload) => {
     if (dynamicActionAcceptInFlightRef.current) return;
     dynamicActionAcceptInFlightRef.current = true;
+    let shouldReleaseWhatToSay = false;
 
     try {
+      if (!tryBeginOverlayAction('what_to_say')) {
+        showWhatToSayBusyMessage();
+        return;
+      }
+      shouldReleaseWhatToSay = true;
+
       if (actionNeedsScreenCapture(action)) {
         try {
           const captured = await captureScreenshotForDynamicAction();
@@ -3548,8 +3563,10 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
         }
       }
 
-      await handleWhatToSay(action.promptInstruction);
+      shouldReleaseWhatToSay = false;
+      await runWhatToSay(action.promptInstruction);
     } finally {
+      if (shouldReleaseWhatToSay) endOverlayAction('what_to_say');
       dynamicActionAcceptInFlightRef.current = false;
     }
   };

--- a/src/components/NativelyInterface.tsx
+++ b/src/components/NativelyInterface.tsx
@@ -128,6 +128,11 @@ import {
 } from '../lib/overlayActionDedup.mjs';
 import { shouldDedupeManualSubmit } from '../lib/overlaySubmitDedup.mjs';
 import {
+  actionNeedsScreenCapture,
+  appendScreenshotAttachment,
+  mergePendingScreenshotAttachment,
+} from '../lib/screenshotAttachment.mjs';
+import {
   applyWhatToAnswerNullFeedbackMessages,
   finalizeStreamingByIntentMessages,
   prepareIntelligenceStreamPlaceholderMessages,
@@ -2395,12 +2400,8 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
 
   const handleScreenshotAttach = (data: { path: string; preview: string }) => {
     setIsExpanded(true);
-    setAttachedContext((prev) => {
-      // Prevent duplicates and cap at 5
-      if (prev.some((s) => s.path === data.path)) return prev;
-      const updated = [...prev, data];
-      return updated.slice(-5); // Keep last 5
-    });
+    pendingCaptureRef.current = data;
+    setAttachedContext((prev) => appendScreenshotAttachment(prev, data));
   };
 
   // STT Status listener — must survive isExpanded changes.
@@ -3357,10 +3358,8 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
     // Also merge in any screenshot from the capture-and-process shortcut that
     // arrived via pendingCaptureRef before the React state flush (React 18 fix).
     const pending = pendingCaptureRef.current;
-    let currentAttachments = attachedContext;
-    if (pending && !currentAttachments.some((s) => s.path === pending.path)) {
-      currentAttachments = [...currentAttachments, pending].slice(-5);
-    }
+    const currentAttachments = mergePendingScreenshotAttachment(attachedContext, pending);
+    if (pending) pendingCaptureRef.current = null;
 
     if (currentAttachments.length > 0) {
       setAttachedContext([]);
@@ -3504,6 +3503,47 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
       endOverlayAction('what_to_say');
       setIsProcessing(false);
     }
+  };
+
+  const captureScreenshotForDynamicAction = async (): Promise<boolean> => {
+    const data = await window.electronAPI.takeScreenshot();
+    if (!data?.path) return false;
+    handleScreenshotAttach(data as { path: string; preview: string });
+    return true;
+  };
+
+  const handleDynamicActionAccept = async (action: DynamicActionPayload) => {
+    if (actionNeedsScreenCapture(action)) {
+      try {
+        const captured = await captureScreenshotForDynamicAction();
+        if (!captured && attachedContext.length === 0 && !pendingCaptureRef.current) {
+          setScreenContextStatus('failed');
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: genMessageId(),
+              role: 'system',
+              text: 'Could not capture the screen for this action. Check Screen Recording permission and try again.',
+            },
+          ]);
+          return;
+        }
+      } catch (err) {
+        console.error('Error capturing screen for dynamic action:', err);
+        setScreenContextStatus('failed');
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: genMessageId(),
+            role: 'system',
+            text: 'Could not capture the screen for this action. Check Screen Recording permission and try again.',
+          },
+        ]);
+        return;
+      }
+    }
+
+    await handleWhatToSay(action.promptInstruction);
   };
 
   const handleFollowUp = async (intent: string = 'rephrase') => {
@@ -5899,7 +5939,7 @@ Provide only the answer, nothing else.`;
                                 when no actions are present. */}
               <DynamicActionBar
                 onAcceptAction={(action: DynamicActionPayload) => {
-                  void handleWhatToSay(action.promptInstruction);
+                  void handleDynamicActionAccept(action);
                 }}
               />
 

--- a/src/components/NativelyInterface.tsx
+++ b/src/components/NativelyInterface.tsx
@@ -1081,6 +1081,7 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
   // handleWhatToSay() can access it even in React 18 concurrent mode (where
   // a plain setTimeout(0) may fire before setAttachedContext flushes).
   const pendingCaptureRef = useRef<{ path: string; preview: string } | null>(null);
+  const dynamicActionAcceptInFlightRef = useRef(false);
 
   // Latent Context State (Screenshots attached but not sent)
   const [attachedContext, setAttachedContext] = useState<Array<{ path: string; preview: string }>>(
@@ -3513,10 +3514,27 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
   };
 
   const handleDynamicActionAccept = async (action: DynamicActionPayload) => {
-    if (actionNeedsScreenCapture(action)) {
-      try {
-        const captured = await captureScreenshotForDynamicAction();
-        if (!captured && attachedContext.length === 0 && !pendingCaptureRef.current) {
+    if (dynamicActionAcceptInFlightRef.current) return;
+    dynamicActionAcceptInFlightRef.current = true;
+
+    try {
+      if (actionNeedsScreenCapture(action)) {
+        try {
+          const captured = await captureScreenshotForDynamicAction();
+          if (!captured && attachedContext.length === 0 && !pendingCaptureRef.current) {
+            setScreenContextStatus('failed');
+            setMessages((prev) => [
+              ...prev,
+              {
+                id: genMessageId(),
+                role: 'system',
+                text: 'Could not capture the screen for this action. Check Screen Recording permission and try again.',
+              },
+            ]);
+            return;
+          }
+        } catch (err) {
+          console.error('Error capturing screen for dynamic action:', err);
           setScreenContextStatus('failed');
           setMessages((prev) => [
             ...prev,
@@ -3528,22 +3546,12 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
           ]);
           return;
         }
-      } catch (err) {
-        console.error('Error capturing screen for dynamic action:', err);
-        setScreenContextStatus('failed');
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: genMessageId(),
-            role: 'system',
-            text: 'Could not capture the screen for this action. Check Screen Recording permission and try again.',
-          },
-        ]);
-        return;
       }
-    }
 
-    await handleWhatToSay(action.promptInstruction);
+      await handleWhatToSay(action.promptInstruction);
+    } finally {
+      dynamicActionAcceptInFlightRef.current = false;
+    }
   };
 
   const handleFollowUp = async (intent: string = 'rephrase') => {
@@ -5001,10 +5009,7 @@ Provide only the answer, nothing else.`;
       // with an empty attachedContext and causing silent failures.
       pendingCaptureRef.current = data;
 
-      setAttachedContext((prev) => {
-        if (prev.some((s) => s.path === data.path)) return prev;
-        return [...prev, data].slice(-5);
-      });
+      setAttachedContext((prev) => appendScreenshotAttachment(prev, data));
 
       // Use requestAnimationFrame so we wait for at least one paint cycle —
       // more reliable than setTimeout(0) under React 18 concurrent scheduling.

--- a/src/lib/__tests__/screenshotAttachment.test.mjs
+++ b/src/lib/__tests__/screenshotAttachment.test.mjs
@@ -1,0 +1,70 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  actionNeedsScreenCapture,
+  appendScreenshotAttachment,
+  mergePendingScreenshotAttachment,
+} from '../screenshotAttachment.mjs';
+
+describe('screenshotAttachment', () => {
+  test('appendScreenshotAttachment dedupes by path and caps at five', () => {
+    const existing = Array.from({ length: 5 }, (_, idx) => ({
+      path: `/tmp/screenshot-${idx}.png`,
+      preview: `preview-${idx}`,
+    }));
+
+    const duplicate = appendScreenshotAttachment(existing, {
+      path: '/tmp/screenshot-2.png',
+      preview: 'duplicate-preview',
+    });
+    assert.equal(duplicate, existing);
+
+    const next = appendScreenshotAttachment(existing, {
+      path: '/tmp/screenshot-new.png',
+      preview: 'new-preview',
+    });
+    assert.equal(next.length, 5);
+    assert.deepEqual(
+      next.map(item => item.path),
+      [
+        '/tmp/screenshot-1.png',
+        '/tmp/screenshot-2.png',
+        '/tmp/screenshot-3.png',
+        '/tmp/screenshot-4.png',
+        '/tmp/screenshot-new.png',
+      ],
+    );
+  });
+
+  test('mergePendingScreenshotAttachment keeps immediate capture available before React state flush', () => {
+    const merged = mergePendingScreenshotAttachment([], {
+      path: '/tmp/fresh-capture.png',
+      preview: 'data:image/png;base64,abc',
+    });
+
+    assert.deepEqual(merged, [
+      {
+        path: '/tmp/fresh-capture.png',
+        preview: 'data:image/png;base64,abc',
+      },
+    ]);
+  });
+
+  test('actionNeedsScreenCapture recognizes screen action type and screen evidence', () => {
+    assert.equal(actionNeedsScreenCapture({ type: 'screen_coding_problem' }), true);
+    assert.equal(
+      actionNeedsScreenCapture({
+        type: 'coding_problem',
+        evidenceRefs: [{ source: 'screen' }],
+      }),
+      true,
+    );
+    assert.equal(
+      actionNeedsScreenCapture({
+        type: 'coding_problem',
+        evidenceRefs: [{ source: 'transcript' }],
+      }),
+      false,
+    );
+  });
+});

--- a/src/lib/__tests__/screenshotAttachment.test.mjs
+++ b/src/lib/__tests__/screenshotAttachment.test.mjs
@@ -50,8 +50,9 @@ describe('screenshotAttachment', () => {
     ]);
   });
 
-  test('actionNeedsScreenCapture recognizes screen action type and screen evidence', () => {
-    assert.equal(actionNeedsScreenCapture({ type: 'screen_coding_problem' }), true);
+  test('actionNeedsScreenCapture recognizes requiresScreen flag and screen evidence', () => {
+    assert.equal(actionNeedsScreenCapture({ type: 'screen_coding_problem' }), false);
+    assert.equal(actionNeedsScreenCapture({ requiresScreen: true }), true);
     assert.equal(
       actionNeedsScreenCapture({
         type: 'coding_problem',

--- a/src/lib/screenshotAttachment.d.mts
+++ b/src/lib/screenshotAttachment.d.mts
@@ -9,6 +9,7 @@ export interface ScreenCaptureEvidenceRef {
 
 export interface ScreenCaptureAction {
   type?: string;
+  requiresScreen?: boolean;
   evidenceRefs?: ScreenCaptureEvidenceRef[];
 }
 

--- a/src/lib/screenshotAttachment.d.mts
+++ b/src/lib/screenshotAttachment.d.mts
@@ -1,0 +1,29 @@
+export interface ScreenshotAttachment {
+  path: string;
+  preview?: string;
+}
+
+export interface ScreenCaptureEvidenceRef {
+  source?: string;
+}
+
+export interface ScreenCaptureAction {
+  type?: string;
+  evidenceRefs?: ScreenCaptureEvidenceRef[];
+}
+
+export declare const MAX_SCREENSHOT_ATTACHMENTS: 5;
+
+export declare function appendScreenshotAttachment<T extends ScreenshotAttachment>(
+  existing: T[],
+  screenshot: T | null | undefined,
+  max?: number,
+): T[];
+
+export declare function mergePendingScreenshotAttachment<T extends ScreenshotAttachment>(
+  existing: T[],
+  pending: T | null | undefined,
+  max?: number,
+): T[];
+
+export declare function actionNeedsScreenCapture(action: ScreenCaptureAction | null | undefined): boolean;

--- a/src/lib/screenshotAttachment.mjs
+++ b/src/lib/screenshotAttachment.mjs
@@ -1,0 +1,20 @@
+export const MAX_SCREENSHOT_ATTACHMENTS = 5;
+
+export function appendScreenshotAttachment(existing, screenshot, max = MAX_SCREENSHOT_ATTACHMENTS) {
+  const current = Array.isArray(existing) ? existing : [];
+  if (!screenshot || typeof screenshot.path !== 'string' || screenshot.path.length === 0) {
+    return current;
+  }
+  if (current.some(item => item?.path === screenshot.path)) return current;
+  return [...current, screenshot].slice(-max);
+}
+
+export function mergePendingScreenshotAttachment(existing, pending, max = MAX_SCREENSHOT_ATTACHMENTS) {
+  return appendScreenshotAttachment(existing, pending, max);
+}
+
+export function actionNeedsScreenCapture(action) {
+  if (!action || typeof action !== 'object') return false;
+  if (action.type === 'screen_coding_problem') return true;
+  return Array.isArray(action.evidenceRefs) && action.evidenceRefs.some(ref => ref?.source === 'screen');
+}

--- a/src/lib/screenshotAttachment.mjs
+++ b/src/lib/screenshotAttachment.mjs
@@ -15,6 +15,6 @@ export function mergePendingScreenshotAttachment(existing, pending, max = MAX_SC
 
 export function actionNeedsScreenCapture(action) {
   if (!action || typeof action !== 'object') return false;
-  if (action.type === 'screen_coding_problem') return true;
+  if (action.requiresScreen === true) return true;
   return Array.isArray(action.evidenceRefs) && action.evidenceRefs.some(ref => ref?.source === 'screen');
 }

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -20,6 +20,7 @@ export interface DynamicActionPayload {
   description?: string
   confidence: number
   priority: number
+  requiresScreen?: boolean
   evidenceRefs: DynamicActionEvidenceRef[]
   status: 'candidate' | 'shown' | 'accepted' | 'dismissed' | 'completed' | 'expired'
   createdAt: number


### PR DESCRIPTION
## Summary
- mark screen-coding dynamic actions as screen-backed so the renderer can distinguish them from transcript-only actions
- keep newly attached screenshots in a pending ref so immediate What To Say calls forward image paths before React state settles
- capture a fresh screenshot before accepting screen-backed dynamic action cards, with focused helper and routing tests

Fixes #334

## Testing
- npm run build:electron
- node --test src/lib/__tests__/screenshotAttachment.test.mjs
- node --test electron/services/__tests__/DynamicActionEngine.test.mjs electron/services/__tests__/DynamicActionPromptInstructionWiring.test.mjs
- npm run typecheck:electron
- npx tsc --noEmit
- npm run build
- Chrome smoke test with a synthetic Electron bridge: accepted a screen-backed action, called takeScreenshot once, and forwarded imagePaths to generateWhatToSay

## Notes
- Full npm test was attempted but not completed because the clean public worktree hit unrelated optional premium-module and pre-existing source-assertion failures before I stopped it.