### PR TITLE
feat(openrouter): full provider integration — vision routing, key management & settings UI

### DIFF
--- a/electron/LLMHelper.ts
+++ b/electron/LLMHelper.ts
@@ -115,6 +115,8 @@ const CLAUDE_MODEL = "claude-sonnet-4-6"
 const DEEPSEEK_MODEL = "deepseek-v4-flash"
 const DEEPSEEK_BASE_URL = "https://api.deepseek.com"
 const DEEPSEEK_MAX_OUTPUT_TOKENS = 8192
+const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+const OPENROUTER_MAX_OUTPUT_TOKENS = 8192
 // LiteLLM fronts arbitrary upstream models with widely varying output ceilings.
 // Resolution order per request: (1) user manual override from Settings,
 // (2) per-model budget auto-discovered from the proxy's /model/info
@@ -233,6 +235,10 @@ export class LLMHelper {
   private claudeApiKey: string | null = null
   private deepseekApiKey: string | null = null
   private litellmApiKey: string | null = null
+  // OpenRouter is OpenAI-compatible; reuse the OpenAI SDK with a custom baseURL.
+  // Kept as a separate client so credentials/scope/telemetry stay provider-specific.
+  private openrouterClient: OpenAI | null = null
+  private openrouterApiKey: string | null = null
   private litellmBaseURL: string = "http://localhost:4000/v1"
   // Manual output-ceiling override (Settings → LiteLLM Proxy dropdown).
   // null = Auto: resolve per-model from the proxy's /model/info, falling back
@@ -397,7 +403,7 @@ export class LLMHelper {
     console.warn(`[ScopeFallback] ${scope} denied; Ollama unavailable, omitting from context`);
   }
 
-  constructor(apiKey?: string, useOllama: boolean = false, ollamaModel?: string, ollamaUrl?: string, groqApiKey?: string, openaiApiKey?: string, claudeApiKey?: string, deepseekApiKey?: string) {
+  constructor(apiKey?: string, useOllama: boolean = false, ollamaModel?: string, ollamaUrl?: string, groqApiKey?: string, openaiApiKey?: string, claudeApiKey?: string, deepseekApiKey?: string, openrouterApiKey?: string) {
     this.useOllama = useOllama
 
     // Initialize rate limiters
@@ -435,6 +441,13 @@ export class LLMHelper {
       this.deepseekApiKey = deepseekApiKey
       this.deepseekClient = new OpenAI({ apiKey: deepseekApiKey, baseURL: DEEPSEEK_BASE_URL })
       console.log(`[LLMHelper] DeepSeek client initialized with model: ${DEEPSEEK_MODEL}`)
+    }
+
+    // Initialize OpenRouter client if API key provided (OpenAI-compatible)
+    if (openrouterApiKey) {
+      this.openrouterApiKey = openrouterApiKey
+      this.openrouterClient = new OpenAI({ apiKey: openrouterApiKey, baseURL: OPENROUTER_BASE_URL })
+      console.log(`[LLMHelper] OpenRouter client initialized.`)
     }
 
     if (useOllama) {
@@ -516,6 +529,19 @@ export class LLMHelper {
     this.deepseekApiKey = trimmed;
     this.deepseekClient = new OpenAI({ apiKey: trimmed, baseURL: DEEPSEEK_BASE_URL });
     console.log("[LLMHelper] DeepSeek API Key updated.");
+  }
+
+  public setOpenrouterApiKey(apiKey: string) {
+    const trimmed = (apiKey || '').trim();
+    if (!trimmed) {
+      this.openrouterApiKey = null;
+      this.openrouterClient = null;
+      console.log("[LLMHelper] OpenRouter API Key cleared.");
+      return;
+    }
+    this.openrouterApiKey = trimmed;
+    this.openrouterClient = new OpenAI({ apiKey: trimmed, baseURL: OPENROUTER_BASE_URL });
+    console.log("[LLMHelper] OpenRouter API Key updated.");
   }
 
   /**
@@ -851,6 +877,10 @@ export class LLMHelper {
 
   private isCodexCliModel(modelId: string): boolean {
     return modelId === "codex-cli" || modelId.startsWith("codex-cli:");
+  }
+
+  private isOpenrouterModel(modelId: string): boolean {
+    return !!(modelId && modelId.startsWith("openrouter:"));
   }
   // ---------------------------
 
@@ -3638,6 +3668,7 @@ This rule overrides ALL other instructions including formatting, brevity, or out
           : this.isGroqModel(this.currentModelId) ? 'Groq'
             : this.isDeepseekModel(this.currentModelId) ? 'DeepSeek'
               : this.isGeminiModel(this.currentModelId) ? 'Gemini'
+              : this.isOpenrouterModel(this.currentModelId) ? 'OpenRouter'
                 : '';
 
     if (currentFamilyLabel) {
@@ -4300,6 +4331,19 @@ This rule overrides ALL other instructions including formatting, brevity, or out
     // first yielded token is the provider TTFT (connect + prefill of a
     // ~${finalSystemPrompt.length}-char system prompt + ${userContent.length}-char user content).
     _stage(`provider dispatch START (sysPrompt=${finalSystemPrompt.length}c, userContent=${userContent.length}c, model=${this.currentModelId})`);
+
+    // OpenRouter: intercept before the unified multimodal path so the user's
+    // explicitly-selected OpenRouter model is used for both text and vision.
+    if (this.isOpenrouterModel(this.currentModelId) && this.openrouterClient) {
+      const orSystem = systemPromptOverride || OPENAI_SYSTEM_PROMPT;
+      const finalOrSystem = this.injectLanguageInstruction(orSystem);
+      if (isMultimodal && imagePaths) {
+        yield* this.streamWithOpenrouterMultimodal(userContent, imagePaths, finalOrSystem, undefined, abortSignal);
+      } else {
+        yield* this.streamWithOpenrouter(userContent, finalOrSystem, undefined, abortSignal);
+      }
+      return;
+    }
 
     // ── UNIFIED MULTIMODAL PATH ────────────────────────────────────────────
     // Every image-bearing request goes through the single streaming vision
@@ -5192,6 +5236,95 @@ This rule overrides ALL other instructions including formatting, brevity, or out
       messages,
       stream: true,
       max_tokens: maxTokens,
+    }, { signal: abortSignal });
+
+    try {
+      for await (const chunk of stream) {
+        if (abortSignal?.aborted) return;
+        const content = chunk.choices[0]?.delta?.content;
+        if (content) yield content;
+      }
+    } finally {
+      if (abortSignal?.aborted && typeof (stream as any).abort === 'function') (stream as any).abort();
+    }
+  }
+
+  private async * streamWithOpenrouter(
+    userMessage: string,
+    systemPrompt?: string,
+    modelId?: string,
+    abortSignal?: AbortSignal
+  ): AsyncGenerator<string, void, unknown> {
+    if (this.isLocalOnlyMode) throw new Error("Cloud providers disabled in local-only mode");
+    if (!this.openrouterClient) throw new Error("OpenRouter client not initialized");
+    this.assertOutboundScopes('openrouter', userMessage);
+    await this.rateLimiters.openrouter.acquire();
+
+    const wireModel = (modelId || this.currentModelId).replace('openrouter:', '');
+    const messages: any[] = [];
+    if (systemPrompt) messages.push({ role: "system", content: systemPrompt });
+    messages.push({ role: "user", content: userMessage });
+
+    if (abortSignal?.aborted) return;
+    const stream = await this.openrouterClient.chat.completions.create({
+      model: wireModel,
+      messages,
+      stream: true,
+      max_tokens: OPENROUTER_MAX_OUTPUT_TOKENS,
+    }, { signal: abortSignal });
+
+    try {
+      for await (const chunk of stream) {
+        if (abortSignal?.aborted) return;
+        const content = chunk.choices[0]?.delta?.content;
+        if (content) yield content;
+      }
+    } finally {
+      if (abortSignal?.aborted && typeof (stream as any).abort === 'function') (stream as any).abort();
+    }
+  }
+
+  private async * streamWithOpenrouterMultimodal(
+    userMessage: string,
+    imagePaths: string[],
+    systemPrompt?: string,
+    modelId?: string,
+    abortSignal?: AbortSignal
+  ): AsyncGenerator<string, void, unknown> {
+    if (this.isLocalOnlyMode) throw new Error("Cloud providers disabled in local-only mode");
+    if (!this.openrouterClient) throw new Error("OpenRouter client not initialized");
+    this.assertOutboundScopes('openrouter', userMessage, imagePaths);
+    await this.rateLimiters.openrouter.acquire();
+
+    const wireModel = (modelId || this.currentModelId).replace('openrouter:', '');
+
+    // processImage converts any input format to JPEG via sharp (max 1536 px, 80 % quality)
+    // so the MIME type in the data-URI is always valid, regardless of whether the source
+    // file is PNG (the typical screenshot format) or another format.
+    const contentParts: any[] = [{ type: "text", text: userMessage }];
+    const imageParts = await Promise.all(
+      imagePaths
+        .filter(p => fs.existsSync(p))
+        .map(async p => {
+          const { mimeType, data } = await this.processImage(p);
+          return { type: "image_url" as const, image_url: { url: `data:${mimeType};base64,${data}` } };
+        })
+    );
+    if (imageParts.length === 0) {
+      console.warn('[OpenRouter] streamWithOpenrouterMultimodal: no valid image paths found — sending text-only');
+    }
+    contentParts.push(...imageParts);
+
+    const messages: any[] = [];
+    if (systemPrompt) messages.push({ role: "system", content: systemPrompt });
+    messages.push({ role: "user", content: contentParts });
+
+    if (abortSignal?.aborted) return;
+    const stream = await this.openrouterClient.chat.completions.create({
+      model: wireModel,
+      messages,
+      stream: true,
+      max_tokens: OPENROUTER_MAX_OUTPUT_TOKENS,
     }, { signal: abortSignal });
 
     try {

--- a/electron/ProcessingHelper.ts
+++ b/electron/ProcessingHelper.ts
@@ -98,6 +98,12 @@ export class ProcessingHelper {
       this.llmHelper.setNativelyKey(nativelyKey);
     }
 
+    const openrouterKey = credManager.getOpenrouterApiKey();
+    if (openrouterKey) {
+      console.log("[ProcessingHelper] Loading stored OpenRouter API Key from CredentialsManager");
+      this.llmHelper.setOpenrouterApiKey(openrouterKey);
+    }
+
     // CRITICAL: Re-initialize IntelligenceManager now that keys are loaded
     // This fixes the issue where buttons don't work in production because of late key loading
     this.appState.getIntelligenceManager().initializeLLMs();

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -3223,6 +3223,22 @@ export function initializeIpcHandlers(appState: AppState): void {
     }
   });
 
+  safeHandle('set-openrouter-api-key', async (_, apiKey: string) => {
+    try {
+      const { CredentialsManager } = require('./services/CredentialsManager');
+      const cm = CredentialsManager.getInstance();
+      cm.setOpenrouterApiKey(apiKey);
+      const llmHelper = appState.processingHelper.getLLMHelper();
+      llmHelper.setOpenrouterApiKey(apiKey);
+      appState.getIntelligenceManager().resetEngine();
+      appState.getIntelligenceManager().initializeLLMs();
+      return { success: true };
+    } catch (error: any) {
+      console.error('Error saving OpenRouter API key:', error);
+      return { success: false, error: error.message };
+    }
+  });
+
   safeHandle('set-litellm-config', async (_, config: { apiKey: string; baseURL: string; maxTokens?: number }) => {
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
@@ -4054,6 +4070,7 @@ export function initializeIpcHandlers(appState: AppState): void {
         hasClaudeKey: hasKey(creds.claudeApiKey),
         hasDeepseekKey: hasKey(creds.deepseekApiKey),
         hasLitellmBaseURL: hasKey(creds.litellmBaseURL),
+        hasOpenrouterKey: hasKey(creds.openrouterApiKey),
         // The base URL is config, not a secret — returned in full so Settings can
         // prefill it (unlike API keys, which are only reported as booleans).
         litellmBaseURL: creds.litellmBaseURL || null,
@@ -4089,6 +4106,7 @@ export function initializeIpcHandlers(appState: AppState): void {
         openaiPreferredModel: creds.openaiPreferredModel || undefined,
         claudePreferredModel: creds.claudePreferredModel || undefined,
         deepseekPreferredModel: creds.deepseekPreferredModel || undefined,
+        openrouterPreferredModel: creds.openrouterPreferredModel || undefined,
       };
     } catch (error: any) {
       // SECURITY FIX (P0): Error fallback returns masked keys, not raw strings
@@ -4098,6 +4116,7 @@ export function initializeIpcHandlers(appState: AppState): void {
         hasOpenaiKey: false,
         hasClaudeKey: false,
         hasDeepseekKey: false,
+        hasOpenrouterKey: false,
         hasLitellmBaseURL: false,
         litellmBaseURL: null,
         litellmMaxTokens: null,
@@ -4132,7 +4151,7 @@ export function initializeIpcHandlers(appState: AppState): void {
 
   safeHandle(
     'fetch-provider-models',
-    async (_, provider: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek', apiKey: string) => {
+    async (_, provider: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek' | 'openrouter', apiKey: string) => {
       try {
         // Fall back to stored key if no key was explicitly provided
         let key = apiKey?.trim();
@@ -4144,6 +4163,7 @@ export function initializeIpcHandlers(appState: AppState): void {
           else if (provider === 'openai') key = cm.getOpenaiApiKey();
           else if (provider === 'claude') key = cm.getClaudeApiKey();
           else if (provider === 'deepseek') key = cm.getDeepseekApiKey();
+          else if (provider === 'openrouter') key = cm.getOpenrouterApiKey();
         }
 
         if (!key) {
@@ -4164,7 +4184,7 @@ export function initializeIpcHandlers(appState: AppState): void {
 
   safeHandle(
     'set-provider-preferred-model',
-    async (_, provider: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek', modelId: string) => {
+    async (_, provider: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek' | 'openrouter', modelId: string) => {
       try {
         const { CredentialsManager } = require('./services/CredentialsManager');
         CredentialsManager.getInstance().setPreferredModel(provider, modelId);
@@ -4869,7 +4889,7 @@ export function initializeIpcHandlers(appState: AppState): void {
 
   safeHandle(
     'test-llm-connection',
-    async (_, provider: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek', apiKey?: string) => {
+    async (_, provider: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek' | 'openrouter', apiKey?: string) => {
       console.log(`[IPC] Received test-llm-connection request for provider: ${provider}`);
       try {
         if (!apiKey || !apiKey.trim()) {
@@ -4880,6 +4900,7 @@ export function initializeIpcHandlers(appState: AppState): void {
           else if (provider === 'openai') apiKey = creds.getOpenaiApiKey();
           else if (provider === 'claude') apiKey = creds.getClaudeApiKey();
           else if (provider === 'deepseek') apiKey = creds.getDeepseekApiKey();
+          else if (provider === 'openrouter') apiKey = creds.getOpenrouterApiKey();
         }
 
         if (!apiKey || !apiKey.trim()) {
@@ -4947,6 +4968,22 @@ export function initializeIpcHandlers(appState: AppState): void {
             'https://api.deepseek.com/chat/completions',
             {
               model: 'deepseek-v4-flash',
+              max_tokens: 10,
+              messages: [{ role: 'user', content: 'Hello' }],
+            },
+            {
+              headers: {
+                Authorization: `Bearer ${apiKey}`,
+                'content-type': 'application/json',
+              },
+              timeout: 15000,
+            },
+          );
+        } else if (provider === 'openrouter') {
+          response = await axios.post(
+            'https://openrouter.ai/api/v1/chat/completions',
+            {
+              model: 'openai/gpt-4o-mini',
               max_tokens: 10,
               messages: [{ role: 'user', content: 'Hello' }],
             },

--- a/electron/llm/ProviderRouter.ts
+++ b/electron/llm/ProviderRouter.ts
@@ -1,4 +1,4 @@
-export type LLMProviderId = 'natively' | 'groq' | 'codex' | 'gemini_flash' | 'gemini_pro' | 'openai' | 'claude' | 'deepseek' | 'ollama';
+export type LLMProviderId = 'natively' | 'groq' | 'codex' | 'gemini_flash' | 'gemini_pro' | 'openai' | 'claude' | 'deepseek' | 'ollama' | 'openrouter';
 export type ProviderCapability = 'chat' | 'stream_chat' | 'structured' | 'vision';
 export type ProviderAttemptStatus = 'available' | 'unavailable';
 export type ProviderUnavailableReason = 'missing_api_key' | 'missing_config' | 'unsupported_capability' | 'disabled';
@@ -38,6 +38,7 @@ export interface ProviderAvailabilityState {
     hasClaude?: boolean;
     hasDeepseek?: boolean;
     hasOllama?: boolean;
+    hasOpenrouter?: boolean;
 }
 
 export interface ProviderModelState {
@@ -50,6 +51,7 @@ export interface ProviderModelState {
     claude?: string;
     deepseek?: string;
     ollama?: string;
+    openrouter?: string;
 }
 
 export interface ProviderRouteOptions {
@@ -174,12 +176,21 @@ export function routeLLMProviders(options: ProviderRouteOptions): ProviderAttemp
         supports: ['chat', 'stream_chat', 'structured', 'vision'],
     };
 
+    const openrouter: ProviderSpec = {
+        provider: 'openrouter',
+        name: `OpenRouter (${models.openrouter ?? 'default'})`,
+        model: models.openrouter,
+        available: Boolean(availability.hasOpenrouter),
+        unavailableReason: 'missing_api_key',
+        supports: ['chat', 'stream_chat', 'structured', 'vision'],
+    };
+
     // DeepSeek is placed after Claude in the text-only chain (between the existing
     // cloud chat providers and the local Ollama fallback) and is omitted from the
     // multimodal chain since no DeepSeek vision model is supported.
     const orderedSpecs: ProviderSpec[] = options.multimodal
-        ? [natively, codex, openai, geminiFlash, claude, geminiPro, groq]
-        : [natively, groq, codex, geminiFlash, geminiPro, openai, claude, deepseek];
+        ? [natively, codex, openai, geminiFlash, claude, geminiPro, groq, openrouter]
+        : [natively, groq, codex, geminiFlash, geminiPro, openai, claude, deepseek, openrouter];
 
     if (availability.hasOllama) {
         orderedSpecs.push(ollama);
@@ -304,7 +315,7 @@ export class ProviderRouter {
     constructor(circuitConfig?: Partial<CircuitBreakerConfig>) {
         const config = { ...this.defaultCircuitConfig, ...circuitConfig };
         // Initialize circuit breakers for each provider
-        ['gemini', 'groq', 'openai', 'claude', 'deepseek', 'natively', 'codex'].forEach(provider => {
+        ['gemini', 'groq', 'openai', 'claude', 'deepseek', 'natively', 'codex', 'openrouter'].forEach(provider => {
             this.circuitBreakers.set(provider, new CircuitBreaker(provider, config));
         });
     }

--- a/electron/llm/modelCapabilities.ts
+++ b/electron/llm/modelCapabilities.ts
@@ -48,6 +48,7 @@ function isCloudIdentifier(id: string): boolean {
   // DeepSeek cloud API (OpenAI-compatible). The local Ollama "deepseek-coder"
   // family is handled by the isOllama branch above.
   if (/^deepseek-v\d/.test(s)) return true;
+  if (s.startsWith('openrouter:')) return true;
   return false;
 }
 
@@ -109,7 +110,8 @@ export function getModelCapabilities(modelId: string, isOllama: boolean): ModelC
     const b = TIER_BUDGETS['cloud'];
     const supportsImages = lower.startsWith('gemini-') || lower.startsWith('claude-')
       || lower.startsWith('gpt-4o') || lower.startsWith('gpt-4.1') || lower.startsWith('gpt-5')
-      || lower === 'natively' || lower.startsWith('natively-');
+      || lower === 'natively' || lower.startsWith('natively-')
+      || lower.startsWith('openrouter:');
     return {
       tier: 'cloud',
       maxContextTokens: b.max,

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -62,7 +62,7 @@ interface ElectronAPI {
     modelId?: string,
   ) => Promise<{ success: boolean; error?: string }>;
   testLlmConnection: (
-    provider: 'gemini' | 'groq' | 'openai' | 'claude',
+    provider: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek' | 'openrouter',
     apiKey?: string,
   ) => Promise<{ success: boolean; error?: string }>;
   selectServiceAccount: () => Promise<{
@@ -78,6 +78,7 @@ interface ElectronAPI {
   setOpenaiApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>;
   setClaudeApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>;
   setDeepseekApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>;
+  setOpenrouterApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>;
   setLitellmConfig: (config: { apiKey: string; baseURL: string; maxTokens?: number }) => Promise<{ success: boolean; error?: string }>;
   getAvailableLiteLLMModels: () => Promise<string[]>;
   setNativelyApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>;
@@ -1219,7 +1220,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('switch-to-ollama', model, url),
   switchToGemini: (apiKey?: string, modelId?: string) =>
     ipcRenderer.invoke('switch-to-gemini', apiKey, modelId),
-  testLlmConnection: (provider: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek', apiKey: string) =>
+  testLlmConnection: (provider: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek' | 'openrouter', apiKey: string) =>
     ipcRenderer.invoke('test-llm-connection', provider, apiKey),
   selectServiceAccount: () => ipcRenderer.invoke('select-service-account'),
 
@@ -1229,6 +1230,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   setOpenaiApiKey: (apiKey: string) => ipcRenderer.invoke('set-openai-api-key', apiKey),
   setClaudeApiKey: (apiKey: string) => ipcRenderer.invoke('set-claude-api-key', apiKey),
   setDeepseekApiKey: (apiKey: string) => ipcRenderer.invoke('set-deepseek-api-key', apiKey),
+  setOpenrouterApiKey: (apiKey: string) => ipcRenderer.invoke('set-openrouter-api-key', apiKey),
   setLitellmConfig: (config: { apiKey: string; baseURL: string; maxTokens?: number }) => ipcRenderer.invoke('set-litellm-config', config),
   getAvailableLiteLLMModels: () => ipcRenderer.invoke('get-available-litellm-models'),
   setNativelyApiKey: (apiKey: string) => ipcRenderer.invoke('set-natively-api-key', apiKey),
@@ -2211,9 +2213,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
   setTavilyApiKey: (apiKey: string) => ipcRenderer.invoke('set-tavily-api-key', apiKey),
 
   // Dynamic Model Discovery
-  fetchProviderModels: (provider: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek', apiKey: string) =>
+  fetchProviderModels: (provider: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek' | 'openrouter', apiKey: string) =>
     ipcRenderer.invoke('fetch-provider-models', provider, apiKey),
-  setProviderPreferredModel: (provider: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek', modelId: string) =>
+  setProviderPreferredModel: (provider: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek' | 'openrouter', modelId: string) =>
     ipcRenderer.invoke('set-provider-preferred-model', provider, modelId),
 
   // License Management

--- a/electron/services/CredentialsManager.ts
+++ b/electron/services/CredentialsManager.ts
@@ -45,6 +45,7 @@ export interface StoredCredentials {
     openaiApiKey?: string;
     claudeApiKey?: string;
     deepseekApiKey?: string;
+    openrouterApiKey?: string;
     litellmApiKey?: string;
     litellmBaseURL?: string;
     /** Manual output ceiling for LiteLLM-proxied models. Unset → Auto (per-model via /model/info). */
@@ -79,6 +80,7 @@ export interface StoredCredentials {
     openaiPreferredModel?: string;
     claudePreferredModel?: string;
     deepseekPreferredModel?: string;
+    openrouterPreferredModel?: string;
     // Free trial state
     trialToken?: string;   // server-issued signed token (natively_trial_…)
     trialExpiresAt?: string;   // ISO timestamp — local copy for startup check
@@ -230,6 +232,10 @@ export class CredentialsManager {
 
     public getDeepseekApiKey(): string | undefined {
         return this.credentials.deepseekApiKey;
+    }
+
+    public getOpenrouterApiKey(): string | undefined {
+        return this.credentials.openrouterApiKey;
     }
 
     /** Persisted loopback-scoped companion-extension token (stable across restarts). */
@@ -438,6 +444,13 @@ export class CredentialsManager {
         this.credentials.deepseekApiKey = trimmed || undefined;
         this.saveCredentials();
         console.log('[CredentialsManager] DeepSeek API Key updated');
+    }
+
+    public setOpenrouterApiKey(key: string): void {
+        const trimmed = (key || '').trim();
+        this.credentials.openrouterApiKey = trimmed || undefined;
+        this.saveCredentials();
+        console.log('[CredentialsManager] OpenRouter API Key updated');
     }
 
     /**
@@ -672,12 +685,12 @@ export class CredentialsManager {
         console.log('[CredentialsManager] Natively API Key updated');
     }
 
-    public getPreferredModel(provider: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek'): string | undefined {
+    public getPreferredModel(provider: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek' | 'openrouter'): string | undefined {
         const key = `${provider}PreferredModel` as keyof StoredCredentials;
         return this.credentials[key] as string | undefined;
     }
 
-    public setPreferredModel(provider: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek', modelId: string): void {
+    public setPreferredModel(provider: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek' | 'openrouter', modelId: string): void {
         const key = `${provider}PreferredModel` as keyof StoredCredentials;
         (this.credentials as any)[key] = modelId;
         this.saveCredentials();

--- a/electron/services/RateLimiter.ts
+++ b/electron/services/RateLimiter.ts
@@ -113,5 +113,6 @@ export function createProviderRateLimiters() {
         claude: new RateLimiter(120, 2.0),    // 120 req/min
         deepseek: new RateLimiter(120, 2.0),  // OpenAI-compatible — conservative default
         litellm: new RateLimiter(120, 2.0),   // OpenAI-compatible proxy — conservative default
+        openrouter: new RateLimiter(60, 1.0), // 60 req/min
     };
 }

--- a/electron/utils/modelFetcher.ts
+++ b/electron/utils/modelFetcher.ts
@@ -10,7 +10,7 @@ export interface ProviderModel {
     label: string;
 }
 
-type Provider = 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek';
+type Provider = 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek' | 'openrouter';
 
 /**
  * Fetch available models from a provider's API.
@@ -31,6 +31,8 @@ export async function fetchProviderModels(
             return fetchGeminiModels(apiKey);
         case 'deepseek':
             return fetchDeepSeekModels(apiKey);
+        case 'openrouter':
+            return fetchOpenRouterModels(apiKey);
         default:
             throw new Error(`Unknown provider: ${provider}`);
     }
@@ -210,5 +212,26 @@ async function fetchGeminiModels(apiKey: string): Promise<ProviderModel[]> {
             const id = (m.name || '').replace(/^models\//, '');
             return { id, label: m.displayName || id };
         })
+        .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+// ─── OpenRouter ───────────────────────────────────────────────────────────────
+
+async function fetchOpenRouterModels(apiKey: string): Promise<ProviderModel[]> {
+    // Intentionally restrict to vision-capable models only (text+image input, text output).
+    // Text-only models (e.g. reasoning-only variants) are excluded because this app uses
+    // OpenRouter primarily for multimodal requests. Adjust the query string if that changes.
+    const response = await axios.get(
+        'https://openrouter.ai/api/v1/models?input_modalities=text%2Cimage&output_modalities=text',
+        {
+            headers: { Authorization: `Bearer ${apiKey}` },
+            timeout: 15000,
+        }
+    );
+
+    const models: any[] = response.data?.data || [];
+
+    return models
+        .map((m: any) => ({ id: `openrouter:${m.id}`, label: m.name || m.id }))
         .sort((a, b) => a.label.localeCompare(b.label));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "natively",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "natively",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
@@ -29,7 +29,6 @@
         "@types/marked": "^5.0.2",
         "@types/qrcode": "^1.5.6",
         "@types/three": "^0.182.0",
-        "@vectorize-io/hindsight-client": "0.8.2",
         "axios": "^1.7.7",
         "better-sqlite3": "12.6.2",
         "class-variance-authority": "^0.7.0",

--- a/src/components/settings/AIProvidersSettings.tsx
+++ b/src/components/settings/AIProvidersSettings.tsx
@@ -70,6 +70,7 @@ interface CustomProvider {
 interface ModelOption {
     id: string;
     name: string;
+    group?: string;
 }
 
 interface ModelSelectProps {
@@ -110,22 +111,31 @@ const ModelSelect: React.FC<ModelSelectProps> = ({ value, options, onChange, pla
             </button>
 
             {isOpen && (
-                <div className="absolute top-full right-0 mt-1 w-full bg-bg-elevated border border-border-subtle rounded-lg shadow-xl z-50 max-h-60 overflow-y-auto animated fadeIn">
-                    <div className="p-1 space-y-0.5">
-                        {options.map((option) => (
-                            <button
-                                key={option.id}
-                                onClick={() => {
-                                    onChange(option.id);
-                                    setIsOpen(false);
-                                }}
-                                className={`w-full text-left px-3 py-2 text-xs rounded-md flex items-center justify-between group transition-colors ${value === option.id ? 'bg-bg-input hover:bg-bg-elevated text-text-primary' : 'text-text-secondary hover:bg-bg-input hover:text-text-primary'}`}
-                                type="button"
-                            >
-                                <span className="truncate">{option.name}</span>
-                                {value === option.id && <Check size={14} className="text-accent-primary shrink-0 ml-2" />}
-                            </button>
-                        ))}
+                <div className="absolute top-full right-0 mt-1 w-56 bg-bg-elevated border border-border-subtle rounded-lg shadow-xl z-50 max-h-60 overflow-y-auto animated fadeIn">
+                    <div className="p-1">
+                        {options.map((option, i) => {
+                            const showHeader = option.group && (i === 0 || options[i - 1].group !== option.group);
+                            return (
+                                <React.Fragment key={option.id}>
+                                    {showHeader && (
+                                        <div className={`px-3 pt-2 pb-1 text-[10px] font-semibold text-text-tertiary uppercase tracking-wider select-none ${i > 0 ? 'mt-1 border-t border-border-subtle' : ''}`}>
+                                            {option.group}
+                                        </div>
+                                    )}
+                                    <button
+                                        onClick={() => {
+                                            onChange(option.id);
+                                            setIsOpen(false);
+                                        }}
+                                        className={`w-full text-left px-3 py-2 text-xs rounded-md flex items-center justify-between transition-colors ${value === option.id ? 'bg-bg-input hover:bg-bg-elevated text-text-primary' : 'text-text-secondary hover:bg-bg-input hover:text-text-primary'}`}
+                                        type="button"
+                                    >
+                                        <span className="truncate">{option.name}</span>
+                                        {value === option.id && <Check size={14} className="text-accent-primary shrink-0 ml-2" />}
+                                    </button>
+                                </React.Fragment>
+                            );
+                        })}
                         {options.length === 0 && (
                             <div className="px-3 py-2 text-xs text-gray-500 italic">No models available</div>
                         )}
@@ -177,6 +187,8 @@ export const AIProvidersSettings: React.FC = () => {
     const [openaiApiKey, setOpenaiApiKey] = useState('');
     const [claudeApiKey, setClaudeApiKey] = useState('');
     const [deepseekApiKey, setDeepseekApiKey] = useState('');
+    const [openrouterApiKey, setOpenrouterApiKey] = useState('');
+    const [providerModels, setProviderModels] = useState<Record<string, Array<{id: string; label: string}>>>({});
 
     // --- LiteLLM proxy (OpenAI-compatible gateway: baseURL + optional virtual key) ---
     const [litellmBaseURL, setLitellmBaseURL] = useState('');
@@ -259,7 +271,8 @@ export const AIProvidersSettings: React.FC = () => {
                         claude: creds.hasClaudeKey,
                         deepseek: creds.hasDeepseekKey || false,
                         litellm: creds.hasLitellmBaseURL || false,
-                        natively: creds.hasNativelyKey || false
+                        natively: creds.hasNativelyKey || false,
+                        openrouter: creds.hasOpenrouterKey || false
                     });
                     // Prefill stored LiteLLM config so re-saving doesn't silently reset it.
                     // (baseURL is config, not a secret; the key stays masked/blank = keep.)
@@ -272,7 +285,23 @@ export const AIProvidersSettings: React.FC = () => {
                     if (creds.openaiPreferredModel) pm.openai = creds.openaiPreferredModel;
                     if (creds.claudePreferredModel) pm.claude = creds.claudePreferredModel;
                     if (creds.deepseekPreferredModel) pm.deepseek = creds.deepseekPreferredModel;
+                    if (creds.openrouterPreferredModel) pm.openrouter = creds.openrouterPreferredModel;
                     setPreferredModels(pm);
+
+                    // Auto-fetch OpenRouter models so the Active Model dropdown is
+                    // populated on open without requiring a manual "Fetch Models" click.
+                    if (creds.hasOpenrouterKey) {
+                        try {
+                            // @ts-ignore
+                            const orResult = await window.electronAPI?.fetchProviderModels('openrouter', '');
+                            if (orResult?.success && orResult.models) {
+                                const models: Array<{ id: string; label: string }> = orResult.models;
+                                setProviderModels(prev => ({ ...prev, openrouter: models }));
+                            }
+                        } catch (e) {
+                            console.error('[Settings] Failed to auto-fetch OpenRouter models:', e);
+                        }
+                    }
                 }
 
                 // Now it's safe to read fast mode — hasStoredKey is already set so
@@ -646,6 +675,8 @@ export const AIProvidersSettings: React.FC = () => {
             if (provider === 'claude') result = await window.electronAPI.setClaudeApiKey(key);
             // @ts-ignore
             if (provider === 'deepseek') result = await window.electronAPI.setDeepseekApiKey(key);
+            // @ts-ignore
+            if (provider === 'openrouter') result = await window.electronAPI.setOpenrouterApiKey(key);
 
             if (result && result.success) {
                 setSavedStatus(prev => ({ ...prev, [provider]: true }));
@@ -716,6 +747,8 @@ export const AIProvidersSettings: React.FC = () => {
             if (provider === 'claude') result = await window.electronAPI.setClaudeApiKey('');
             // @ts-ignore
             if (provider === 'deepseek') result = await window.electronAPI.setDeepseekApiKey('');
+            // @ts-ignore
+            if (provider === 'openrouter') result = await window.electronAPI.setOpenrouterApiKey('');
 
             if (result && result.success) {
                 setHasStoredKey(prev => ({ ...prev, [provider]: false }));
@@ -857,31 +890,50 @@ export const AIProvidersSettings: React.FC = () => {
                     <ModelSelect
                         value={defaultModel}
                         options={(() => {
-                            const opts: { id: string; name: string }[] = [];
+                            const PROV_LABEL: Record<string, string> = {
+                                gemini: 'Gemini', openai: 'OpenAI', claude: 'Claude',
+                                groq: 'Groq', deepseek: 'DeepSeek', openrouter: 'OpenRouter',
+                            };
+                            const opts: ModelOption[] = [];
 
                             if (hasStoredKey.natively) {
-                                opts.push({ id: 'natively', name: 'Natively API' });
+                                opts.push({ id: 'natively', name: 'Natively API', group: 'Natively' });
                             }
 
                             for (const [prov, cfg] of Object.entries(STANDARD_CLOUD_MODELS)) {
                                 if (!hasStoredKey[prov as keyof typeof hasStoredKey]) continue;
-                                cfg.ids.forEach((id, i) => opts.push({ id, name: cfg.names[i] }));
+                                const grp = PROV_LABEL[prov] ?? prov;
+                                cfg.ids.forEach((id, i) => opts.push({ id, name: cfg.names[i], group: grp }));
+                                // For dynamic-only providers (e.g. openrouter, ids=[]), include fetched models.
+                                // Active/preferred model goes first, rest sorted alphabetically.
+                                if (cfg.ids.length === 0 && providerModels[prov]) {
+                                    const activePm = preferredModels[prov as keyof typeof preferredModels];
+                                    const sorted = [...providerModels[prov]].sort((a, b) => {
+                                        if (activePm) {
+                                            if (a.id === activePm) return -1;
+                                            if (b.id === activePm) return 1;
+                                        }
+                                        return a.label.localeCompare(b.label);
+                                    });
+                                    sorted.forEach(m => opts.push({ id: m.id, name: m.label, group: grp }));
+                                }
                                 const pm = preferredModels[prov as keyof typeof preferredModels];
-                                if (pm && !cfg.ids.includes(pm)) {
-                                    opts.push({ id: pm, name: prettifyModelId(pm) });
+                                if (pm && !cfg.ids.includes(pm) && !opts.find(o => o.id === pm)) {
+                                    const wireId = pm.replace(`${prov}:`, '');
+                                    opts.push({ id: pm, name: wireId, group: grp });
                                 }
                             }
-                            if (codexOauthStatus.signedIn || codexCliConfig.enabled) {
-                                opts.push({ id: CODEX_CLI_MODEL.id, name: `${CODEX_CLI_MODEL.name} (${prettifyModelId(codexCliConfig.model)})` });
+                            if (codexOauthStatus.signedIn && codexCliConfig.enabled) {
+                                opts.push({ id: CODEX_CLI_MODEL.id, name: `${CODEX_CLI_MODEL.name} (${prettifyModelId(codexCliConfig.model)})`, group: 'Codex' });
                                 CODEX_CLI_MODEL_PRESETS.forEach(model => {
                                     const id = codexCliSelectorId(model.id);
                                     if (!opts.find(o => o.id === id)) {
-                                        opts.push({ id, name: `${CODEX_CLI_MODEL.name}: ${model.name}` });
+                                        opts.push({ id, name: `${CODEX_CLI_MODEL.name}: ${model.name}`, group: 'Codex' });
                                     }
                                 });
                             }
-                            customProviders.forEach(p => opts.push({ id: p.id, name: p.name }));
-                            ollamaModels.forEach(m => opts.push({ id: `ollama-${m}`, name: `${m} (Local)` }));
+                            customProviders.forEach(p => opts.push({ id: p.id, name: p.name, group: 'Custom' }));
+                            ollamaModels.forEach(m => opts.push({ id: `ollama-${m}`, name: `${m} (Local)`, group: 'Ollama' }));
 
                             if (defaultModel && !opts.find(o => o.id === defaultModel)) {
                                 opts.unshift({ id: defaultModel, name: prettifyModelId(defaultModel) });
@@ -1037,6 +1089,28 @@ export const AIProvidersSettings: React.FC = () => {
                         keyPlaceholder="sk-..."
                         keyUrl="https://platform.deepseek.com/api_keys"
                         onPreferredModelChange={(model) => setPreferredModels(prev => ({ ...prev, deepseek: model }))}
+                    />
+
+                    {/* OpenRouter — routes to 100+ models from many providers via a single API key */}
+                    <ProviderCard
+                        providerId="openrouter"
+                        providerName="OpenRouter"
+                        apiKey={openrouterApiKey}
+                        preferredModel={preferredModels.openrouter}
+                        hasStoredKey={!!hasStoredKey.openrouter}
+                        onKeyChange={setOpenrouterApiKey}
+                        onSaveKey={async () => { await handleSaveKey('openrouter', openrouterApiKey, setOpenrouterApiKey); }}
+                        onRemoveKey={() => handleRemoveKey('openrouter', setOpenrouterApiKey)}
+                        onTestConnection={() => handleTestConnection('openrouter', openrouterApiKey)}
+                        testStatus={testStatus.openrouter || 'idle'}
+                        testError={testError.openrouter}
+                        savingStatus={!!savingStatus.openrouter}
+                        savedStatus={!!savedStatus.openrouter}
+                        keyPlaceholder="sk-or-..."
+                        keyUrl="https://openrouter.ai/keys"
+                        onPreferredModelChange={(model) => setPreferredModels(prev => ({ ...prev, openrouter: model }))}
+                        cachedModels={providerModels['openrouter'] || []}
+                        onModelsFetched={(models) => setProviderModels(prev => ({ ...prev, openrouter: models }))}
                     />
 
                     {/* LiteLLM — OpenAI-compatible AI gateway (100+ providers via one proxy).

--- a/src/components/settings/AIProvidersSettings.tsx
+++ b/src/components/settings/AIProvidersSettings.tsx
@@ -923,7 +923,7 @@ export const AIProvidersSettings: React.FC = () => {
                                     opts.push({ id: pm, name: wireId, group: grp });
                                 }
                             }
-                            if (codexOauthStatus.signedIn && codexCliConfig.enabled) {
+                            if (codexOauthStatus.signedIn || codexCliConfig.enabled) {
                                 opts.push({ id: CODEX_CLI_MODEL.id, name: `${CODEX_CLI_MODEL.name} (${prettifyModelId(codexCliConfig.model)})`, group: 'Codex' });
                                 CODEX_CLI_MODEL_PRESETS.forEach(model => {
                                     const id = codexCliSelectorId(model.id);

--- a/src/components/settings/ProviderCard.tsx
+++ b/src/components/settings/ProviderCard.tsx
@@ -7,7 +7,7 @@ interface FetchedModel {
 }
 
 interface ProviderCardProps {
-    providerId: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek';
+    providerId: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek' | 'openrouter';
     providerName: string;
     apiKey: string;
     preferredModel?: string;
@@ -23,6 +23,8 @@ interface ProviderCardProps {
     keyPlaceholder: string;
     keyUrl: string;
     onPreferredModelChange?: (modelId: string) => void;
+    cachedModels?: FetchedModel[];
+    onModelsFetched?: (models: FetchedModel[]) => void;
 }
 
 export const ProviderCard: React.FC<ProviderCardProps> = ({
@@ -42,6 +44,8 @@ export const ProviderCard: React.FC<ProviderCardProps> = ({
     keyPlaceholder,
     keyUrl,
     onPreferredModelChange,
+    cachedModels,
+    onModelsFetched,
 }) => {
     const [fetchedModels, setFetchedModels] = useState<FetchedModel[]>([]);
     const [isFetching, setIsFetching] = useState(false);
@@ -72,6 +76,11 @@ export const ProviderCard: React.FC<ProviderCardProps> = ({
         if (preferredModel) setSelectedModel(preferredModel);
     }, [preferredModel]);
 
+    // Seed fetchedModels from cachedModels provided by parent
+    useEffect(() => {
+        if (cachedModels && cachedModels.length > 0) setFetchedModels(cachedModels);
+    }, [cachedModels]);
+
     // Close dropdown on outside click
     useEffect(() => {
         const handleClickOutside = (event: MouseEvent) => {
@@ -100,6 +109,7 @@ export const ProviderCard: React.FC<ProviderCardProps> = ({
 
             if (result?.success && result.models) {
                 setFetchedModels(result.models);
+                onModelsFetched?.(result.models);
                 // If we have a preferred model that exists in the list, keep it; otherwise auto-select first
                 if (result.models.length > 0) {
                     const existsInList = result.models.some((m: FetchedModel) => m.id === selectedModel);
@@ -138,6 +148,16 @@ export const ProviderCard: React.FC<ProviderCardProps> = ({
     };
 
     const selectedOption = fetchedModels.find(m => m.id === selectedModel);
+
+    // Selected model first, remaining sorted alphabetically by label.
+    const displayModels = React.useMemo(() => {
+        if (!fetchedModels.length) return fetchedModels;
+        return [...fetchedModels].sort((a, b) => {
+            if (a.id === selectedModel) return -1;
+            if (b.id === selectedModel) return 1;
+            return a.label.localeCompare(b.label);
+        });
+    }, [fetchedModels, selectedModel]);
 
     return (
         <div className="bg-bg-item-surface rounded-xl p-5 border border-border-subtle">
@@ -205,21 +225,21 @@ export const ProviderCard: React.FC<ProviderCardProps> = ({
                 </button>
 
                 {/* Inline Model Dropdown */}
-                {fetchedModels.length > 0 || preferredModel ? (
+                {displayModels.length > 0 || preferredModel ? (
                     <div className="relative flex-1 max-w-[200px] mx-4" ref={dropdownRef}>
                         <button
-                            onClick={() => fetchedModels.length > 0 && setIsDropdownOpen(!isDropdownOpen)}
-                            className={`w-full bg-bg-input border border-border-subtle rounded-md px-3 py-1.5 text-xs text-text-primary focus:outline-none focus:border-accent-primary flex items-center justify-between transition-colors ${fetchedModels.length > 0 ? 'hover:bg-bg-elevated' : 'opacity-80 cursor-default'}`}
+                            onClick={() => displayModels.length > 0 && setIsDropdownOpen(!isDropdownOpen)}
+                            className={`w-full bg-bg-input border border-border-subtle rounded-md px-3 py-1.5 text-xs text-text-primary focus:outline-none focus:border-accent-primary flex items-center justify-between transition-colors ${displayModels.length > 0 ? 'hover:bg-bg-elevated' : 'opacity-80 cursor-default'}`}
                             type="button"
                         >
                             <span className="truncate pr-2">{selectedOption ? selectedOption.label : (preferredModel || 'Select model')}</span>
-                            <ChevronDown size={14} className={`text-text-secondary transition-transform ${isDropdownOpen ? 'rotate-180' : ''} ${fetchedModels.length === 0 ? 'opacity-50' : ''}`} />
+                            <ChevronDown size={14} className={`text-text-secondary transition-transform ${isDropdownOpen ? 'rotate-180' : ''} ${displayModels.length === 0 ? 'opacity-50' : ''}`} />
                         </button>
 
-                        {isDropdownOpen && fetchedModels.length > 0 && (
+                        {isDropdownOpen && displayModels.length > 0 && (
                             <div className="absolute top-full left-1/2 -translate-x-1/2 mt-1 w-full min-w-[200px] bg-bg-elevated border border-border-subtle rounded-lg shadow-xl z-50 max-h-60 overflow-y-auto animated fadeIn">
                                 <div className="p-1 space-y-0.5">
-                                    {fetchedModels.map((model) => (
+                                    {displayModels.map((model) => (
                                         <button
                                             key={model.id}
                                             onClick={() => handleSelectModel(model.id)}

--- a/src/components/settings/ProviderCard.tsx
+++ b/src/components/settings/ProviderCard.tsx
@@ -78,7 +78,7 @@ export const ProviderCard: React.FC<ProviderCardProps> = ({
 
     // Seed fetchedModels from cachedModels provided by parent
     useEffect(() => {
-        if (cachedModels && cachedModels.length > 0) setFetchedModels(cachedModels);
+        if (cachedModels) setFetchedModels(cachedModels);
     }, [cachedModels]);
 
     // Close dropdown on outside click

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -119,7 +119,7 @@ export interface ElectronAPI {
   getAvailableOllamaModels: () => Promise<string[]>
   switchToOllama: (model?: string, url?: string) => Promise<{ success: boolean; error?: string }>
   switchToGemini: (apiKey?: string, modelId?: string) => Promise<{ success: boolean; error?: string }>
-  testLlmConnection: (provider: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek', apiKey?: string) => Promise<{ success: boolean; error?: string }>
+  testLlmConnection: (provider: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek' | 'openrouter', apiKey?: string) => Promise<{ success: boolean; error?: string }>
   selectServiceAccount: () => Promise<{ success: boolean; path?: string; cancelled?: boolean; error?: string }>
 
   // API Key Management
@@ -128,6 +128,7 @@ export interface ElectronAPI {
   setOpenaiApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>
   setClaudeApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>
   setDeepseekApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>
+  setOpenrouterApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>
   setLitellmConfig: (config: { apiKey: string; baseURL: string; maxTokens?: number }) => Promise<{ success: boolean; error?: string }>
   getAvailableLiteLLMModels: () => Promise<string[]>
   setNativelyApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>
@@ -163,7 +164,7 @@ export interface ElectronAPI {
   }) => Promise<{ ok: boolean; error?: string; status?: number }>
   getNativelyPricing: () => Promise<{ ok: boolean; currency?: string; fetchedAt?: string; stale?: boolean; products?: Record<string, { id: string; dodoProductId: string; name: string; amount: number | null; currency: string; formattedPrice: string | null; interval: 'month' | 'year' | 'lifetime'; checkoutUrl: string; coupon: { code: string; eligible: boolean; discountPercent: number; reason?: string } }>; error?: string; status?: number }>
   getNativelyUsage: () => Promise<{ ok: boolean; error?: string; plan?: string; quota?: { transcription: { used: number; limit: number; remaining: number }; ai: { used: number; limit: number; remaining: number }; search: { used: number; limit: number; remaining: number }; resets_at: string }; member_since?: string }>
-  getStoredCredentials: () => Promise<{ hasNativelyKey?: boolean; hasGeminiKey: boolean; hasGroqKey: boolean; hasOpenaiKey: boolean; hasClaudeKey: boolean; hasDeepseekKey: boolean; hasLitellmBaseURL?: boolean; litellmBaseURL?: string | null; litellmMaxTokens?: number | null; googleServiceAccountPath: string | null; sttProvider: 'none' | 'google' | 'groq' | 'openai' | 'deepgram' | 'elevenlabs' | 'azure' | 'ibmwatson' | 'soniox' | 'natively'; hasSttGroqKey: boolean; hasSttOpenaiKey: boolean; hasDeepgramKey: boolean; hasElevenLabsKey: boolean; hasAzureKey: boolean; azureRegion: string; hasIbmWatsonKey: boolean; ibmWatsonRegion: string; groqSttModel?: string; hasSonioxKey?: boolean; hasTavilyKey?: boolean; geminiPreferredModel?: string; groqPreferredModel?: string; openaiPreferredModel?: string; claudePreferredModel?: string; deepseekPreferredModel?: string; sttGroqKey?: string; sttOpenaiKey?: string; sttDeepgramKey?: string; sttElevenLabsKey?: string; sttAzureKey?: string; sttIbmKey?: string; sttSonioxKey?: string; openAiSttBaseUrl?: string }>
+  getStoredCredentials: () => Promise<{ hasNativelyKey?: boolean; hasGeminiKey: boolean; hasGroqKey: boolean; hasOpenaiKey: boolean; hasClaudeKey: boolean; hasDeepseekKey: boolean; hasLitellmBaseURL?: boolean; litellmBaseURL?: string | null; litellmMaxTokens?: number | null; googleServiceAccountPath: string | null; sttProvider: 'none' | 'google' | 'groq' | 'openai' | 'deepgram' | 'elevenlabs' | 'azure' | 'ibmwatson' | 'soniox' | 'natively'; hasSttGroqKey: boolean; hasSttOpenaiKey: boolean; hasDeepgramKey: boolean; hasElevenLabsKey: boolean; hasAzureKey: boolean; azureRegion: string; hasIbmWatsonKey: boolean; ibmWatsonRegion: string; groqSttModel?: string; hasSonioxKey?: boolean; hasTavilyKey?: boolean; geminiPreferredModel?: string; groqPreferredModel?: string; openaiPreferredModel?: string; claudePreferredModel?: string; deepseekPreferredModel?: string; hasOpenrouterKey?: boolean; openrouterPreferredModel?: string; sttGroqKey?: string; sttOpenaiKey?: string; sttDeepgramKey?: string; sttElevenLabsKey?: string; sttAzureKey?: string; sttIbmKey?: string; sttSonioxKey?: string; openAiSttBaseUrl?: string }>
   // Permissions
   checkPermissions:     () => Promise<{ microphone: 'granted'|'denied'|'not-determined'|'restricted'; screen: 'granted'|'denied'|'not-determined'|'restricted'; platform: string }>
   requestMicPermission: () => Promise<boolean>
@@ -523,8 +524,8 @@ export interface ElectronAPI {
   setTavilyApiKey: (apiKey: string) => Promise<{ success: boolean; error?: string }>
 
   // Dynamic Model Discovery
-  fetchProviderModels: (provider: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek', apiKey: string) => Promise<{ success: boolean; models?: {id: string, label: string}[]; error?: string }>
-  setProviderPreferredModel: (provider: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek', modelId: string) => Promise<void>
+  fetchProviderModels: (provider: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek' | 'openrouter', apiKey: string) => Promise<{ success: boolean; models?: {id: string, label: string}[]; error?: string }>
+  setProviderPreferredModel: (provider: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek' | 'openrouter', modelId: string) => Promise<void>
 
   // License Management
   licenseActivate: (key: string) => Promise<{ success: boolean; error?: string }>

--- a/src/utils/modelUtils.ts
+++ b/src/utils/modelUtils.ts
@@ -3,7 +3,7 @@ export const STANDARD_CLOUD_MODELS: Record<string, {
     ids: string[];
     names: string[];
     descs: string[];
-    pmKey: 'geminiPreferredModel' | 'openaiPreferredModel' | 'claudePreferredModel' | 'groqPreferredModel' | 'deepseekPreferredModel';
+    pmKey: 'geminiPreferredModel' | 'openaiPreferredModel' | 'claudePreferredModel' | 'groqPreferredModel' | 'deepseekPreferredModel' | 'openrouterPreferredModel';
 }> = {
     gemini: {
         hasKeyCheck: (creds) => !!creds?.hasGeminiKey,
@@ -39,6 +39,13 @@ export const STANDARD_CLOUD_MODELS: Record<string, {
         names: ['DeepSeek V4 Flash', 'DeepSeek V4 Pro'],
         descs: ['Fast • Text-only', 'Reasoning • Text-only'],
         pmKey: 'deepseekPreferredModel'
+    },
+    openrouter: {
+        hasKeyCheck: (creds) => !!creds?.hasOpenrouterKey,
+        ids: [],
+        names: [],
+        descs: [],
+        pmKey: 'openrouterPreferredModel'
     },
 };
 


### PR DESCRIPTION
## Summary

Adds OpenRouter as a fully integrated provider. Fixes two root-cause bugs that
silently dropped screenshots when OpenRouter was the active model, and wires up
all the missing Settings plumbing (key storage, model picker, auto-fetch, grouping).

## What changed and why

### Vision routing (bug fix)
`_streamChatInner` had an unconditional early-exit that intercepted every
image-bearing request and routed it through the hardcoded vision fallback chain
(OpenAI → Claude → Gemini → Groq) before OpenRouter dispatch was ever reached.
Fix: move the OpenRouter block above that early-exit.

`streamWithOpenrouterMultimodal` was reading screenshot bytes with `fs.readFileSync`
then labelling them `image/jpeg`. Screenshots are PNGs — the MIME mismatch caused
models to silently ignore the image content.
Fix: use `processImage()` (sharp resize to 1536 px, 80 % JPEG quality) — same as
the OpenAI and Claude multimodal paths. Also parallelised with `Promise.all`.

### Provider plumbing (new)
- `LLMHelper`: `openrouterClient` (OpenAI SDK, custom base URL), `setOpenrouterApiKey`,
  `isOpenrouterModel`, `streamWithOpenrouter`, `streamWithOpenrouterMultimodal`
- `CredentialsManager`: key + preferred model storage
- `ipcHandlers`: `set-openrouter-api-key`, `test-llm-connection`, `fetch-provider-models`,
  `set-provider-preferred-model`, `get-stored-credentials` — all extended for OpenRouter
- `preload` + `electron.d.ts`: bridge + type signatures updated
- `ProviderRouter`: OpenRouter registered with `vision` capability + circuit breaker

### Settings UI (new)
- OpenRouter `ProviderCard`: API key save / remove / test, inline model picker, Fetch Models
- Active Model dropdown grouped by provider (OpenRouter / Gemini / OpenAI / Claude …)
- OpenRouter models auto-fetched on settings open.
- All provider dropdowns sorted: active/preferred model first, then alphabetical
- `fetchOpenRouterModels` restricts to vision-capable models only (`input_modalities=text,image`)

## Related Issue

Closes #343 

