### PR TITLE
fix(cropper): convert local selection bounds to global coordinates fo…

### DIFF
--- a/electron/CropperWindowHelper.ts
+++ b/electron/CropperWindowHelper.ts
@@ -111,15 +111,7 @@ export class CropperWindowHelper {
                 this.hideOrClose();
                 return;
             }
-
-            // Validate input data for security
-            if (!this.validateBounds(bounds)) {
-                console.error('[CropperWindowHelper] Invalid bounds received:', bounds);
-                this.rejectCurrentSelection(null);
-                this.hideOrClose();
-                return;
-            }
-
+            
             const cropperBounds = this.cropperWindow?.getBounds();
 
             const globalBounds = cropperBounds
@@ -129,8 +121,16 @@ export class CropperWindowHelper {
                     y: bounds.y + cropperBounds.y,
                 }
                 : bounds;
+
+            // Validate input data for security using global coordinates to support multi-monitor setups
+            if (!this.validateBounds(globalBounds)) {
+                console.error('[CropperWindowHelper] Invalid bounds received:', globalBounds);
+                this.rejectCurrentSelection(null);
+                this.hideOrClose();
+                return;
+            }
             
-            this.resolveCurrentSelection(bounds);
+            this.resolveCurrentSelection(globalBounds);
             this.hideOrClose();
         };
 

--- a/electron/CropperWindowHelper.ts
+++ b/electron/CropperWindowHelper.ts
@@ -120,6 +120,16 @@ export class CropperWindowHelper {
                 return;
             }
 
+            const cropperBounds = this.cropperWindow?.getBounds();
+
+            const globalBounds = cropperBounds
+                ? {
+                    ...bounds,
+                    x: bounds.x + cropperBounds.x,
+                    y: bounds.y + cropperBounds.y,
+                }
+                : bounds;
+            
             this.resolveCurrentSelection(bounds);
             this.hideOrClose();
         };


### PR DESCRIPTION
…r multi-monitor support

fix(cropper): fix wrong screenshot coordinates on multi-monitor setups

PROBLEM:
When taking a selective screenshot, the selection bounds received from the renderer process were calculated relative to the cropper window itself (local coordinates), rather than the absolute screen space. This caused the screenshot tool to capture the wrong area or completely fail validation (out of bounds) if the cropper window was opened on a secondary monitor.

SOLUTION:
Modified CropperWindowHelper to transform local selection bounds into global screen coordinates. If the cropper window exists, its absolute X and Y screen offsets are now added to the selection bounds, properly aligning the capture region within the global multi-monitor viewport.
