### PR TITLE
fix(docgrounded): remove working-tree drift in ModeContextRetriever.ts

### DIFF
--- a/electron/services/ModeContextRetriever.ts
+++ b/electron/services/ModeContextRetriever.ts
@@ -6,7 +6,7 @@ import { DatabaseManager } from '../db/DatabaseManager';
 // Imported from the leaf module (not the ../llm barrel) to avoid a require cycle.
 import { classifyCustomContext, selectCustomContextForAnswer } from '../llm/customContextClassifier';
 import type { AnswerType } from '../llm/AnswerPlanner';
-import { buildDocumentMap, resolveTargetSections, sectionAwareChunksFromMap, sentenceAwareWindows, type DocumentMap } from './modes/DocumentMap';
+import { buildDocumentMap, resolveTargetSections, sectionAwareChunksFromMap, type DocumentMap } from './modes/DocumentMap';
 
 /**
  * Gate the mode's raw customContext blob by answer type (Phase 3). Returns only
@@ -43,15 +43,10 @@ export interface ModeRetrievedContext {
     snippets: ModeRetrievedSnippet[];
     formattedContext: string;
     usedFallback: boolean;
-    /** Document-type-agnostic retrieval confidence in [0,1] for this query:
-     *  the top snippet's raw score normalized against this query's OWN
-     *  adaptive relevance floor (which already scales for query size and the
-     *  flat-doc lexical cap). ~1.0 = the top chunk scored well above the floor
-     *  (a confident match); ~0 = nothing cleared the floor. Lets a downstream
-     *  gate (the doc-grounded false-refusal repair in ipcHandlers) compare a
-     *  single threshold across BOTH ToC-structured docs (raw scores 0.5-0.9)
-     *  and flat prose docs (raw scores cap ~0.25) by construction. Absent on
-     *  the empty/fallback returns (treat as 0). */
+    /** Document-type-agnostic retrieval confidence in [0,1] (diagnostics-only).
+     *  top snippet's raw score normalized against this query's own adaptive
+     *  relevance floor, clamped to [0,1] — works across ToC and flat-prose docs
+     *  by construction. Absent on empty/fallback returns (treat as 0). */
     topScoreConfidence?: number;
 }
 
@@ -237,12 +232,12 @@ function chunkText(content: string, fineChunk: boolean = false): string[] {
                 chunks.push(fullText);
                 continue;
             }
-            // Sentence-aware windowing (mirror of ModeHybridRetriever): never split
-            // a normative clause mid-sentence across a chunk boundary.
-            const bodyForWindows = headingLine ? bodyText : fullText;
-            for (const window of sentenceAwareWindows(bodyForWindows, CHUNK_WORDS, CHUNK_OVERLAP)) {
-                const ct = headingLine ? `${headingLine}\n${window}` : window;
+            for (let i = 0; i < words.length; i += CHUNK_WORDS - CHUNK_OVERLAP) {
+                const window = words.slice(i, i + CHUNK_WORDS);
+                if (window.length === 0) break;
+                const ct = headingLine ? `${headingLine}\n${window.join(' ')}` : window.join(' ');
                 if (ct.trim()) chunks.push(ct);
+                if (i + CHUNK_WORDS >= words.length) break;
             }
             continue;
         }
@@ -1252,13 +1247,10 @@ export class ModeContextRetriever {
         }
         lines.push('</active_mode_retrieved_context>');
 
-        // Document-type-agnostic confidence: normalize the top selected score
-        // against this query's OWN adaptive floor. A confidently-answering
-        // chunk scores ~2.5x+ the floor on BOTH ToC docs (floor ~0.18, strong
-        // ~0.5-0.9) and flat prose (floor scaled down by query size, strong
-        // ~0.25) — so dividing by (floor * 2.5) maps "clearly strong" → ~1.0
-        // and "barely cleared the floor / off-topic" → ~0.4 or less,
-        // regardless of the raw score's absolute magnitude. Clamped to [0,1].
+        // Document-type-agnostic confidence (diagnostics; consumed only by the
+        // modes:build-retrieved-context debug IPC, NOT by the doc-grounded
+        // false-refusal repair gate). Raw top score normalized against this
+        // query's own adaptive floor — works across ToC and flat-prose docs.
         const topRawScore = selected.length > 0 ? Math.max(...selected.map(s => s.score)) : 0;
         const confidenceReference = Math.max(adaptiveThreshold * 2.5, 1e-6);
         const topScoreConfidence = Math.max(0, Math.min(1, topRawScore / confidenceReference));
@@ -1363,12 +1355,6 @@ export class ModeContextRetriever {
             topK: options.topK,
             hasTranscript,
             allowRerank: options.allowRerank,
-            // CRITICAL: forward the document-grounding flag. Without it, the hybrid
-            // retriever never applies the doc-grounded budget/topK upgrade
-            // (DOC_GROUNDED_TOKEN_BUDGET_LOCAL=3600 / TOP_K=12) nor the per-section
-            // dedup + identity block — so grounded answers were retrieving only the
-            // default 1800-token / 6-chunk window, dropping multi-fact evidence.
-            forceDocumentGrounding: options.forceDocumentGrounding,
         });
 
         return result;


### PR DESCRIPTION
## Summary

Follow-up to #347. The previous PR's commit (`c0cbc23`) inadvertently picked up unrelated working-tree edits to `ModeContextRetriever.ts` when I staged the file:

- an import of `sentenceAwareWindows` from `./modes/DocumentMap` (not exported on `main` → broken `e58c16e`, causing the post-merge electron typecheck to fail at module-resolution time)
- a chunking-loop rewrite (word-window → `sentenceAwareWindows()`) that lived only locally
- a `forceDocumentGrounding` forwarding on a `retrieveHybrid` call shape that didn't exist in the merge base

This PR reverts `ModeContextRetriever.ts` to the merge base (`90d7f84`, which is what `main` actually had before #347) and re-applies ONLY the legitimate additions from #347 — the `topScoreConfidence` diagnostics field on `ModeRetrievedContext` and the corresponding computation at the return site.

No behavioral change to the production path. Fixes the post-merge electron typecheck that I should have caught before opening #347.

## Changes

- `electron/services/ModeContextRetriever.ts`: replace whole file with merge-base content + the two legitimate additions (+13/-0 net vs my originally-staged change; the working-tree drift accounted for the extra noise).

## Test plan

- `npx tsc -p electron/tsconfig.json --noEmit` → 0 errors (was 1 broken import)
- `npx tsc --noEmit` → 0 errors
- `npm run build:electron` → clean
- `ELECTRON_RUN_AS_NODE=1 ./node_modules/.bin/electron --test` over Phase-0 / Phase-1 / DocGroundedRetrievalFix / ModeContextRetriever / ModesManager / all OKF knowledge tests → **283/283 pass**

## Risk

Strictly surgical: 1 file, +13/-0 relative to the intended change. The discarded lines were unused-by-main working-tree drift; the gate's behavior on `main` after this PR is identical to the intended change.

## What does NOT need to change

`ModesManager.lastRetrievalConfidence` (in `ModesManager.ts` and used by the debug IPC in `ipcHandlers.ts:9128`) reads `result.topScoreConfidence`. After this PR that field is again populated correctly. The Phase-0 gate tests in `OkfPhase0FalseRefusalGuard.test.mjs` that pass are independent of this field — they key off the `ipcHandlers` gate, not on retrieval confidence.