### PR TITLE
fix(onboarding): prevent Windows launcher native OOM

### DIFF
--- a/electron/WindowHelper.ts
+++ b/electron/WindowHelper.ts
@@ -438,9 +438,21 @@ export class WindowHelper {
     // line naming the exact failing module/line on the user's machine.
     this.attachRendererDiagnostics(this.launcherWindow, 'launcher');
 
-    // if (isDev) {
-    //   this.launcherWindow.webContents.openDevTools({ mode: 'detach' }); // DEBUG: Open DevTools
-    // }
+    // DIAGNOSTIC (2026-07-11): NATIVELY_OPEN_DEVTOOLS=1 force-opens the launcher
+    // DevTools DETACHED (survives a renderer hang, unlike an in-window panel).
+    // For debugging the "window appears then freezes / renderer not responsive"
+    // report: open the Performance tab and record during the freeze — a single
+    // long yellow Scripting block = a JS main-thread loop; a flat gap with no JS
+    // = a compositor/GPU stall (the software-compositing blur path). Detached so
+    // it stays usable even when the launcher renderer stops pumping its loop.
+    if (process.env.NATIVELY_OPEN_DEVTOOLS === '1') {
+      try {
+        this.launcherWindow.webContents.openDevTools({ mode: 'detach' });
+        console.warn('[Diag] NATIVELY_OPEN_DEVTOOLS=1 → launcher DevTools opened (detached)');
+      } catch (e: any) {
+        console.warn('[Diag] openDevTools failed:', e?.message || e);
+      }
+    }
 
     // --- 2. Create Overlay Window (Hidden initially) ---
     // Always start centered on the primary display so the OS (macOS NSUserDefaults /

--- a/electron/WindowHelper.ts
+++ b/electron/WindowHelper.ts
@@ -394,7 +394,17 @@ export class WindowHelper {
     const noOrchSuffix = process.env.NATIVELY_DISABLE_ONBOARDING_ORCH === '1' ? '&noorch=1' : '';
     if (noOrchSuffix) console.warn('[LeakTest] NATIVELY_DISABLE_ONBOARDING_ORCH=1 → launcher with ?noorch=1 (onboarding orchestrator OFF)');
 
-    const launcherUrl = `${startUrl}?window=launcher${nofxSuffix}${noOrchSuffix}`;
+    // DEV-ONLY launcher mount isolation for native-OOM bisection. This preserves
+    // the launcher shell and normal production behavior while allowing a valid
+    // Vite run to exclude either onboarding alone or all root-level surfaces.
+    const requestedIsolation = process.env.NATIVELY_LAUNCHER_ISOLATION;
+    const launcherIsolation = isDev && (requestedIsolation === 'onboarding' || requestedIsolation === 'global-surfaces')
+      ? requestedIsolation
+      : '';
+    const isolationSuffix = launcherIsolation ? `&isolate=${launcherIsolation}` : '';
+    if (launcherIsolation) console.warn(`[LeakTest] NATIVELY_LAUNCHER_ISOLATION=${launcherIsolation} → launcher root isolation enabled`);
+
+    const launcherUrl = `${startUrl}?window=launcher${nofxSuffix}${noOrchSuffix}${isolationSuffix}`;
 
     this.launcherWindow
       .loadURL(launcherUrl)
@@ -441,7 +451,7 @@ export class WindowHelper {
         webContentsId: launcher.webContents.id,
         rendererPid,
       });
-      this.appState.startNativeOomContentTrace(rendererPid);
+      this.appState.armNativeOomContentTrace(rendererPid);
     });
 
     // Pipe renderer-side diagnostics into the main-process log file. Without

--- a/electron/WindowHelper.ts
+++ b/electron/WindowHelper.ts
@@ -364,6 +364,11 @@ export class WindowHelper {
 
     try {
       this.launcherWindow = new BrowserWindow(launcherSettings);
+      this.appState.recordNativeOomTrace('launcher-window-created', {
+        window: 'launcher',
+        webContentsId: this.launcherWindow.webContents.id,
+        rendererPid: this.launcherWindow.webContents.getOSProcessId(),
+      });
       console.log('[WindowHelper] BrowserWindow created successfully');
     } catch (err) {
       console.error('[WindowHelper] Failed to create BrowserWindow:', err);
@@ -428,6 +433,15 @@ export class WindowHelper {
     // retry budget instead of being starved by earlier retries.
     this.launcherWindow.webContents.on('did-finish-load', () => {
       launcherLoadRetries = 0;
+      const launcher = this.launcherWindow;
+      if (!launcher || launcher.isDestroyed()) return;
+      const rendererPid = launcher.webContents.getOSProcessId();
+      this.appState.recordNativeOomTrace('launcher-did-finish-load', {
+        window: 'launcher',
+        webContentsId: launcher.webContents.id,
+        rendererPid,
+      });
+      this.appState.startNativeOomContentTrace(rendererPid);
     });
 
     // Pipe renderer-side diagnostics into the main-process log file. Without
@@ -627,6 +641,16 @@ export class WindowHelper {
       });
 
       wc.on('render-process-gone', (_event, details) => {
+        if (tag === 'launcher') {
+          this.appState.recordNativeOomTrace('launcher-render-process-gone', {
+            window: 'launcher',
+            webContentsId: wc.id,
+            rendererPid: wc.getOSProcessId(),
+            reason: typeof details?.reason === 'string' ? details.reason : 'unknown',
+            exitCode: typeof details?.exitCode === 'number' ? details.exitCode : 0,
+          });
+          this.appState.stopNativeOomContentTrace('launcher-render-process-gone');
+        }
         console.error(
           `[Renderer:${tag}] RENDER-PROCESS-GONE reason=${details?.reason} exitCode=${details?.exitCode}`,
         );
@@ -713,6 +737,8 @@ export class WindowHelper {
     }
 
     this.launcherWindow.on('closed', () => {
+      this.appState.recordNativeOomTrace('launcher-window-closed', { window: 'launcher' });
+      this.appState.stopNativeOomContentTrace('launcher-window-closed');
       this.launcherWindow = null;
       // If launcher closes, we should probably quit app or close overlay
       if (this.overlayWindow && !this.overlayWindow.isDestroyed()) {

--- a/electron/WindowHelper.ts
+++ b/electron/WindowHelper.ts
@@ -377,8 +377,19 @@ export class WindowHelper {
     // src/App.tsx + src/index.css). Used to test whether the Windows native-RSS
     // leak is the CPU-composited blur raster-tile path. Remove after fix.
     const nofxSuffix = process.env.NATIVELY_NOFX === '1' ? '&nofx=1' : '';
-    const launcherUrl = `${startUrl}?window=launcher${nofxSuffix}`;
     if (nofxSuffix) console.warn('[LeakTest] NATIVELY_NOFX=1 → loading launcher with ?nofx=1 (blur effects OFF)');
+
+    // A/B KILL-SWITCH (2026-07-10): NATIVELY_DISABLE_ONBOARDING_ORCH=1 appends
+    // ?noorch=1, which makes App.tsx skip orch.start() entirely (no drain loop,
+    // no onboarding toasters). The onboarding orchestrator's drain loop was
+    // bisected to the 2026-07-04 native-memory-leak regression; this switch lets
+    // the same build be run with the orchestrator ON vs OFF to confirm the leak
+    // source in the field. The loop is now setTimeout-based (fixed), so this is
+    // a confirmation/rollback lever, not the fix itself.
+    const noOrchSuffix = process.env.NATIVELY_DISABLE_ONBOARDING_ORCH === '1' ? '&noorch=1' : '';
+    if (noOrchSuffix) console.warn('[LeakTest] NATIVELY_DISABLE_ONBOARDING_ORCH=1 → launcher with ?noorch=1 (onboarding orchestrator OFF)');
+
+    const launcherUrl = `${startUrl}?window=launcher${nofxSuffix}${noOrchSuffix}`;
 
     this.launcherWindow
       .loadURL(launcherUrl)

--- a/electron/WindowHelper.ts
+++ b/electron/WindowHelper.ts
@@ -398,13 +398,22 @@ export class WindowHelper {
     // the launcher shell and normal production behavior while allowing a valid
     // Vite run to exclude either onboarding alone or all root-level surfaces.
     const requestedIsolation = process.env.NATIVELY_LAUNCHER_ISOLATION;
-    const launcherIsolation = isDev && (requestedIsolation === 'onboarding' || requestedIsolation === 'global-surfaces')
-      ? requestedIsolation
-      : '';
+    const launcherIsolation = isDev && (
+      requestedIsolation === 'onboarding' ||
+      requestedIsolation === 'global-surfaces' ||
+      requestedIsolation === 'permissions-toaster' ||
+      requestedIsolation === 'no-modals'
+    ) ? requestedIsolation : '';
     const isolationSuffix = launcherIsolation ? `&isolate=${launcherIsolation}` : '';
     if (launcherIsolation) console.warn(`[LeakTest] NATIVELY_LAUNCHER_ISOLATION=${launcherIsolation} → launcher root isolation enabled`);
 
-    const launcherUrl = `${startUrl}?window=launcher${nofxSuffix}${noOrchSuffix}${isolationSuffix}`;
+    // The review modal deliberately force-opens in development for UI iteration.
+    // This switch keeps every other launcher surface unchanged while excluding
+    // only that dev convenience mount during a native-memory A/B run.
+    const reviewOffSuffix = isDev && process.env.NATIVELY_DISABLE_DEV_REVIEW === '1' ? '&review=off' : '';
+    if (reviewOffSuffix) console.warn('[LeakTest] NATIVELY_DISABLE_DEV_REVIEW=1 → dev review modal disabled');
+
+    const launcherUrl = `${startUrl}?window=launcher${nofxSuffix}${noOrchSuffix}${isolationSuffix}${reviewOffSuffix}`;
 
     this.launcherWindow
       .loadURL(launcherUrl)

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -9192,10 +9192,16 @@ export function initializeIpcHandlers(appState: AppState): void {
   // or a phone connects/disconnects. Idempotent — multiple windows can listen.
   PhoneMirrorService.getInstance().onStatusChange((info) => {
     const win = appState.getMainWindow();
-    win?.webContents.send('phone-mirror:status', info);
+    if (win && !win.isDestroyed()) {
+      appState.recordNativeOomOutboundIpc(win.webContents.id, 'phone-mirror:status', [info]);
+      win.webContents.send('phone-mirror:status', info);
+    }
     try {
       const settingsWin = (appState as any).settingsWindowHelper?.getWindow?.();
-      settingsWin?.webContents?.send('phone-mirror:status', info);
+      if (settingsWin && !settingsWin.isDestroyed()) {
+        appState.recordNativeOomOutboundIpc(settingsWin.webContents.id, 'phone-mirror:status', [info]);
+        settingsWin.webContents.send('phone-mirror:status', info);
+      }
     } catch (_) {
       /* settings window may not exist yet */
     }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -7090,6 +7090,22 @@ if (process.env.THINKING_MATRIX === '1') {
     windowCount: BrowserWindow.getAllWindows().length,
   });
 
+  // DIAGNOSTIC (2026-07-11): dump Chromium's GPU feature status once at boot.
+  // The "window appears then freezes / renderer not responsive" report is
+  // consistent with a machine that fell back to SOFTWARE compositing (Chromium
+  // blocklisted the GPU / driver state), where the launcher splash's heavy
+  // blur/backdrop-filter becomes catastrophically expensive and can wedge the
+  // renderer's main thread. This logs, in one line, whether gpu_compositing and
+  // rasterization are 'enabled' (hardware) or 'software'/'disabled'. If a user
+  // who freezes shows software/disabled here while a healthy machine shows
+  // enabled, the compositing path is confirmed and `?nofx=1` should unblock it.
+  try {
+    const status = app.getGPUFeatureStatus();
+    console.log('[GPU] featureStatus', JSON.stringify(status));
+  } catch (e: any) {
+    console.warn('[GPU] getGPUFeatureStatus failed:', e?.message || e);
+  }
+
   // Run the local-fallback preflight AFTER the launcher paints. We schedule
   // it via setTimeout so the visible launch is not blocked by:
   //   - native module requires (onnxruntime-node, sqlite-vec)

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1066,6 +1066,9 @@ export class AppState {
   private ragManager: RAGManager | null = null
   private modeReferenceRetryPromise: Promise<void> | null = null
   private stabilityHeartbeatTimer: NodeJS.Timeout | null = null
+  // Diagnostic-only, independently paced native-memory sampler. Normal product
+  // heartbeats remain at 30 seconds; this exists only for a short-lived OOM run.
+  private nativeOomTraceTimer: NodeJS.Timeout | null = null
   private knowledgeOrchestrator: any = null
 
   public recordNativeOomTrace(event: string, data: Record<string, unknown> = {}): void {
@@ -1076,8 +1079,8 @@ export class AppState {
     nativeOomTrace.recordOutboundIpc(webContentsId, channel, args)
   }
 
-  public startNativeOomContentTrace(launcherPid: number): void {
-    void nativeOomTrace.startContentTrace(launcherPid)
+  public armNativeOomContentTrace(launcherPid: number): void {
+    nativeOomTrace.armContentTrace(launcherPid)
   }
 
   public stopNativeOomContentTrace(reason: string): void {
@@ -1673,6 +1676,7 @@ export class AppState {
     this.setupAutoUpdater()
 
     this.startStabilityHeartbeat();
+    this.startNativeOomTraceSampling();
   }
 
   private startStabilityHeartbeat(): void {
@@ -1708,25 +1712,7 @@ export class AppState {
             .sort((a: any, b: any) => b.rssMB - a.rssMB);
         } catch { /* getAppMetrics unavailable pre-ready — skip */ }
 
-        if (nativeOomTrace.isEnabled()) {
-          nativeOomTrace.sample(
-            mem,
-            (() => {
-              try {
-                return (app.getAppMetrics?.() || []) as unknown as Array<Record<string, unknown>>;
-              } catch {
-                return [];
-              }
-            })(),
-            (() => {
-              const launcher = this.windowHelper?.getLauncherWindow?.();
-              if (!launcher || launcher.isDestroyed()) return undefined;
-              const pid = launcher.webContents.getOSProcessId();
-              return pid > 0 ? { webContentsId: launcher.webContents.id, pid } : undefined;
-            })(),
-            { freeMemory: os.freemem(), totalMemory: os.totalmem() },
-          );
-        }
+        this.sampleNativeOomTrace(mem);
 
         console.log('[StabilityHeartbeat]', {
           rssMB: mb(mem.rss),
@@ -1755,6 +1741,41 @@ export class AppState {
     setTimeout(emit, 10_000).unref?.();
     this.stabilityHeartbeatTimer = setInterval(emit, 30_000);
     this.stabilityHeartbeatTimer.unref?.();
+  }
+
+  private sampleNativeOomTrace(memory = process.memoryUsage()): void {
+    if (!nativeOomTrace.isEnabled()) return;
+    nativeOomTrace.sample(
+      memory,
+      (() => {
+        try {
+          return (app.getAppMetrics?.() || []) as unknown as Array<Record<string, unknown>>;
+        } catch {
+          return [];
+        }
+      })(),
+      (() => {
+        const launcher = this.windowHelper?.getLauncherWindow?.();
+        if (!launcher || launcher.isDestroyed()) return undefined;
+        const pid = launcher.webContents.getOSProcessId();
+        return pid > 0 ? { webContentsId: launcher.webContents.id, pid } : undefined;
+      })(),
+      { freeMemory: os.freemem(), totalMemory: os.totalmem() },
+    );
+  }
+
+  private startNativeOomTraceSampling(): void {
+    if (!nativeOomTrace.isEnabled() || this.nativeOomTraceTimer) return;
+    // A prior incident rose from 497 MB to more than 2 GB in roughly four
+    // seconds; the ordinary 30-second heartbeat cannot observe that onset.
+    this.nativeOomTraceTimer = setInterval(() => this.sampleNativeOomTrace(), 1000);
+    this.nativeOomTraceTimer.unref?.();
+  }
+
+  public stopNativeOomTraceSampling(): void {
+    if (!this.nativeOomTraceTimer) return;
+    clearInterval(this.nativeOomTraceTimer);
+    this.nativeOomTraceTimer = null;
   }
 
   private sendToWindow(win: BrowserWindow | null | undefined, channel: string, ...args: any[]): boolean {
@@ -7442,6 +7463,7 @@ if (process.env.THINKING_MATRIX === '1') {
   }
 
   app.on('will-quit', () => {
+    appState.stopNativeOomTraceSampling();
     nativeOomTrace.stop('will-quit');
     stopAppManagedHindsight('will-quit');
     checkpointDatabase('will-quit');

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1030,6 +1030,11 @@ import { ReleaseNotesManager } from "./update/ReleaseNotesManager"
 import { OllamaManager } from './services/OllamaManager'
 import { ProviderStatusRegistry } from './services/ProviderStatusRegistry'
 import { decideToggle, decideDockTransition } from './services/toggleStateReducer'
+import { NativeOomTrace } from './utils/NativeOomTrace'
+
+// Opt-in only: this trace writes allowlisted process metadata and IPC byte estimates
+// for a copied-profile native OOM investigation. It is inert unless explicitly enabled.
+const nativeOomTrace = new NativeOomTrace()
 
 // Valid disguise modes. The persisted setting is untyped on disk and historical
 // builds wrote values that are no longer part of the union (e.g. 'service'),
@@ -1062,6 +1067,23 @@ export class AppState {
   private modeReferenceRetryPromise: Promise<void> | null = null
   private stabilityHeartbeatTimer: NodeJS.Timeout | null = null
   private knowledgeOrchestrator: any = null
+
+  public recordNativeOomTrace(event: string, data: Record<string, unknown> = {}): void {
+    nativeOomTrace.record(event, data)
+  }
+
+  public recordNativeOomOutboundIpc(webContentsId: number, channel: string, args: unknown[]): void {
+    nativeOomTrace.recordOutboundIpc(webContentsId, channel, args)
+  }
+
+  public startNativeOomContentTrace(launcherPid: number): void {
+    void nativeOomTrace.startContentTrace(launcherPid)
+  }
+
+  public stopNativeOomContentTrace(reason: string): void {
+    void nativeOomTrace.stopContentTrace(reason)
+  }
+
   private tray: Tray | null = null
   private updateAvailable: boolean = false
   private updateDownloadState: 'idle' | 'available' | 'downloading' | 'downloaded' = 'idle'
@@ -1686,6 +1708,26 @@ export class AppState {
             .sort((a: any, b: any) => b.rssMB - a.rssMB);
         } catch { /* getAppMetrics unavailable pre-ready — skip */ }
 
+        if (nativeOomTrace.isEnabled()) {
+          nativeOomTrace.sample(
+            mem,
+            (() => {
+              try {
+                return (app.getAppMetrics?.() || []) as unknown as Array<Record<string, unknown>>;
+              } catch {
+                return [];
+              }
+            })(),
+            (() => {
+              const launcher = this.windowHelper?.getLauncherWindow?.();
+              if (!launcher || launcher.isDestroyed()) return undefined;
+              const pid = launcher.webContents.getOSProcessId();
+              return pid > 0 ? { webContentsId: launcher.webContents.id, pid } : undefined;
+            })(),
+            { freeMemory: os.freemem(), totalMemory: os.totalmem() },
+          );
+        }
+
         console.log('[StabilityHeartbeat]', {
           rssMB: mb(mem.rss),
           heapUsedMB: mb(mem.heapUsed),
@@ -1718,6 +1760,7 @@ export class AppState {
   private sendToWindow(win: BrowserWindow | null | undefined, channel: string, ...args: any[]): boolean {
     if (!win || win.isDestroyed()) return false;
     try {
+      nativeOomTrace.recordOutboundIpc(win.webContents.id, channel, args);
       win.webContents.send(channel, ...args);
       return true;
     } catch {
@@ -6794,6 +6837,12 @@ async function initializeApp() {
   // 2. Wait for app to be ready
   logStartupPhase('before-app-whenReady');
   await app.whenReady()
+  nativeOomTrace.initialize()
+  nativeOomTrace.record('app-ready', {
+    pid: process.pid,
+    platform: process.platform,
+    electron: process.versions.electron,
+  })
   logStartupPhase('after-app-whenReady', { userData: app.getPath('userData') });
 
   // 2a. PRE-EMPTIVE dock hide / activation-policy clamp: must happen before ANY
@@ -7201,7 +7250,14 @@ if (process.env.THINKING_MATRIX === '1') {
 
   // Restore Phone Mirror service if it was enabled in a previous session.
   // Failure here is non-fatal — the user can re-enable from Settings.
-  if (SettingsManager.getInstance().get('phoneMirrorEnabled')) {
+  //
+  // DIAGNOSTIC: this is an explicit A/B lever for copied-profile OOM runs only.
+  // It does not alter PhoneMirror's port selection, persisted setting, or normal
+  // startup behavior when unset; it simply prevents the WS server from starting
+  // so the companion extension cannot connect during the isolated comparison.
+  if (process.env.NATIVELY_DISABLE_PHONE_MIRROR === '1') {
+    console.warn('[LeakTest] NATIVELY_DISABLE_PHONE_MIRROR=1 → PhoneMirror WS server NOT started this run');
+  } else if (SettingsManager.getInstance().get('phoneMirrorEnabled')) {
     PhoneMirrorService.getInstance()
       .start({ exposeOnLan: !!SettingsManager.getInstance().get('phoneMirrorExposeOnLan'), persist: false })
       .catch((err) => console.error('[Init] PhoneMirror auto-start failed:', err));
@@ -7386,6 +7442,7 @@ if (process.env.THINKING_MATRIX === '1') {
   }
 
   app.on('will-quit', () => {
+    nativeOomTrace.stop('will-quit');
     stopAppManagedHindsight('will-quit');
     checkpointDatabase('will-quit');
   });

--- a/electron/nativeArchGate.ts
+++ b/electron/nativeArchGate.ts
@@ -33,6 +33,21 @@
  * better-sqlite3.
  */
 (() => {
+  // ESCAPE HATCH: this gate's only failure mode of last resort is a
+  // FALSE POSITIVE — misclassifying a healthy `.node` as wrong-arch and
+  // showing a fatal modal + app.exit(1) BEFORE any window exists, which
+  // permanently locks the user out of boot with no in-app recovery. A
+  // packaging or `file`-classification regression is exactly the kind of
+  // thing that has bricked a shipped build before. NATIVELY_SKIP_ARCH_GATE=1
+  // disables the gate entirely so a false positive can never trap a user;
+  // worst case without the gate is a clear dlopen error later, not a silent
+  // lockout. (The gate remains ON by default — this is a support-desk
+  // "run this and reopen" lever, not a normal-operation flag.)
+  if (process.env.NATIVELY_SKIP_ARCH_GATE === '1') {
+    try { console.warn('[nativeArch] NATIVELY_SKIP_ARCH_GATE=1 — boot arch gate DISABLED'); } catch { /* best-effort */ }
+    return;
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const path = require('path');
   // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/electron/services/__tests__/PhoneMirrorKillSwitch.test.mjs
+++ b/electron/services/__tests__/PhoneMirrorKillSwitch.test.mjs
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const electronRoot = path.resolve(here, '..', '..');
+const mainSource = fs.readFileSync(path.join(electronRoot, 'main.ts'), 'utf8');
+const serviceSource = fs.readFileSync(path.join(electronRoot, 'services', 'PhoneMirrorService.ts'), 'utf8');
+
+test('PhoneMirror diagnostic kill switch guards only startup', () => {
+  const startAt = mainSource.indexOf('PhoneMirrorService.getInstance()\n      .start');
+  const flagAt = mainSource.indexOf("process.env.NATIVELY_DISABLE_PHONE_MIRROR === '1'");
+
+  assert.ok(flagAt >= 0, 'expected NATIVELY_DISABLE_PHONE_MIRROR startup guard');
+  assert.ok(startAt > flagAt, 'expected guard to precede PhoneMirror auto-start');
+  assert.match(mainSource, /NATIVELY_DISABLE_PHONE_MIRROR=1 → PhoneMirror WS server NOT started this run/);
+});
+
+test('PhoneMirror service port behavior remains unchanged', () => {
+  assert.match(serviceSource, /const DEFAULT_PORT = 4123;/);
+  assert.match(serviceSource, /const PORT_PROBE_RANGE = 12;/);
+});

--- a/electron/utils/NativeOomTrace.ts
+++ b/electron/utils/NativeOomTrace.ts
@@ -1,0 +1,305 @@
+import { app, contentTracing } from 'electron';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const TRACE_ENV = 'NATIVELY_NATIVE_OOM_TRACE';
+const CONTENT_TRACE_ENV = 'NATIVELY_NATIVE_OOM_CONTENT_TRACE';
+const MAX_TRACE_BYTES = 5 * 1024 * 1024;
+const CONTENT_TRACE_DURATION_MS = 25_000;
+
+type TraceRecord = Record<string, unknown>;
+type TraceApp = Pick<typeof app, 'getPath'>;
+type TraceContentTracing = Pick<typeof contentTracing, 'startRecording' | 'stopRecording'>;
+
+type IpcLedgerEntry = {
+  messages: number;
+  estimatedBytes: number;
+};
+
+type NativeOomTraceOptions = {
+  enabled?: boolean;
+  contentTraceEnabled?: boolean;
+  electronApp?: TraceApp;
+  tracing?: TraceContentTracing;
+  traceFs?: Pick<typeof fs, 'appendFileSync' | 'existsSync' | 'mkdirSync' | 'statSync'>;
+  now?: () => number;
+  maxTraceBytes?: number;
+};
+
+const SAFE_STRING_FIELDS = new Set([
+  'event',
+  'platform',
+  'electron',
+  'window',
+  'reason',
+  'type',
+  'channel',
+]);
+
+const SAFE_NUMBER_FIELDS = new Set([
+  'schema',
+  'contentTraceRequested',
+  'pid',
+  'webContentsId',
+  'rendererPid',
+  'exitCode',
+  'rss',
+  'heapUsed',
+  'heapTotal',
+  'external',
+  'arrayBuffers',
+  'freeMemory',
+  'totalMemory',
+  'messages',
+  'estimatedBytes',
+  'workingSetSize',
+  'peakWorkingSetSize',
+  'privateBytes',
+  'sharedBytes',
+]);
+
+const SAFE_OBJECT_FIELDS = new Set(['main', 'system', 'launcher', 'processes', 'memory', 'ipc']);
+
+const numericMemory = (memory: Record<string, unknown> | undefined): Record<string, number> => {
+  if (!memory) return {};
+  return Object.fromEntries(
+    Object.entries(memory).filter(([, value]) => typeof value === 'number' && Number.isFinite(value)),
+  ) as Record<string, number>;
+};
+
+const estimateValueBytes = (value: unknown, depth = 0): number => {
+  if (depth > 4 || value == null) return 0;
+  if (typeof value === 'string') return Buffer.byteLength(value, 'utf8');
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') return 8;
+  if (Buffer.isBuffer(value) || value instanceof Uint8Array) return value.byteLength;
+  if (Array.isArray(value)) {
+    return value.slice(0, 64).reduce<number>((total, item) => total + estimateValueBytes(item, depth + 1), 0);
+  }
+  if (typeof value === 'object') {
+    return Object.values(value as Record<string, unknown>)
+      .slice(0, 64)
+      .reduce<number>((total, item) => total + estimateValueBytes(item, depth + 1), 0);
+  }
+  return 0;
+};
+
+const sanitizeTraceData = (data: TraceRecord): TraceRecord => {
+  const sanitized: TraceRecord = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (SAFE_STRING_FIELDS.has(key) && typeof value === 'string') {
+      sanitized[key] = value.slice(0, 100);
+      continue;
+    }
+    if (SAFE_NUMBER_FIELDS.has(key) && typeof value === 'number' && Number.isFinite(value)) {
+      sanitized[key] = value;
+      continue;
+    }
+    if (SAFE_OBJECT_FIELDS.has(key)) {
+      if (Array.isArray(value)) {
+        sanitized[key] = value.slice(0, 128).map((item) =>
+          item && typeof item === 'object' ? sanitizeTraceData(item as TraceRecord) : null,
+        );
+      } else if (value && typeof value === 'object') {
+        sanitized[key] = sanitizeTraceData(value as TraceRecord);
+      }
+    }
+  }
+  return sanitized;
+};
+
+/**
+ * Opt-in, local-only attribution for a native Browser/renderer OOM.
+ *
+ * Records only allowlisted process/window metadata and IPC channel byte estimates.
+ * Payload values are never written to disk. Content tracing is separately opt-in,
+ * uses Chromium's argument filter, and is capped to one 25-second capture.
+ */
+export class NativeOomTrace {
+  private readonly enabled: boolean;
+  private readonly contentTraceEnabled: boolean;
+  private readonly electronApp: TraceApp;
+  private readonly tracing: TraceContentTracing;
+  private readonly traceFs: Pick<typeof fs, 'appendFileSync' | 'existsSync' | 'mkdirSync' | 'statSync'>;
+  private readonly now: () => number;
+  private readonly maxTraceBytes: number;
+  private readonly ledger = new Map<string, IpcLedgerEntry>();
+  private tracePath: string | null = null;
+  private contentTracePath: string | null = null;
+  private contentTraceTimer: NodeJS.Timeout | null = null;
+  private contentTraceRunning = false;
+  private contentTraceStarted = false;
+  private stopped = false;
+
+  constructor(options: NativeOomTraceOptions = {}) {
+    this.enabled = options.enabled ?? process.env[TRACE_ENV] === '1';
+    this.contentTraceEnabled = options.contentTraceEnabled ?? process.env[CONTENT_TRACE_ENV] === '1';
+    this.electronApp = options.electronApp ?? app;
+    this.tracing = options.tracing ?? contentTracing;
+    this.traceFs = options.traceFs ?? fs;
+    this.now = options.now ?? Date.now;
+    this.maxTraceBytes = options.maxTraceBytes ?? MAX_TRACE_BYTES;
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  initialize(): void {
+    if (!this.enabled || this.tracePath) return;
+    try {
+      const dir = path.join(this.electronApp.getPath('userData'), 'diagnostics');
+      this.traceFs.mkdirSync(dir, { recursive: true });
+      this.tracePath = path.join(dir, `native-oom-${this.now()}-${process.pid}.ndjson`);
+      this.write('session-start', {
+        schema: 1,
+        contentTraceRequested: this.contentTraceEnabled ? 1 : 0,
+        pid: process.pid,
+        platform: process.platform,
+        electron: process.versions.electron,
+      });
+      console.warn(`[NativeOomTrace] enabled; metadata trace: ${this.tracePath}`);
+    } catch (error: any) {
+      console.warn('[NativeOomTrace] failed to initialize:', error?.message || error);
+    }
+  }
+
+  record(event: string, data: TraceRecord = {}): void {
+    if (!this.enabled || this.stopped) return;
+    this.write(event, data);
+  }
+
+  sample(
+    mainMemory: NodeJS.MemoryUsage,
+    metrics: Array<Record<string, unknown>>,
+    launcher?: { webContentsId: number; pid: number },
+    system?: { freeMemory: number; totalMemory: number },
+  ): void {
+    if (!this.enabled || this.stopped) return;
+    const processes = metrics.map((metric) => ({
+      type: typeof metric.type === 'string' ? metric.type : 'unknown',
+      pid: typeof metric.pid === 'number' ? metric.pid : 0,
+      memory: numericMemory(metric.memory as Record<string, unknown> | undefined),
+    }));
+    this.write('sample', {
+      main: {
+        rss: mainMemory.rss,
+        heapUsed: mainMemory.heapUsed,
+        heapTotal: mainMemory.heapTotal,
+        external: mainMemory.external,
+        arrayBuffers: mainMemory.arrayBuffers,
+      },
+      system: system ?? {},
+      launcher: launcher ?? {},
+      processes,
+      ipc: this.ledgerSnapshot(),
+    });
+  }
+
+  recordOutboundIpc(webContentsId: number, channel: string, args: unknown[]): void {
+    if (!this.enabled || this.stopped) return;
+    const key = `${webContentsId}:${channel}`;
+    const entry = this.ledger.get(key) ?? { messages: 0, estimatedBytes: 0 };
+    entry.messages += 1;
+    entry.estimatedBytes += args.reduce<number>((total, arg) => total + estimateValueBytes(arg), 0);
+    this.ledger.set(key, entry);
+  }
+
+  async startContentTrace(launcherPid: number): Promise<void> {
+    if (
+      !this.enabled ||
+      !this.contentTraceEnabled ||
+      this.contentTraceRunning ||
+      this.contentTraceStarted ||
+      this.stopped ||
+      launcherPid <= 0
+    ) {
+      return;
+    }
+    this.contentTraceStarted = true;
+    try {
+      const dir = path.join(this.electronApp.getPath('userData'), 'diagnostics');
+      this.traceFs.mkdirSync(dir, { recursive: true });
+      this.contentTracePath = path.join(dir, `native-oom-content-${this.now()}-${process.pid}.json`);
+      await this.tracing.startRecording({
+        included_categories: [
+          'electron',
+          'memory-infra',
+          'disabled-by-default-memory-infra',
+          'disabled-by-default-memory-infra.v8.code_stats',
+          'mojom',
+          'toplevel',
+          'cc',
+          'gpu',
+          'renderer.scheduler',
+        ],
+        included_process_ids: [process.pid, launcherPid],
+        enable_argument_filter: true,
+        recording_mode: 'record-until-full',
+        trace_buffer_size_in_kb: 16 * 1024,
+      });
+      this.contentTraceRunning = true;
+      this.write('content-trace-started', { rendererPid: launcherPid });
+      console.warn(`[NativeOomTrace] Chromium content trace started; will stop in ${CONTENT_TRACE_DURATION_MS / 1000}s`);
+      this.contentTraceTimer = setTimeout(() => void this.stopContentTrace('timeout'), CONTENT_TRACE_DURATION_MS);
+      this.contentTraceTimer.unref?.();
+      if (this.stopped) await this.stopContentTrace('session-stop-during-start');
+    } catch (error: any) {
+      this.write('content-trace-start-failed', { reason: 'start-failed' });
+      console.warn('[NativeOomTrace] content trace start failed:', error?.message || error);
+    }
+  }
+
+  async stopContentTrace(reason: string): Promise<void> {
+    if (!this.contentTraceRunning) return;
+    this.contentTraceRunning = false;
+    if (this.contentTraceTimer) {
+      clearTimeout(this.contentTraceTimer);
+      this.contentTraceTimer = null;
+    }
+    try {
+      await this.tracing.stopRecording(this.contentTracePath || undefined);
+      this.write('content-trace-stopped', { reason });
+      console.warn(`[NativeOomTrace] Chromium content trace saved: ${this.contentTracePath}`);
+    } catch (error: any) {
+      this.write('content-trace-stop-failed', { reason: 'stop-failed' });
+      console.warn('[NativeOomTrace] content trace stop failed:', error?.message || error);
+    }
+  }
+
+  stop(reason: string): void {
+    if (!this.enabled || this.stopped) return;
+    this.write('session-stop', { reason });
+    void this.stopContentTrace(reason);
+    this.stopped = true;
+  }
+
+  private ledgerSnapshot(): Array<{ webContentsId: number; channel: string; messages: number; estimatedBytes: number }> {
+    const snapshot = [...this.ledger.entries()].map(([key, value]) => {
+      const separator = key.indexOf(':');
+      return {
+        webContentsId: Number(key.slice(0, separator)),
+        channel: key.slice(separator + 1),
+        ...value,
+      };
+    });
+    // Each sample reports the preceding heartbeat interval. Clearing here keeps
+    // the opt-in diagnostic itself bounded even across long-running sessions or
+    // repeated renderer recovery (new webContents IDs).
+    this.ledger.clear();
+    return snapshot;
+  }
+
+  private write(event: string, data: TraceRecord): void {
+    if (!this.tracePath) return;
+    try {
+      if (this.traceFs.existsSync(this.tracePath) && this.traceFs.statSync(this.tracePath).size >= this.maxTraceBytes) return;
+      const safe = sanitizeTraceData(data);
+      this.traceFs.appendFileSync(
+        this.tracePath,
+        `${JSON.stringify({ at: new Date().toISOString(), event, ...safe})}\n`,
+      );
+    } catch {
+      // Diagnostics must not affect the product or an OOM path.
+    }
+  }
+}

--- a/electron/utils/NativeOomTrace.ts
+++ b/electron/utils/NativeOomTrace.ts
@@ -6,6 +6,8 @@ const TRACE_ENV = 'NATIVELY_NATIVE_OOM_TRACE';
 const CONTENT_TRACE_ENV = 'NATIVELY_NATIVE_OOM_CONTENT_TRACE';
 const MAX_TRACE_BYTES = 5 * 1024 * 1024;
 const CONTENT_TRACE_DURATION_MS = 25_000;
+const CONTENT_TRACE_RSS_DELTA_BYTES = 512 * 1024 * 1024;
+const CONTENT_TRACE_RSS_MULTIPLIER = 2;
 
 type TraceRecord = Record<string, unknown>;
 type TraceApp = Pick<typeof app, 'getPath'>;
@@ -39,6 +41,8 @@ const SAFE_STRING_FIELDS = new Set([
 const SAFE_NUMBER_FIELDS = new Set([
   'schema',
   'contentTraceRequested',
+  'baselineRss',
+  'triggerRss',
   'pid',
   'webContentsId',
   'rendererPid',
@@ -128,6 +132,8 @@ export class NativeOomTrace {
   private contentTraceTimer: NodeJS.Timeout | null = null;
   private contentTraceRunning = false;
   private contentTraceStarted = false;
+  private baselineRss: number | null = null;
+  private armedLauncherPid: number | null = null;
   private stopped = false;
 
   constructor(options: NativeOomTraceOptions = {}) {
@@ -180,6 +186,25 @@ export class NativeOomTrace {
       pid: typeof metric.pid === 'number' ? metric.pid : 0,
       memory: numericMemory(metric.memory as Record<string, unknown> | undefined),
     }));
+    const launcherPid = launcher?.pid ?? this.armedLauncherPid;
+    if (this.baselineRss === null && mainMemory.rss > 0) {
+      this.baselineRss = mainMemory.rss;
+      this.write('rss-baseline', { baselineRss: this.baselineRss, rendererPid: launcherPid ?? 0 });
+    } else if (
+      this.baselineRss !== null &&
+      this.armedLauncherPid &&
+      mainMemory.rss >= Math.max(
+        this.baselineRss + CONTENT_TRACE_RSS_DELTA_BYTES,
+        this.baselineRss * CONTENT_TRACE_RSS_MULTIPLIER,
+      )
+    ) {
+      this.write('rss-growth-threshold-crossed', {
+        baselineRss: this.baselineRss,
+        triggerRss: mainMemory.rss,
+        rendererPid: this.armedLauncherPid,
+      });
+      void this.startContentTrace(this.armedLauncherPid);
+    }
     this.write('sample', {
       main: {
         rss: mainMemory.rss,
@@ -202,6 +227,17 @@ export class NativeOomTrace {
     entry.messages += 1;
     entry.estimatedBytes += args.reduce<number>((total, arg) => total + estimateValueBytes(arg), 0);
     this.ledger.set(key, entry);
+  }
+
+  /**
+   * Arm a bounded Chromium capture for the first meaningful native RSS jump.
+   * Starting a fixed 25-second trace at first paint missed the historical leak,
+   * which accumulated several minutes later in a healthy Vite session.
+   */
+  armContentTrace(launcherPid: number): void {
+    if (!this.enabled || !this.contentTraceEnabled || this.stopped || launcherPid <= 0) return;
+    this.armedLauncherPid = launcherPid;
+    this.write('content-trace-armed', { rendererPid: launcherPid });
   }
 
   async startContentTrace(launcherPid: number): Promise<void> {

--- a/electron/utils/__tests__/NativeOomTrace.test.mjs
+++ b/electron/utils/__tests__/NativeOomTrace.test.mjs
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const source = fs.readFileSync(path.resolve(here, '..', 'NativeOomTrace.ts'), 'utf8');
+
+test('native OOM trace is explicitly opt-in and bounded', () => {
+  assert.match(source, /NATIVELY_NATIVE_OOM_TRACE/);
+  assert.match(source, /NATIVELY_NATIVE_OOM_CONTENT_TRACE/);
+  assert.match(source, /MAX_TRACE_BYTES = 5 \* 1024 \* 1024/);
+  assert.match(source, /CONTENT_TRACE_DURATION_MS = 25_000/);
+  assert.match(source, /trace_buffer_size_in_kb: 16 \* 1024/);
+});
+
+test('native OOM trace allowlist excludes payload text and credentials', () => {
+  assert.match(source, /const SAFE_STRING_FIELDS/);
+  assert.match(source, /const SAFE_NUMBER_FIELDS/);
+  assert.match(source, /const SAFE_OBJECT_FIELDS/);
+  assert.doesNotMatch(source, /'text'/);
+  assert.doesNotMatch(source, /'prompt'/);
+  assert.doesNotMatch(source, /'apiKey'/);
+  assert.match(source, /Payload values are never written to disk/);
+});
+
+test('native OOM trace records only estimated IPC payload sizes', () => {
+  assert.match(source, /recordOutboundIpc\(webContentsId: number, channel: string, args: unknown\[\]\)/);
+  assert.match(source, /estimatedBytes/);
+  assert.match(source, /estimateValueBytes/);
+  assert.match(source, /ipc: this\.ledgerSnapshot\(\)/);
+});
+
+test('native OOM trace clears its interval IPC ledger after each sample', () => {
+  assert.match(source, /this\.ledger\.clear\(\)/);
+  assert.match(source, /Each sample reports the preceding heartbeat interval/);
+});

--- a/electron/utils/__tests__/NativeOomTrace.test.mjs
+++ b/electron/utils/__tests__/NativeOomTrace.test.mjs
@@ -36,3 +36,10 @@ test('native OOM trace clears its interval IPC ledger after each sample', () => 
   assert.match(source, /this\.ledger\.clear\(\)/);
   assert.match(source, /Each sample reports the preceding heartbeat interval/);
 });
+
+test('native OOM trace arms content tracing only after a bounded RSS-growth threshold', () => {
+  assert.match(source, /CONTENT_TRACE_RSS_DELTA_BYTES = 512 \* 1024 \* 1024/);
+  assert.match(source, /CONTENT_TRACE_RSS_MULTIPLIER = 2/);
+  assert.match(source, /armContentTrace\(launcherPid: number\)/);
+  assert.match(source, /rss-growth-threshold-crossed/);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,6 +137,15 @@ const App: React.FC = () => {
 
   // State
   const [showStartup, setShowStartup] = useState(true);
+  // Stable identity: StartupSequence arms its dismissal timers in a
+  // useEffect(deps:[onComplete]). An inline closure would be a new identity on
+  // every App re-render — and the boot path re-renders many times (7-10 async
+  // IPCs each setState on resolve, plus orchestrator notifies). That would tear
+  // down and re-arm BOTH the 2.2s primary AND the 5s hard-cap timer on every
+  // render, so under a slow/re-render-heavy boot the hard-cap could keep
+  // resetting and never fire — the "stuck at the startup animation" symptom.
+  // Memoizing to [] makes the splash timers arm exactly once.
+  const dismissStartup = useCallback(() => setShowStartup(false), []);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [settingsInitialTab, setSettingsInitialTab] = useState<string>('general');
   const [isModesOpen, setIsModesOpen] = useState(false);
@@ -820,7 +829,7 @@ const App: React.FC = () => {
             animate={{ opacity: 1, scale: 1, transition: { duration: 0.5, ease: [0.23, 1, 0.32, 1] } }}
             exit={{ opacity: 0, scale: 1.04, pointerEvents: "none", transition: { duration: 0.55, ease: [0.4, 0, 0.2, 1] } }}
           >
-            <StartupSequence onComplete={() => setShowStartup(false)} />
+            <StartupSequence onComplete={dismissStartup} />
           </motion.div>
         ) : (
           <motion.div

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,7 +76,7 @@ function shouldMountDevReviewHost(): boolean {
 const queryClient = new QueryClient()
 const CropperWindow = React.lazy(() => import('./components/Cropper'))
 
-type LauncherIsolation = 'onboarding' | 'global-surfaces' | null
+type LauncherIsolation = 'onboarding' | 'global-surfaces' | 'permissions-toaster' | 'no-modals' | null
 
 // The Electron main process only appends `isolate` during an explicit dev-mode
 // native-OOM run. Keeping this query-driven and default-off makes it impossible
@@ -85,7 +85,7 @@ function getLauncherIsolation(): LauncherIsolation {
   try {
     if (!(import.meta as any)?.env?.DEV) return null
     const isolate = new URLSearchParams(window.location.search).get('isolate')
-    return isolate === 'onboarding' || isolate === 'global-surfaces' ? isolate : null
+    return isolate === 'onboarding' || isolate === 'global-surfaces' || isolate === 'permissions-toaster' || isolate === 'no-modals' ? isolate : null
   } catch {
     return null
   }
@@ -114,6 +114,8 @@ const App: React.FC = () => {
   const isCropperWindow = new URLSearchParams(window.location.search).get('window') === 'cropper';
   const launcherIsolation = getLauncherIsolation();
   const isolateOnboarding = launcherIsolation === 'onboarding' || launcherIsolation === 'global-surfaces';
+  const isolatePermissionsToaster = launcherIsolation === 'permissions-toaster';
+  const isolateModals = launcherIsolation === 'no-modals' || launcherIsolation === 'global-surfaces';
   const isolateGlobalSurfaces = launcherIsolation === 'global-surfaces';
 
   // Default to launcher if not specified (dev mode safety)
@@ -1060,7 +1062,7 @@ const App: React.FC = () => {
       )}
 
       {/* Post-trial upgrade modal — shown when trial expires */}
-      {!isolateGlobalSurfaces && (isLauncherWindow || isDefault) && showTrialExpiredModal && (
+      {!isolateModals && (isLauncherWindow || isDefault) && showTrialExpiredModal && (
         <FreeTrialModal
           usage={activeTrial?.usage ?? { ai: 0, stt_seconds: 0, search: 0 }}
           onByok={async () => {
@@ -1080,14 +1082,14 @@ const App: React.FC = () => {
       )}
 
       {/* Ad toasters */}
-      {!isolateGlobalSurfaces && isLauncherMainView && !isSettingsOpen && (
+      {!isolateModals && isLauncherMainView && !isSettingsOpen && (
         <NativelyApiPromoToaster
           isOpen={activeAd === 'natively_api'}
           onDismiss={() => dismissAd('natively_api')}
           onOpenSettings={(tab: string) => openSettingsExclusive(tab)}
         />
       )}
-      {!isolateGlobalSurfaces && isLauncherMainView && (
+      {!isolateModals && isLauncherMainView && (
         <>
           <ProfileFeatureToaster
             isOpen={activeAd === 'profile'}
@@ -1124,7 +1126,7 @@ const App: React.FC = () => {
         </>
       )}
 
-      <PremiumUpgradeModal
+      {!isolateModals && <PremiumUpgradeModal
         isOpen={showPremiumModal}
         onClose={() => setShowPremiumModal(false)}
         isPremium={isPremiumActive}
@@ -1144,7 +1146,7 @@ const App: React.FC = () => {
           }, 300);
         }}
         onDeactivated={() => { setIsPremiumActive(false); setPlanDetails({ isPremium: false }); }}
-      />
+      />}
     </div>
     </ErrorBoundary>
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,6 +76,21 @@ function shouldMountDevReviewHost(): boolean {
 const queryClient = new QueryClient()
 const CropperWindow = React.lazy(() => import('./components/Cropper'))
 
+type LauncherIsolation = 'onboarding' | 'global-surfaces' | null
+
+// The Electron main process only appends `isolate` during an explicit dev-mode
+// native-OOM run. Keeping this query-driven and default-off makes it impossible
+// for packaged launcher sessions to lose product surfaces accidentally.
+function getLauncherIsolation(): LauncherIsolation {
+  try {
+    if (!(import.meta as any)?.env?.DEV) return null
+    const isolate = new URLSearchParams(window.location.search).get('isolate')
+    return isolate === 'onboarding' || isolate === 'global-surfaces' ? isolate : null
+  } catch {
+    return null
+  }
+}
+
 // TEMPORARY LEAK-DIAGNOSIS (2026-07-10): the Windows native-RSS climb is a
 // non-JS (flat V8 heap) leak in the launcher renderer + main in lockstep,
 // GPU-process-independent — consistent with CPU-composited backdrop-filter /
@@ -97,6 +112,9 @@ const App: React.FC = () => {
   const isOverlayWindow = new URLSearchParams(window.location.search).get('window') === 'overlay';
   const isModelSelectorWindow = new URLSearchParams(window.location.search).get('window') === 'model-selector';
   const isCropperWindow = new URLSearchParams(window.location.search).get('window') === 'cropper';
+  const launcherIsolation = getLauncherIsolation();
+  const isolateOnboarding = launcherIsolation === 'onboarding' || launcherIsolation === 'global-surfaces';
+  const isolateGlobalSurfaces = launcherIsolation === 'global-surfaces';
 
   // Default to launcher if not specified (dev mode safety)
   const isDefault = !isSettingsWindow && !isOverlayWindow && !isModelSelectorWindow && !isCropperWindow;
@@ -260,8 +278,8 @@ const App: React.FC = () => {
     // entirely — no drain loop, no toasters. Lets the same build A/B the
     // orchestrator ON vs OFF to confirm/deny the 2026-07-04 native-leak
     // regression in the field. Remove once the leak fix is field-verified.
-    if (new URLSearchParams(window.location.search).get('noorch') === '1') {
-      console.warn('[LeakTest] ?noorch=1 → onboarding orchestrator DISABLED (orch.start skipped)');
+    if (new URLSearchParams(window.location.search).get('noorch') === '1' || isolateOnboarding) {
+      console.warn(`[LeakTest] onboarding orchestrator disabled (${isolateOnboarding ? 'launcher isolation' : '?noorch=1'})`);
       return;
     }
     let cancelled = false;
@@ -295,7 +313,7 @@ const App: React.FC = () => {
       cancelled = true;
       stopFn?.();
     };
-  }, [isLauncherWindow, isDefault]);
+  }, [isLauncherWindow, isDefault, isolateOnboarding]);
 
   // Push user-state patches to the orchestrator as plan/profile state evolves.
   useEffect(() => {
@@ -819,7 +837,7 @@ const App: React.FC = () => {
   return (
     <ErrorBoundary context="Launcher">
     <div className="h-full min-h-0 w-full relative bg-transparent">
-      <HindsightStatusBanner />
+      {!isolateGlobalSurfaces && <HindsightStatusBanner />}
       <AnimatePresence>
         {showStartup ? (
           <motion.div
@@ -1015,23 +1033,25 @@ const App: React.FC = () => {
         )}
       </AnimatePresence>
 
-      <UpdateBanner />
-      <NativelyQuotaBanner />
+      {!isolateGlobalSurfaces && <UpdateBanner />}
+      {!isolateGlobalSurfaces && <NativelyQuotaBanner />}
 
       {/* Orchestrated onboarding toasters (single-slot, controlled by OnboardingOrchestrator) */}
-      <OrchestratorProvider>
-        <OrchestratedToasterHost />
-      </OrchestratorProvider>
+      {!isolateOnboarding && (
+        <OrchestratorProvider>
+          <OrchestratedToasterHost />
+        </OrchestratorProvider>
+      )}
 
       {/* DEV-ONLY: direct ReviewPromptHost mount for iterating on the modal UX.
           Gated on import.meta.env.DEV plus the same opt-in flags the host
           already respects (?review=force, window.__reviewForceShow). When
           active, this bypasses the orchestrator entirely so the persisted
           onboarding ledger is not modified. */}
-      {shouldMountDevReviewHost() && <ReviewPromptHost />}
+      {!isolateGlobalSurfaces && shouldMountDevReviewHost() && <ReviewPromptHost />}
 
       {/* Free trial countdown banner — only in launcher window while trial is active */}
-      {(isLauncherWindow || isDefault) && activeTrial && (
+      {!isolateGlobalSurfaces && (isLauncherWindow || isDefault) && activeTrial && (
         <FreeTrialBanner
           expiresAt={activeTrial.expiresAt}
           usage={activeTrial.usage}
@@ -1040,7 +1060,7 @@ const App: React.FC = () => {
       )}
 
       {/* Post-trial upgrade modal — shown when trial expires */}
-      {(isLauncherWindow || isDefault) && showTrialExpiredModal && (
+      {!isolateGlobalSurfaces && (isLauncherWindow || isDefault) && showTrialExpiredModal && (
         <FreeTrialModal
           usage={activeTrial?.usage ?? { ai: 0, stt_seconds: 0, search: 0 }}
           onByok={async () => {
@@ -1060,14 +1080,14 @@ const App: React.FC = () => {
       )}
 
       {/* Ad toasters */}
-      {isLauncherMainView && !isSettingsOpen && (
+      {!isolateGlobalSurfaces && isLauncherMainView && !isSettingsOpen && (
         <NativelyApiPromoToaster
           isOpen={activeAd === 'natively_api'}
           onDismiss={() => dismissAd('natively_api')}
           onOpenSettings={(tab: string) => openSettingsExclusive(tab)}
         />
       )}
-      {isLauncherMainView && (
+      {!isolateGlobalSurfaces && isLauncherMainView && (
         <>
           <ProfileFeatureToaster
             isOpen={activeAd === 'profile'}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -246,6 +246,15 @@ const App: React.FC = () => {
   // mounted.
   useEffect(() => {
     if (!isLauncherWindow && !isDefault) return;
+    // A/B KILL-SWITCH (2026-07-10): ?noorch=1 (set by WindowHelper when
+    // NATIVELY_DISABLE_ONBOARDING_ORCH=1) skips the onboarding orchestrator
+    // entirely — no drain loop, no toasters. Lets the same build A/B the
+    // orchestrator ON vs OFF to confirm/deny the 2026-07-04 native-leak
+    // regression in the field. Remove once the leak fix is field-verified.
+    if (new URLSearchParams(window.location.search).get('noorch') === '1') {
+      console.warn('[LeakTest] ?noorch=1 → onboarding orchestrator DISABLED (orch.start skipped)');
+      return;
+    }
     let cancelled = false;
     let stopFn: (() => void) | null = null;
     // Explicit `.ts` extensions here for the same reason as the static

--- a/src/components/StartupSequence.tsx
+++ b/src/components/StartupSequence.tsx
@@ -7,10 +7,21 @@ interface StartupSequenceProps {
 }
 
 const StartupSequence: React.FC<StartupSequenceProps> = ({ onComplete }) => {
+    // Keep the latest onComplete in a ref so the timer effect can depend on []
+    // and arm EXACTLY ONCE for the splash's lifetime. If the effect depended on
+    // `onComplete` directly, an un-memoized caller (a new closure per parent
+    // re-render) would tear down and re-arm both timers on every render — and
+    // the boot path re-renders many times — so the 5s hard-cap safety net could
+    // keep resetting and never fire, trapping the user at the black splash. The
+    // ref makes the safety net immune to prop-identity churn regardless of how
+    // the caller passes onComplete.
+    const onCompleteRef = React.useRef(onComplete);
+    onCompleteRef.current = onComplete;
+
     useEffect(() => {
         // Primary dismiss at 2.2s (matches the logo animation length).
         const timer = setTimeout(() => {
-            onComplete();
+            onCompleteRef.current();
         }, 2200);
         // Hard-cap safety net: no matter what, the splash must never persist past
         // 5s. If the primary timer's onComplete is ever prevented from advancing
@@ -19,13 +30,16 @@ const StartupSequence: React.FC<StartupSequenceProps> = ({ onComplete }) => {
         // black logo — the "stuck at logo" failure mode. Idempotent: onComplete
         // just flips showStartup=false, so a double-call is harmless.
         const hardCap = setTimeout(() => {
-            try { onComplete(); } catch { /* never let the splash trap the user */ }
+            try { onCompleteRef.current(); } catch { /* never let the splash trap the user */ }
         }, 5000);
         return () => {
             clearTimeout(timer);
             clearTimeout(hardCap);
         };
-    }, [onComplete]);
+        // Mount-once: arm the dismissal timers a single time. onComplete is read
+        // through onCompleteRef so it is intentionally NOT a dependency.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     return (
         <div className="fixed inset-0 z-[100] bg-[#000000] flex items-center justify-center overflow-hidden">

--- a/src/components/onboarding/OrchestratedToasterHost.tsx
+++ b/src/components/onboarding/OrchestratedToasterHost.tsx
@@ -77,8 +77,21 @@ export const OrchestratedToasterHost: React.FC = () => {
 
   if (!activeId) return null;
 
+  // Development-only native-OOM bisection. Keep orchestration/state updates
+  // alive but exclude every visible onboarding modal, which distinguishes the
+  // host's scheduling work from the currently-active modal implementation.
+  if (new URLSearchParams(window.location.search).get('isolate') === 'no-modals') {
+    return null;
+  }
+
   switch (activeId) {
     case 'permissions':
+      // Dev-only native-OOM bisection: keep the orchestrator and every later
+      // stage active while excluding only the permissions card's animated,
+      // backdrop-filter-heavy visual guide.
+      if (new URLSearchParams(window.location.search).get('isolate') === 'permissions-toaster') {
+        return null;
+      }
       return (
         <PermissionsToaster
           isOpen={true}

--- a/src/lib/onboarding/__tests__/orchestratorClass.test.mjs
+++ b/src/lib/onboarding/__tests__/orchestratorClass.test.mjs
@@ -290,7 +290,7 @@ test('LEAK GUARD: the drain loop uses setTimeout, never requestAnimationFrame', 
   // the drain loop is timer-based.
 });
 
-test('LEAK GUARD: the drain loop STOPS scheduling once every stage is resolved', () => {
+test('LEAK GUARD: the deadline scheduler STOPS scheduling once every stage is resolved', () => {
   localStorage.clear();
   timerQueue = [];
   mockNow = 0;
@@ -325,21 +325,20 @@ test('LEAK GUARD: the drain loop STOPS scheduling once every stage is resolved',
   assert.ok(drainIsIdle(), 'drain loop must stay idle with no new events');
 });
 
-test('LEAK GUARD: a state-change event re-arms the drain loop after it went idle', () => {
+test('LEAK GUARD: an event re-arms the deadline scheduler after it went idle', () => {
   localStorage.clear();
   timerQueue = [];
   mockNow = 0;
 
   const orch = new OnboardingOrchestrator();
   orch.start(STAGES);
-  // Not foreground yet → shouldEvaluate() is false, but there IS pending work,
-  // so the loop stays armed. Drain the initial ticks.
+  // Not foreground yet → there is no time deadline that can be acted on, so
+  // the scheduler must stay idle until an eligibility event arrives.
   let guard = 0;
   while (!drainIsIdle() && guard < 5) { flushOneFrame(); guard += 1; }
 
-  // Backgrounded with pending work: the loop keeps a single armed timer (it must
-  // not busy-loop, but it must not permanently give up either). Now deliver a
-  // foreground + mount + duration so permissions becomes eligible.
+  // Now deliver foreground + mount + duration so permissions becomes eligible.
+  // notify() must schedule one evaluation pass without recreating a poll loop.
   orch.emit({ type: 'launcher:mounted' });
   orch.emit({ type: 'foreground:change', isForeground: true });
   orch.emit({
@@ -357,4 +356,30 @@ test('LEAK GUARD: a state-change event re-arms the drain loop after it went idle
     guard += 1;
   }
   assert.ok(raised, 'a state-change event must re-arm the loop and let a newly-eligible stage fire');
+});
+
+test('LEAK GUARD: event-gated stages do not leave a polling timer armed', () => {
+  localStorage.clear();
+  timerQueue = [];
+  mockNow = 0;
+
+  const orch = new OnboardingOrchestrator();
+  orch.start([{
+    id: 'permissions',
+    order: 1,
+    triggers: { requiresHomepageMounted: true, requiresForeground: true, requiresTurnCount: 1 },
+  }]);
+  orch.emit({ type: 'launcher:mounted' });
+  orch.emit({ type: 'foreground:change', isForeground: true });
+
+  assert.ok(
+    drainIsIdle(),
+    'a stage blocked only on a future event must not wake the renderer on a polling timer',
+  );
+
+  orch.emit({ type: 'turn:done' });
+  assert.equal(timerQueue.length, 1, 'the qualifying event must schedule exactly one evaluation');
+  flushOneFrame();
+  assert.equal(orch.getSnapshot().activeToasterId, 'permissions');
+  assert.ok(drainIsIdle(), 'an active toaster must not keep a scheduler timer alive');
 });

--- a/src/lib/onboarding/__tests__/orchestratorClass.test.mjs
+++ b/src/lib/onboarding/__tests__/orchestratorClass.test.mjs
@@ -34,12 +34,22 @@ const STAGES_TS = join(__dirname, '..', 'stageCatalog.ts');
 
 // ── DOM polyfills the orchestrator class touches ───────────────────────────
 // A manual RAF queue: scheduleTick() recurses (tick → scheduleTick), so a
-// synchronous RAF would infinitely recurse. Instead we buffer callbacks and
-// flush exactly one frame at a time from the test, which is enough to run one
+// synchronous timer would infinitely recurse. Instead we buffer callbacks and
+// flush exactly one tick at a time from the test, which is enough to run one
 // evaluate/dispatch pass deterministically.
-let rafQueue = [];
-let rafId = 0;
+//
+// NATIVE-LEAK FIX (2026-07-10): the drain loop is now a self-terminating
+// setTimeout, NOT a per-frame requestAnimationFrame (the perpetual rAF was the
+// native memory leak — see orchestrator.ts scheduleTick note). A rAF polyfill
+// is intentionally NOT installed: if the class ever regresses to
+// requestAnimationFrame it throws ("requestAnimationFrame is not defined"),
+// which is the regression guard we want.
+let timerQueue = [];
+let timerSeq = 0;
 let mockNow = 0;
+
+const realSetTimeout = globalThis.setTimeout;
+const realClearTimeout = globalThis.clearTimeout;
 
 function installPolyfills() {
   const store = new Map();
@@ -49,29 +59,46 @@ function installPolyfills() {
     removeItem: (k) => store.delete(k),
     clear: () => store.clear(),
   };
-  globalThis.requestAnimationFrame = (cb) => {
-    const id = ++rafId;
-    rafQueue.push({ id, cb });
+  globalThis.performance = { now: () => mockNow };
+  // Deliberately NO requestAnimationFrame — the orchestrator must never use it
+  // again (the perpetual rAF loop was the leak). Manual setTimeout queue so the
+  // mock clock drives the drain cadence deterministically.
+  delete globalThis.requestAnimationFrame;
+  delete globalThis.cancelAnimationFrame;
+  globalThis.setTimeout = (cb, _ms) => {
+    const id = ++timerSeq;
+    timerQueue.push({ id, cb });
     return id;
   };
-  globalThis.cancelAnimationFrame = (id) => {
-    rafQueue = rafQueue.filter((e) => e.id !== id);
+  globalThis.clearTimeout = (id) => {
+    timerQueue = timerQueue.filter((e) => e.id !== id);
   };
-  globalThis.performance = { now: () => mockNow };
+}
+
+// eslint-disable-next-line no-unused-vars
+function restoreTimers() {
+  globalThis.setTimeout = realSetTimeout;
+  globalThis.clearTimeout = realClearTimeout;
 }
 
 /**
- * Run exactly one buffered RAF frame. The orchestrator's scheduleTick() does
- * `tick(); scheduleTick();`, so each callback runs one evaluate/dispatch pass
- * and re-queues exactly one follow-up frame. We snapshot the currently-pending
- * callbacks and run only those — the re-scheduled follow-up stays queued for
- * the NEXT flush, preserving the self-perpetuating RAF loop (clearing it would
- * silently stop the drain loop and mask re-raise bugs).
+ * Run exactly one buffered drain tick. The orchestrator's tick() runs one
+ * evaluate/dispatch pass and then calls ensureDraining(), which re-arms exactly
+ * one follow-up timer IFF there is still unresolved work. We snapshot the
+ * currently-pending callbacks and run only those — a re-armed follow-up stays
+ * queued for the NEXT flush. When the queue drains fully, ensureDraining stops
+ * scheduling, timerQueue goes empty, and flushOneFrame becomes a no-op: that
+ * self-termination is the leak fix (the loop no longer runs forever).
  */
 function flushOneFrame() {
-  const pending = rafQueue;
-  rafQueue = [];
+  const pending = timerQueue;
+  timerQueue = [];
   for (const { cb } of pending) cb();
+}
+
+/** True once the drain loop has stopped re-scheduling itself. */
+function drainIsIdle() {
+  return timerQueue.length === 0;
 }
 
 // ── Load the REAL class via esbuild (no twin, no drift) ────────────────────
@@ -96,12 +123,22 @@ async function loadModule(entryTs) {
   return import(pathToFileURL(outFile).href);
 }
 
+let ALL_STAGES; // [...STAGES, QUIET_WINDOW_STAGE] — matches App.tsx's start() call
+
 before(async () => {
   installPolyfills();
   const orchMod = await loadModule(ORCH_TS);
   const stagesMod = await loadModule(STAGES_TS);
   OnboardingOrchestrator = orchMod.OnboardingOrchestrator;
   STAGES = stagesMod.STAGES;
+  // Production starts the orchestrator with the quiet_window stage appended
+  // (App.tsx: orch.start([...STAGES, QUIET_WINDOW_STAGE])). quiet_window is
+  // inserted into the queue when trial_promo completes, so its config must be
+  // registered or that id would sit unresolved in the queue. Include it here so
+  // the drain-termination guard reflects real startup.
+  ALL_STAGES = stagesMod.QUIET_WINDOW_STAGE
+    ? [...STAGES, stagesMod.QUIET_WINDOW_STAGE]
+    : STAGES;
   assert.ok(OnboardingOrchestrator, 'OnboardingOrchestrator export loaded');
   assert.ok(Array.isArray(STAGES) && STAGES.length > 0, 'STAGES catalog loaded');
 });
@@ -119,7 +156,7 @@ before(async () => {
 // dismissedThisSession guard is still fresh (it is never persisted).
 function raisePermissions({ preservePersistedState = false } = {}) {
   if (!preservePersistedState) localStorage.clear();
-  rafQueue = [];
+  timerQueue = [];
   mockNow = 0;
 
   const orch = new OnboardingOrchestrator();
@@ -230,4 +267,94 @@ test('dismissing permissions does NOT wedge other toaster stages', () => {
     'browser_extension',
     'the next stage must still be reachable — the session guard is per-stage, not global',
   );
+});
+
+// ─── NATIVE-LEAK REGRESSION GUARDS (2026-07-10) ─────────────────────────────
+// These lock in the fix for the perpetual-requestAnimationFrame native memory
+// leak (introduced by cf6a2f9, bisected to the 2026-07-04 window). The drain
+// loop MUST self-terminate when there is no pending work, and MUST NOT run on
+// requestAnimationFrame — otherwise the renderer's compositor never idles and,
+// under software compositing, leaks native raster tiles until OOM.
+
+test('LEAK GUARD: the drain loop uses setTimeout, never requestAnimationFrame', () => {
+  // requestAnimationFrame is intentionally undefined in installPolyfills(). If
+  // the class regressed to a rAF loop, start()/tick() would throw here.
+  assert.equal(
+    typeof globalThis.requestAnimationFrame,
+    'undefined',
+    'test harness must NOT provide requestAnimationFrame (regression guard)',
+  );
+  const orch = raisePermissions(); // exercises start() + several ticks
+  assert.equal(orch.getSnapshot().activeToasterId, 'permissions');
+  // Reaching here without a "requestAnimationFrame is not defined" throw proves
+  // the drain loop is timer-based.
+});
+
+test('LEAK GUARD: the drain loop STOPS scheduling once every stage is resolved', () => {
+  localStorage.clear();
+  timerQueue = [];
+  mockNow = 0;
+
+  const orch = new OnboardingOrchestrator();
+  orch.start(ALL_STAGES);
+  orch.emit({ type: 'launcher:mounted' });
+  orch.emit({ type: 'foreground:change', isForeground: true });
+
+  // Resolve EVERY stage: mark them all completed so nothing can ever fire. This
+  // is the fully-drained terminal state — the loop must stop re-arming itself.
+  for (const stage of ALL_STAGES) {
+    orch.markSkipped(stage.id);
+  }
+
+  // Drain any pending ticks. After the queue is fully resolved, ensureDraining()
+  // must not re-schedule, so the timer queue settles to empty within a couple of
+  // flushes (not spin forever like the old per-frame rAF).
+  let guard = 0;
+  while (!drainIsIdle() && guard < 10) {
+    flushOneFrame();
+    guard += 1;
+  }
+  assert.ok(
+    drainIsIdle(),
+    `drain loop must self-terminate when fully drained (still pending after ${guard} flushes)`,
+  );
+
+  // And it must NOT wake back up on its own — advancing the clock without any
+  // new event leaves it idle (the old loop would have re-fired every frame).
+  mockNow += 60_000;
+  assert.ok(drainIsIdle(), 'drain loop must stay idle with no new events');
+});
+
+test('LEAK GUARD: a state-change event re-arms the drain loop after it went idle', () => {
+  localStorage.clear();
+  timerQueue = [];
+  mockNow = 0;
+
+  const orch = new OnboardingOrchestrator();
+  orch.start(STAGES);
+  // Not foreground yet → shouldEvaluate() is false, but there IS pending work,
+  // so the loop stays armed. Drain the initial ticks.
+  let guard = 0;
+  while (!drainIsIdle() && guard < 5) { flushOneFrame(); guard += 1; }
+
+  // Backgrounded with pending work: the loop keeps a single armed timer (it must
+  // not busy-loop, but it must not permanently give up either). Now deliver a
+  // foreground + mount + duration so permissions becomes eligible.
+  orch.emit({ type: 'launcher:mounted' });
+  orch.emit({ type: 'foreground:change', isForeground: true });
+  orch.emit({
+    type: 'user-state:change',
+    patch: { permsShown: false, macTCCBlocked: true, extensionConnected: true },
+  });
+  mockNow += 3_000;
+
+  // The events called ensureDraining via notify(); flushing must now raise it.
+  guard = 0;
+  let raised = false;
+  while (guard < 5) {
+    flushOneFrame();
+    if (orch.getSnapshot().activeToasterId === 'permissions') { raised = true; break; }
+    guard += 1;
+  }
+  assert.ok(raised, 'a state-change event must re-arm the loop and let a newly-eligible stage fire');
 });

--- a/src/lib/onboarding/__tests__/orchestratorShadowGuard.test.mjs
+++ b/src/lib/onboarding/__tests__/orchestratorShadowGuard.test.mjs
@@ -1,0 +1,68 @@
+// src/lib/onboarding/__tests__/orchestratorShadowGuard.test.mjs
+//
+// REGRESSION GUARD (2026-07-10) for the "stuck at startup / blank launcher"
+// field bug.
+//
+// Root cause (bisected): src/lib/onboarding/orchestrator.mjs used to export a
+// NO-OP `getOrchestrator()`. The app imports the orchestrator with an
+// unqualified specifier ('./onboarding/orchestrator'); Vite's DEFAULT
+// resolve.extensions order puts `.mjs` before `.ts`, so the PACKAGED bundle
+// silently resolved the no-op `.mjs` stub instead of the real orchestrator.ts
+// class. The stub's `start()` did nothing (no toasters ever), and its
+// `getSnapshot()` returned a FRESH object literal on every call — which makes
+// React's useSyncExternalStore infinite-render ("Maximum update depth"),
+// unmounting the tree to a blank/black launcher.
+//
+// It was masked by two fragile guardrails: explicit `.ts` import extensions and
+// a vite.config.mts `resolve.extensions` override (commit 6f32a64). This guard
+// makes the FIX permanent and fail-loud: the `.mjs` companion must expose ONLY
+// the pure decision predicate — no stateful orchestrator handle that could
+// shadow the real singleton.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MJS = join(__dirname, '..', 'orchestrator.mjs');
+
+test('orchestrator.mjs must NOT export a stateful getOrchestrator (shadow footgun)', async () => {
+  const mod = await import('../orchestrator.mjs');
+  assert.equal(
+    typeof mod.getOrchestrator,
+    'undefined',
+    'orchestrator.mjs must not export getOrchestrator — it silently shadows the real orchestrator.ts singleton in the Vite bundle and reintroduces the blank-launcher infinite-render bug. Keep the real singleton exclusively in orchestrator.ts.',
+  );
+});
+
+test('orchestrator.mjs exposes only the pure predicate + default state', async () => {
+  const mod = await import('../orchestrator.mjs');
+  // shouldShowToaster is what tests actually import; DEFAULT_USER_STATE is pure data.
+  assert.equal(typeof mod.shouldShowToaster, 'function', 'shouldShowToaster must remain exported for tests');
+  assert.equal(typeof mod.DEFAULT_USER_STATE, 'object', 'DEFAULT_USER_STATE must remain exported');
+  // No stateful/handle-shaped exports.
+  for (const banned of ['getOrchestrator', 'createNoopOrchestrator', 'OnboardingOrchestrator']) {
+    assert.equal(mod[banned], undefined, `orchestrator.mjs must not export ${banned}`);
+  }
+});
+
+test('orchestrator.mjs source defines no getSnapshot (the unstable-snapshot leak site)', () => {
+  const src = readFileSync(MJS, 'utf8');
+  // A getSnapshot returning a fresh literal was the infinite-render trigger.
+  // The pure companion has no business DEFINING one. We scan only non-comment
+  // lines so the header's cautionary mention of getSnapshot() doesn't false-trip.
+  const codeLines = src
+    .split('\n')
+    .filter((l) => {
+      const s = l.trim();
+      return s && !s.startsWith('*') && !s.startsWith('//') && !s.startsWith('/*');
+    });
+  const definesGetSnapshot = codeLines.some((l) => /\bgetSnapshot\s*[:(]/.test(l));
+  assert.equal(
+    definesGetSnapshot,
+    false,
+    'orchestrator.mjs must not define getSnapshot — that stub was the useSyncExternalStore infinite-render source',
+  );
+});

--- a/src/lib/onboarding/orchestrator.mjs
+++ b/src/lib/onboarding/orchestrator.mjs
@@ -2,9 +2,26 @@
  * OnboardingOrchestrator — .mjs companion exposing the pure decision-engine
  * function for unit tests under `node --test`.
  *
- * The full class (with RAF, pub/sub, event bus) lives in orchestrator.ts. This
- * file re-implements `shouldShowToaster` as a pure function with the same
- * logic so tests can exercise it without DOM polyfills.
+ * The full class (with the drain loop, pub/sub, event bus) lives in
+ * orchestrator.ts. This file re-implements ONLY the pure `shouldShowToaster`
+ * predicate so tests can exercise it without DOM polyfills.
+ *
+ * ⚠️ DO NOT re-add a `getOrchestrator()` / stateful-orchestrator export here.
+ * History (bisected 2026-07-10): this file used to export a NO-OP
+ * `getOrchestrator()` "for test/static contexts". Because the app imported the
+ * orchestrator with an UNQUALIFIED specifier (`'./onboarding/orchestrator'`)
+ * and Vite's default `resolve.extensions` puts `.mjs` BEFORE `.ts`, the
+ * PACKAGED bundle silently resolved THIS no-op stub instead of the real
+ * orchestrator.ts class. Result: `orch.start()` did nothing, no toaster ever
+ * showed, and the stub's `getSnapshot()` returned a fresh object literal every
+ * call → `useSyncExternalStore` infinite-render → "Maximum update depth" →
+ * blank/black launcher (the "stuck at startup" field bug). It was only masked
+ * later by adding explicit `.ts` extensions + a `vite.config.mts`
+ * `resolve.extensions` override (commit 6f32a64). Keeping a stateful export
+ * here re-arms that footgun: if either guardrail regresses, the shadow returns
+ * SILENTLY. By exporting only the pure function, a shadowing regression instead
+ * fails LOUD — `getOrchestrator is not a function` at import — which is what we
+ * want. The real singleton lives exclusively in orchestrator.ts.
  */
 
 /**
@@ -53,8 +70,8 @@ export function shouldShowToaster(config, ctx) {
 }
 
 /**
- * Default UserState — exported here so the orchestrator.ts source-of-truth
- * is mirrored in the .mjs companion that the Vite bundle resolves to.
+ * Default UserState — mirrors orchestrator.ts's DEFAULT_USER_STATE for tests
+ * that build a Ctx without the full class. Pure data, safe to export.
  */
 export const DEFAULT_USER_STATE = {
   isPremium: false,
@@ -72,59 +89,7 @@ export const DEFAULT_USER_STATE = {
   isV2_8_OrNewer: true,
 };
 
-/**
- * No-op orchestrator handle for use in test/static contexts where the real
- * singleton isn't available. Returns the same shape as getOrchestrator() so
- * callers can call .emit() / .subscribe() without crashing — but they're
- * all no-ops.
- */
-export function getOrchestrator() {
-  if (!getOrchestrator.__instance) {
-    getOrchestrator.__instance = createNoopOrchestrator();
-  }
-  return getOrchestrator.__instance;
-}
-
-function createNoopOrchestrator() {
-  const noop = () => {};
-  // Referentially STABLE snapshot object — React's useSyncExternalStore
-  // (used by OrchestratedToasterHost.tsx) compares consecutive getSnapshot()
-  // return values with Object.is(). A fresh object literal on every call
-  // always compares unequal, which React interprets as "the store changed
-  // mid-render" and immediately re-renders to re-check — forever. That
-  // infinite render loop trips React's "Maximum update depth exceeded"
-  // safety valve, which unmounts the entire tree (blank #root / black
-  // screen) since nothing here ever wraps in an error boundary that can
-  // recover from a render-phase throw. Returning the SAME object every call
-  // (this noop orchestrator's state truly never changes) is what
-  // useSyncExternalStore requires. See orchestrator.ts's real getSnapshot(),
-  // which already returns `this.state` (a stable reference) for the same
-  // reason.
-  const snapshot = {
-    version: '1.0',
-    startupCount: 0,
-    totalUsageMs: 0,
-    turnCount: 0,
-    homepageMountedAt: null,
-    homepageFrozenAt: null,
-    homepageCurrentlyMounted: false,
-    appInForeground: true,
-    meetingActive: false,
-    queue: [],
-    completed: {},
-    skipped: new Set(),
-    activeToasterId: null,
-    lastShownTimes: {},
-  };
-  return {
-    start: noop,
-    stop: noop,
-    emit: noop,
-    subscribe: () => noop,
-    getSnapshot: () => snapshot,
-    markDismissed: noop,
-    markSkipped: noop,
-    setUserState: noop,
-    getUserState: () => DEFAULT_USER_STATE,
-  };
-}
+// NOTE: a stateful `getOrchestrator()` export was DELIBERATELY REMOVED here
+// (2026-07-10) — see the file header. The real, only orchestrator singleton
+// is `getOrchestrator()` in orchestrator.ts. Re-adding one here silently
+// shadows it in the Vite bundle and reintroduces the blank-launcher bug.

--- a/src/lib/onboarding/orchestrator.ts
+++ b/src/lib/onboarding/orchestrator.ts
@@ -170,7 +170,13 @@ export class OnboardingOrchestrator {
   private state: OrchestratorState;
   private userState: UserState = DEFAULT_USER_STATE;
   private listeners = new Set<Listener>();
-  private rafHandle: number | null = null;
+  // Drain-loop handle. Historically this was a per-FRAME requestAnimationFrame
+  // that rescheduled itself forever (see the NATIVE-LEAK note on scheduleTick).
+  // It is now a low-frequency setTimeout so the renderer can go idle between
+  // ticks — a rAF loop keeps Chromium's compositor permanently non-idle, and
+  // under software compositing (Windows / macOS-GPU-fallback) that turns the
+  // launcher's always-on animations into unbounded native raster-tile churn.
+  private tickTimer: ReturnType<typeof setTimeout> | null = null;
   private running = false;
   private stageConfigs: StageConfig[] = [];
   // Bumped on every notify() so useSyncExternalStore consumers see a new
@@ -209,14 +215,14 @@ export class OnboardingOrchestrator {
     }
 
     this.persist();
-    this.scheduleTick();
+    this.ensureDraining();
   }
 
   stop(): void {
     this.running = false;
-    if (this.rafHandle !== null) {
-      cancelAnimationFrame(this.rafHandle);
-      this.rafHandle = null;
+    if (this.tickTimer !== null) {
+      clearTimeout(this.tickTimer);
+      this.tickTimer = null;
     }
   }
 
@@ -253,6 +259,11 @@ export class OnboardingOrchestrator {
   private notify(): void {
     this.revision++;
     this.listeners.forEach(l => l(this.state))
+    // A state change may have made a stage newly eligible (foreground regained,
+    // meeting ended, usage tick, user-state patch, slot freed on dismiss). Re-arm
+    // the drain timer if it had stopped. Idempotent — no-op if already ticking or
+    // fully drained. This is what replaces the old always-on per-frame loop.
+    this.ensureDraining();
   }
 
   // ─── Event bus ────────────────────────────────────────────────
@@ -337,19 +348,74 @@ export class OnboardingOrchestrator {
   }
 
   // ─── Drain loop ───────────────────────────────────────────────
+  //
+  // NATIVE-LEAK FIX (2026-07-10): this used to be a self-perpetuating
+  // requestAnimationFrame loop (scheduleTick → rAF → tick → scheduleTick) that
+  // rescheduled EVERY FRAME (~60fps) for the entire lifetime of the launcher
+  // window, regardless of whether there was any pending onboarding work. A
+  // never-idling rAF keeps Chromium's compositor permanently in the
+  // "BeginFrame pending" state, so it produces a real frame every vsync and
+  // never enters the idle path that reclaims raster tiles. Combined with the
+  // launcher's `repeat: Infinity` toaster animations, under SOFTWARE
+  // compositing (Windows 10, macOS-27 GPU-fallback) that drove unbounded
+  // PartitionAlloc raster-tile churn — a native (non-V8) memory leak that grew
+  // RSS to multiple GB with a flat JS heap and OOM-froze the app / crashed the
+  // renderer in fontations_ffi. Confirmed by per-day git bisect: introduced by
+  // the orchestrator (cf6a2f9, 2026-07-04), absent at 8836b40 (2026-07-03).
+  //
+  // The loop is now:
+  //   • a low-frequency setTimeout (DRAIN_INTERVAL_MS), NOT a rAF — a timer
+  //     does not request animation frames, so the renderer goes idle between
+  //     ticks and the compositor reclaims tiles normally;
+  //   • self-terminating: it stops scheduling once every stage is resolved
+  //     (drained) or the app leaves the evaluable state, and re-arms lazily via
+  //     ensureDraining() whenever a state-change event lands (see notify()).
+  // Time-based stage triggers (2–10s homepage-duration gates) still fire within
+  // one DRAIN_INTERVAL_MS, so the onboarding funnel is behaviourally unchanged.
 
-  private scheduleTick(): void {
+  private static readonly DRAIN_INTERVAL_MS = 1000;
+
+  /** Lazily (re)start the drain timer if there is still work to evaluate. */
+  private ensureDraining(): void {
     if (!this.running) return;
-    this.rafHandle = requestAnimationFrame(() => {
+    if (this.tickTimer !== null) return;          // already scheduled
+    if (this.isFullyDrained()) return;            // nothing left to show, ever
+    this.tickTimer = setTimeout(() => {
+      this.tickTimer = null;
       this.tick();
-      this.scheduleTick();
-    });
+    }, OnboardingOrchestrator.DRAIN_INTERVAL_MS);
   }
 
   private tick(): void {
     if (!this.running) return;
-    if (!this.shouldEvaluate()) return;
-    this.evaluateAndDispatch();
+    if (this.shouldEvaluate()) {
+      this.evaluateAndDispatch();
+    }
+    // Re-arm only while there is still an unresolved stage. When the queue is
+    // fully drained the timer stops entirely and the renderer stays idle until
+    // a new event (foreground/usage/meeting/user-state) calls ensureDraining().
+    this.ensureDraining();
+  }
+
+  /**
+   * True when no queued stage can ever be shown again this session — every
+   * stage is completed, skipped, or dismissed-this-session — so the drain
+   * timer has no reason to keep ticking. A time-gated stage that is merely
+   * "not yet eligible" is NOT drained (returns false) so its duration trigger
+   * still gets a chance to fire.
+   */
+  private isFullyDrained(): boolean {
+    if (this.state.activeToasterId !== null) return false; // a toaster is up
+    return this.state.queue.every(
+      id =>
+        this.state.completed[id] != null ||
+        this.state.skipped.has(id) ||
+        this.dismissedThisSession.has(id) ||
+        // A queued id with no registered config can never be shown (e.g. a
+        // legacy/persisted stage that no longer exists, or one whose config
+        // wasn't passed to start()), so it must not keep the drain loop alive.
+        !this.stageConfigs.some(c => c.id === id),
+    );
   }
 
   private shouldEvaluate(): boolean {

--- a/src/lib/onboarding/orchestrator.ts
+++ b/src/lib/onboarding/orchestrator.ts
@@ -17,9 +17,9 @@
  *   - The user-state patch (premium/profile/etc.) — pushed in via emit()
  *   - The renderer — that lives in OrchestratedToasterHost.tsx
  *
- * Event-driven: no wall-clock timers for stage eligibility. The drain loop
- * runs on requestAnimationFrame and only evaluates when foreground +
- * homepage-mounted + not-in-meeting + no active toaster.
+ * Event-driven: events re-evaluate state changes, while a one-shot deadline
+ * timer handles only the next known time-gated eligibility transition. It never
+ * polls while waiting for a user or IPC event.
  */
 
 // Explicit `.ts` extension — this directory also has a `.mjs` companion
@@ -170,12 +170,9 @@ export class OnboardingOrchestrator {
   private state: OrchestratorState;
   private userState: UserState = DEFAULT_USER_STATE;
   private listeners = new Set<Listener>();
-  // Drain-loop handle. Historically this was a per-FRAME requestAnimationFrame
-  // that rescheduled itself forever (see the NATIVE-LEAK note on scheduleTick).
-  // It is now a low-frequency setTimeout so the renderer can go idle between
-  // ticks — a rAF loop keeps Chromium's compositor permanently non-idle, and
-  // under software compositing (Windows / macOS-GPU-fallback) that turns the
-  // launcher's always-on animations into unbounded native raster-tile churn.
+  // A single one-shot deadline timer. Never use it as a recurring poll: doing
+  // so needlessly wakes the renderer and can retain compositor work under
+  // Windows software compositing.
   private tickTimer: ReturnType<typeof setTimeout> | null = null;
   private running = false;
   private stageConfigs: StageConfig[] = [];
@@ -259,10 +256,14 @@ export class OnboardingOrchestrator {
   private notify(): void {
     this.revision++;
     this.listeners.forEach(l => l(this.state))
-    // A state change may have made a stage newly eligible (foreground regained,
-    // meeting ended, usage tick, user-state patch, slot freed on dismiss). Re-arm
-    // the drain timer if it had stopped. Idempotent — no-op if already ticking or
-    // fully drained. This is what replaces the old always-on per-frame loop.
+    // A state change can remove a prerequisite or move the earliest deadline
+    // sooner. Replace (rather than retain) a stale future deadline so skips and
+    // newly-eligible stages are dispatched promptly; waiting for another event
+    // still leaves no timer.
+    if (this.tickTimer !== null) {
+      clearTimeout(this.tickTimer);
+      this.tickTimer = null;
+    }
     this.ensureDraining();
   }
 
@@ -347,75 +348,91 @@ export class OnboardingOrchestrator {
     this.notify();
   }
 
-  // ─── Drain loop ───────────────────────────────────────────────
+  // ─── Deadline scheduler ───────────────────────────────────────
   //
-  // NATIVE-LEAK FIX (2026-07-10): this used to be a self-perpetuating
-  // requestAnimationFrame loop (scheduleTick → rAF → tick → scheduleTick) that
-  // rescheduled EVERY FRAME (~60fps) for the entire lifetime of the launcher
-  // window, regardless of whether there was any pending onboarding work. A
-  // never-idling rAF keeps Chromium's compositor permanently in the
-  // "BeginFrame pending" state, so it produces a real frame every vsync and
-  // never enters the idle path that reclaims raster tiles. Combined with the
-  // launcher's `repeat: Infinity` toaster animations, under SOFTWARE
-  // compositing (Windows 10, macOS-27 GPU-fallback) that drove unbounded
-  // PartitionAlloc raster-tile churn — a native (non-V8) memory leak that grew
-  // RSS to multiple GB with a flat JS heap and OOM-froze the app / crashed the
-  // renderer in fontations_ffi. Confirmed by per-day git bisect: introduced by
-  // the orchestrator (cf6a2f9, 2026-07-04), absent at 8836b40 (2026-07-03).
+  // This originally used a self-perpetuating requestAnimationFrame loop. That
+  // kept Chromium's compositor in the BeginFrame path on Windows software
+  // compositing and produced an unbounded native-RSS climb. Replacing rAF with
+  // a one-second recursive timer was still insufficient: a pending stage kept
+  // the launcher waking forever even while no state could change. A copied
+  // real-profile dev run reproduced the same ~70 MB/s native renderer growth
+  // with every modal hidden, while disabling only orch.start() remained flat.
   //
-  // The loop is now:
-  //   • a low-frequency setTimeout (DRAIN_INTERVAL_MS), NOT a rAF — a timer
-  //     does not request animation frames, so the renderer goes idle between
-  //     ticks and the compositor reclaims tiles normally;
-  //   • self-terminating: it stops scheduling once every stage is resolved
-  //     (drained) or the app leaves the evaluable state, and re-arms lazily via
-  //     ensureDraining() whenever a state-change event lands (see notify()).
-  // Time-based stage triggers (2–10s homepage-duration gates) still fire within
-  // one DRAIN_INTERVAL_MS, so the onboarding funnel is behaviourally unchanged.
+  // Schedule only the next *known time deadline*. All non-time eligibility
+  // inputs (foreground, homepage mount, user-state, turns, usage, dependencies
+  // and custom predicates) arrive through emit()/setUserState(), whose notify()
+  // call re-arms this scheduler. Once a toaster is active there is deliberately
+  // no timer: its dismiss/skip event is the next meaningful state transition.
+  private static readonly MAX_TIMEOUT_MS = 2_147_483_647;
 
-  private static readonly DRAIN_INTERVAL_MS = 1000;
-
-  /** Lazily (re)start the drain timer if there is still work to evaluate. */
+  /** Lazily schedule the next eligibility deadline, if one is knowable. */
   private ensureDraining(): void {
-    if (!this.running) return;
-    if (this.tickTimer !== null) return;          // already scheduled
-    if (this.isFullyDrained()) return;            // nothing left to show, ever
+    if (!this.running || this.tickTimer !== null) return;
+    const delayMs = this.nextEvaluationDelayMs();
+    if (delayMs === null) return;
     this.tickTimer = setTimeout(() => {
       this.tickTimer = null;
       this.tick();
-    }, OnboardingOrchestrator.DRAIN_INTERVAL_MS);
+    }, Math.min(delayMs, OnboardingOrchestrator.MAX_TIMEOUT_MS));
   }
 
   private tick(): void {
-    if (!this.running) return;
-    if (this.shouldEvaluate()) {
-      this.evaluateAndDispatch();
-    }
-    // Re-arm only while there is still an unresolved stage. When the queue is
-    // fully drained the timer stops entirely and the renderer stays idle until
-    // a new event (foreground/usage/meeting/user-state) calls ensureDraining().
+    if (!this.running || !this.shouldEvaluate()) return;
+    this.evaluateAndDispatch();
+    // evaluateAndDispatch may have skipped gate stages or found a later
+    // time-gated stage. Recompute once; never turn this into a polling loop.
     this.ensureDraining();
   }
 
   /**
-   * True when no queued stage can ever be shown again this session — every
-   * stage is completed, skipped, or dismissed-this-session — so the drain
-   * timer has no reason to keep ticking. A time-gated stage that is merely
-   * "not yet eligible" is NOT drained (returns false) so its duration trigger
-   * still gets a chance to fire.
+   * Return milliseconds until the earliest stage whose only unmet condition is
+   * a clock-based trigger, or 0 when a stage can be evaluated immediately.
+   * Return null when a user/event transition is required instead of polling.
    */
-  private isFullyDrained(): boolean {
-    if (this.state.activeToasterId !== null) return false; // a toaster is up
-    return this.state.queue.every(
-      id =>
-        this.state.completed[id] != null ||
-        this.state.skipped.has(id) ||
-        this.dismissedThisSession.has(id) ||
-        // A queued id with no registered config can never be shown (e.g. a
-        // legacy/persisted stage that no longer exists, or one whose config
-        // wasn't passed to start()), so it must not keep the drain loop alive.
-        !this.stageConfigs.some(c => c.id === id),
-    );
+  private nextEvaluationDelayMs(): number | null {
+    if (!this.shouldEvaluate()) return null;
+
+    const ctx = this.buildCtx();
+    let nextDelay: number | null = null;
+    const consider = (delay: number) => {
+      const bounded = Math.max(0, Math.ceil(delay));
+      nextDelay = nextDelay === null ? bounded : Math.min(nextDelay, bounded);
+    };
+
+    for (const id of this.state.queue) {
+      const config = this.stageConfigs.find(c => c.id === id);
+      if (!config || this.state.completed[id] != null || this.state.skipped.has(id) || this.dismissedThisSession.has(id)) continue;
+
+      // A hard skip is progress that evaluateAndDispatch can make immediately.
+      if (config.skipWhen?.(ctx.userState)) {
+        consider(0);
+        continue;
+      }
+      if (config.onceEver && ctx.completed[id] && !config.reEligibility?.(ctx.userState, ctx.completed)) continue;
+      if (config.requiresStages?.some(dep => !ctx.completed[dep] && !ctx.skipped.has(dep))) continue;
+
+      const triggers = config.triggers;
+      // These values cannot become true merely by waiting, so wait for their
+      // event instead of keeping the renderer on a timer.
+      if (
+        (triggers.requiresStartupCount != null && ctx.startupCount < triggers.requiresStartupCount) ||
+        (triggers.requiresTurnCount != null && ctx.turnCount < triggers.requiresTurnCount) ||
+        (triggers.requiresTotalUsageMs != null && ctx.totalUsageMs < triggers.requiresTotalUsageMs) ||
+        (config.customPredicate && !config.customPredicate(ctx))
+      ) continue;
+
+      let delay = 0;
+      if (triggers.requiresHomepageDuration != null) {
+        delay = Math.max(delay, triggers.requiresHomepageDuration - ctx.homepageMountedFor);
+      }
+      const cooldownMs = config.cooldownMs?.(ctx.userState) ?? 0;
+      if (cooldownMs > 0) {
+        delay = Math.max(delay, cooldownMs - (ctx.now - (ctx.lastShownTimes[id] ?? 0)));
+      }
+      consider(delay);
+    }
+
+    return nextDelay;
   }
 
   private shouldEvaluate(): boolean {


### PR DESCRIPTION
## Summary

- add bounded native-RSS/IPC diagnostics plus a copied-profile Vite reproduction runner for the Windows launcher investigation
- add development-only launcher-surface isolation controls used to distinguish the scheduler from visible toaster/modal effects
- replace onboarding's recurring eligibility timer with a one-shot deadline scheduler: event-gated stages leave no timer armed, and state changes schedule only the next meaningful eligibility check
- add class-level regression coverage for timer-free event gating

## Root cause and evidence

The copied-real-profile Vite reproduction showed the launcher renderer's native working set growing at roughly 70 MB/s with a flat V8 heap. Hiding modal/toaster surfaces and globally disabling blur effects did not change the slope. Disabling only `orch.start()` did: over 90 seconds the launcher renderer remained bounded (about 64 MB → 169 MB), identifying the recurring onboarding eligibility timer as the active compositor wake source under Windows software compositing.

The repaired normal dev session ran for 330 seconds (past the historical ~271-second failure point) with a fresh copied profile: launcher renderer 63.8 MB → 181.1 MB, 200 MB peak; Browser 180.6 MB → 448.3 MB. There were no RSS-growth threshold events, `render-process-gone`, `UNRESPONSIVE`, or `did-fail-load` events. Port 20128 stayed exclusively owned by the protected Node process throughout.

## Validation

- `node --test src/lib/onboarding/__tests__/orchestratorClass.test.mjs` (8 passing)
- `npm run typecheck:electron`
- `npm run build:electron`
- 330-second fresh-profile Vite/Electron dev reproduction with native trace
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)