### PR TITLE
fix: fall back to app-managed encryption when OS keyring save fails

### DIFF
--- a/electron/WindowHelper.ts
+++ b/electron/WindowHelper.ts
@@ -438,9 +438,21 @@ export class WindowHelper {
     // line naming the exact failing module/line on the user's machine.
     this.attachRendererDiagnostics(this.launcherWindow, 'launcher');
 
-    // if (isDev) {
-    //   this.launcherWindow.webContents.openDevTools({ mode: 'detach' }); // DEBUG: Open DevTools
-    // }
+    // DIAGNOSTIC (2026-07-11): NATIVELY_OPEN_DEVTOOLS=1 force-opens the launcher
+    // DevTools DETACHED (survives a renderer hang, unlike an in-window panel).
+    // For debugging the "window appears then freezes / renderer not responsive"
+    // report: open the Performance tab and record during the freeze — a single
+    // long yellow Scripting block = a JS main-thread loop; a flat gap with no JS
+    // = a compositor/GPU stall (the software-compositing blur path). Detached so
+    // it stays usable even when the launcher renderer stops pumping its loop.
+    if (process.env.NATIVELY_OPEN_DEVTOOLS === '1') {
+      try {
+        this.launcherWindow.webContents.openDevTools({ mode: 'detach' });
+        console.warn('[Diag] NATIVELY_OPEN_DEVTOOLS=1 → launcher DevTools opened (detached)');
+      } catch (e: any) {
+        console.warn('[Diag] openDevTools failed:', e?.message || e);
+      }
+    }
 
     // --- 2. Create Overlay Window (Hidden initially) ---
     // Always start centered on the primary display so the OS (macOS NSUserDefaults /

--- a/electron/WindowHelper.ts
+++ b/electron/WindowHelper.ts
@@ -377,8 +377,19 @@ export class WindowHelper {
     // src/App.tsx + src/index.css). Used to test whether the Windows native-RSS
     // leak is the CPU-composited blur raster-tile path. Remove after fix.
     const nofxSuffix = process.env.NATIVELY_NOFX === '1' ? '&nofx=1' : '';
-    const launcherUrl = `${startUrl}?window=launcher${nofxSuffix}`;
     if (nofxSuffix) console.warn('[LeakTest] NATIVELY_NOFX=1 → loading launcher with ?nofx=1 (blur effects OFF)');
+
+    // A/B KILL-SWITCH (2026-07-10): NATIVELY_DISABLE_ONBOARDING_ORCH=1 appends
+    // ?noorch=1, which makes App.tsx skip orch.start() entirely (no drain loop,
+    // no onboarding toasters). The onboarding orchestrator's drain loop was
+    // bisected to the 2026-07-04 native-memory-leak regression; this switch lets
+    // the same build be run with the orchestrator ON vs OFF to confirm the leak
+    // source in the field. The loop is now setTimeout-based (fixed), so this is
+    // a confirmation/rollback lever, not the fix itself.
+    const noOrchSuffix = process.env.NATIVELY_DISABLE_ONBOARDING_ORCH === '1' ? '&noorch=1' : '';
+    if (noOrchSuffix) console.warn('[LeakTest] NATIVELY_DISABLE_ONBOARDING_ORCH=1 → launcher with ?noorch=1 (onboarding orchestrator OFF)');
+
+    const launcherUrl = `${startUrl}?window=launcher${nofxSuffix}${noOrchSuffix}`;
 
     this.launcherWindow
       .loadURL(launcherUrl)

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -7090,6 +7090,22 @@ if (process.env.THINKING_MATRIX === '1') {
     windowCount: BrowserWindow.getAllWindows().length,
   });
 
+  // DIAGNOSTIC (2026-07-11): dump Chromium's GPU feature status once at boot.
+  // The "window appears then freezes / renderer not responsive" report is
+  // consistent with a machine that fell back to SOFTWARE compositing (Chromium
+  // blocklisted the GPU / driver state), where the launcher splash's heavy
+  // blur/backdrop-filter becomes catastrophically expensive and can wedge the
+  // renderer's main thread. This logs, in one line, whether gpu_compositing and
+  // rasterization are 'enabled' (hardware) or 'software'/'disabled'. If a user
+  // who freezes shows software/disabled here while a healthy machine shows
+  // enabled, the compositing path is confirmed and `?nofx=1` should unblock it.
+  try {
+    const status = app.getGPUFeatureStatus();
+    console.log('[GPU] featureStatus', JSON.stringify(status));
+  } catch (e: any) {
+    console.warn('[GPU] getGPUFeatureStatus failed:', e?.message || e);
+  }
+
   // Run the local-fallback preflight AFTER the launcher paints. We schedule
   // it via setTimeout so the visible launch is not blocked by:
   //   - native module requires (onnxruntime-node, sqlite-vec)

--- a/electron/nativeArchGate.ts
+++ b/electron/nativeArchGate.ts
@@ -33,6 +33,21 @@
  * better-sqlite3.
  */
 (() => {
+  // ESCAPE HATCH: this gate's only failure mode of last resort is a
+  // FALSE POSITIVE — misclassifying a healthy `.node` as wrong-arch and
+  // showing a fatal modal + app.exit(1) BEFORE any window exists, which
+  // permanently locks the user out of boot with no in-app recovery. A
+  // packaging or `file`-classification regression is exactly the kind of
+  // thing that has bricked a shipped build before. NATIVELY_SKIP_ARCH_GATE=1
+  // disables the gate entirely so a false positive can never trap a user;
+  // worst case without the gate is a clear dlopen error later, not a silent
+  // lockout. (The gate remains ON by default — this is a support-desk
+  // "run this and reopen" lever, not a normal-operation flag.)
+  if (process.env.NATIVELY_SKIP_ARCH_GATE === '1') {
+    try { console.warn('[nativeArch] NATIVELY_SKIP_ARCH_GATE=1 — boot arch gate DISABLED'); } catch { /* best-effort */ }
+    return;
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const path = require('path');
   // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/electron/services/CredentialsManager.ts
+++ b/electron/services/CredentialsManager.ts
@@ -901,6 +901,12 @@ export class CredentialsManager {
      * to decide whether to warn.
      */
     private saveCredentials(): boolean {
+        // Try the OS keyring first. When safeStorage is available, this is the
+        // preferred path. On Windows the underlying DPAPI can still throw after
+        // isEncryptionAvailable() returns true (e.g. policy restrictions, roaming
+        // profiles) — we must catch that and fall through to the app-managed
+        // fallback instead of returning false, otherwise keys are silently lost
+        // on restart (the bug reported for Deepgram and other STT keys).
         try {
             if (safeStorage.isEncryptionAvailable()) {
                 const data = JSON.stringify(this.credentials);
@@ -912,14 +918,25 @@ export class CredentialsManager {
                 this.removeFallbackFile();
                 return true;
             }
+        } catch (keyringErr) {
+            // Keyring write failed — don't give up yet. Try the fallback below.
+            console.warn('[CredentialsManager] Keyring save failed, trying app-managed fallback:', keyringErr);
+        }
 
-            // OS keyring unavailable — use the app-managed encrypted fallback so the
-            // key is not silently lost on restart. Weaker than the keyring (see
-            // credentialFallbackCrypto.ts) but never plaintext at rest.
+        // OS keyring unavailable or threw — use the app-managed encrypted fallback so the
+        // key is not silently lost on restart. Weaker than the keyring (see
+        // credentialFallbackCrypto.ts) but never plaintext at rest.
+        try {
             const blob = encryptCredentialBlob(JSON.stringify(this.credentials), this.getFallbackKey());
             const tmpFb = FALLBACK_PATH + '.tmp';
             fs.writeFileSync(tmpFb, blob, { mode: 0o600 });
             fs.renameSync(tmpFb, FALLBACK_PATH);
+            // Stale keyring file is now out of sync (the fallback has the latest
+            // credentials). Remove it so loadCredentials() does not find it on
+            // next startup and treat the old keyring data as authoritative —
+            // otherwise the just-saved key would be silently overwritten by the
+            // stale keyring contents when loadCredentials() deletes the fallback.
+            this.removeKeyringFile();
             console.warn('[CredentialsManager] OS keyring unavailable; saved via app-managed encrypted fallback (machine-bound, will survive restart)');
             return true;
         } catch (error) {
@@ -936,6 +953,24 @@ export class CredentialsManager {
             }
         } catch (err) {
             console.warn('[CredentialsManager] Could not remove stale fallback file:', err);
+        }
+    }
+
+    /**
+     * Remove the stale OS keyring credential file (best-effort).
+     * Called when the keyring write failed and we fell back to the app-managed
+     * fallback — the old keyring file contains stale credentials and would
+     * be treated as authoritative by loadCredentials() on next startup,
+     * silently discarding the just-saved keys.
+     */
+    private removeKeyringFile(): void {
+        try {
+            if (fs.existsSync(CREDENTIALS_PATH)) {
+                fs.unlinkSync(CREDENTIALS_PATH);
+                console.log('[CredentialsManager] Removed stale keyring credential file (fallback is authoritative)');
+            }
+        } catch (err) {
+            console.warn('[CredentialsManager] Could not remove stale keyring file:', err);
         }
     }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,6 +137,15 @@ const App: React.FC = () => {
 
   // State
   const [showStartup, setShowStartup] = useState(true);
+  // Stable identity: StartupSequence arms its dismissal timers in a
+  // useEffect(deps:[onComplete]). An inline closure would be a new identity on
+  // every App re-render — and the boot path re-renders many times (7-10 async
+  // IPCs each setState on resolve, plus orchestrator notifies). That would tear
+  // down and re-arm BOTH the 2.2s primary AND the 5s hard-cap timer on every
+  // render, so under a slow/re-render-heavy boot the hard-cap could keep
+  // resetting and never fire — the "stuck at the startup animation" symptom.
+  // Memoizing to [] makes the splash timers arm exactly once.
+  const dismissStartup = useCallback(() => setShowStartup(false), []);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [settingsInitialTab, setSettingsInitialTab] = useState<string>('general');
   const [isModesOpen, setIsModesOpen] = useState(false);
@@ -820,7 +829,7 @@ const App: React.FC = () => {
             animate={{ opacity: 1, scale: 1, transition: { duration: 0.5, ease: [0.23, 1, 0.32, 1] } }}
             exit={{ opacity: 0, scale: 1.04, pointerEvents: "none", transition: { duration: 0.55, ease: [0.4, 0, 0.2, 1] } }}
           >
-            <StartupSequence onComplete={() => setShowStartup(false)} />
+            <StartupSequence onComplete={dismissStartup} />
           </motion.div>
         ) : (
           <motion.div

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -246,6 +246,15 @@ const App: React.FC = () => {
   // mounted.
   useEffect(() => {
     if (!isLauncherWindow && !isDefault) return;
+    // A/B KILL-SWITCH (2026-07-10): ?noorch=1 (set by WindowHelper when
+    // NATIVELY_DISABLE_ONBOARDING_ORCH=1) skips the onboarding orchestrator
+    // entirely — no drain loop, no toasters. Lets the same build A/B the
+    // orchestrator ON vs OFF to confirm/deny the 2026-07-04 native-leak
+    // regression in the field. Remove once the leak fix is field-verified.
+    if (new URLSearchParams(window.location.search).get('noorch') === '1') {
+      console.warn('[LeakTest] ?noorch=1 → onboarding orchestrator DISABLED (orch.start skipped)');
+      return;
+    }
     let cancelled = false;
     let stopFn: (() => void) | null = null;
     // Explicit `.ts` extensions here for the same reason as the static

--- a/src/components/StartupSequence.tsx
+++ b/src/components/StartupSequence.tsx
@@ -7,10 +7,21 @@ interface StartupSequenceProps {
 }
 
 const StartupSequence: React.FC<StartupSequenceProps> = ({ onComplete }) => {
+    // Keep the latest onComplete in a ref so the timer effect can depend on []
+    // and arm EXACTLY ONCE for the splash's lifetime. If the effect depended on
+    // `onComplete` directly, an un-memoized caller (a new closure per parent
+    // re-render) would tear down and re-arm both timers on every render — and
+    // the boot path re-renders many times — so the 5s hard-cap safety net could
+    // keep resetting and never fire, trapping the user at the black splash. The
+    // ref makes the safety net immune to prop-identity churn regardless of how
+    // the caller passes onComplete.
+    const onCompleteRef = React.useRef(onComplete);
+    onCompleteRef.current = onComplete;
+
     useEffect(() => {
         // Primary dismiss at 2.2s (matches the logo animation length).
         const timer = setTimeout(() => {
-            onComplete();
+            onCompleteRef.current();
         }, 2200);
         // Hard-cap safety net: no matter what, the splash must never persist past
         // 5s. If the primary timer's onComplete is ever prevented from advancing
@@ -19,13 +30,16 @@ const StartupSequence: React.FC<StartupSequenceProps> = ({ onComplete }) => {
         // black logo — the "stuck at logo" failure mode. Idempotent: onComplete
         // just flips showStartup=false, so a double-call is harmless.
         const hardCap = setTimeout(() => {
-            try { onComplete(); } catch { /* never let the splash trap the user */ }
+            try { onCompleteRef.current(); } catch { /* never let the splash trap the user */ }
         }, 5000);
         return () => {
             clearTimeout(timer);
             clearTimeout(hardCap);
         };
-    }, [onComplete]);
+        // Mount-once: arm the dismissal timers a single time. onComplete is read
+        // through onCompleteRef so it is intentionally NOT a dependency.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     return (
         <div className="fixed inset-0 z-[100] bg-[#000000] flex items-center justify-center overflow-hidden">

--- a/src/lib/onboarding/__tests__/orchestratorClass.test.mjs
+++ b/src/lib/onboarding/__tests__/orchestratorClass.test.mjs
@@ -34,12 +34,22 @@ const STAGES_TS = join(__dirname, '..', 'stageCatalog.ts');
 
 // ── DOM polyfills the orchestrator class touches ───────────────────────────
 // A manual RAF queue: scheduleTick() recurses (tick → scheduleTick), so a
-// synchronous RAF would infinitely recurse. Instead we buffer callbacks and
-// flush exactly one frame at a time from the test, which is enough to run one
+// synchronous timer would infinitely recurse. Instead we buffer callbacks and
+// flush exactly one tick at a time from the test, which is enough to run one
 // evaluate/dispatch pass deterministically.
-let rafQueue = [];
-let rafId = 0;
+//
+// NATIVE-LEAK FIX (2026-07-10): the drain loop is now a self-terminating
+// setTimeout, NOT a per-frame requestAnimationFrame (the perpetual rAF was the
+// native memory leak — see orchestrator.ts scheduleTick note). A rAF polyfill
+// is intentionally NOT installed: if the class ever regresses to
+// requestAnimationFrame it throws ("requestAnimationFrame is not defined"),
+// which is the regression guard we want.
+let timerQueue = [];
+let timerSeq = 0;
 let mockNow = 0;
+
+const realSetTimeout = globalThis.setTimeout;
+const realClearTimeout = globalThis.clearTimeout;
 
 function installPolyfills() {
   const store = new Map();
@@ -49,29 +59,46 @@ function installPolyfills() {
     removeItem: (k) => store.delete(k),
     clear: () => store.clear(),
   };
-  globalThis.requestAnimationFrame = (cb) => {
-    const id = ++rafId;
-    rafQueue.push({ id, cb });
+  globalThis.performance = { now: () => mockNow };
+  // Deliberately NO requestAnimationFrame — the orchestrator must never use it
+  // again (the perpetual rAF loop was the leak). Manual setTimeout queue so the
+  // mock clock drives the drain cadence deterministically.
+  delete globalThis.requestAnimationFrame;
+  delete globalThis.cancelAnimationFrame;
+  globalThis.setTimeout = (cb, _ms) => {
+    const id = ++timerSeq;
+    timerQueue.push({ id, cb });
     return id;
   };
-  globalThis.cancelAnimationFrame = (id) => {
-    rafQueue = rafQueue.filter((e) => e.id !== id);
+  globalThis.clearTimeout = (id) => {
+    timerQueue = timerQueue.filter((e) => e.id !== id);
   };
-  globalThis.performance = { now: () => mockNow };
+}
+
+// eslint-disable-next-line no-unused-vars
+function restoreTimers() {
+  globalThis.setTimeout = realSetTimeout;
+  globalThis.clearTimeout = realClearTimeout;
 }
 
 /**
- * Run exactly one buffered RAF frame. The orchestrator's scheduleTick() does
- * `tick(); scheduleTick();`, so each callback runs one evaluate/dispatch pass
- * and re-queues exactly one follow-up frame. We snapshot the currently-pending
- * callbacks and run only those — the re-scheduled follow-up stays queued for
- * the NEXT flush, preserving the self-perpetuating RAF loop (clearing it would
- * silently stop the drain loop and mask re-raise bugs).
+ * Run exactly one buffered drain tick. The orchestrator's tick() runs one
+ * evaluate/dispatch pass and then calls ensureDraining(), which re-arms exactly
+ * one follow-up timer IFF there is still unresolved work. We snapshot the
+ * currently-pending callbacks and run only those — a re-armed follow-up stays
+ * queued for the NEXT flush. When the queue drains fully, ensureDraining stops
+ * scheduling, timerQueue goes empty, and flushOneFrame becomes a no-op: that
+ * self-termination is the leak fix (the loop no longer runs forever).
  */
 function flushOneFrame() {
-  const pending = rafQueue;
-  rafQueue = [];
+  const pending = timerQueue;
+  timerQueue = [];
   for (const { cb } of pending) cb();
+}
+
+/** True once the drain loop has stopped re-scheduling itself. */
+function drainIsIdle() {
+  return timerQueue.length === 0;
 }
 
 // ── Load the REAL class via esbuild (no twin, no drift) ────────────────────
@@ -96,12 +123,22 @@ async function loadModule(entryTs) {
   return import(pathToFileURL(outFile).href);
 }
 
+let ALL_STAGES; // [...STAGES, QUIET_WINDOW_STAGE] — matches App.tsx's start() call
+
 before(async () => {
   installPolyfills();
   const orchMod = await loadModule(ORCH_TS);
   const stagesMod = await loadModule(STAGES_TS);
   OnboardingOrchestrator = orchMod.OnboardingOrchestrator;
   STAGES = stagesMod.STAGES;
+  // Production starts the orchestrator with the quiet_window stage appended
+  // (App.tsx: orch.start([...STAGES, QUIET_WINDOW_STAGE])). quiet_window is
+  // inserted into the queue when trial_promo completes, so its config must be
+  // registered or that id would sit unresolved in the queue. Include it here so
+  // the drain-termination guard reflects real startup.
+  ALL_STAGES = stagesMod.QUIET_WINDOW_STAGE
+    ? [...STAGES, stagesMod.QUIET_WINDOW_STAGE]
+    : STAGES;
   assert.ok(OnboardingOrchestrator, 'OnboardingOrchestrator export loaded');
   assert.ok(Array.isArray(STAGES) && STAGES.length > 0, 'STAGES catalog loaded');
 });
@@ -119,7 +156,7 @@ before(async () => {
 // dismissedThisSession guard is still fresh (it is never persisted).
 function raisePermissions({ preservePersistedState = false } = {}) {
   if (!preservePersistedState) localStorage.clear();
-  rafQueue = [];
+  timerQueue = [];
   mockNow = 0;
 
   const orch = new OnboardingOrchestrator();
@@ -230,4 +267,94 @@ test('dismissing permissions does NOT wedge other toaster stages', () => {
     'browser_extension',
     'the next stage must still be reachable — the session guard is per-stage, not global',
   );
+});
+
+// ─── NATIVE-LEAK REGRESSION GUARDS (2026-07-10) ─────────────────────────────
+// These lock in the fix for the perpetual-requestAnimationFrame native memory
+// leak (introduced by cf6a2f9, bisected to the 2026-07-04 window). The drain
+// loop MUST self-terminate when there is no pending work, and MUST NOT run on
+// requestAnimationFrame — otherwise the renderer's compositor never idles and,
+// under software compositing, leaks native raster tiles until OOM.
+
+test('LEAK GUARD: the drain loop uses setTimeout, never requestAnimationFrame', () => {
+  // requestAnimationFrame is intentionally undefined in installPolyfills(). If
+  // the class regressed to a rAF loop, start()/tick() would throw here.
+  assert.equal(
+    typeof globalThis.requestAnimationFrame,
+    'undefined',
+    'test harness must NOT provide requestAnimationFrame (regression guard)',
+  );
+  const orch = raisePermissions(); // exercises start() + several ticks
+  assert.equal(orch.getSnapshot().activeToasterId, 'permissions');
+  // Reaching here without a "requestAnimationFrame is not defined" throw proves
+  // the drain loop is timer-based.
+});
+
+test('LEAK GUARD: the drain loop STOPS scheduling once every stage is resolved', () => {
+  localStorage.clear();
+  timerQueue = [];
+  mockNow = 0;
+
+  const orch = new OnboardingOrchestrator();
+  orch.start(ALL_STAGES);
+  orch.emit({ type: 'launcher:mounted' });
+  orch.emit({ type: 'foreground:change', isForeground: true });
+
+  // Resolve EVERY stage: mark them all completed so nothing can ever fire. This
+  // is the fully-drained terminal state — the loop must stop re-arming itself.
+  for (const stage of ALL_STAGES) {
+    orch.markSkipped(stage.id);
+  }
+
+  // Drain any pending ticks. After the queue is fully resolved, ensureDraining()
+  // must not re-schedule, so the timer queue settles to empty within a couple of
+  // flushes (not spin forever like the old per-frame rAF).
+  let guard = 0;
+  while (!drainIsIdle() && guard < 10) {
+    flushOneFrame();
+    guard += 1;
+  }
+  assert.ok(
+    drainIsIdle(),
+    `drain loop must self-terminate when fully drained (still pending after ${guard} flushes)`,
+  );
+
+  // And it must NOT wake back up on its own — advancing the clock without any
+  // new event leaves it idle (the old loop would have re-fired every frame).
+  mockNow += 60_000;
+  assert.ok(drainIsIdle(), 'drain loop must stay idle with no new events');
+});
+
+test('LEAK GUARD: a state-change event re-arms the drain loop after it went idle', () => {
+  localStorage.clear();
+  timerQueue = [];
+  mockNow = 0;
+
+  const orch = new OnboardingOrchestrator();
+  orch.start(STAGES);
+  // Not foreground yet → shouldEvaluate() is false, but there IS pending work,
+  // so the loop stays armed. Drain the initial ticks.
+  let guard = 0;
+  while (!drainIsIdle() && guard < 5) { flushOneFrame(); guard += 1; }
+
+  // Backgrounded with pending work: the loop keeps a single armed timer (it must
+  // not busy-loop, but it must not permanently give up either). Now deliver a
+  // foreground + mount + duration so permissions becomes eligible.
+  orch.emit({ type: 'launcher:mounted' });
+  orch.emit({ type: 'foreground:change', isForeground: true });
+  orch.emit({
+    type: 'user-state:change',
+    patch: { permsShown: false, macTCCBlocked: true, extensionConnected: true },
+  });
+  mockNow += 3_000;
+
+  // The events called ensureDraining via notify(); flushing must now raise it.
+  guard = 0;
+  let raised = false;
+  while (guard < 5) {
+    flushOneFrame();
+    if (orch.getSnapshot().activeToasterId === 'permissions') { raised = true; break; }
+    guard += 1;
+  }
+  assert.ok(raised, 'a state-change event must re-arm the loop and let a newly-eligible stage fire');
 });

--- a/src/lib/onboarding/__tests__/orchestratorShadowGuard.test.mjs
+++ b/src/lib/onboarding/__tests__/orchestratorShadowGuard.test.mjs
@@ -1,0 +1,68 @@
+// src/lib/onboarding/__tests__/orchestratorShadowGuard.test.mjs
+//
+// REGRESSION GUARD (2026-07-10) for the "stuck at startup / blank launcher"
+// field bug.
+//
+// Root cause (bisected): src/lib/onboarding/orchestrator.mjs used to export a
+// NO-OP `getOrchestrator()`. The app imports the orchestrator with an
+// unqualified specifier ('./onboarding/orchestrator'); Vite's DEFAULT
+// resolve.extensions order puts `.mjs` before `.ts`, so the PACKAGED bundle
+// silently resolved the no-op `.mjs` stub instead of the real orchestrator.ts
+// class. The stub's `start()` did nothing (no toasters ever), and its
+// `getSnapshot()` returned a FRESH object literal on every call — which makes
+// React's useSyncExternalStore infinite-render ("Maximum update depth"),
+// unmounting the tree to a blank/black launcher.
+//
+// It was masked by two fragile guardrails: explicit `.ts` import extensions and
+// a vite.config.mts `resolve.extensions` override (commit 6f32a64). This guard
+// makes the FIX permanent and fail-loud: the `.mjs` companion must expose ONLY
+// the pure decision predicate — no stateful orchestrator handle that could
+// shadow the real singleton.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MJS = join(__dirname, '..', 'orchestrator.mjs');
+
+test('orchestrator.mjs must NOT export a stateful getOrchestrator (shadow footgun)', async () => {
+  const mod = await import('../orchestrator.mjs');
+  assert.equal(
+    typeof mod.getOrchestrator,
+    'undefined',
+    'orchestrator.mjs must not export getOrchestrator — it silently shadows the real orchestrator.ts singleton in the Vite bundle and reintroduces the blank-launcher infinite-render bug. Keep the real singleton exclusively in orchestrator.ts.',
+  );
+});
+
+test('orchestrator.mjs exposes only the pure predicate + default state', async () => {
+  const mod = await import('../orchestrator.mjs');
+  // shouldShowToaster is what tests actually import; DEFAULT_USER_STATE is pure data.
+  assert.equal(typeof mod.shouldShowToaster, 'function', 'shouldShowToaster must remain exported for tests');
+  assert.equal(typeof mod.DEFAULT_USER_STATE, 'object', 'DEFAULT_USER_STATE must remain exported');
+  // No stateful/handle-shaped exports.
+  for (const banned of ['getOrchestrator', 'createNoopOrchestrator', 'OnboardingOrchestrator']) {
+    assert.equal(mod[banned], undefined, `orchestrator.mjs must not export ${banned}`);
+  }
+});
+
+test('orchestrator.mjs source defines no getSnapshot (the unstable-snapshot leak site)', () => {
+  const src = readFileSync(MJS, 'utf8');
+  // A getSnapshot returning a fresh literal was the infinite-render trigger.
+  // The pure companion has no business DEFINING one. We scan only non-comment
+  // lines so the header's cautionary mention of getSnapshot() doesn't false-trip.
+  const codeLines = src
+    .split('\n')
+    .filter((l) => {
+      const s = l.trim();
+      return s && !s.startsWith('*') && !s.startsWith('//') && !s.startsWith('/*');
+    });
+  const definesGetSnapshot = codeLines.some((l) => /\bgetSnapshot\s*[:(]/.test(l));
+  assert.equal(
+    definesGetSnapshot,
+    false,
+    'orchestrator.mjs must not define getSnapshot — that stub was the useSyncExternalStore infinite-render source',
+  );
+});

--- a/src/lib/onboarding/orchestrator.mjs
+++ b/src/lib/onboarding/orchestrator.mjs
@@ -2,9 +2,26 @@
  * OnboardingOrchestrator — .mjs companion exposing the pure decision-engine
  * function for unit tests under `node --test`.
  *
- * The full class (with RAF, pub/sub, event bus) lives in orchestrator.ts. This
- * file re-implements `shouldShowToaster` as a pure function with the same
- * logic so tests can exercise it without DOM polyfills.
+ * The full class (with the drain loop, pub/sub, event bus) lives in
+ * orchestrator.ts. This file re-implements ONLY the pure `shouldShowToaster`
+ * predicate so tests can exercise it without DOM polyfills.
+ *
+ * ⚠️ DO NOT re-add a `getOrchestrator()` / stateful-orchestrator export here.
+ * History (bisected 2026-07-10): this file used to export a NO-OP
+ * `getOrchestrator()` "for test/static contexts". Because the app imported the
+ * orchestrator with an UNQUALIFIED specifier (`'./onboarding/orchestrator'`)
+ * and Vite's default `resolve.extensions` puts `.mjs` BEFORE `.ts`, the
+ * PACKAGED bundle silently resolved THIS no-op stub instead of the real
+ * orchestrator.ts class. Result: `orch.start()` did nothing, no toaster ever
+ * showed, and the stub's `getSnapshot()` returned a fresh object literal every
+ * call → `useSyncExternalStore` infinite-render → "Maximum update depth" →
+ * blank/black launcher (the "stuck at startup" field bug). It was only masked
+ * later by adding explicit `.ts` extensions + a `vite.config.mts`
+ * `resolve.extensions` override (commit 6f32a64). Keeping a stateful export
+ * here re-arms that footgun: if either guardrail regresses, the shadow returns
+ * SILENTLY. By exporting only the pure function, a shadowing regression instead
+ * fails LOUD — `getOrchestrator is not a function` at import — which is what we
+ * want. The real singleton lives exclusively in orchestrator.ts.
  */
 
 /**
@@ -53,8 +70,8 @@ export function shouldShowToaster(config, ctx) {
 }
 
 /**
- * Default UserState — exported here so the orchestrator.ts source-of-truth
- * is mirrored in the .mjs companion that the Vite bundle resolves to.
+ * Default UserState — mirrors orchestrator.ts's DEFAULT_USER_STATE for tests
+ * that build a Ctx without the full class. Pure data, safe to export.
  */
 export const DEFAULT_USER_STATE = {
   isPremium: false,
@@ -72,59 +89,7 @@ export const DEFAULT_USER_STATE = {
   isV2_8_OrNewer: true,
 };
 
-/**
- * No-op orchestrator handle for use in test/static contexts where the real
- * singleton isn't available. Returns the same shape as getOrchestrator() so
- * callers can call .emit() / .subscribe() without crashing — but they're
- * all no-ops.
- */
-export function getOrchestrator() {
-  if (!getOrchestrator.__instance) {
-    getOrchestrator.__instance = createNoopOrchestrator();
-  }
-  return getOrchestrator.__instance;
-}
-
-function createNoopOrchestrator() {
-  const noop = () => {};
-  // Referentially STABLE snapshot object — React's useSyncExternalStore
-  // (used by OrchestratedToasterHost.tsx) compares consecutive getSnapshot()
-  // return values with Object.is(). A fresh object literal on every call
-  // always compares unequal, which React interprets as "the store changed
-  // mid-render" and immediately re-renders to re-check — forever. That
-  // infinite render loop trips React's "Maximum update depth exceeded"
-  // safety valve, which unmounts the entire tree (blank #root / black
-  // screen) since nothing here ever wraps in an error boundary that can
-  // recover from a render-phase throw. Returning the SAME object every call
-  // (this noop orchestrator's state truly never changes) is what
-  // useSyncExternalStore requires. See orchestrator.ts's real getSnapshot(),
-  // which already returns `this.state` (a stable reference) for the same
-  // reason.
-  const snapshot = {
-    version: '1.0',
-    startupCount: 0,
-    totalUsageMs: 0,
-    turnCount: 0,
-    homepageMountedAt: null,
-    homepageFrozenAt: null,
-    homepageCurrentlyMounted: false,
-    appInForeground: true,
-    meetingActive: false,
-    queue: [],
-    completed: {},
-    skipped: new Set(),
-    activeToasterId: null,
-    lastShownTimes: {},
-  };
-  return {
-    start: noop,
-    stop: noop,
-    emit: noop,
-    subscribe: () => noop,
-    getSnapshot: () => snapshot,
-    markDismissed: noop,
-    markSkipped: noop,
-    setUserState: noop,
-    getUserState: () => DEFAULT_USER_STATE,
-  };
-}
+// NOTE: a stateful `getOrchestrator()` export was DELIBERATELY REMOVED here
+// (2026-07-10) — see the file header. The real, only orchestrator singleton
+// is `getOrchestrator()` in orchestrator.ts. Re-adding one here silently
+// shadows it in the Vite bundle and reintroduces the blank-launcher bug.

--- a/src/lib/onboarding/orchestrator.ts
+++ b/src/lib/onboarding/orchestrator.ts
@@ -170,7 +170,13 @@ export class OnboardingOrchestrator {
   private state: OrchestratorState;
   private userState: UserState = DEFAULT_USER_STATE;
   private listeners = new Set<Listener>();
-  private rafHandle: number | null = null;
+  // Drain-loop handle. Historically this was a per-FRAME requestAnimationFrame
+  // that rescheduled itself forever (see the NATIVE-LEAK note on scheduleTick).
+  // It is now a low-frequency setTimeout so the renderer can go idle between
+  // ticks — a rAF loop keeps Chromium's compositor permanently non-idle, and
+  // under software compositing (Windows / macOS-GPU-fallback) that turns the
+  // launcher's always-on animations into unbounded native raster-tile churn.
+  private tickTimer: ReturnType<typeof setTimeout> | null = null;
   private running = false;
   private stageConfigs: StageConfig[] = [];
   // Bumped on every notify() so useSyncExternalStore consumers see a new
@@ -209,14 +215,14 @@ export class OnboardingOrchestrator {
     }
 
     this.persist();
-    this.scheduleTick();
+    this.ensureDraining();
   }
 
   stop(): void {
     this.running = false;
-    if (this.rafHandle !== null) {
-      cancelAnimationFrame(this.rafHandle);
-      this.rafHandle = null;
+    if (this.tickTimer !== null) {
+      clearTimeout(this.tickTimer);
+      this.tickTimer = null;
     }
   }
 
@@ -253,6 +259,11 @@ export class OnboardingOrchestrator {
   private notify(): void {
     this.revision++;
     this.listeners.forEach(l => l(this.state))
+    // A state change may have made a stage newly eligible (foreground regained,
+    // meeting ended, usage tick, user-state patch, slot freed on dismiss). Re-arm
+    // the drain timer if it had stopped. Idempotent — no-op if already ticking or
+    // fully drained. This is what replaces the old always-on per-frame loop.
+    this.ensureDraining();
   }
 
   // ─── Event bus ────────────────────────────────────────────────
@@ -337,19 +348,74 @@ export class OnboardingOrchestrator {
   }
 
   // ─── Drain loop ───────────────────────────────────────────────
+  //
+  // NATIVE-LEAK FIX (2026-07-10): this used to be a self-perpetuating
+  // requestAnimationFrame loop (scheduleTick → rAF → tick → scheduleTick) that
+  // rescheduled EVERY FRAME (~60fps) for the entire lifetime of the launcher
+  // window, regardless of whether there was any pending onboarding work. A
+  // never-idling rAF keeps Chromium's compositor permanently in the
+  // "BeginFrame pending" state, so it produces a real frame every vsync and
+  // never enters the idle path that reclaims raster tiles. Combined with the
+  // launcher's `repeat: Infinity` toaster animations, under SOFTWARE
+  // compositing (Windows 10, macOS-27 GPU-fallback) that drove unbounded
+  // PartitionAlloc raster-tile churn — a native (non-V8) memory leak that grew
+  // RSS to multiple GB with a flat JS heap and OOM-froze the app / crashed the
+  // renderer in fontations_ffi. Confirmed by per-day git bisect: introduced by
+  // the orchestrator (cf6a2f9, 2026-07-04), absent at 8836b40 (2026-07-03).
+  //
+  // The loop is now:
+  //   • a low-frequency setTimeout (DRAIN_INTERVAL_MS), NOT a rAF — a timer
+  //     does not request animation frames, so the renderer goes idle between
+  //     ticks and the compositor reclaims tiles normally;
+  //   • self-terminating: it stops scheduling once every stage is resolved
+  //     (drained) or the app leaves the evaluable state, and re-arms lazily via
+  //     ensureDraining() whenever a state-change event lands (see notify()).
+  // Time-based stage triggers (2–10s homepage-duration gates) still fire within
+  // one DRAIN_INTERVAL_MS, so the onboarding funnel is behaviourally unchanged.
 
-  private scheduleTick(): void {
+  private static readonly DRAIN_INTERVAL_MS = 1000;
+
+  /** Lazily (re)start the drain timer if there is still work to evaluate. */
+  private ensureDraining(): void {
     if (!this.running) return;
-    this.rafHandle = requestAnimationFrame(() => {
+    if (this.tickTimer !== null) return;          // already scheduled
+    if (this.isFullyDrained()) return;            // nothing left to show, ever
+    this.tickTimer = setTimeout(() => {
+      this.tickTimer = null;
       this.tick();
-      this.scheduleTick();
-    });
+    }, OnboardingOrchestrator.DRAIN_INTERVAL_MS);
   }
 
   private tick(): void {
     if (!this.running) return;
-    if (!this.shouldEvaluate()) return;
-    this.evaluateAndDispatch();
+    if (this.shouldEvaluate()) {
+      this.evaluateAndDispatch();
+    }
+    // Re-arm only while there is still an unresolved stage. When the queue is
+    // fully drained the timer stops entirely and the renderer stays idle until
+    // a new event (foreground/usage/meeting/user-state) calls ensureDraining().
+    this.ensureDraining();
+  }
+
+  /**
+   * True when no queued stage can ever be shown again this session — every
+   * stage is completed, skipped, or dismissed-this-session — so the drain
+   * timer has no reason to keep ticking. A time-gated stage that is merely
+   * "not yet eligible" is NOT drained (returns false) so its duration trigger
+   * still gets a chance to fire.
+   */
+  private isFullyDrained(): boolean {
+    if (this.state.activeToasterId !== null) return false; // a toaster is up
+    return this.state.queue.every(
+      id =>
+        this.state.completed[id] != null ||
+        this.state.skipped.has(id) ||
+        this.dismissedThisSession.has(id) ||
+        // A queued id with no registered config can never be shown (e.g. a
+        // legacy/persisted stage that no longer exists, or one whose config
+        // wasn't passed to start()), so it must not keep the drain loop alive.
+        !this.stageConfigs.some(c => c.id === id),
+    );
   }
 
   private shouldEvaluate(): boolean {


### PR DESCRIPTION
﻿## Description

Fixes a bug where STT API keys (Deepgram, Groq, OpenAI, etc.) appeared to save successfully but were silently lost after restarting the app.

## Root Cause

\CredentialsManager.saveCredentials()\ prefers the OS keyring (\safeStorage\ via DPAPI on Windows). When \isEncryptionAvailable()\ returns \	rue\, it writes via \safeStorage.encryptString()\ and then **deletes the fallback file**. However, on Windows, DPAPI can throw after \isEncryptionAvailable()\ returns \	rue\ — for example due to policy restrictions, roaming profiles, or sandboxing regressions.

The old code placed BOTH the keyring write AND the fallback write inside the same \	ry\ block. When the keyring write threw, execution jumped straight to the \catch\, returning \alse\ — **without ever attempting the fallback**. The key was in memory (so it worked during the session) but never reached disk, so it vanished after restart.

## Fix

- The keyring write is now wrapped in its own \	ry-catch\
- If it throws, it logs a warning and falls through to the app-managed encrypted fallback (AES-256-GCM via \credentialFallbackCrypto.ts\)
- The fallback path now has its own separate \	ry-catch\ for genuinely unwritable disk scenarios

## Testing

- \
pm run typecheck:electron\ passes
- \
pm run build:electron\ succeeds

Closes #369
