### PR TITLE
fix(credentials): fall back to app-managed encryption when OS keyring save fails (PR #370 + senior review follow-ups)

### DIFF
--- a/electron/services/CredentialsManager.ts
+++ b/electron/services/CredentialsManager.ts
@@ -901,6 +901,12 @@ export class CredentialsManager {
      * to decide whether to warn.
      */
     private saveCredentials(): boolean {
+        // Try the OS keyring first. When safeStorage is available, this is the
+        // preferred path. On Windows the underlying DPAPI can still throw after
+        // isEncryptionAvailable() returns true (e.g. policy restrictions, roaming
+        // profiles) — we must catch that and fall through to the app-managed
+        // fallback instead of returning false, otherwise keys are silently lost
+        // on restart (the bug reported for Deepgram and other STT keys).
         try {
             if (safeStorage.isEncryptionAvailable()) {
                 const data = JSON.stringify(this.credentials);
@@ -912,18 +918,32 @@ export class CredentialsManager {
                 this.removeFallbackFile();
                 return true;
             }
+        } catch (keyringErr) {
+            // Keyring write failed — don't give up yet. Try the fallback below.
+            // Whitelist `message` only: on Windows, DPAPI exceptions can include
+            // user SIDs and profile paths, which we don't want in any downstream
+            // log scraper.
+            console.warn('[CredentialsManager] Keyring save failed, trying app-managed fallback:', (keyringErr as Error)?.message ?? String(keyringErr));
+        }
 
-            // OS keyring unavailable — use the app-managed encrypted fallback so the
-            // key is not silently lost on restart. Weaker than the keyring (see
-            // credentialFallbackCrypto.ts) but never plaintext at rest.
+        // OS keyring unavailable or threw — use the app-managed encrypted fallback so the
+        // key is not silently lost on restart. Weaker than the keyring (see
+        // credentialFallbackCrypto.ts) but never plaintext at rest.
+        try {
             const blob = encryptCredentialBlob(JSON.stringify(this.credentials), this.getFallbackKey());
             const tmpFb = FALLBACK_PATH + '.tmp';
             fs.writeFileSync(tmpFb, blob, { mode: 0o600 });
             fs.renameSync(tmpFb, FALLBACK_PATH);
+            // Stale keyring file is now out of sync (the fallback has the latest
+            // credentials). Remove it so loadCredentials() does not find it on
+            // next startup and treat the old keyring data as authoritative —
+            // otherwise the just-saved key would be silently overwritten by the
+            // stale keyring contents when loadCredentials() deletes the fallback.
+            this.removeKeyringFile();
             console.warn('[CredentialsManager] OS keyring unavailable; saved via app-managed encrypted fallback (machine-bound, will survive restart)');
             return true;
         } catch (error) {
-            console.error('[CredentialsManager] Failed to save credentials:', error);
+            console.error('[CredentialsManager] Failed to save credentials:', (error as Error)?.message ?? String(error));
             return false;
         }
     }
@@ -935,7 +955,25 @@ export class CredentialsManager {
                 fs.unlinkSync(FALLBACK_PATH);
             }
         } catch (err) {
-            console.warn('[CredentialsManager] Could not remove stale fallback file:', err);
+            console.warn('[CredentialsManager] Could not remove fallback credential file:', err);
+        }
+    }
+
+    /**
+     * Remove the stale OS keyring credential file (best-effort).
+     * Called when the keyring write failed and we fell back to the app-managed
+     * fallback — the old keyring file contains stale credentials and would
+     * be treated as authoritative by loadCredentials() on next startup,
+     * silently discarding the just-saved keys.
+     */
+    private removeKeyringFile(): void {
+        try {
+            if (fs.existsSync(CREDENTIALS_PATH)) {
+                fs.unlinkSync(CREDENTIALS_PATH);
+                console.log('[CredentialsManager] Removed keyring credential file');
+            }
+        } catch (err) {
+            console.warn('[CredentialsManager] Could not remove keyring credential file:', err);
         }
     }
 
@@ -955,11 +993,64 @@ export class CredentialsManager {
     private loadCredentials(): void {
         try {
             // 1) Encrypted keyring file is authoritative when the keyring is available.
+            //    However, if a previous saveCredentials() hit the fallback path AND the
+            //    stale-keyring cleanup failed (rare — locked file, permissions, etc.),
+            //    the on-disk keyring is stale relative to the fallback we just wrote.
+            //    Reading it would silently discard the fresh fallback. Detect this via
+            //    mtimes: when the fallback is newer than the keyring, drop the keyring
+            //    before loading.
+            //
+            //    Caveat: this check assumes that any legitimate round-trip through
+            //    the keyring path leaves the keyring mtime >= fallback mtime (the
+            //    fallback is removed by removeFallbackFile() on line ~1035 immediately
+            //    after a keyring load). It will mis-fire in two scenarios:
+            //      (a) backup-restore copies a stale fallback next to a current keyring
+            //          — the fallback is newer (from the restore time) but contains
+            //          STALE data from another machine. This is rare; the user will
+            //          re-enter the key on first save.
+            //      (b) cross-machine copy where both files share a salt (impossible —
+            //          SALT_PATH is machine-bound via os.userInfo/MachineGuid, so a
+            //          cross-machine fallback cannot decrypt anyway).
+            //    Both edge cases are bounded and recoverable; the worst outcome is a
+            //    single re-entry of the affected credential.
             if (fs.existsSync(CREDENTIALS_PATH)) {
                 let keyringAvailable = false;
                 try { keyringAvailable = safeStorage.isEncryptionAvailable(); } catch { keyringAvailable = false; }
 
-                if (keyringAvailable) {
+                if (keyringAvailable && fs.existsSync(FALLBACK_PATH)) {
+                    try {
+                        const keyringMtime = fs.statSync(CREDENTIALS_PATH).mtimeMs;
+                        const fallbackMtime = fs.statSync(FALLBACK_PATH).mtimeMs;
+                        // The fallback's mtime reflects the LAST time a saveCredentials()
+                        // completed its atomic rename. If the keyring is older than the
+                        // fallback, the only way that can happen on a healthy machine is
+                        // a saveCredentials() that hit the fallback path because the
+                        // keyring write threw (rare — DPAPI policy/roaming profile), or a
+                        // one-time migration when isEncryptionAvailable() flipped back
+                        // from false to true (in which case the migrate-up branch at line
+                        // ~1067 deletes the fallback immediately after re-writing the
+                        // keyring, so this comparison won't see the new mtimes).
+                        //
+                        // KNOWN MIS-FIRE: a user-side backup-restore that drops a stale
+                        // `credentials.fallback.enc` (different machine, different salt)
+                        // next to a current `credentials.enc` would trigger this branch.
+                        // The fallback would then "win" — but the fallback decrypts with
+                        // THIS machine's salt and key material, so decryption would fail
+                        // with an auth error (the GCM tag wouldn't verify) and loadCredentials
+                        // would log "Failed to read app-managed fallback" and start fresh.
+                        // The user would simply re-enter the affected key on next save.
+                        // Bounded and recoverable; documented in the comment block above.
+                        if (fallbackMtime > keyringMtime) {
+                            console.warn('[CredentialsManager] Stale keyring file detected (older than fallback); removing before load');
+                            this.removeKeyringFile();
+                        }
+                    } catch (statErr) {
+                        // statSync failed — proceed with the normal path; if the keyring
+                        // is unreadable we'll fall through to the fallback below.
+                    }
+                }
+
+                if (keyringAvailable && fs.existsSync(CREDENTIALS_PATH)) {
                     const encrypted = fs.readFileSync(CREDENTIALS_PATH);
                     const decrypted = safeStorage.decryptString(encrypted);
                     try {

--- a/electron/services/__tests__/CredentialPersistenceBehavior.test.mjs
+++ b/electron/services/__tests__/CredentialPersistenceBehavior.test.mjs
@@ -28,13 +28,22 @@ const COMPILED = path.resolve(
 // hostname is irrelevant to the key now — that's the point of one of the tests).
 function makeEnv() {
   const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'cred-persist-'));
-  const state = { keyringAvailable: false, userData };
+  const state = { keyringAvailable: false, userData, encryptShouldThrow: false };
   const fakeElectron = {
     app: { getPath: () => state.userData, isPackaged: false, getVersion: () => '0.0.0-test' },
     safeStorage: {
       isEncryptionAvailable: () => state.keyringAvailable,
       // Trivial reversible transform so the keyring path is exercisable in tests.
-      encryptString: (s) => Buffer.concat([Buffer.from('KR'), Buffer.from(s, 'utf8')]),
+      // When `encryptShouldThrow` is set, encryptString throws to model the
+      // Windows DPAPI failure shape (`isEncryptionAvailable()` returns true but
+      // `encryptString()` throws on the actual call due to policy/roaming
+      // profile/sandboxing).
+      encryptString: (s) => {
+        if (state.encryptShouldThrow) {
+          throw new Error('DPAPI: policy blocked encryption');
+        }
+        return Buffer.concat([Buffer.from('KR'), Buffer.from(s, 'utf8')]);
+      },
       decryptString: (b) => Buffer.from(b).subarray(2).toString('utf8'),
       getSelectedStorageBackend: () => 'basic_text',
     },
@@ -411,4 +420,105 @@ test('SettingsOverlay sends USE_STORED sentinel when input empty but key on disk
   assert.match(fnBody, /hasStoredStt[A-Za-z]+Key/, 'handleTestSttConnection must consult hasStored*Key flags');
   assert.match(fnBody, /apiKeyToSend/, 'handleTestSttConnection must use the apiKeyToSend variable');
   assert.doesNotMatch(fnBody, /'Please enter an API key first'/, 'misleading "Please enter an API key first" message must be removed');
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// PR #370 regression: STT key persistence on Windows when safeStorage.encryptString
+// throws after isEncryptionAvailable() returns true (DPAPI policy/roaming
+// profile/sandboxing failures). The save must fall through to the app-managed
+// fallback instead of returning false (which would surface a misleading "Save
+// Failed" badge to the user). Closes the bug reported for Deepgram + other
+// STT keys.
+// ───────────────────────────────────────────────────────────────────────────
+
+test('PR #370: keyring AVAILABLE but encryptString throws → save falls through to fallback (returns true, NOT false)', () => {
+  const env = makeEnv();
+  env.state.keyringAvailable = true;
+  env.state.encryptShouldThrow = true;
+
+  const cm = freshManager(env);
+  const SECRET = 'dg-LIVE-PR370-FALLTHROUGH-abc123';
+  const persisted = cm.setDeepgramApiKey(SECRET);
+
+  // CRITICAL: the save MUST succeed (true), NOT fail (false). The user entered a
+  // key, sees "Saved" badge, and the key is actually persisted via the fallback.
+  assert.equal(persisted, true,
+    'a keyring write that throws must fall through to the fallback, not return false');
+
+  // Verify the fallback file exists and contains the secret.
+  const fbPath = path.join(env.userData, 'credentials.fallback.enc');
+  assert.ok(fs.existsSync(fbPath), 'fallback file must exist after a keyring-throws save');
+
+  // Verify a fresh cold-start loads the secret from the fallback.
+  const cm2 = freshManager(env);
+  assert.equal(cm2.getDeepgramApiKey(), SECRET,
+    'a saved-via-fallback key must survive a restart');
+});
+
+test('PR #370: keyring-throws save leaves NO stale credentials.enc on disk', () => {
+  const env = makeEnv();
+  env.state.keyringAvailable = true;
+  env.state.encryptShouldThrow = true;
+
+  const cm = freshManager(env);
+  cm.setDeepgramApiKey('dg-LIVE-PR370-CLEANUP-xyz');
+
+  // The stale keyring file (if any pre-existed) must have been removed before
+  // the fallback write returned. Otherwise loadCredentials() would read it on
+  // next startup and discard the fresh fallback.
+  const keyringPath = path.join(env.userData, 'credentials.enc');
+  assert.ok(!fs.existsSync(keyringPath),
+    'a successful fallback save must unlink any pre-existing stale credentials.enc');
+});
+
+test('PR #370: loadCredentials detects stale-keyring state via mtime and unlinks before read', () => {
+  const env = makeEnv();
+
+  // Pre-populate BOTH stores with mtimes that make the fallback strictly newer
+  // than the keyring — modeling a saveCredentials() that hit the fallback path
+  // (fallback just-written) but failed to clean up the stale keyring.
+  const keyringPath = path.join(env.userData, 'credentials.enc');
+  const fallbackPath = path.join(env.userData, 'credentials.fallback.enc');
+  const OLD_TIME = new Date('2026-01-01T00:00:00Z');
+  const NEW_TIME = new Date('2026-07-01T00:00:00Z');
+  fs.writeFileSync(keyringPath, Buffer.from('KR{"deepgramApiKey":"OLD-STALE-VALUE"}'));
+  fs.writeFileSync(fallbackPath, Buffer.from('garbage-encrypted-blob'));
+  fs.utimesSync(keyringPath, OLD_TIME, OLD_TIME);
+  fs.utimesSync(fallbackPath, NEW_TIME, NEW_TIME);
+
+  // Keyring reports available (the normal macOS/healthy-Windows state).
+  env.state.keyringAvailable = true;
+
+  // Cold-start: loadCredentials must detect the mtime inversion and unlink the
+  // stale keyring BEFORE attempting to decrypt it (otherwise it would either
+  // corrupt the credential set or shadow the fallback).
+  freshManager(env);
+
+  assert.ok(!fs.existsSync(keyringPath),
+    'a keyring older than the fallback must be unlinked before load attempts to decrypt it');
+});
+
+test('PR #370: loadCredentials does NOT discard a fresh keyring when fallback is older (legitimate round-trip)', () => {
+  const env = makeEnv();
+
+  // Inverse: keyring is newer than fallback. Models the normal
+  // keyring-saves-everything case where removeFallbackFile() ran cleanly and
+  // the fallback is just a stale leftover from a previous machine.
+  const keyringPath = path.join(env.userData, 'credentials.enc');
+  const fallbackPath = path.join(env.userData, 'credentials.fallback.enc');
+  const NEW_TIME = new Date('2026-07-01T00:00:00Z');
+  const OLD_TIME = new Date('2026-01-01T00:00:00Z');
+  fs.writeFileSync(keyringPath, Buffer.from('KR{"deepgramApiKey":"CURRENT-VALID-VIA-KEYRING"}'));
+  fs.writeFileSync(fallbackPath, Buffer.from('garbage-from-old-machine'));
+  fs.utimesSync(keyringPath, NEW_TIME, NEW_TIME);
+  fs.utimesSync(fallbackPath, OLD_TIME, OLD_TIME);
+
+  env.state.keyringAvailable = true;
+
+  const cm = freshManager(env);
+
+  assert.ok(fs.existsSync(keyringPath),
+    'a fresher keyring must NOT be discarded just because a stale fallback exists alongside it');
+  assert.equal(cm.getDeepgramApiKey(), 'CURRENT-VALID-VIA-KEYRING',
+    'the keyring path must load the current value (not fall through to the fallback)');
 });


### PR DESCRIPTION
## Summary

Fixes the Windows-specific bug from PR #370 (#369) where `safeStorage.encryptString()` could throw after `isEncryptionAvailable()` returned true (DPAPI policy/roaming profile/sandboxing failures), causing `saveCredentials()` to silently lose STT API keys on restart.

This PR supersedes PR #370. PR #370 was based on a stale fork (parent `addc42c2` from 2026-07-11; current main has 4 days of intervening changes), so I closed it and rebuilt the same fix on top of current main with additional senior-review follow-ups.

## The fix

`saveCredentials()` now wraps the keyring write in its own try-catch; on throw, it falls through to the app-managed AES-256-GCM fallback (`credentialFallbackCrypto.ts`). A successful fallback save unlinks any stale `credentials.enc` so `loadCredentials()` does not find it on next startup and silently overwrite the just-saved keys with old keyring data.

## Load-time defense (this PR's addition)

`loadCredentials()` now compares mtimes of `credentials.enc` vs `credentials.fallback.enc`. When the fallback is newer, the stale keyring is unlinked before read. This catches the rare case where save-time cleanup failed (locked file, EACCES) and prevents the stale keyring from shadowing the fresh fallback on next startup. Documented as a bounded, recoverable mis-fire scenario (cross-machine backup-restore where the fallback has a different salt and GCM auth fails on decrypt).

## Senior review follow-ups

- **Error message redaction:** Whitelist `error.message` only on keyring catches. DPAPI exceptions on Windows can include user SIDs and profile paths; the original `console.warn(..., keyringErr)` would leak those to any downstream log scraper.
- **Log phrasing:** Don't assert 'fallback is authoritative' in a helper that could be called from elsewhere; use neutral 'Removed keyring credential file' and 'Could not remove fallback credential file'.
- **Code dedup:** Use the existing `removeKeyringFile()` helper in `loadCredentials()` instead of duplicating the nested try/catch.
- **Comment expansion:** Document the mtime-check invariant precisely with the mis-fire scenario.

## Tests

Four new regression tests in `CredentialPersistenceBehavior.test.mjs`:
1. Save falls through to fallback when `encryptString` throws (the actual bug scenario).
2. Keyring-throws save leaves NO stale `credentials.enc` on disk.
3. Load detects stale-keyring via mtime and unlinks before read.
4. Load does NOT discard a fresh keyring when fallback is older (legitimate round-trip — regression guard for the dedup refactor).

`makeEnv()` got an `encryptShouldThrow` knob for (1) and (2).

## Verification

- `npm run build:electron`: clean.
- Credential test suite: 59/59 pass (was 55 before; +4 new PR #370 tests).
- Other pre-existing test failures (Issue322KeychainPersistence 9/10, SttReconfigureSerialization 2/8, Issue301 1/8) are unrelated and pre-existing on origin/main.

Fixes #369
Closes #370