### PR TITLE
feat(ui): Apple-level aurora focus micro-interaction for chat input

### DIFF
--- a/src/components/NativelyInterface.tsx
+++ b/src/components/NativelyInterface.tsx
@@ -1136,7 +1136,7 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
   const codeHeaderClass = 'overlay-code-header-surface';
   const codeHeaderTextClass = 'overlay-text-muted';
   const quickActionClass = 'overlay-chip-surface overlay-text-interactive';
-  const inputClass = `${isLightTheme ? 'focus:ring-black/10' : 'focus:ring-white/10'} overlay-input-surface overlay-input-text`;
+  const inputClass = `aurora-focus overlay-input-surface overlay-input-text`;
   const controlSurfaceClass = 'overlay-control-surface overlay-text-interactive';
 
   // PERF: hoist ReactMarkdown `components` maps for every streaming intent
@@ -6387,7 +6387,7 @@ Provide only the answer, nothing else.`;
                     // the CGEventTap, so typing routes through that path.
                     onMouseDown={blockInputFocus}
                     readOnly={stealthTapActive}
-                    className={`w-full border focus:ring-1 rounded-xl pl-3 pr-10 py-2.5 focus:outline-none transition-all duration-200 ease-sculpted text-[13px] leading-relaxed ${inputClass} ${stealthTapActive ? 'ring-2 ring-emerald-400/30 border-emerald-400/40 shadow-[0_0_12px_rgba(52,211,153,0.15)]' : ''}`}
+                    className={`w-full border rounded-xl pl-3 pr-10 py-2.5 text-[13px] leading-relaxed ${inputClass} ${stealthTapActive ? 'ring-2 ring-emerald-400/30 border-emerald-400/40 shadow-[0_0_12px_rgba(52,211,153,0.15)]' : ''}`}
                     style={appearance.inputStyle}
                   />
 

--- a/src/index.css
+++ b/src/index.css
@@ -1897,6 +1897,57 @@ body {
   transform-origin: center;
 }
 
+/* Aurora Focus — Apple-level micro-interaction */
+@keyframes aurora {
+  0%   { box-shadow: 0 0 0 0 rgba(167, 139, 250, 0); }
+  35%  { box-shadow: 0 0 0 4px rgba(167, 139, 250, 0.12), 0 0 18px 2px rgba(99, 102, 241, 0.18); }
+  100% { box-shadow: 0 0 0 0 rgba(167, 139, 250, 0); }
+}
+
+.aurora-focus {
+  position: relative;
+  transform: translateZ(0);
+  transition:
+    background-color 240ms cubic-bezier(0.22, 1, 0.36, 1),
+    border-color 240ms cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 320ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 320ms cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: transform, box-shadow;
+}
+
+.aurora-focus:hover {
+  transform: translateY(-0.5px) translateZ(0);
+}
+
+.aurora-focus:focus {
+  animation: aurora 900ms cubic-bezier(0.22, 1, 0.36, 1);
+  outline: none;
+  transform: translateY(-0.5px) translateZ(0);
+}
+
+.aurora-focus:focus::after {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  pointer-events: none;
+  box-shadow:
+    inset 0 0 0 1px rgba(167, 139, 250, 0.25),
+    inset 0 1px 0 0 rgba(255, 255, 255, 0.06);
+  opacity: 1;
+  transition: opacity 600ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .aurora-focus,
+  .aurora-focus:hover,
+  .aurora-focus:focus {
+    transition: background-color 200ms ease, border-color 200ms ease;
+    transform: none;
+    animation: none;
+  }
+}
+
 .stt-wave-dot:nth-child(2) { animation-delay: 0.15s; }
 .stt-wave-dot:nth-child(3) { animation-delay: 0.3s; }
 .stt-wave-dot:nth-child(4) { animation-delay: 0.45s; }


### PR DESCRIPTION
Replaces the harsh focus:ring with a layered, hardware-accelerated micro-interaction on the overlay chat input bar:

- New @keyframes aurora: soft 35% peak then zero-reset for a graceful pulse
- .aurora-focus class uses Apple's cubic-bezier(0.22, 1, 0.36, 1) easing
- 240/320ms staggered transitions for background, border, shadow, transform
- Hover/focus translateY(-0.5px) lift on GPU layer (translateZ(0))
- Inset focus ring via ::after pseudo-element
- prefers-reduced-motion fallback strips animation, keeps state transitions

Visual effect: Spotlight/iMessage-grade softness on focus, no jank from compositor thrash.

## Summary
<!-- What does this PR do and why? Link to issues: Fixes #123 -->

Fixes #

## Type of Change
- 🐛 Bug Fix
- ✨ New Feature
- 🎨 Refactor / Style Update
- 📝 Documentation

## Testing & Environment
- [ ] Manual test performed on: **[e.g. Windows 11]**
<!-- Describe how to verify the changes below -->

## Visuals (Optional)
<!-- Drag and drop screenshots or videos here. -->
