### PR TITLE
fix(overlay): contain horizontal scrolling to code blocks

### DIFF
--- a/src/components/NativelyInterface.tsx
+++ b/src/components/NativelyInterface.tsx
@@ -316,8 +316,13 @@ const HighlightedCode = React.memo(
         </div>
         {/* No-wrap horizontal scroll: code line layout stays stable as the
                 canvas grows/shrinks. Without this, wrapped lines re-flow at every
-                spring tick, the block height jitters, and content below shifts. */}
-        <div className="bg-transparent overflow-x-auto">
+                spring tick, the block height jitters, and content below shifts.
+                w-full + min-w-0 keep the inner scroller contained — a flex/grid
+                child defaults to min-width:auto, which lets the <pre>'s intrinsic
+                min-content width stretch the surrounding card and ultimately the
+                chat viewport sideways. See MeetingDetails.tsx CodeHero for the
+                same pattern. */}
+        <div className="w-full min-w-0 bg-transparent overflow-x-auto">
           <SyntaxHighlighter
             language={resolved}
             style={codeTheme}
@@ -503,13 +508,13 @@ const MessageRow = React.memo(
         ? 'max-w-[85%] p-0'
         : 'max-w-[85%] px-4 py-3';
     return (
-      <div className="w-full" {...(isCodeMsg ? { 'data-code-msg': 'true' } : {})}>
+      <div className="w-full min-w-0" {...(isCodeMsg ? { 'data-code-msg': 'true' } : {})}>
         <div
-          className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
+          className={`flex min-w-0 ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
         >
           <div
             className={`
-              ${bubbleMaxClass} text-[15px] leading-relaxed relative group whitespace-pre-wrap
+              min-w-0 ${bubbleMaxClass} text-[15px] leading-relaxed relative group whitespace-pre-wrap
               ${
                 msg.role === 'user'
                   ? isLightTheme
@@ -6060,7 +6065,7 @@ Provide only the answer, nothing else.`;
               {showAnswerPanel && (
                 <motion.div
                   ref={scrollContainerRef}
-                  className="relative z-10 flex-1 overflow-y-auto p-4 space-y-3 no-drag isolate"
+                  className="relative z-10 flex-1 overflow-y-auto overflow-x-hidden p-4 space-y-3 no-drag isolate"
                   layout={false}
                   style={{ scrollbarWidth: 'none', maxHeight: scrollMaxH }}
                 >

--- a/src/lib/__tests__/overlayHorizontalScrollContainment.test.mjs
+++ b/src/lib/__tests__/overlayHorizontalScrollContainment.test.mjs
@@ -1,0 +1,54 @@
+// Regression test for the meeting overlay becoming horizontally scrollable.
+//
+// The chat viewport may scroll vertically, but horizontal scrolling belongs only
+// to code blocks. Long unbreakable code lines must therefore scroll inside the
+// dedicated code scroller without widening MessageRow or the outer chat pane.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const sourcePath = path.resolve(__dirname, '../../components/NativelyInterface.tsx');
+const source = readFileSync(sourcePath, 'utf8');
+
+test('meeting chat viewport disables horizontal scrolling while retaining vertical scrolling', () => {
+  assert.match(
+    source,
+    /ref=\{scrollContainerRef\}[\s\S]{0,180}className="[^"]*overflow-y-auto[^"]*overflow-x-hidden[^"]*"/,
+    'BUG: the meeting chat viewport must combine overflow-y-auto with overflow-x-hidden so regular answers cannot move the whole interface sideways.',
+  );
+});
+
+test('code answers retain a dedicated contained horizontal scroller', () => {
+  assert.match(
+    source,
+    /className="w-full min-w-0 bg-transparent overflow-x-auto"/,
+    'BUG: long code lines must keep scrolling inside a w-full min-w-0 overflow-x-auto code container.',
+  );
+  assert.match(
+    source,
+    /wrapLongLines=\{false\}/,
+    'Code lines should remain unwrapped; containment belongs on the code scroller rather than by changing code presentation.',
+  );
+});
+
+test('message flex boundaries allow code scroller to shrink inside the chat viewport', () => {
+  assert.match(
+    source,
+    /<div className="w-full min-w-0"[^>]*data-code-msg/,
+    'BUG: MessageRow root must use min-w-0 or an unbreakable code line can enlarge the entire chat viewport.',
+  );
+  assert.match(
+    source,
+    /className=\{`flex min-w-0 \$\{msg\.role/,
+    'BUG: MessageRow flex wrapper must use min-w-0 so its code child can shrink and scroll internally.',
+  );
+  assert.match(
+    source,
+    /min-w-0 \$\{bubbleMaxClass\} text-\[15px\]/,
+    'BUG: the message bubble must use min-w-0 so intrinsic code width does not escape the row.',
+  );
+});


### PR DESCRIPTION
## Summary
- disable horizontal scrolling on the meeting chat viewport
- preserve horizontal scrolling inside long code blocks
- add min-width containment across message flex boundaries
- add regression coverage for the layout contract

## Verification
- `node --test src/lib/__tests__/overlayHorizontalScrollContainment.test.mjs`
- `npx tsc --noEmit`
- senior code review: APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)