### PR TITLE
fix(onboarding): stop quiet_window infinite drain loop that OOM-crashed the launcher

### DIFF
--- a/electron/intelligence/__tests__/IntelligenceFlags.test.mjs
+++ b/electron/intelligence/__tests__/IntelligenceFlags.test.mjs
@@ -54,7 +54,8 @@ const ALL_FLAG_KEYS = [
   // isInternalDevTestContext() (FALSE under this bare node harness); the two
   // blocking flags default OFF everywhere.
   'contextOsEnabled', 'contextOsManualChatEnabled', 'contextOsWtaEnabled',
-  'contextOsRecapFollowupEnabled', 'contextOsEvidencePackEnabled', 'contextOsMemorySafetyEnabled',
+  'contextOsRecapFollowupEnabled', 'contextOsEvidencePackEnabled', 'contextOsMultiFamilyEvidenceEnabled',
+  'contextOsMemorySafetyEnabled',
   'contextOsEnforceSourceCapabilities', 'contextOsPropertyValidation',
 ];
 

--- a/electron/intelligence/intelligenceFlags.ts
+++ b/electron/intelligence/intelligenceFlags.ts
@@ -167,6 +167,11 @@ export type IntelligenceFlagKey =
   | 'contextOsRecapFollowupEnabled'
   // Build + trace the typed EvidencePack alongside legacy retrieval.
   | 'contextOsEvidencePackEnabled'
+  // Extend the governed EvidencePack path (TurnEvidenceCoordinator multi-family
+  // pack) to EVERY profile/JD-bearing manual-chat turn, not just doc-grounded
+  // custom modes. Narrower gate on top of contextOsEvidencePackEnabled because
+  // its blast radius is larger (see ipcHandlers.ts "CONTEXT OS 2026-07-17").
+  | 'contextOsMultiFamilyEvidenceEnabled'
   // Memory safety: assistant-claim extraction + validated-claim reuse gates.
   | 'contextOsMemorySafetyEnabled'
   // Enforce capability-scoped retrieval (block, not just log, forbidden fetches).
@@ -330,6 +335,13 @@ const FLAGS: Record<IntelligenceFlagKey, FlagSpec> = {
   contextOsWtaEnabled: { env: 'NATIVELY_CONTEXT_OS_WTA', setting: 'contextOsWtaEnabled', default: isInternalDevTestContext },
   contextOsRecapFollowupEnabled: { env: 'NATIVELY_CONTEXT_OS_RECAP_FOLLOWUP', setting: 'contextOsRecapFollowupEnabled', default: isInternalDevTestContext },
   contextOsEvidencePackEnabled: { env: 'NATIVELY_CONTEXT_OS_EVIDENCE_PACK', setting: 'contextOsEvidencePackEnabled', default: isInternalDevTestContext },
+  // Wired into ipcHandlers.ts's manual-chat path (2026-07-17) but the flag
+  // registration was never landed, which broke `typecheck:electron` (and thus
+  // the packaged build). Same dev/test-ON, prod-OFF convention as its siblings:
+  // the coordinator path only ever REPLACES a raw-text injection with an
+  // equal-or-stricter governed pack and falls through to legacy on any failure,
+  // so prod stays OFF until telemetry validates the wider blast radius.
+  contextOsMultiFamilyEvidenceEnabled: { env: 'NATIVELY_CONTEXT_OS_MULTI_FAMILY_EVIDENCE', setting: 'contextOsMultiFamilyEvidenceEnabled', default: isInternalDevTestContext },
   contextOsMemorySafetyEnabled: { env: 'NATIVELY_CONTEXT_OS_MEMORY_SAFETY', setting: 'contextOsMemorySafetyEnabled', default: isInternalDevTestContext },
   // Real-custom-mode-repair (2026-07-11), Phase 7: these two flags gate the
   // ONLY code paths that actually ACT on the kernel's decision (the

--- a/src/lib/onboarding/__tests__/stageCatalog.test.mjs
+++ b/src/lib/onboarding/__tests__/stageCatalog.test.mjs
@@ -9,7 +9,28 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { shouldShowToaster } from '../orchestrator.mjs';
-import { STAGES } from '../stageCatalog.mjs';
+import { STAGES, QUIET_WINDOW_STAGE } from '../stageCatalog.mjs';
+
+// ─── Drain-loop safety invariant ────────────────────────────────────
+// A gate-only stage is auto-completed inside evaluateAndDispatch()'s
+// `do { … } while (progressMade && !activeToasterId)` loop. completeToaster()
+// records completion, but shouldShowToaster() only suppresses a completed stage
+// when `onceEver` is set. So a gate-only stage WITHOUT onceEver stays eligible
+// after completing, keeps setting progressMade=true, and the loop spins
+// synchronously forever — pegging the renderer main thread and OOM-crashing it
+// (the 2026-07-19 quiet_window regression: RSS → ~9 GB, exitCode-5 crash).
+// This invariant makes that misconfiguration a failing test, not a field crash.
+test('INVARIANT: every gate-only stage is onceEver (else the drain loop hangs)', () => {
+  const allStages = [...STAGES, QUIET_WINDOW_STAGE];
+  for (const s of allStages) {
+    if (s.isGateOnly) {
+      assert.equal(
+        s.onceEver, true,
+        `gate-only stage "${s.id}" must set onceEver:true or evaluateAndDispatch spins forever`,
+      );
+    }
+  }
+});
 
 // ─── Fixtures ──────────────────────────────────────────────────────
 

--- a/src/lib/onboarding/orchestrator.ts
+++ b/src/lib/onboarding/orchestrator.ts
@@ -465,7 +465,26 @@ export class OnboardingOrchestrator {
   private evaluateAndDispatch(): void {
     const ctx = this.buildCtx();
     let progressMade = false;
+    // DEFENSE-IN-DEPTH (2026-07-19): each queued stage can legitimately make
+    // progress at most once per drain (auto-skip → skipped set, or gate-complete
+    // → completed), so the number of passes is bounded by the queue length. A
+    // higher count means a stage is re-transitioning every pass — the signature
+    // of a mis-configured gate-only stage (e.g. isGateOnly without onceEver),
+    // which turns this into a synchronous infinite loop that pegs the renderer
+    // main thread and OOM-crashes it (the quiet_window regression). Bound the
+    // loop so a bad config degrades to "one toaster skipped" instead of a hang.
+    const maxPasses = this.state.queue.length + 2;
+    let passes = 0;
     do {
+      if (++passes > maxPasses) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `[orchestrator] evaluateAndDispatch drain exceeded ${maxPasses} passes — ` +
+          `aborting to avoid a synchronous hang. A gate-only stage is likely ` +
+          `re-completing every pass (missing onceEver?). queue=${JSON.stringify(this.state.queue)}`,
+        );
+        break;
+      }
       progressMade = false;
       for (const id of this.state.queue) {
         const config = this.stageConfigs.find(c => c.id === id);

--- a/src/lib/onboarding/stageCatalog.mjs
+++ b/src/lib/onboarding/stageCatalog.mjs
@@ -133,6 +133,10 @@ export const QUIET_WINDOW_STAGE = {
   id: 'quiet_window',
   order: 99,
   isGateOnly: true,
+  // Parity with stageCatalog.ts: gate-only stages MUST be onceEver or the
+  // orchestrator's evaluateAndDispatch drain loop re-completes them forever
+  // (synchronous infinite loop → native OOM). See the .ts for the full note.
+  onceEver: true,
   triggers: {},
   customPredicate: (ctx) => ctx.turnCount - (ctx.completed._turnCountAtQuietStart ?? 0) >= 3,
 };

--- a/src/lib/onboarding/stageCatalog.ts
+++ b/src/lib/onboarding/stageCatalog.ts
@@ -188,6 +188,18 @@ export const QUIET_WINDOW_STAGE: StageConfig = {
   id: 'quiet_window',
   order: 99, // not used in static ordering
   isGateOnly: true, // No UI — auto-resolves once predicate is satisfied
+  // MUST be onceEver like every other gate-only stage (profile_intelligence,
+  // modes_manager). Without it, evaluateAndDispatch()'s auto-complete branch
+  // re-completes this stage on EVERY pass of its `do { … } while (progressMade
+  // && !activeToasterId)` drain loop: completeToaster() records completion, but
+  // shouldShowToaster() only suppresses a completed stage when `onceEver` is set
+  // (see orchestrator.ts step 2), so without it the stage stays eligible, keeps
+  // setting progressMade=true, and the loop spins synchronously forever — each
+  // pass calling persist()+notify(), churning unbounded native memory. That
+  // pegged the launcher renderer's main thread and grew its RSS to ~9 GB before
+  // an exitCode-5 OOM crash (2026-07-19). It resolves exactly once (3 user turns
+  // after trial_promo), so once-ever is also the correct semantics.
+  onceEver: true,
   triggers: {},
   customPredicate: (ctx: Ctx) => {
     const baseline = ctx.completed['_turnCountAtQuietStart'] ?? 0;


### PR DESCRIPTION
## Summary
Two independent, verified bugs found while investigating a launcher "stuck at logo" / OOM crash.

**1. Launcher native-OOM crash (primary).** `quiet_window` is a gate-only onboarding stage but was missing `onceEver`. In `evaluateAndDispatch()`'s `do { … } while (progressMade && !activeToasterId)` drain loop, a gate-only stage auto-completes via `completeToaster()`, but `shouldShowToaster()` only suppresses a completed stage when `onceEver` is set. So once `quiet_window` became eligible (≥3 turns after `trial_promo`, including the crash's own auto-reload replaying persisted state), it re-completed on every pass, `progressMade` stayed true, and the loop spun **synchronously forever** — each pass calling `persist()` + `notify()` → unbounded native RSS in the launcher renderer (~2 → 9 GB in ~90 s) → `exitCode 5` OOM crash → auto-reload → repeat. That synchronous peg is the "stuck at logo" `UNRESPONSIVE` hang.

- `stageCatalog.ts`/`.mjs`: `onceEver: true` on `QUIET_WINDOW_STAGE` — matches the other gate-only stages (`profile_intelligence`, `modes_manager`); correct semantics (it resolves once, then gates `support`).
- `orchestrator.ts`: bound the drain loop to `queue.length + 2` passes (defense-in-depth — a future mis-configured gate-only stage now degrades to a logged warning instead of a synchronous OOM hang).
- `stageCatalog.test.mjs`: regression invariant — every gate-only stage must set `onceEver` (fails on the old config).

**2. Build unblock.** `ipcHandlers.ts`'s manual-chat path ("CONTEXT OS 2026-07-17") gates the `TurnEvidenceCoordinator` multi-family EvidencePack on `contextOsMultiFamilyEvidenceEnabled`, but the flag registration was never landed in `intelligenceFlags.ts` (the code comment even says "new — see intelligenceFlags.ts"). The dangling key failed `typecheck:electron`, which gates `app:build` — so the packaged app could not be built. Registered it (same dev/test-ON, prod-OFF `isInternalDevTestContext` default as its sibling Context OS flags) + updated the flag-parity test. Included here because upstream `main` currently fails `typecheck:electron`, so CI can't go green without it.

Fixes # N/A (no tracked issue)

## Type of Change
- 🐛 Bug Fix

## Testing & Environment
- [x] Manual test performed on: **macOS 26.5 (Apple Silicon), Electron 43.1, dev build**
- Live repro + fix verification: launcher renderer RSS held flat at ~270 MB over 90 s+ (baseline 2 → 9 GB then `exitCode 5` crash), zero `UNRESPONSIVE` events, zero crashes.
- `npm run typecheck:electron` — clean (was failing on `main`).
- `node --test` onboarding + intelligence-flags suites — **51/51 pass** (incl. the new invariant).
- `npm run dist` — now clears `typecheck:electron` + the native all-arch compile (both previously failing).

## Visuals

Launcher renderer RSS, before → after (per StabilityHeartbeat):

| uptime | before (`main`) | after (this PR) |
|---|---|---|
| 11 s | 1988 MB | 265 MB |
| 31 s | 5174 MB | 293 MB |
| 61 s | 8098 MB | 289 MB |
| 91 s | 9312 MB → crash | 278 MB |
