### PR TITLE
feat(overlay): deterministic character-based reveal pacing + code-stream flicker fix

### DIFF
--- a/harness.html
+++ b/harness.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <title>Streaming Code Harness (dev-only, not shipped)</title>
+</head>
+
+<body style="margin:0;">
+  <div id="harness-root"></div>
+  <script type="module" src="/src/dev/streamingCodeHarness.tsx"></script>
+</body>
+
+</html>

--- a/src/dev/streamingCodeHarness.tsx
+++ b/src/dev/streamingCodeHarness.tsx
@@ -71,6 +71,7 @@ function Harness() {
     // sentence" cadence the pacer module's own docs describe as the
     // problem it exists to smooth over.
     let cancelled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
     let cursor = 0;
     const feed = () => {
       if (cancelled) return;
@@ -79,12 +80,13 @@ function Harness() {
       cursor += chunkLen;
       arrivedRef.current += next;
       if (cursor < ANSWER.length) {
-        setTimeout(feed, 90);
+        timeoutId = setTimeout(feed, 90);
       }
     };
     feed();
     return () => {
       cancelled = true;
+      if (timeoutId !== null) clearTimeout(timeoutId);
     };
   }, []);
 

--- a/src/dev/streamingCodeHarness.tsx
+++ b/src/dev/streamingCodeHarness.tsx
@@ -1,0 +1,184 @@
+// DEV-ONLY visual harness for the streaming code-block fix (see
+// StreamingHighlightedCode / CodeStreamLine in NativelyInterface.tsx).
+//
+// Not part of the shipped app — served only via harness.html, which is not
+// referenced from index.html or vite.config.mts's rollup entry, so it is
+// never bundled into the production build.
+//
+// Purpose: flicker, per-line reveal-fade, and pacing are not tsc/unit-
+// testable (they're about WHAT PAINTS WHEN, not pure data transforms). This
+// drives the REAL exported components with the REAL pacer
+// (createPacerState/tickPacer from textRevealPacing.mjs) over a hardcoded
+// answer, fed in deliberately bursty chunks — the same "a few characters,
+// then a whole sentence" cadence real providers exhibit — so a screenshot
+// taken over time is direct evidence of whether the fix behaves, not just
+// that its pure helpers pass unit tests.
+import React, { useEffect, useRef, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import '../index.css';
+import { StreamingHighlightedCode } from '../components/NativelyInterface';
+import { createPacerState, tickPacer } from '../lib/textRevealPacing.mjs';
+
+// Deliberately includes: prose before the fence, a line with an OPEN quote
+// that only closes after more characters arrive (the case the .trim()/
+// unclosed-token bug would show up on), multiple lines, and a trailing
+// explanation after the fence closes.
+const ANSWER =
+  "Here's an O(n) approach using a hash map:\n\n" +
+  '```python\n' +
+  'def two_sum(nums, target):\n' +
+  '    seen = {}\n' +
+  '    for i, n in enumerate(nums):\n' +
+  '        msg = "checking " + str(n)\n' +
+  '        if target - n in seen:\n' +
+  '            return [seen[target - n], i]\n' +
+  '        seen[n] = i\n' +
+  '    return []\n' +
+  '```\n\n' +
+  'This runs in O(n) time and O(n) space.';
+
+// A fixed, module-scope theme object — NOT recreated per render — so the
+// harness itself never causes a re-tokenize by accidentally handing
+// StreamingHighlightedCode a fresh `appearance`/`codeTheme` object identity
+// every tick (that would defeat the exact memoization this fix relies on
+// and produce a false-positive "still flickers").
+const FIXED_APPEARANCE = {
+  codeBlockStyle: { background: '#0d1117' },
+  codeHeaderStyle: { background: '#161b22' },
+};
+const FIXED_CODE_THEME: Record<string, React.CSSProperties> = {
+  'code[class*="language-"]': { color: '#c9d1d9' },
+  'pre[class*="language-"]': { color: '#c9d1d9' },
+  comment: { color: '#8b949e' },
+  string: { color: '#a5d6ff' },
+  keyword: { color: '#ff7b72' },
+  function: { color: '#d2a8ff' },
+  number: { color: '#79c0ff' },
+};
+
+function Harness() {
+  const [text, setText] = useState('');
+  const [tickLog, setTickLog] = useState<string[]>([]);
+  const pacerRef = useRef(createPacerState());
+  const lastTsRef = useRef<number | null>(null);
+  const arrivedRef = useRef('');
+  const startedAtRef = useRef<number | null>(null);
+  const doneLoggedRef = useRef(false);
+
+  useEffect(() => {
+    // Simulate bursty token arrival: a chunk of 20-40 chars, then a
+    // ~90ms pause, matching the "a few characters, a pause, then a whole
+    // sentence" cadence the pacer module's own docs describe as the
+    // problem it exists to smooth over.
+    let cancelled = false;
+    let cursor = 0;
+    const feed = () => {
+      if (cancelled) return;
+      const chunkLen = 20 + Math.floor(Math.random() * 20);
+      const next = ANSWER.slice(cursor, cursor + chunkLen);
+      cursor += chunkLen;
+      arrivedRef.current += next;
+      if (cursor < ANSWER.length) {
+        setTimeout(feed, 90);
+      }
+    };
+    feed();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let raf = 0;
+    const tick = (ts: number) => {
+      if (startedAtRef.current === null) startedAtRef.current = ts;
+      const deltaMs = lastTsRef.current === null ? 1000 / 60 : ts - lastTsRef.current;
+      lastTsRef.current = ts;
+      const fullText = arrivedRef.current;
+      const pacer = pacerRef.current;
+      const prevLen = pacer.revealedLen;
+      tickPacer(pacer, fullText, ts, deltaMs, { reducedMotion: false });
+      if (pacer.revealedLen !== prevLen) {
+        setText(fullText.slice(0, pacer.revealedLen));
+      }
+      if (
+        !doneLoggedRef.current &&
+        pacer.revealedLen >= ANSWER.length &&
+        fullText.length >= ANSWER.length
+      ) {
+        doneLoggedRef.current = true;
+        const elapsed = ts - (startedAtRef.current ?? ts);
+        setTickLog((log) => [
+          ...log,
+          `DONE: revealed ${ANSWER.length} chars in ${elapsed.toFixed(0)}ms ` +
+            `(~${(ANSWER.length / (elapsed / 1000)).toFixed(1)} chars/sec — cap is 120/sec)`,
+        ]);
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  // Extract the still-open fence's code-so-far, the same way
+  // renderMessageText does: split on the fence regex, find the fence part,
+  // strip the ```lang\n marker — WITHOUT trimming (see the .trim() bug fix
+  // comment at the real call site in NativelyInterface.tsx).
+  const parts = text.split(/(```[\s\S]*?(?:```|$))/g);
+  const fencePart = parts.find((p) => p.startsWith('```'));
+  const match = fencePart?.match(/```([\w+#-]*)\s+([\s\S]*?)(?:```|$)/);
+  const code = match?.[2] ?? '';
+  const lang = match?.[1] ?? 'python';
+  const proseBeforeFence = fencePart ? text.slice(0, text.indexOf(fencePart)) : text;
+  const proseAfterFence =
+    fencePart && text.endsWith('```') ? text.slice(text.indexOf(fencePart) + fencePart.length) : '';
+
+  return (
+    <div style={{ padding: 24, fontFamily: 'sans-serif', background: '#0b0e14', minHeight: '100vh', color: '#e6edf3' }}>
+      <h2>Streaming code harness</h2>
+      <p style={{ opacity: 0.7, fontSize: 13 }}>
+        Feeding the fixture in bursty ~20-40 char chunks every ~90ms, painting via the REAL pacer
+        (tickPacer, cap 120 chars/sec). Watch for: (1) text appearing gradually, not in one dump;
+        (2) completed lines never re-flashing/recoloring; (3) the `msg = "checking..."` line staying
+        PLAIN until its closing quote AND newline have both arrived.
+      </p>
+      <div data-testid="prose-before" style={{ whiteSpace: 'pre-wrap', marginBottom: 8 }}>
+        {proseBeforeFence}
+      </div>
+      {fencePart && (
+        <div data-testid="code-block-wrapper">
+          <StreamingHighlightedCode
+            code={code}
+            lang={lang}
+            isLightTheme={false}
+            codeTheme={FIXED_CODE_THEME}
+            codeBlockClass="border-zinc-700"
+            codeHeaderClass="border-zinc-700"
+            codeHeaderTextClass="text-zinc-400"
+            codeLineNumberColor="#6e7681"
+            appearance={FIXED_APPEARANCE}
+            isModernTheme={false}
+            isGlassTheme={false}
+            showCodeHeader={true}
+          />
+        </div>
+      )}
+      <div data-testid="prose-after" style={{ whiteSpace: 'pre-wrap', marginTop: 8 }}>
+        {proseAfterFence}
+      </div>
+      <div data-testid="tick-log" style={{ marginTop: 24, fontSize: 12, opacity: 0.8 }}>
+        {tickLog.map((l, i) => (
+          <div key={i}>{l}</div>
+        ))}
+      </div>
+      <div data-testid="raw-revealed-length" style={{ display: 'none' }}>
+        {text.length}
+      </div>
+    </div>
+  );
+}
+
+const container = document.getElementById('harness-root');
+if (container) {
+  createRoot(container).render(<Harness />);
+}

--- a/src/dev/thinkingDotHarness.tsx
+++ b/src/dev/thinkingDotHarness.tsx
@@ -144,7 +144,7 @@ function Harness() {
         (renderMessageText streaming branch) and the standalone pre-placeholder
         pill.
       </p>
-      <button onClick={() => setRootMode((m) => (m === 'light' ? 'dark' : 'light'))} style={{ marginBottom: 16 }}>
+      <button type="button" onClick={() => setRootMode((m) => (m === 'light' ? 'dark' : 'light'))} style={{ marginBottom: 16 }}>
         Toggle html[data-theme] (currently: {rootMode})
       </button>
       <div>

--- a/src/dev/thinkingDotHarness.tsx
+++ b/src/dev/thinkingDotHarness.tsx
@@ -1,0 +1,162 @@
+// DEV-ONLY visual repro for the "no thinking-dot under liquid-glass/modern"
+// bug report. Not part of the shipped app (see harness.html precedent:
+// streamingCodeHarness.tsx). Renders the REAL class strings used by both
+// thinking-dot render sites in NativelyInterface.tsx (the embedded dot in
+// renderMessageText's streaming branch, ~L5636-5651, and the standalone
+// pre-placeholder pill, ~L7404-7427) under all 6 (theme x light/dark)
+// combinations, each wrapped in the real `[data-theme]` / `[data-interface-theme]`
+// ancestor attributes the real CSS selectors key off of — so the REAL
+// index.css cascade decides what's visible, not a guess.
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import '../index.css';
+import GlassEffectLayer from '../components/ui/GlassEffectLayer';
+import { getOverlayAppearance, getGlassOverlayAppearance } from '../lib/overlayAppearance';
+
+const THEMES: Array<{ value: 'default' | 'liquid-glass' | 'modern'; label: string }> = [
+  { value: 'default', label: 'default' },
+  { value: 'liquid-glass', label: 'liquid-glass' },
+  { value: 'modern', label: 'modern' },
+];
+
+function EmbeddedDot({ isLightTheme }: { isLightTheme: boolean }) {
+  // Exact classes from NativelyInterface.tsx L5605-5651 (the `key="streaming"`
+  // branch, isThinking = true).
+  const cardBgBorderClass = isLightTheme
+    ? 'bg-slate-100/70 backdrop-blur-md border border-slate-200/50 text-slate-900 shadow-sm'
+    : 'bg-zinc-800/60 backdrop-blur-md border border-zinc-700/40 text-zinc-100 shadow-md';
+  return (
+    <div
+      className={`w-fit px-[16.5px] py-[12.5px] rounded-[20px] rounded-tl-[4px] ai-response-card ${cardBgBorderClass} my-2.5 transition-all duration-300 markdown-content whitespace-pre-wrap text-[14.5px] leading-relaxed`}
+    >
+      <div className="flex gap-1.5 items-center py-0.5">
+        <div
+          className={`natively-thinking-dot w-2 h-2 ${isLightTheme ? 'bg-slate-400' : 'bg-white'} rounded-full`}
+          style={{ animationDelay: '0ms' }}
+        />
+        <div
+          className={`natively-thinking-dot w-2 h-2 ${isLightTheme ? 'bg-slate-400' : 'bg-white'} rounded-full`}
+          style={{ animationDelay: '160ms' }}
+        />
+        <div
+          className={`natively-thinking-dot w-2 h-2 ${isLightTheme ? 'bg-slate-400' : 'bg-white'} rounded-full`}
+          style={{ animationDelay: '320ms' }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function StandalonePill({ subtleStyle }: { subtleStyle: React.CSSProperties }) {
+  // Exact classes from NativelyInterface.tsx L7404-7427, now with the REAL
+  // appearance.subtleStyle inline style (advisor-flagged: the earlier repro
+  // omitted this).
+  return (
+    <div className="flex justify-start">
+      <div className="px-3 py-2 flex gap-1.5 overlay-subtle-surface rounded-full border" style={subtleStyle}>
+        <div className="natively-thinking-dot w-2 h-2 bg-slate-400 rounded-full" style={{ animationDelay: '0ms' }} />
+        <div className="natively-thinking-dot w-2 h-2 bg-slate-400 rounded-full" style={{ animationDelay: '160ms' }} />
+        <div className="natively-thinking-dot w-2 h-2 bg-slate-400 rounded-full" style={{ animationDelay: '320ms' }} />
+      </div>
+    </div>
+  );
+}
+
+function ThemeBlock({ theme, mode }: { theme: 'default' | 'liquid-glass' | 'modern'; mode: 'light' | 'dark' }) {
+  const isLightTheme = mode === 'light';
+  const isGlassTheme = theme === 'liquid-glass';
+  const shellRef = React.useRef<HTMLDivElement | null>(null);
+  // Mirrors NativelyInterface.tsx L1462-1467 exactly: glass gets the empty
+  // getGlassOverlayAppearance() object, everyone else (default AND modern —
+  // isModernTheme is NOT in this branch) gets getOverlayAppearance().
+  const appearance = isGlassTheme
+    ? getGlassOverlayAppearance()
+    : getOverlayAppearance(0.65, isLightTheme ? 'light' : 'dark');
+
+  return (
+    <div
+      data-interface-theme={theme}
+      data-mode={mode}
+      style={{
+        padding: 40,
+        margin: 8,
+        // A busy, high-contrast backdrop BEHIND the panel — stands in for
+        // real desktop content the OS-level vibrancy/acrylic blur would show
+        // through in production (GlassEffectLayer.tsx's own comment: blur of
+        // background content is now done by the native BrowserWindow, not
+        // CSS/JS). A flat backdrop can't surface an over-blur/wash-out effect;
+        // this checkerboard-ish gradient can.
+        background:
+          mode === 'light'
+            ? 'repeating-linear-gradient(45deg, #ffffff 0 20px, #cbd5e1 20px 40px)'
+            : 'repeating-linear-gradient(45deg, #000000 0 20px, #1e293b 20px 40px)',
+        borderRadius: 12,
+        display: 'inline-block',
+        verticalAlign: 'top',
+        width: 340,
+      }}
+    >
+      <div style={{ fontSize: 11, opacity: 0.9, marginBottom: 8, fontFamily: 'monospace', color: mode === 'light' ? '#000' : '#fff', background: mode === 'light' ? '#fff8' : '#0008', display: 'inline-block', padding: '2px 4px' }}>
+        theme={theme} / data-theme={mode}
+      </div>
+      {/* Real shellRef structure: NativelyInterface.tsx L6984-7010 */}
+      <div
+        ref={shellRef}
+        data-shell-card=""
+        className="relative max-w-full backdrop-blur-2xl border rounded-[24px] overflow-hidden flex flex-col draggable-area overlay-shell-surface"
+        style={{ ...appearance.shellStyle, contain: 'layout style', width: 300 }}
+      >
+        {isGlassTheme && <GlassEffectLayer parentRef={shellRef} cornerRadius={24} />}
+        {/* Real scroll container: NativelyInterface.tsx L7326-7331 */}
+        <div className="relative z-10 flex-1 overflow-y-auto overflow-x-hidden p-4 space-y-3 no-drag isolate">
+          <div data-testid={`embedded-${theme}-${mode}`}>
+            <EmbeddedDot isLightTheme={isLightTheme} />
+          </div>
+          <div data-testid={`standalone-${theme}-${mode}`} style={{ marginTop: 8 }}>
+            <StandalonePill subtleStyle={appearance.subtleStyle} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Harness() {
+  const [rootMode, setRootMode] = React.useState<'light' | 'dark'>('dark');
+
+  // The real app sets data-theme on <html> (document.documentElement) in
+  // main.tsx — NOT per-subtree. Selectors like
+  // `[data-theme='light'] [data-interface-theme="modern"] .ai-response-card`
+  // therefore require data-theme to be an ANCESTOR of data-interface-theme,
+  // not a sibling attribute on the same node. Mirror that exactly here.
+  React.useEffect(() => {
+    document.documentElement.setAttribute('data-theme', rootMode);
+  }, [rootMode]);
+
+  return (
+    <div style={{ padding: 24, fontFamily: 'sans-serif', background: '#0b0e14', minHeight: '100vh', color: '#e6edf3' }}>
+      <h2>Thinking-dot repro — real classes, real index.css, real [data-theme]/[data-interface-theme] nesting</h2>
+      <p style={{ opacity: 0.7, fontSize: 13, maxWidth: 700 }}>
+        Each box below sets <code>data-interface-theme</code> on its own wrapper
+        div. <code>document.documentElement[data-theme]</code> is toggled by the
+        button (real app sets this on &lt;html&gt;, matching the actual
+        ancestor-selector shape). Two rows per box: the embedded in-bubble dot
+        (renderMessageText streaming branch) and the standalone pre-placeholder
+        pill.
+      </p>
+      <button onClick={() => setRootMode((m) => (m === 'light' ? 'dark' : 'light'))} style={{ marginBottom: 16 }}>
+        Toggle html[data-theme] (currently: {rootMode})
+      </button>
+      <div>
+        {THEMES.map((t) => (
+          <ThemeBlock key={t.value} theme={t.value} mode={rootMode} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const container = document.getElementById('harness-root');
+if (container) {
+  createRoot(container).render(<Harness />);
+}

--- a/src/lib/__tests__/overlayStreamingCodeUi.test.mjs
+++ b/src/lib/__tests__/overlayStreamingCodeUi.test.mjs
@@ -1,6 +1,10 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
-import { shouldUseStreamingCodeUi } from '../overlayStreamingCodeUi.mjs';
+import {
+  shouldUseStreamingCodeUi,
+  isUnclosedCodeFencePart,
+  splitStreamingCodeLines,
+} from '../overlayStreamingCodeUi.mjs';
 
 describe('overlayStreamingCodeUi', () => {
   test('detects unclosed fenced code in accumulated answer stream', () => {
@@ -27,5 +31,73 @@ describe('overlayStreamingCodeUi', () => {
   test('keeps non-answer streams on the imperative generic path', () => {
     assert.equal(shouldUseStreamingCodeUi('recap', '```text\nnotes', ''), false);
     assert.equal(shouldUseStreamingCodeUi('clarify', '```text\nexplain', ''), false);
+  });
+});
+
+describe('isUnclosedCodeFencePart', () => {
+  test('bare opening marker with no content yet is unclosed', () => {
+    assert.equal(isUnclosedCodeFencePart('```'), true);
+  });
+
+  test('opening marker plus language tag with no newline yet is unclosed', () => {
+    assert.equal(isUnclosedCodeFencePart('```python'), true);
+  });
+
+  test('fence still growing without a closer is unclosed', () => {
+    assert.equal(isUnclosedCodeFencePart('```python\ndef f():\n    pass'), true);
+  });
+
+  test('fence terminated by a later ``` is closed', () => {
+    assert.equal(isUnclosedCodeFencePart('```python\nprint(1)\n```'), false);
+  });
+
+  test('minimal empty closed fence (six backticks) is closed', () => {
+    assert.equal(isUnclosedCodeFencePart('``````'), false);
+  });
+
+  test('non-fence text is never treated as a fence part', () => {
+    assert.equal(isUnclosedCodeFencePart('plain text'), false);
+    assert.equal(isUnclosedCodeFencePart(''), false);
+  });
+});
+
+describe('splitStreamingCodeLines', () => {
+  test('no newline yet: everything is the partial (in-progress) line', () => {
+    assert.deepEqual(splitStreamingCodeLines('def f('), {
+      completedLines: [],
+      partialLine: 'def f(',
+    });
+  });
+
+  test('one completed line plus a growing partial line', () => {
+    assert.deepEqual(splitStreamingCodeLines('def f():\n    return'), {
+      completedLines: ['def f():'],
+      partialLine: '    return',
+    });
+  });
+
+  test('multiple completed lines', () => {
+    assert.deepEqual(splitStreamingCodeLines('a\nb\nc\nd'), {
+      completedLines: ['a', 'b', 'c'],
+      partialLine: 'd',
+    });
+  });
+
+  test('trailing newline: last completed line is followed by an empty in-progress line', () => {
+    assert.deepEqual(splitStreamingCodeLines('a\nb\n'), {
+      completedLines: ['a', 'b'],
+      partialLine: '',
+    });
+  });
+
+  test('leading newline: first completed line is blank', () => {
+    assert.deepEqual(splitStreamingCodeLines('\nfoo'), {
+      completedLines: [''],
+      partialLine: 'foo',
+    });
+  });
+
+  test('empty input', () => {
+    assert.deepEqual(splitStreamingCodeLines(''), { completedLines: [], partialLine: '' });
   });
 });

--- a/src/lib/__tests__/ragStreamChunkCoalescing.test.mjs
+++ b/src/lib/__tests__/ragStreamChunkCoalescing.test.mjs
@@ -1,27 +1,55 @@
 // Regression test: onRAGStreamChunk must coalesce chunks via rAF instead of
-// calling setMessages() (full array clone + re-render) on every chunk.
+// calling setMessages() (full array clone + re-render) on every chunk, AND
+// must PACE how much of the accumulated backlog it reveals per frame — via
+// the same deterministic, rate-capped reveal model as the main streaming
+// path (src/lib/textRevealPacing.mjs) — rather than committing the whole
+// backlog to state in one shot.
 //
-// THE BUG THIS PINS: NativelyInterface.tsx's onRAGStreamChunk handler called
-// setMessages() directly per chunk. RAG chunks stream from the SAME
-// async-generator-over-SSE mechanism as onGeminiStreamToken (ipcHandlers.ts
-// `for await (const chunk of stream) event.sender.send('rag:stream-chunk', ...)`),
-// which was ALREADY fixed for exactly this per-token setMessages cost via rAF
-// coalescing (see the "PERF: streaming-token rAF coalescing" block a few
-// hundred lines above in the same file). onRAGStreamChunk was the one sibling
-// stream handler still doing the expensive thing: for a long meeting-recall
-// answer this meant one full messages-array clone + re-render per chunk.
+// THE ORIGINAL BUG THIS PINS: NativelyInterface.tsx's onRAGStreamChunk
+// handler called setMessages() directly per chunk. RAG chunks stream from
+// the SAME async-generator-over-SSE mechanism as onGeminiStreamToken
+// (ipcHandlers.ts `for await (const chunk of stream) event.sender.send('rag:
+// stream-chunk', ...)`), which was already fixed for exactly this per-token
+// setMessages cost via rAF coalescing (see the "PERF: streaming-token rAF
+// coalescing" block a few hundred lines above in the same file).
 //
-// THE FIX: chunks accumulate in a ref (ragChunkBufRef) and flush to state at
-// most once per animation frame (ragChunkRafRef), matching the pattern already
-// proven via useStreamBuffer in MeetingChatOverlay.tsx. onRAGStreamComplete /
-// onRAGStreamError flush any pending buffered text BEFORE finalizing (so the
-// last frame's chunk is never dropped), and the effect's cleanup cancels any
-// pending RAF + drops the buffer on unmount/teardown.
+// THE SECOND BUG THIS PINS (smooth-reveal follow-up): the original rAF fix
+// still committed the ENTIRE buffered backlog to state on the very next
+// frame — if several chunks land in the same event-loop tick (normal under
+// load), the whole burst appears in the bubble at once ("dumping tokens").
+//
+// THE THIRD SHAPE (deterministic-streaming rewrite): ragArrivedTextRef now
+// accumulates the FULL arrived text (never truncated, mirroring
+// streamingTextRef in the main path) and ragPacerRef is a cursor into it —
+// NOT a shrinking queue that slices its revealed prefix off the front. A
+// shrinking queue doesn't carry per-stream pacer state (initial-buffer
+// timestamp, fractional rate budget, punctuation-hold deadline) cleanly, and
+// a boundary holdback returning zero progress against a buffer that never
+// grows again before the stream ends would stall it permanently. The
+// cursor-over-accumulated-text shape has no such failure mode.
+//
+// THE FOURTH SHAPE (deterministic character-based streaming, v2 —
+// "Deterministic Character-Based Streaming" spec): per
+// STREAM_RENDER_CONFIG.flushImmediatelyOnComplete (default false), the
+// provider finishing does NOT snap the remaining backlog to full text
+// anymore. onRAGStreamComplete marks ragDoneRef instead of force-flushing,
+// and ragRevealTick's own catch-up branch performs the actual
+// isStreaming:false commit once the reveal has genuinely caught up — so the
+// animation drains at the same deterministic rate all the way to the final
+// character regardless of when the network finished. Errors are the one
+// exception that stays instant (never deferred). Because RAG has no
+// explicit per-message id (it operates positionally on "the last
+// isStreaming system message"), a NEW RAG query starting while a PREVIOUS
+// one is still deferred-draining would otherwise collide — both racing to
+// own the same position. forceFinalizeStaleRagStream, called immediately
+// before both ragQueryLive call sites, closes that gap by force-finalizing
+// whatever stale stream was left mid-drain first.
 //
 // This is a source-structural test (the logic lives inline in a large
 // component effect, not extracted to a testable pure module) — it pins the
-// invariants a regression could silently break: buffering, RAF scheduling,
-// flush-before-finalize, and cleanup.
+// invariants a regression could silently break: buffering, paced (not
+// all-at-once) reveal via the shared pacer, deferred-vs-instant completion,
+// the RAG-collision guard, and cleanup.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -35,46 +63,94 @@ const source = fs.readFileSync(
   'utf8',
 );
 
-test('ragChunkBufRef / ragChunkRafRef refs are declared', () => {
-  assert.match(source, /const ragChunkBufRef = useRef<string>\(''\)/);
+test('ragArrivedTextRef / ragPacerRef / ragChunkRafRef refs are declared', () => {
+  assert.match(source, /const ragArrivedTextRef = useRef<string>\(''\)/);
+  assert.match(source, /const ragPacerRef = useRef\(createPacerState\(\)\)/);
   assert.match(source, /const ragChunkRafRef = useRef<number \| null>\(null\)/);
 });
 
-test('onRAGStreamChunk buffers into the ref instead of calling setMessages directly', () => {
+test('onRAGStreamChunk accumulates the FULL arrived text and defers to the paced ticker instead of calling setMessages directly', () => {
   const chunkHandlerStart = source.indexOf('window.electronAPI.onRAGStreamChunk((data: { chunk: string }) => {');
   assert.ok(chunkHandlerStart >= 0, 'onRAGStreamChunk handler must exist');
-  // Slice a bounded window after the handler start and confirm it buffers +
-  // schedules RAF, and does NOT call setMessages synchronously in that body.
-  const window_ = source.slice(chunkHandlerStart, chunkHandlerStart + 400);
-  assert.match(window_, /ragChunkBufRef\.current \+= data\.chunk/, 'must accumulate the chunk in the ref buffer');
-  assert.match(window_, /if \(ragChunkRafRef\.current === null\)/, 'must only schedule one RAF per frame');
-  assert.match(window_, /requestAnimationFrame\(\(\) => \{/, 'must schedule the flush via requestAnimationFrame');
-  assert.doesNotMatch(window_, /setMessages\(/, 'the chunk handler body itself must not call setMessages synchronously');
+  const body = source.slice(chunkHandlerStart, chunkHandlerStart + 250);
+  assert.match(body, /ragArrivedTextRef\.current \+= data\.chunk/, 'must accumulate the chunk into the never-truncated arrived-text ref');
+  assert.match(body, /ensureRagRevealTicker\(\)/, 'must hand off to the paced reveal ticker, not schedule its own ad-hoc RAF');
+  assert.doesNotMatch(body, /setMessages\(/, 'the chunk handler body itself must not call setMessages synchronously');
 });
 
-test('flushRagChunkBuffer performs the actual setMessages commit with isCode detection', () => {
+test('ragRevealTick paces the reveal via the shared tickPacer state machine, as a cursor over accumulated text', () => {
+  const fnStart = source.indexOf('const ragRevealTick = (ts: number) => {');
+  assert.ok(fnStart >= 0, 'ragRevealTick must exist and take the rAF timestamp');
+  const body = source.slice(fnStart, fnStart + 900);
+  assert.match(body, /tickPacer\(pacer, fullText, ts, deltaMs, \{ reducedMotion: prefersReducedMotionRef\.current \}\)/, 'must pace via the shared deterministic tickPacer, not a bespoke fraction-of-backlog formula');
+  assert.match(body, /commitRagText\(fullText\.slice\(0, pacer\.revealedLen\)\)/, 'must commit the revealed PREFIX of the accumulated text (cursor shape), not an appended delta off a shrinking buffer');
+  assert.match(body, /if \(pacer\.revealedLen < fullText\.length\) \{/, 'must only reschedule while backlog remains (self-terminate once caught up)');
+  assert.doesNotMatch(body, /ragChunkBufRef/, 'must not reference the old shrinking-queue buffer');
+});
+
+test('commitRagText sets the full revealed prefix (not an append) and preserves isCode detection', () => {
+  const fnStart = source.indexOf('const commitRagText = (revealedText: string) => {');
+  assert.ok(fnStart >= 0, 'commitRagText must exist, taking the full revealed-so-far text');
+  const body = source.slice(fnStart, fnStart + 500);
+  assert.match(body, /setMessages\(\(prev\) => \{/, 'commitRagText is the only place that commits to React state');
+  assert.match(body, /text: revealedText, isCode: revealedText\.includes\('```'\)/, 'must set text to the revealed prefix directly and preserve isCode detection');
+});
+
+test('flushRagChunkBuffer cancels the RAF, commits the FULL remaining backlog instantly (no pacing at stream end), and resets pacer state for the next answer', () => {
   const fnStart = source.indexOf('const flushRagChunkBuffer = () => {');
   assert.ok(fnStart >= 0, 'flushRagChunkBuffer must exist');
-  const body = source.slice(fnStart, fnStart + 700);
-  assert.match(body, /cancelRagChunkRaf\(\)/, 'flush must cancel any pending RAF (avoid double-flush)');
-  assert.match(body, /setMessages\(\(prev\) => \{/, 'flush is the only place that commits to React state');
-  assert.match(body, /isCode: text\.includes\('```'\)/, 'must preserve the original isCode-detection behavior');
+  const body = source.slice(fnStart, fnStart + 500);
+  assert.match(body, /cancelRagChunkRaf\(\)/, 'flush must cancel any pending RAF (avoid a stray paced tick after finalize)');
+  assert.match(body, /commitRagText\(fullText\)/, 'flush must commit the FULL arrived text, bypassing pacing');
+  assert.match(body, /ragArrivedTextRef\.current = ''/, 'must reset the accumulator so the next RAG answer starts fresh');
+  assert.match(body, /ragPacerRef\.current = createPacerState\(\)/, 'must reset the pacer so the next RAG answer gets its own initial-buffer window, not stale state from this one');
+  assert.doesNotMatch(body, /tickPacer/, 'flush must NOT pace — any queued-but-unrevealed text must appear instantly when the stream ends');
 });
 
-test('onRAGStreamComplete and onRAGStreamError flush the buffer before finalizing', () => {
+test('onRAGStreamComplete honors flushImmediatelyOnComplete: instant flush when true, deferred-to-catch-up when false (default)', () => {
   const completeStart = source.indexOf("window.electronAPI.onRAGStreamComplete(() => {");
-  const errorStart = source.indexOf("window.electronAPI.onRAGStreamError((data: { error: string }) => {");
-  assert.ok(completeStart >= 0 && errorStart >= 0);
-  const completeBody = source.slice(completeStart, completeStart + 400);
-  const errorBody = source.slice(errorStart, errorStart + 250);
-  assert.match(completeBody, /flushRagChunkBuffer\(\)/, 'stream-complete must flush any buffered trailing chunk first');
-  assert.match(errorBody, /flushRagChunkBuffer\(\)/, 'stream-error must flush any buffered trailing chunk first');
+  assert.ok(completeStart >= 0, 'onRAGStreamComplete handler must exist');
+  const body = source.slice(completeStart, completeStart + 2000);
+  assert.match(body, /if \(STREAM_RENDER_CONFIG\.flushImmediatelyOnComplete\) \{/, 'must branch on the config flag rather than always flushing instantly');
+  assert.match(body, /flushRagChunkBuffer\(\)/, 'the flushImmediatelyOnComplete=true branch must still flush instantly (config escape hatch preserved)');
+  assert.match(body, /ragDoneRef\.current = true/, 'the default (deferred) branch must mark done rather than force-finalize immediately');
+  assert.match(body, /ensureRagRevealTicker\(\)/, 'the deferred branch must wake the ticker in case it had already self-terminated, or the row would never finalize');
 });
 
-test('the effect cleanup cancels the RAF and clears the buffer', () => {
+test('ragRevealTick only commits isStreaming:false once BOTH caught up AND ragDoneRef is set — the deferred-completion catch-up branch', () => {
+  const fnStart = source.indexOf('const ragRevealTick = (ts: number) => {');
+  assert.ok(fnStart >= 0);
+  const body = source.slice(fnStart, fnStart + 1800);
+  assert.match(body, /if \(ragDoneRef\.current\) \{/, 'the catch-up branch must gate the actual finalize commit on ragDoneRef');
+  assert.match(body, /isStreaming: false/, 'must still perform the isStreaming:false commit somewhere in the catch-up path');
+});
+
+test('onRAGStreamError stays instant (never deferred) and resets ragDoneRef so a still-running ticker cannot overwrite the appended error text', () => {
+  const errorStart = source.indexOf("window.electronAPI.onRAGStreamError((data: { error: string }) => {");
+  assert.ok(errorStart >= 0);
+  const errorBody = source.slice(errorStart, errorStart + 400);
+  assert.match(errorBody, /flushRagChunkBuffer\(\)/, 'stream-error must flush (and reset ragDoneRef) instantly, never deferred');
+  const flushFnStart = source.indexOf('const flushRagChunkBuffer = () => {');
+  assert.ok(flushFnStart >= 0);
+  const flushBody = source.slice(flushFnStart, flushFnStart + 400);
+  assert.match(flushBody, /ragDoneRef\.current = false/, 'flushRagChunkBuffer must reset ragDoneRef so the NEXT RAG answer never inherits a stale done flag');
+});
+
+test('forceFinalizeStaleRagStream exists and is called before both ragQueryLive invocations, so a new RAG query never collides with a previous one still deferred-draining', () => {
+  const fnStart = source.indexOf('const forceFinalizeStaleRagStream = useCallback(() => {');
+  assert.ok(fnStart >= 0, 'forceFinalizeStaleRagStream must exist');
+  const body = source.slice(fnStart, fnStart + 900);
+  assert.match(body, /isStreaming: false/, 'must instantly finalize whatever stale RAG row was left mid-drain');
+  assert.match(body, /ragDoneRef\.current = false/, 'must reset ragDoneRef for the upcoming new stream');
+
+  const callSites = [...source.matchAll(/forceFinalizeStaleRagStream\(\);/g)];
+  assert.ok(callSites.length >= 2, `expected at least 2 call sites (one per ragQueryLive invocation), found ${callSites.length}`);
+});
+
+test('the effect cleanup cancels the RAF and clears the accumulated text', () => {
   const cleanupComment = source.indexOf('// Cleanup: cancel any pending RAF and drop buffered');
-  assert.ok(cleanupComment >= 0, 'a dedicated cleanup entry for the RAG chunk buffer must exist');
+  assert.ok(cleanupComment >= 0, 'a dedicated cleanup entry for the RAG accumulator must exist');
   const body = source.slice(cleanupComment, cleanupComment + 250);
   assert.match(body, /cancelRagChunkRaf\(\)/);
-  assert.match(body, /ragChunkBufRef\.current = ''/);
+  assert.match(body, /ragArrivedTextRef\.current = ''/);
 });

--- a/src/lib/__tests__/textRevealPacing.test.mjs
+++ b/src/lib/__tests__/textRevealPacing.test.mjs
@@ -1,0 +1,280 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createPacerState,
+  tickPacer,
+  snapRevealBoundary,
+  estimateRevealDurationMs,
+  MAX_REVEAL_CHARS_PER_MS,
+  MAX_REVEAL_CHARACTERS_PER_SECOND,
+  INITIAL_BUFFER_MS,
+  INITIAL_BUFFER_CHAR_THRESHOLD,
+  SENTENCE_END_PAUSE_MS,
+  CLAUSE_PAUSE_MS,
+  FLUSH_IMMEDIATELY_ON_COMPLETE,
+  STREAM_RENDER_CONFIG,
+} from '../textRevealPacing.mjs';
+
+const FRAME_MS = 1000 / 60;
+
+// Drive `frames` rAF ticks (each FRAME_MS apart) against `fullText`, starting
+// at time 0. Returns the final state.
+function run(state, fullText, frames, opts) {
+  let now = 0;
+  for (let i = 0; i < frames; i += 1) {
+    now += FRAME_MS;
+    tickPacer(state, fullText, now, FRAME_MS, opts);
+  }
+  return state;
+}
+
+test('config matches the current tuning (180 chars/sec ≈ 45 tok/s, 80ms/12-char initial buffer, deferred flush by default)', () => {
+  assert.equal(MAX_REVEAL_CHARACTERS_PER_SECOND, 180);
+  assert.equal(MAX_REVEAL_CHARS_PER_MS, 0.18);
+  assert.equal(INITIAL_BUFFER_MS, 80);
+  assert.equal(INITIAL_BUFFER_CHAR_THRESHOLD, 12);
+  assert.equal(FLUSH_IMMEDIATELY_ON_COMPLETE, false);
+  assert.deepEqual(STREAM_RENDER_CONFIG, {
+    maxCharactersPerSecond: 180,
+    initialBufferMs: 80,
+    initialBufferCharacterThreshold: 12,
+    useAnimationFrame: true,
+    flushImmediatelyOnComplete: false,
+  });
+});
+
+test('initial smoothing buffer: reveals nothing until INITIAL_BUFFER_MS elapses (short text, never hits the char threshold)', () => {
+  const state = createPacerState();
+  const text = 'hi'; // well under INITIAL_BUFFER_CHAR_THRESHOLD
+  let now = 0;
+  // Step in small increments up to just under the buffer window.
+  while (now < INITIAL_BUFFER_MS - FRAME_MS) {
+    now += FRAME_MS;
+    tickPacer(state, text, now, FRAME_MS);
+    assert.equal(state.revealedLen, 0, `must not reveal before the buffer window closes (now=${now})`);
+  }
+  // Cross the threshold.
+  now += FRAME_MS * 2;
+  tickPacer(state, text, now, FRAME_MS);
+  assert.ok(state.revealedLen > 0, 'must start revealing once the buffer window has elapsed');
+});
+
+test('initial smoothing buffer: opens early once INITIAL_BUFFER_CHAR_THRESHOLD chars have arrived, even before the timer', () => {
+  const state = createPacerState();
+  const text = 'x'.repeat(INITIAL_BUFFER_CHAR_THRESHOLD + 10);
+  // Single tick, well within INITIAL_BUFFER_MS.
+  tickPacer(state, text, FRAME_MS, FRAME_MS);
+  assert.ok(state.revealedLen > 0, 'char-count trigger should open the gate without waiting for the timer');
+});
+
+test('never reveals faster than the configured max rate over a sustained window', () => {
+  const state = createPacerState();
+  const text = 'a'.repeat(5000);
+  // Run for exactly 1 real second (60 frames of 16.667ms), well past the
+  // initial buffer window.
+  run(state, text, 60);
+  // Allow small slack for the initial-buffer window eating a few ms of the
+  // first second, and for floor()-truncation losing fractional chars.
+  assert.ok(
+    state.revealedLen <= MAX_REVEAL_CHARACTERS_PER_SECOND + 2,
+    `revealed ${state.revealedLen} chars in ~1s, cap is ${MAX_REVEAL_CHARACTERS_PER_SECOND}/s`,
+  );
+  assert.ok(state.revealedLen > MAX_REVEAL_CHARACTERS_PER_SECOND * 0.7, 'should still get close to the cap, not far under it');
+});
+
+test('a slow provider (below the cap) is shown essentially immediately — the cap never becomes the bottleneck', () => {
+  const state = createPacerState();
+  // Simulate text arriving one word at a time, far slower than the cap.
+  const words = ['The', 'quick', 'brown', 'fox', 'jumps'];
+  let arrived = '';
+  let now = 0;
+  for (const word of words) {
+    arrived += (arrived ? ' ' : '') + word;
+    // Real gap between provider chunks: 300ms — much slower than 180 char/s
+    // could ever fall behind on a few-character word.
+    for (let i = 0; i < Math.round(300 / FRAME_MS); i += 1) {
+      now += FRAME_MS;
+      tickPacer(state, arrived, now, FRAME_MS);
+    }
+    // Well after the initial buffer window and multiple 300ms gaps in, the
+    // pacer must have fully caught up to each slow arrival before the next
+    // word lands — nothing artificially withheld.
+    if (now > INITIAL_BUFFER_MS + 300) {
+      assert.equal(state.revealedLen, arrived.length, `should have caught up to "${arrived}" by now=${now}`);
+    }
+  }
+});
+
+test('a fast burst (provider faster than the cap) is buffered and drained smoothly, never dumped in one frame', () => {
+  const state = createPacerState();
+  const text = 'x'.repeat(2000); // the "whole answer lands in one IPC tick" case
+  let now = 0;
+  let frames = 0;
+  const perFrameDeltas = [];
+  while (state.revealedLen < text.length && frames < 2000) {
+    now += FRAME_MS;
+    const prev = state.revealedLen;
+    tickPacer(state, text, now, FRAME_MS);
+    perFrameDeltas.push(state.revealedLen - prev);
+    frames += 1;
+  }
+  assert.equal(state.revealedLen, text.length);
+  const maxDelta = Math.max(...perFrameDeltas);
+  // No single frame should ever reveal more than a couple of frames' worth
+  // of the rate cap (small slack for the initial-buffer catch-up frame).
+  assert.ok(maxDelta <= Math.ceil(MAX_REVEAL_CHARS_PER_MS * FRAME_MS) + 2, `no frame should dump far more than the per-frame cap (saw ${maxDelta})`);
+  assert.ok(frames > 50, 'a 2000-char burst at 180 chars/sec should take multiple seconds worth of frames, not a handful');
+});
+
+test('reducedMotion reveals everything on the very first tick, bypassing buffer/cap/pauses', () => {
+  const state = createPacerState();
+  const text = 'a whole paragraph of streamed text with punctuation. And more!';
+  tickPacer(state, text, 0, FRAME_MS, { reducedMotion: true });
+  assert.equal(state.revealedLen, text.length);
+});
+
+test('punctuation hold: a sentence-ending period pauses the reveal for SENTENCE_END_PAUSE_MS without losing budget to a burst on release', () => {
+  const state = createPacerState();
+  const text = 'Hi.' + 'x'.repeat(200);
+  // Run long enough to clear the initial buffer and reach the period.
+  let now = 0;
+  while (state.revealedLen < 3 && now < 5000) {
+    now += FRAME_MS;
+    tickPacer(state, text, now, FRAME_MS);
+  }
+  assert.equal(state.revealedLen, 3, 'should have stopped right at/after the period');
+  const pausedAt = now;
+  // Immediately after crossing the period, no forward progress until the
+  // hold elapses.
+  now += FRAME_MS;
+  tickPacer(state, text, now, FRAME_MS);
+  assert.equal(state.revealedLen, 3, 'must hold at the punctuation boundary');
+  // Advance past the hold.
+  now = pausedAt + SENTENCE_END_PAUSE_MS + FRAME_MS;
+  tickPacer(state, text, now, FRAME_MS);
+  assert.ok(state.revealedLen > 3, 'should resume after the hold elapses');
+  // The frame that resumes must not dump a giant banked burst (the pause
+  // must not have accumulated budget while frozen).
+  const resumedDelta = state.revealedLen - 3;
+  assert.ok(resumedDelta <= Math.ceil(MAX_REVEAL_CHARS_PER_MS * FRAME_MS) + 2, `resume frame revealed ${resumedDelta} chars — pause must not bank budget`);
+});
+
+test('clause punctuation (comma) gets the shorter CLAUSE_PAUSE_MS hold, not the sentence-end one', () => {
+  assert.ok(CLAUSE_PAUSE_MS < SENTENCE_END_PAUSE_MS, 'clause pause should be shorter than sentence-end pause');
+});
+
+test('no idle credit: a long silence before a burst does not let the burst reveal faster than the cap', () => {
+  const stateAfterSilence = createPacerState();
+  const stateNoSilence = createPacerState();
+  const text = 'y'.repeat(500);
+  // stateAfterSilence: sit idle (empty text) for a long time first.
+  tickPacer(stateAfterSilence, '', 5000, FRAME_MS); // 5s of "nothing arrived yet"
+  // stateNoSilence: no idle period at all.
+  // Now both see the same burst arrive at t=5000 (or t=0) and are compared
+  // frame-for-frame afterward using a fresh, comparable clock baseline.
+  let now = 5000;
+  let now2 = 0;
+  const deltasA = [];
+  const deltasB = [];
+  for (let i = 0; i < 20; i += 1) {
+    now += FRAME_MS;
+    now2 += FRAME_MS;
+    const prevA = stateAfterSilence.revealedLen;
+    const prevB = stateNoSilence.revealedLen;
+    tickPacer(stateAfterSilence, text, now, FRAME_MS);
+    tickPacer(stateNoSilence, text, now2, FRAME_MS);
+    deltasA.push(stateAfterSilence.revealedLen - prevA);
+    deltasB.push(stateNoSilence.revealedLen - prevB);
+  }
+  assert.deepEqual(deltasA, deltasB, 'a preceding idle silence must not let the subsequent burst reveal any faster than an identical burst with no silence before it');
+});
+
+test('snapRevealBoundary is a no-op at the live edge of arrival (no buffered text beyond candidate)', () => {
+  const text = 'Hello wor';
+  assert.equal(snapRevealBoundary(text, text.length, 0), text.length);
+});
+
+test('snapRevealBoundary holds back a partial word when the rest of it is already buffered', () => {
+  const text = 'Hello interview panel';
+  const candidateLen = 'Hello interv'.length;
+  const result = snapRevealBoundary(text, candidateLen, 0);
+  assert.equal(result, 'Hello '.length, 'should hold back to the start of "interview" rather than reveal the fragment');
+});
+
+test('snapRevealBoundary holds back a trailing markdown delimiter run when more text is buffered beyond it', () => {
+  const text = 'Hello **bold** world';
+  const candidateLen = 'Hello **'.length;
+  const result = snapRevealBoundary(text, candidateLen, 0);
+  assert.equal(result, 'Hello '.length, 'should trim back to before the ** run');
+});
+
+test('snapRevealBoundary never returns below minLen, and reveals through when no valid holdback point exists above it', () => {
+  // "**" is a 2-char delimiter run with minLen=1 already inside it (one "*"
+  // already shown last frame) — trimming the whole run would land at 0,
+  // which is below minLen. There is no word-boundary to hold at either
+  // (the whole span from minLen to candidateLen is inside the delimiter
+  // run). Forward progress wins: reveal through to the raw candidate (2)
+  // rather than freeze at minLen forever.
+  const text = '**bold** more text follows';
+  const result = snapRevealBoundary(text, 2, 1);
+  assert.equal(result, 2, 'no valid holdback point above minLen exists — must reveal through, not stall');
+  assert.ok(result >= 1, 'never below minLen');
+});
+
+test('snapRevealBoundary does not touch a candidate that already sits at a clean word boundary', () => {
+  const text = 'Hello world, more text follows';
+  const candidateLen = 'Hello world'.length;
+  assert.equal(snapRevealBoundary(text, candidateLen, 0), candidateLen);
+});
+
+test('snapRevealBoundary always makes forward progress while backlog remains (never stalls, RAG-shrinking-window shape)', () => {
+  const corpus = 'Some **bold** and `code` and [a](b) and ~~x~~ and # head and _em_ text and interview panel';
+  for (let r = 0; r < corpus.length; r += 1) {
+    assert.ok(snapRevealBoundary(corpus, corpus.length, r) > r || corpus.length === r, `stalled at minLen=${r}`);
+  }
+  // RAG path shape: minLen always 0 against a shrinking rolling window that
+  // may be JUST a stuck fragment like "**bo" or "interv".
+  for (let n = 1; n <= 14; n += 1) {
+    const win = corpus.slice(0, n);
+    assert.ok(snapRevealBoundary(win, win.length, 0) > 0, `stalled on window "${win}"`);
+  }
+});
+
+test('tickPacer forward-progress invariant: any frame with spendable budget reveals at least one character', () => {
+  const state = createPacerState();
+  const text = 'Some **bold** and interview panel text that keeps going and going';
+  // Clear the initial buffer first.
+  let now = 0;
+  while (state.buffering) {
+    now += FRAME_MS;
+    tickPacer(state, text, now, FRAME_MS);
+  }
+  while (state.revealedLen < text.length) {
+    const prev = state.revealedLen;
+    now += FRAME_MS;
+    // Skip frames sitting inside a punctuation hold — those are SUPPOSED to
+    // make zero progress by design.
+    if (now < state.pauseUntilMs) continue;
+    tickPacer(state, text, now, FRAME_MS);
+    assert.ok(state.revealedLen > prev, `stalled at revealedLen=${prev} (now=${now})`);
+  }
+});
+
+test('estimateRevealDurationMs matches the configured rate', () => {
+  assert.equal(estimateRevealDurationMs(180), 1000); // 180 chars at 180 chars/sec = 1s
+  assert.equal(estimateRevealDurationMs(1800), 10000);
+});
+
+test('a full stream (buffer -> steady reveal -> punctuation holds) eventually reaches the full text with no stalls', () => {
+  const state = createPacerState();
+  const text = 'Based on the project requirements, I outlined the critical path. '
+    + 'Next, we should confirm the timeline; then, ship it. Sound good?';
+  let now = 0;
+  let frames = 0;
+  while (state.revealedLen < text.length && frames < 10000) {
+    now += FRAME_MS;
+    tickPacer(state, text, now, FRAME_MS);
+    frames += 1;
+  }
+  assert.equal(state.revealedLen, text.length);
+});

--- a/src/lib/__tests__/textRevealPacing.test.mjs
+++ b/src/lib/__tests__/textRevealPacing.test.mjs
@@ -163,6 +163,29 @@ test('clause punctuation (comma) gets the shorter CLAUSE_PAUSE_MS hold, not the 
   assert.ok(CLAUSE_PAUSE_MS < SENTENCE_END_PAUSE_MS, 'clause pause should be shorter than sentence-end pause');
 });
 
+test('a punctuation mark crossed MID-TICK (not landing exactly at the tick boundary) still triggers the pause', () => {
+  // Regression: the pause check used to only examine the single last
+  // character revealed by a tick (fullText[snapped - 1]). A tick spanning
+  // several characters (a large budget after the initial buffer closes, or
+  // catching up from a burst) can jump PAST a period/comma without landing
+  // exactly on it, silently skipping the reading-rhythm hold.
+  const state = createPacerState();
+  // "Hi. World" — period at index 2. Force a single huge tick (a giant
+  // deltaMs) that reveals the whole string in one call, well past the
+  // period, so `snapped` lands at the end, not on the period itself.
+  const text = 'Hi. World';
+  // Clear the initial buffer first with a zero-effect tiny tick, then a
+  // single huge tick that reveals everything at once.
+  tickPacer(state, text, 1, 1);
+  const beforeHugeTick = state.pauseUntilMs;
+  tickPacer(state, text, 10_000, 10_000 - 1);
+  assert.equal(state.revealedLen, text.length, 'the huge tick should reveal the whole string in one shot');
+  assert.ok(
+    state.pauseUntilMs > beforeHugeTick,
+    'a period crossed mid-tick must still arm a pause, even though revealedLen landed at the end, not on the period',
+  );
+});
+
 test('no idle credit: a long silence before a burst does not let the burst reveal faster than the cap', () => {
   const stateAfterSilence = createPacerState();
   const stateNoSilence = createPacerState();

--- a/src/lib/overlayStreamingCodeUi.d.mts
+++ b/src/lib/overlayStreamingCodeUi.d.mts
@@ -3,3 +3,10 @@ export function shouldUseStreamingCodeUi(
   token: string,
   previousText?: string,
 ): boolean;
+
+export function isUnclosedCodeFencePart(part: string): boolean;
+
+export function splitStreamingCodeLines(code: string): {
+  completedLines: string[];
+  partialLine: string;
+};

--- a/src/lib/overlayStreamingCodeUi.mjs
+++ b/src/lib/overlayStreamingCodeUi.mjs
@@ -5,3 +5,54 @@ export function shouldUseStreamingCodeUi(intent, token, previousText = '') {
   const combined = `${typeof previousText === 'string' ? previousText : ''}${token}`;
   return combined.includes('```');
 }
+
+/**
+ * Whether `part` — one element of
+ * `msg.text.split(/(```[\s\S]*?(?:```|$))/g)` — is a fence block still open
+ * at the live edge of arrival (opened by ``` but not yet closed by a later
+ * one). Only the LAST element of that split can ever be in this state: every
+ * earlier element's content is fixed the moment a later fence marker appears
+ * after it, so this is safe to call per-render without memoizing.
+ *
+ * The `length < 6` guard covers the bare-marker states ("```", "```py") that
+ * have no possible closing marker yet — `endsWith('```')` alone would wrongly
+ * treat the literal 3-backtick opening marker as "closed" (it both starts AND
+ * ends with the same 3 characters). Six is the shortest STRING that could
+ * legitimately contain both an opening and a closing marker (e.g. an empty
+ * fenced block written as six backticks with nothing between).
+ */
+export function isUnclosedCodeFencePart(part) {
+  if (typeof part !== 'string' || !part.startsWith('```')) return false;
+  return part.length < 6 || !part.endsWith('```');
+}
+
+/**
+ * Split an in-progress code fence's raw code content (already stripped of
+ * the leading ```lang\n marker) into:
+ *   - completedLines: lines terminated by a newline that has already
+ *     arrived — these will never change again, so they're safe to run
+ *     through Prism and cache.
+ *   - partialLine: whatever text follows the last newline (or the whole
+ *     string, if no newline has arrived yet) — still growing character by
+ *     character, so it must NOT be syntax-highlighted yet (an incomplete
+ *     token — an unclosed string/comment/bracket — would tokenize wrong and
+ *     then visibly recolor the instant it closes).
+ *
+ * Pure and clock-free, mirroring the rest of this module — called once per
+ * render from the streaming code-block component, not from any RAF loop.
+ */
+export function splitStreamingCodeLines(code) {
+  if (typeof code !== 'string' || code.length === 0) {
+    return { completedLines: [], partialLine: '' };
+  }
+  const lastNewline = code.lastIndexOf('\n');
+  if (lastNewline === -1) {
+    return { completedLines: [], partialLine: code };
+  }
+  const completed = code.slice(0, lastNewline);
+  const partial = code.slice(lastNewline + 1);
+  return {
+    completedLines: completed.length > 0 ? completed.split('\n') : [''],
+    partialLine: partial,
+  };
+}

--- a/src/lib/textRevealPacing.d.mts
+++ b/src/lib/textRevealPacing.d.mts
@@ -1,0 +1,44 @@
+export const MAX_REVEAL_CHARACTERS_PER_SECOND: number;
+export const INITIAL_BUFFER_MS: number;
+export const INITIAL_BUFFER_CHAR_THRESHOLD: number;
+export const USE_ANIMATION_FRAME: boolean;
+export const FLUSH_IMMEDIATELY_ON_COMPLETE: boolean;
+export const SENTENCE_END_PAUSE_MS: number;
+export const CLAUSE_PAUSE_MS: number;
+export const MAX_REVEAL_CHARS_PER_MS: number;
+
+export interface StreamRenderConfig {
+  maxCharactersPerSecond: number;
+  initialBufferMs: number;
+  initialBufferCharacterThreshold: number;
+  useAnimationFrame: boolean;
+  flushImmediatelyOnComplete: boolean;
+}
+
+export const STREAM_RENDER_CONFIG: StreamRenderConfig;
+
+export interface PacerState {
+  revealedLen: number;
+  charBudget: number;
+  bufferStartMs: number | null;
+  buffering: boolean;
+  pauseUntilMs: number;
+}
+
+export function snapRevealBoundary(
+  text: string,
+  candidateLen: number,
+  minLen: number,
+): number;
+
+export function createPacerState(): PacerState;
+
+export function tickPacer(
+  state: PacerState,
+  fullText: string,
+  nowMs: number,
+  deltaMs: number,
+  opts?: { reducedMotion?: boolean },
+): PacerState;
+
+export function estimateRevealDurationMs(charCount: number): number;

--- a/src/lib/textRevealPacing.mjs
+++ b/src/lib/textRevealPacing.mjs
@@ -1,0 +1,277 @@
+/**
+ * Deterministic AI-response streaming: a rate-capped, word-aware "reveal"
+ * layer that decouples how fast text is DISPLAYED from how fast the
+ * provider actually emits it.
+ *
+ * Problem this replaces: different providers (Groq, Gemini, MiniMax,
+ * DeepSeek, ...) chunk their output at wildly different, bursty intervals —
+ * a few characters, a pause, then a whole sentence. Mirroring that directly
+ * in the UI reads as jittery and "cheap", and the pattern differs per
+ * provider, which is the opposite of a consistent product feel.
+ *
+ * Fix: the model keeps generating at full speed in the background (nothing
+ * here slows inference down) — this module only paces how much of the
+ * already-arrived backlog is shown per frame:
+ *
+ *   displayRate = min(providerRate, MAX_REVEAL_RATE)
+ *
+ * If the provider is slower than the cap, whatever has arrived is shown
+ * essentially immediately (the cap never becomes the bottleneck for a slow
+ * trickle). If the provider bursts faster than the cap, the excess is
+ * buffered and drained smoothly over subsequent frames instead of dumped in
+ * one paint — same visual cadence regardless of which provider is behind
+ * the answer.
+ *
+ * This module is a pure, clock-free state machine: every timestamp
+ * (`nowMs`) and frame delta (`deltaMs`) is passed in by the caller (a
+ * requestAnimationFrame loop in NativelyInterface.tsx), never read via
+ * Date.now()/performance.now() here — that's what makes it exhaustively
+ * unit-testable without faking the DOM or the clock.
+ */
+
+// ── Configuration (tune here) ───────────────────────────────────────────────
+// v2: character-based rate (the token/chars-per-token estimate from v1 added
+// an indirection this spec doesn't need — chars/sec is specified directly).
+// 180 chars/sec ≈ 45 tokens/sec — raised from 120 (≈30 tok/s, the middle of
+// the 20-40 tok/s UI display-speed band) per explicit request for a faster
+// cap. Above the commonly-cited band's upper edge; the initial buffer,
+// word/punctuation-aware boundaries, and deferred-completion behavior all
+// still apply unchanged at this rate.
+export const MAX_REVEAL_CHARACTERS_PER_SECOND = 180;
+export const INITIAL_BUFFER_MS = 80;
+export const INITIAL_BUFFER_CHAR_THRESHOLD = 12;
+// Informational only — the render loop is driven by real rAF timestamps
+// (variable deltaMs), not a fixed-interval timer built around this number.
+// Real deltas are strictly more robust to dropped/late frames than a
+// setTimeout(1000/60) would be, and the rate-cap math below already adapts
+// to whatever deltaMs it's given.
+export const USE_ANIMATION_FRAME = true;
+// When false (the default): a stream's natural completion does NOT snap the
+// remaining backlog to full text — the reveal keeps draining at the same
+// deterministic rate all the way to the last character, so the animation
+// feels identical from the first character to the final period regardless
+// of when the network finished. When true: stream-end commits the full text
+// immediately (the v1 behavior) — useful for a future experiment/rollback
+// without code changes. NativelyInterface.tsx's finalize call sites are
+// expected to honor this flag explicitly (it is NOT auto-applied inside
+// tickPacer, which has no concept of "the provider is done").
+export const FLUSH_IMMEDIATELY_ON_COMPLETE = false;
+
+// Exposed as one object matching the shape callers may want to pass around /
+// log / tune together, per spec. The individual named exports above remain
+// the source of truth (this just mirrors them).
+export const STREAM_RENDER_CONFIG = {
+  maxCharactersPerSecond: MAX_REVEAL_CHARACTERS_PER_SECOND,
+  initialBufferMs: INITIAL_BUFFER_MS,
+  initialBufferCharacterThreshold: INITIAL_BUFFER_CHAR_THRESHOLD,
+  useAnimationFrame: USE_ANIMATION_FRAME,
+  flushImmediatelyOnComplete: FLUSH_IMMEDIATELY_ON_COMPLETE,
+};
+
+// Brief holds after punctuation so the reveal has a natural reading rhythm
+// instead of a metronomic character drip. Frozen budget during a hold (see
+// tickPacer) means the pause costs real wall-clock time, not banked chars —
+// no burst on release. Not part of the v2 spec's explicit config list, but
+// not contradicted by it either — kept from v1 since it measurably improves
+// reading feel and is already built/tested.
+export const SENTENCE_END_PAUSE_MS = 140; // . ! ?
+export const CLAUSE_PAUSE_MS = 70; // , ; :
+
+// Derived shorthand for the per-frame math below (deltaMs is in
+// milliseconds).
+export const MAX_REVEAL_CHARS_PER_MS = MAX_REVEAL_CHARACTERS_PER_SECOND / 1000;
+
+const SENTENCE_END_CHARS = new Set(['.', '!', '?']);
+const CLAUSE_PAUSE_CHARS = new Set([',', ';', ':']);
+
+// Markdown constructs (bold/italic/code/link/heading/strikethrough) are
+// delimited by these characters. Stopping a reveal exactly mid-run of them
+// (e.g. showing "...text **" and pausing there) is the one case where
+// pausing costs nothing (more text is already buffered) but skipping it
+// avoids ever presenting a lone, ambiguous delimiter run as the visible
+// edge of the answer.
+const MARKDOWN_TAIL_HOLDBACK_RE = /[*_`[\]~#]+$/;
+
+// A "word character" continues the current word — letters, digits,
+// underscore, and apostrophe (so contractions like "don't" aren't split at
+// the apostrophe). Anything else — whitespace, AND punctuation (comma,
+// period, closing quote, ...) — is a boundary: a candidate landing right
+// before a comma has already revealed a COMPLETE word ("Hello world," with
+// the cursor after "world"), it should not be treated as mid-word just
+// because the very next character happens to be punctuation rather than
+// whitespace. (Markdown delimiters are also non-word by this definition —
+// deliberately: holding back a bare "**" run is MARKDOWN_TAIL_HOLDBACK_RE's
+// job above, not this function's; this function only cares about words.)
+function isWordChar(ch) {
+  return ch !== undefined && /[\p{L}\p{N}_']/u.test(ch);
+}
+
+function isWordBoundaryChar(ch) {
+  return !isWordChar(ch);
+}
+
+/**
+ * Snap `candidateLen` back to the start of an in-progress word so a reveal
+ * never stops mid-fragment ("interv" this frame, "iew" the next) when the
+ * rest of the word has already arrived. A no-op if `candidateLen` already
+ * sits at a clean boundary (end of a word, or the true live edge of
+ * arrival — handled by the caller). Never returns below `minLen`; if no
+ * boundary exists between `minLen` and `candidateLen` (the whole span is one
+ * unbroken word), returns `candidateLen` unchanged rather than stall.
+ */
+function snapToWordBoundary(text, candidateLen, minLen) {
+  if (candidateLen <= minLen) return candidateLen;
+  if (isWordBoundaryChar(text[candidateLen]) || isWordBoundaryChar(text[candidateLen - 1])) {
+    return candidateLen;
+  }
+  let i = candidateLen;
+  while (i > minLen && !isWordBoundaryChar(text[i - 1])) i -= 1;
+  return i > minLen ? i : candidateLen;
+}
+
+/**
+ * The single boundary-holdback policy for a reveal candidate: never end a
+ * frame's reveal mid-markdown-delimiter-run or mid-word when the rest is
+ * already sitting in the buffer. A no-op at the true live edge of arrival
+ * (`candidateLen >= text.length`) — there is nothing buffered beyond it to
+ * wait for, so the true arrived tail is shown as-is and self-resolves the
+ * moment more text arrives.
+ *
+ * Forward progress is the one invariant that always wins: if honoring every
+ * holdback would produce zero progress (result <= minLen), the raw
+ * candidate is returned instead. A one-frame partial-word/partial-delimiter
+ * flash is strictly better than a permanently frozen reveal — this is what
+ * keeps the RAG chunk path (which calls this against a shrinking window that
+ * may never grow past a stuck fragment like "**bo") from stalling forever.
+ */
+export function snapRevealBoundary(text, candidateLen, minLen) {
+  if (candidateLen >= text.length) return candidateLen;
+
+  let snapped = candidateLen;
+  const mdMatch = text.slice(0, snapped).match(MARKDOWN_TAIL_HOLDBACK_RE);
+  if (mdMatch) {
+    const trimmed = snapped - mdMatch[0].length;
+    if (trimmed > minLen) snapped = trimmed;
+  }
+  snapped = snapToWordBoundary(text, snapped, minLen);
+
+  return snapped > minLen ? snapped : candidateLen;
+}
+
+/**
+ * Fresh per-stream pacer state. Create one per answer (reset whenever a new
+ * stream/msgId is adopted) — never share across concurrent/successive
+ * streams, since `revealedLen` and the initial-buffer/pause timestamps are
+ * only meaningful relative to one text's arrival.
+ */
+export function createPacerState() {
+  return {
+    revealedLen: 0,
+    // Fractional characters carried across frames (the rate cap is
+    // ~3 chars/frame at 60fps, which does not divide evenly into whole
+    // chars — dropping the remainder every frame would make the effective
+    // rate visibly slower than configured).
+    charBudget: 0,
+    // Wall-clock timestamp of this stream's first tick (for the initial
+    // smoothing buffer window). Null until the first tickPacer call.
+    bufferStartMs: null,
+    // True until the initial smoothing buffer's gate has been passed.
+    buffering: true,
+    // While `nowMs < pauseUntilMs`, hold the reveal (a punctuation beat).
+    pauseUntilMs: 0,
+  };
+}
+
+/**
+ * Advance one frame of the deterministic reveal. Mutates and returns
+ * `state`. `nowMs`/`deltaMs` come from the caller's requestAnimationFrame
+ * timestamp — this function never reads the clock itself.
+ *
+ * Behavior, in order:
+ *   1. `reducedMotion` (WCAG 2.3.3) bypasses everything — full text, no
+ *      buffer, no rate cap, no punctuation holds. Matches this file's
+ *      "snap, don't animate" convention elsewhere in the codebase.
+ *   2. Initial smoothing buffer: reveal nothing until EITHER
+ *      INITIAL_BUFFER_MS has elapsed since this stream's first tick OR
+ *      the arrived text has reached INITIAL_BUFFER_CHAR_THRESHOLD chars —
+ *      whichever comes first. Removes the common "two characters then a
+ *      dead pause" startup stutter.
+ *   3. No backlog (revealed has fully caught up to arrived): the char
+ *      budget is reset to zero rather than left to accumulate "idle
+ *      credit". This is deliberate — every burst is paced at the exact
+ *      same cap regardless of how long the preceding silence was, which is
+ *      what makes the cadence read as consistent/deterministic rather than
+ *      "sometimes fast after a pause, sometimes not".
+ *   4. A punctuation hold in effect: skip this frame entirely, INCLUDING
+ *      budget accumulation, so release-after-pause resumes at the normal
+ *      rate rather than bursting on banked time.
+ *   5. Otherwise: accumulate `deltaMs * MAX_REVEAL_CHARS_PER_MS` into the
+ *      budget, spend the whole-character part of it (snapped to a clean
+ *      word/markdown boundary), and — if the just-revealed run ends on
+ *      sentence/clause punctuation — arm the next hold.
+ */
+export function tickPacer(state, fullText, nowMs, deltaMs, opts = {}) {
+  const { reducedMotion = false } = opts;
+
+  if (reducedMotion) {
+    state.revealedLen = fullText.length;
+    state.buffering = false;
+    state.charBudget = 0;
+    state.pauseUntilMs = 0;
+    return state;
+  }
+
+  if (state.bufferStartMs === null) {
+    state.bufferStartMs = nowMs;
+  }
+
+  if (state.buffering) {
+    const elapsed = nowMs - state.bufferStartMs;
+    if (elapsed >= INITIAL_BUFFER_MS || fullText.length >= INITIAL_BUFFER_CHAR_THRESHOLD) {
+      state.buffering = false;
+    } else {
+      return state;
+    }
+  }
+
+  const backlog = fullText.length - state.revealedLen;
+  if (backlog <= 0) {
+    state.charBudget = 0;
+    return state;
+  }
+
+  if (nowMs < state.pauseUntilMs) return state;
+
+  state.charBudget += deltaMs * MAX_REVEAL_CHARS_PER_MS;
+  const chunk = Math.floor(state.charBudget);
+  if (chunk <= 0) return state;
+
+  const prevRevealedLen = state.revealedLen;
+  const rawCandidate = Math.min(prevRevealedLen + chunk, fullText.length);
+  const snapped = snapRevealBoundary(fullText, rawCandidate, prevRevealedLen);
+
+  // Only spend budget for what was actually revealed — a word/delimiter held
+  // back for this frame keeps its saved-up budget for the next one instead
+  // of being charged for characters the user didn't actually see yet.
+  state.charBudget -= snapped - prevRevealedLen;
+  state.revealedLen = snapped;
+
+  const lastRevealedChar = fullText[snapped - 1];
+  if (SENTENCE_END_CHARS.has(lastRevealedChar)) {
+    state.pauseUntilMs = nowMs + SENTENCE_END_PAUSE_MS;
+  } else if (CLAUSE_PAUSE_CHARS.has(lastRevealedChar)) {
+    state.pauseUntilMs = nowMs + CLAUSE_PAUSE_MS;
+  }
+
+  return state;
+}
+
+/**
+ * Worst-case wall-clock time this pacer could legitimately take to fully
+ * reveal `charCount` characters, ignoring punctuation holds (a slight
+ * underestimate — used to size safety-net timeouts generously, not to
+ * predict the exact finish time).
+ */
+export function estimateRevealDurationMs(charCount) {
+  return Math.ceil(charCount / MAX_REVEAL_CHARS_PER_MS);
+}

--- a/src/lib/textRevealPacing.mjs
+++ b/src/lib/textRevealPacing.mjs
@@ -256,11 +256,25 @@ export function tickPacer(state, fullText, nowMs, deltaMs, opts = {}) {
   state.charBudget -= snapped - prevRevealedLen;
   state.revealedLen = snapped;
 
-  const lastRevealedChar = fullText[snapped - 1];
-  if (SENTENCE_END_CHARS.has(lastRevealedChar)) {
-    state.pauseUntilMs = nowMs + SENTENCE_END_PAUSE_MS;
-  } else if (CLAUSE_PAUSE_CHARS.has(lastRevealedChar)) {
-    state.pauseUntilMs = nowMs + CLAUSE_PAUSE_MS;
+  // Scan the WHOLE slice revealed this tick, not just its last character.
+  // A single tick can span multiple characters (a large character budget
+  // after the initial buffer closes, or catching up from a burst), so a
+  // sentence/clause boundary can land mid-slice instead of exactly at the
+  // end — checking only fullText[snapped - 1] would silently skip the
+  // pause for text that jumped past a period/comma without landing on it.
+  // Walk backward so the LAST (most recently reached) punctuation mark in
+  // the slice wins, matching how a reader would pause at the boundary they
+  // just arrived at, not an earlier one further back in the same tick.
+  for (let i = snapped - 1; i >= prevRevealedLen; i -= 1) {
+    const ch = fullText[i];
+    if (SENTENCE_END_CHARS.has(ch)) {
+      state.pauseUntilMs = nowMs + SENTENCE_END_PAUSE_MS;
+      break;
+    }
+    if (CLAUSE_PAUSE_CHARS.has(ch)) {
+      state.pauseUntilMs = nowMs + CLAUSE_PAUSE_MS;
+      break;
+    }
   }
 
   return state;

--- a/thinkingDotHarness.html
+++ b/thinkingDotHarness.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <title>Thinking Dot Harness (dev-only, not shipped)</title>
+</head>
+
+<body style="margin:0;">
+  <div id="harness-root"></div>
+  <script type="module" src="/src/dev/thinkingDotHarness.tsx"></script>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary

- Adds a rate-capped, word/punctuation-aware reveal pacer (`src/lib/textRevealPacing.mjs`) so streamed answers display at a consistent, provider-independent cadence (currently 180 chars/sec, configurable) instead of mirroring raw provider chunking. Includes an initial smoothing buffer and deferred-completion support (the reveal keeps draining at the same rate after the network finishes, rather than snapping to full text).
- Fixes streaming-code-block flicker (`src/lib/overlayStreamingCodeUi.mjs`): mid-stream syntax highlighting was re-tokenizing incomplete lines and visibly recoloring them once they closed. Completed lines (terminated by an arrived newline) are now highlighted once and never re-rendered; only the in-progress last line updates as plain text until its own newline lands.
- Includes two dev-only, unbundled verification harnesses (`src/dev/streamingCodeHarness.tsx`, `src/dev/thinkingDotHarness.tsx` + `harness.html`, `thinkingDotHarness.html`) used to visually verify these fixes via Playwright against the real CSS/JSX shapes, since neither is easily verifiable through unit tests alone.

**Note on scope:** this branch does NOT include `NativelyInterface.tsx`/`index.css` wiring changes. `main` already has a separate commit (`259e3bf5`) that imports `textRevealPacing.mjs` but never actually committed that file — this PR supplies the missing dependency plus its test coverage, so that import resolves. No production wiring is touched here.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] 70/70 tests pass (`textRevealPacing.test.mjs`, `ragStreamChunkCoalescing.test.mjs`, `streamingTokenQueue*.test.mjs`, `overlayStreamingCodeUi.test.mjs`)
- [ ] Confirm `main`'s existing `NativelyInterface.tsx` import of `textRevealPacing.mjs` resolves correctly once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)