### PR TITLE
fix(overlay): vivid VS-Code-style code block theme

### DIFF
--- a/src/components/MeetingDetails.tsx
+++ b/src/components/MeetingDetails.tsx
@@ -12,7 +12,7 @@ import NativelyLogo from './icon.png';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import SyntaxHighlighter from 'react-syntax-highlighter/dist/esm/prism-light';
-import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { vividDarkCodeTheme } from '../lib/codeTheme';
 
 registerPrismLanguages();
 
@@ -344,7 +344,7 @@ const mdComponents = {
     ol: ({ node, ...props }: any) => <ol className="list-decimal ml-4 mb-2 space-y-1.5" {...props} />,
     li: ({ node, ...props }: any) => <li className="text-[15px] text-text-secondary font-normal leading-relaxed" {...props} />,
     strong: ({ node, ...props }: any) => <strong className="font-semibold text-text-primary" {...props} />,
-    a: ({ node, ...props }: any) => <a target="_blank" rel="noopener noreferrer" className="text-blue-400 hover:text-blue-300 underline underline-offset-2 transition-colors duration-150" {...props} />,
+    a: ({ node, ...props }: any) => <a target="_blank" rel="noopener noreferrer" className="text-accent-primary hover:text-accent-hover underline underline-offset-2 transition-colors duration-150" {...props} />,
     pre: ({ children }: any) => <div className="mb-3 last:mb-0">{children}</div>,
     code: ({ node, className, children, ...props }: any) => {
         const match = /language-([\w+#-]+)/.exec(className || '');
@@ -385,7 +385,7 @@ const CodeHero: React.FC<{ lang: string; code: string; technique?: string }> = (
         return () => { el.removeEventListener('scroll', update); ro.disconnect(); };
     }, [code]);
     return (
-        <div className="group relative w-full min-w-0 rounded-xl overflow-hidden border border-white/[0.08] ring-1 ring-inset ring-white/[0.05] bg-zinc-900/80 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.05)] transition-colors duration-200 hover:border-white/[0.12]">
+        <div className="group relative w-full min-w-0 rounded-xl overflow-hidden border border-white/[0.08] ring-1 ring-inset ring-white/[0.05] bg-[#0a0a0d]/90 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.05)] transition-colors duration-200 hover:border-white/[0.12]">
             <div className="flex items-center gap-2 h-9 px-3 border-b border-white/[0.05] bg-white/[0.02]">
                 <span className="text-[11px] uppercase tracking-[0.04em] font-medium text-text-tertiary font-mono select-none cursor-default">
                     {resolved || 'code'}
@@ -405,7 +405,7 @@ const CodeHero: React.FC<{ lang: string; code: string; technique?: string }> = (
             >
                 <SyntaxHighlighter
                     language={resolved}
-                    style={vscDarkPlus}
+                    style={vividDarkCodeTheme}
                     customStyle={{ margin: 0, borderRadius: 0, fontSize: '13px', lineHeight: '1.6', background: 'transparent', padding: '14px 16px', fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace' }}
                     showLineNumbers={lineCount > 8}
                     lineNumberStyle={{ minWidth: '2.2em', paddingRight: '1.2em', color: 'rgba(255,255,255,0.2)', textAlign: 'right', fontSize: '11px', userSelect: 'none' }}
@@ -1230,7 +1230,7 @@ ${meeting.detailedSummary.keyPoints?.map(item => `- ${item}`).join('\n') || 'Non
                                             ol: ({ node, ...props }) => <ol className="list-decimal ml-4 mb-2 space-y-1" {...props} />,
                                             li: ({ node, ...props }) => <li className="text-sm text-text-secondary" {...props} />,
                                             strong: ({ node, ...props }) => <strong className="font-semibold text-text-primary" {...props} />,
-                                            a: ({ node, ...props }) => <a className="text-blue-500 hover:underline" {...props} />,
+                                            a: ({ node, ...props }) => <a className="text-accent-primary hover:underline" {...props} />,
                                         }}
                                     >
                                         {meeting.detailedSummary?.overview || ''}
@@ -1306,7 +1306,7 @@ ${meeting.detailedSummary.keyPoints?.map(item => `- ${item}`).join('\n') || 'Non
                                                 whileTap={prefersReducedMotion ? undefined : { scale: 0.96 }}
                                                 transition={{ duration: 0.16, ease: [0.23, 1, 0.32, 1] }}
                                                 aria-pressed={showEvidence}
-                                                className={`h-7 inline-flex items-center gap-1.5 text-[11px] font-medium px-2.5 rounded-md transition-colors ${showEvidence ? 'text-accent-primary bg-accent-primary/10' : 'text-text-secondary hover:text-text-primary hover:bg-white/[0.06]'}`}
+                                                className={`h-7 inline-flex items-center gap-1.5 text-[11px] font-medium px-2.5 rounded-md transition-colors ${showEvidence ? 'text-accent-primary bg-accent-subtle' : 'text-text-secondary hover:text-text-primary hover:bg-white/[0.06]'}`}
                                             >
                                                 <span className="relative w-3.5 h-3.5 shrink-0">
                                                     <AnimatePresence initial={false} mode="wait">
@@ -1416,7 +1416,7 @@ ${meeting.detailedSummary.keyPoints?.map(item => `- ${item}`).join('\n') || 'Non
                                                             <div className="min-w-0 flex-1">
                                                                 <p className="text-sm text-text-secondary leading-relaxed">{bullet.text}</p>
                                                                 {showEvidence && evidenceLabel(bullet.evidence) && (
-                                                                    <button type="button" onClick={() => jumpToEvidence(bullet.evidence)} className="text-[11px] text-blue-400/80 hover:text-blue-300 mt-1 text-left">↳ {evidenceLabel(bullet.evidence)}</button>
+                                                                    <button type="button" onClick={() => jumpToEvidence(bullet.evidence)} className="text-[11px] text-accent-primary hover:text-accent-hover mt-1 text-left">↳ {evidenceLabel(bullet.evidence)}</button>
                                                                 )}
                                                             </div>
                                                         </li>
@@ -1460,7 +1460,7 @@ ${meeting.detailedSummary.keyPoints?.map(item => `- ${item}`).join('\n') || 'Non
                                                                 <span>{item.confidence} {t('confidence')}</span>
                                                             </p>
                                                             {showEvidence && evidenceLabel(item.evidence) && (
-                                                                <button type="button" onClick={() => jumpToEvidence(item.evidence)} className="text-[11px] text-blue-400/80 hover:text-blue-300 mt-1 text-left">↳ {evidenceLabel(item.evidence)}</button>
+                                                                <button type="button" onClick={() => jumpToEvidence(item.evidence)} className="text-[11px] text-accent-primary hover:text-accent-hover mt-1 text-left">↳ {evidenceLabel(item.evidence)}</button>
                                                             )}
                                                         </div>
                                                     </div>
@@ -1487,7 +1487,7 @@ ${meeting.detailedSummary.keyPoints?.map(item => `- ${item}`).join('\n') || 'Non
                                                                 <span>{item.confidence} {t('confidence')}</span>
                                                             </p>
                                                             {showEvidence && evidenceLabel(item.evidence) && (
-                                                                <button type="button" onClick={() => jumpToEvidence(item.evidence)} className="text-[11px] text-blue-400/80 hover:text-blue-300 mt-1 text-left">↳ {evidenceLabel(item.evidence)}</button>
+                                                                <button type="button" onClick={() => jumpToEvidence(item.evidence)} className="text-[11px] text-accent-primary hover:text-accent-hover mt-1 text-left">↳ {evidenceLabel(item.evidence)}</button>
                                                             )}
                                                         </div>
                                                     </div>
@@ -1631,7 +1631,7 @@ ${meeting.detailedSummary.keyPoints?.map(item => `- ${item}`).join('\n') || 'Non
                                         <ul className="space-y-3">
                                             {meeting.detailedSummary.actionItems.map((item, i) => (
                                                 <li key={actionItemKeys[i] ?? i} className="flex items-start gap-3 group">
-                                                    <div className="mt-2 w-1.5 h-1.5 rounded-full bg-text-secondary group-hover:bg-blue-500 transition-colors shrink-0" />
+                                                    <div className="mt-2 w-1.5 h-1.5 rounded-full bg-text-secondary group-hover:bg-accent-primary transition-colors shrink-0" />
                                                     <div className="flex-1">
                                                         <EditableTextBlock
                                                             initialValue={item}
@@ -1830,7 +1830,7 @@ ${meeting.detailedSummary.keyPoints?.map(item => `- ${item}`).join('\n') || 'Non
                                                             initial={prefersReducedMotion ? undefined : { opacity: 0, scale: 0.96 }}
                                                             animate={prefersReducedMotion ? undefined : { opacity: 1, scale: 1 }}
                                                             transition={{ duration: 0.16, ease: [0.23, 1, 0.32, 1] }}
-                                                            className="inline-flex items-center gap-1 h-7 pl-2 pr-1 rounded-full bg-bg-secondary border border-accent-primary/50 ring-1 ring-accent-primary/20"
+                                                            className="inline-flex items-center gap-1 h-7 pl-2 pr-1 rounded-full bg-bg-secondary border border-accent-focus ring-1 ring-accent-border"
                                                         >
                                                             <input
                                                                 autoFocus
@@ -1845,7 +1845,7 @@ ${meeting.detailedSummary.keyPoints?.map(item => `- ${item}`).join('\n') || 'Non
                                                                 onMouseDown={e => e.preventDefault()}
                                                                 onClick={() => handleSaveSpeakerLabel(id, speakerDraft)}
                                                                 whileTap={prefersReducedMotion ? undefined : { scale: 0.9 }}
-                                                                className="inline-flex items-center justify-center w-5 h-5 rounded-full text-accent-primary hover:bg-accent-primary/15 transition-colors"
+                                                                className="inline-flex items-center justify-center w-5 h-5 rounded-full text-accent-primary hover:bg-accent-muted transition-colors"
                                                                 title={t("Save")}
                                                             >
                                                                 <Check className="w-3 h-3" strokeWidth={2.5} />
@@ -1903,7 +1903,7 @@ ${meeting.detailedSummary.keyPoints?.map(item => `- ${item}`).join('\n') || 'Non
                                         return filteredTranscript.map((entry, i) => (
                                             <div
                                                 key={i}
-                                                className={`group rounded-md transition-colors ${i === scrollIndex ? 'bg-blue-500/10 ring-1 ring-blue-400/30 -mx-2 px-2 py-1' : ''}`}
+                                                className={`group rounded-md transition-colors ${i === scrollIndex ? 'bg-accent-subtle ring-1 ring-accent-border -mx-2 px-2 py-1' : ''}`}
                                                 ref={i === scrollIndex ? (el) => { if (el && pendingScrollTs != null) { el.scrollIntoView({ behavior: 'smooth', block: 'center' }); setTimeout(() => setPendingScrollTs(null), 1500); } } : undefined}
                                             >
                                                 <div className="flex items-center gap-2 mb-1">

--- a/src/components/NativelyInterface.tsx
+++ b/src/components/NativelyInterface.tsx
@@ -131,7 +131,7 @@ const CodeBlockCopyButton = ({ code }: { code: string }) => {
       type="button"
       onClick={handleCopy}
       aria-label={copied ? 'Copied' : 'Copy code'}
-      className="absolute top-2 right-2 z-10 w-7 h-7 rounded-md bg-black/55 backdrop-blur-md border border-white/[0.08] flex items-center justify-center opacity-0 group-hover/code:opacity-100 transition-opacity duration-150 active:scale-[0.92]"
+      className="absolute top-2 right-2 z-10 w-7 h-7 rounded-md bg-black/55 backdrop-blur-md border border-white/[0.08] flex items-center justify-center opacity-0 group-hover/code:opacity-100 transition-opacity duration-150 active:scale-[0.92] focus:outline-none focus-visible:opacity-100 focus-visible:ring-1 focus-visible:ring-white/20"
     >
       <AnimatePresence mode="wait" initial={false}>
         {copied ? (

--- a/src/components/NativelyInterface.tsx
+++ b/src/components/NativelyInterface.tsx
@@ -1,4 +1,4 @@
-import { animate, motion, useMotionValue, useTransform } from 'framer-motion';
+import { animate, AnimatePresence, motion, useMotionValue, useTransform } from 'framer-motion';
 import {
   ArrowRight,
   ChevronDown,
@@ -113,6 +113,41 @@ const CardCopyButton = ({
   );
 };
 
+const CodeBlockCopyButton = ({ code }: { code: string }) => {
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
+  const handleCopy = () => {
+    const p = navigator.clipboard?.writeText(code);
+    if (!p) return;
+    p.then(() => {
+      setCopied(true);
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(() => setCopied(false), 2000);
+    }).catch(() => {});
+  };
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      aria-label={copied ? 'Copied' : 'Copy code'}
+      className="absolute top-2 right-2 z-10 w-7 h-7 rounded-md bg-black/55 backdrop-blur-md border border-white/[0.08] flex items-center justify-center opacity-0 group-hover/code:opacity-100 transition-opacity duration-150 active:scale-[0.92]"
+    >
+      <AnimatePresence mode="wait" initial={false}>
+        {copied ? (
+          <motion.span key="check" initial={{ opacity: 0, scale: 0.8 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, scale: 0.8 }} transition={{ duration: 0.14 }} className="absolute inset-0 flex items-center justify-center">
+            <Check className="w-3.5 h-3.5 text-emerald-400" strokeWidth={2.5} />
+          </motion.span>
+        ) : (
+          <motion.span key="copy" initial={{ opacity: 0, scale: 0.8 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, scale: 0.8 }} transition={{ duration: 0.14 }} className="absolute inset-0 flex items-center justify-center text-white/70 hover:text-white/95">
+            <Copy className="w-3.5 h-3.5" strokeWidth={2} />
+          </motion.span>
+        )}
+      </AnimatePresence>
+    </button>
+  );
+};
+
 import React, {
   startTransition as reactStartTransition,
   useCallback,
@@ -162,7 +197,8 @@ import {
   shouldFlushPreviousStream,
 } from '../lib/streamingTokenQueue.mjs';
 import SyntaxHighlighter from 'react-syntax-highlighter/dist/esm/prism-light';
-import { oneLight, vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { vividDarkCodeTheme, VIVID_DARK_LINE_NUMBER_COLOR } from '../lib/codeTheme';
 
 registerPrismLanguages();
 // import { ModelSelector } from './ui/ModelSelector'; // REMOVED
@@ -281,6 +317,7 @@ interface HighlightedCodeProps {
   appearance: any;
   isModernTheme?: boolean;
   isGlassTheme?: boolean;
+  showCodeHeader: boolean;
 }
 
 const HighlightedCode = React.memo(
@@ -295,25 +332,39 @@ const HighlightedCode = React.memo(
     appearance,
     isModernTheme,
     isGlassTheme,
+    showCodeHeader,
   }: HighlightedCodeProps) {
     const isSpecialTheme = isModernTheme || isGlassTheme;
     const resolved = mapLanguageForPrism(lang, code);
     return (
       <div
-        className={`my-3 rounded-xl overflow-hidden border shadow-lg ${codeBlockClass}`}
+        className={`relative group/code my-3 rounded-xl overflow-hidden border shadow-lg ${codeBlockClass}`}
         style={isSpecialTheme ? undefined : appearance.codeBlockStyle}
       >
         {/* Minimalist Apple Header */}
-        <div
-          className={`px-3 py-1.5 border-b ${codeHeaderClass}`}
-          style={isSpecialTheme ? undefined : appearance.codeHeaderStyle}
-        >
-          <span
-            className={`text-[10px] uppercase tracking-widest font-semibold font-mono ${codeHeaderTextClass}`}
+        {showCodeHeader && (
+          <div
+            className={`px-3 py-1.5 border-b ${codeHeaderClass}`}
+            style={isSpecialTheme ? undefined : appearance.codeHeaderStyle}
           >
-            {resolved || 'CODE'}
-          </span>
-        </div>
+            <span
+              className={`text-[10px] uppercase tracking-widest font-semibold font-mono ${codeHeaderTextClass}`}
+            >
+              {resolved || 'CODE'}
+            </span>
+          </div>
+        )}
+        {!showCodeHeader && (
+          <>
+            <span
+              className="absolute top-2.5 left-3 z-10 text-[10px] uppercase tracking-widest font-mono pointer-events-none opacity-0 group-hover/code:opacity-100 transition-opacity duration-150"
+              style={{ color: VIVID_DARK_LINE_NUMBER_COLOR }}
+            >
+              {resolved || 'CODE'}
+            </span>
+            <CodeBlockCopyButton code={code} />
+          </>
+        )}
         {/* No-wrap horizontal scroll: code line layout stays stable as the
                 canvas grows/shrinks. Without this, wrapped lines re-flow at every
                 spring tick, the block height jitters, and content below shifts.
@@ -350,7 +401,8 @@ const HighlightedCode = React.memo(
     prev.lang === next.lang &&
     prev.appearance === next.appearance &&
     prev.isModernTheme === next.isModernTheme &&
-    prev.isGlassTheme === next.isGlassTheme,
+    prev.isGlassTheme === next.isGlassTheme &&
+    prev.showCodeHeader === next.showCodeHeader,
 );
 
 // PERF: MessageRow renders one chat-message bubble. Module-scope + React.memo
@@ -1163,8 +1215,9 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
   }, []);
 
   const useDarkCodeTheme = !isLightTheme || isGlassTheme || isModernTheme;
-  const codeTheme = useDarkCodeTheme ? vscDarkPlus : oneLight;
-  const codeLineNumberColor = useDarkCodeTheme ? 'rgba(255,255,255,0.2)' : 'rgba(15,23,42,0.35)';
+  const codeTheme = useDarkCodeTheme ? vividDarkCodeTheme : oneLight;
+  const codeLineNumberColor = useDarkCodeTheme ? VIVID_DARK_LINE_NUMBER_COLOR : 'rgba(24,24,24,0.4)';
+  const showCodeHeader = !useDarkCodeTheme || isModernTheme || isGlassTheme;
   const appearance = useMemo(
     () =>
       isGlassTheme
@@ -1238,6 +1291,7 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
                 appearance={appearance}
                 isModernTheme={isModernTheme}
                 isGlassTheme={isGlassTheme}
+                showCodeHeader={showCodeHeader}
               />
             );
           }
@@ -4556,6 +4610,7 @@ Provide only the answer, nothing else.`;
                         appearance={appearance}
                         isModernTheme={isModernTheme}
                         isGlassTheme={isGlassTheme}
+                        showCodeHeader={showCodeHeader}
                       />
                     );
                   }
@@ -4704,6 +4759,7 @@ Provide only the answer, nothing else.`;
                         appearance={appearance}
                         isModernTheme={isModernTheme}
                         isGlassTheme={isGlassTheme}
+                        showCodeHeader={showCodeHeader}
                       />
                     );
                   }

--- a/src/lib/codeTheme.ts
+++ b/src/lib/codeTheme.ts
@@ -1,0 +1,131 @@
+import type React from 'react';
+
+// Custom vivid-on-black Prism theme for code blocks, replacing vscDarkPlus in
+// the default (non-modern, non-glass) dark meeting overlay + the recap page's
+// CodeHero. Same object shape as react-syntax-highlighter's built-in
+// vsc-dark-plus.js (see node_modules/react-syntax-highlighter/src/styles/prism/vsc-dark-plus.js)
+// so it's a drop-in `style` prop replacement.
+//
+// Four accent hues, each used for exactly one semantic role everywhere so the
+// palette stays legible across languages instead of accumulating one-off
+// per-language colors:
+//   pink   #ff5fa8 — keywords / control-flow / tags / selectors / at-rules
+//   orange #ffb454 — numeric literals / booleans / units (never anything else)
+//   cyan   #5ccfe6 — operators / entities / escapes
+//   green  #95e6a0 — strings / chars / attr values / regex
+// Everything identifier-shaped (functions, class names, variables, params,
+// properties, builtins, attr names) stays base white (#e7e7ea) — confirmed
+// against the reference screenshot, where `hammingWeight` (function) and
+// `Solution` (class-name) render as plain text, not a 5th accent color.
+//
+// Deliberately OMITTED vs. vsc-dark-plus: the per-language base-color
+// overrides (`pre/code[class*="language-javascript|jsx|typescript|tsx|css"]`)
+// — those override the base foreground only for those languages (e.g. JS/TS
+// get a light-blue base), which would contradict "identifiers are plain
+// everywhere" the moment a JS block sat next to a Java block.
+const PINK = '#ff5fa8';
+const ORANGE = '#ffb454';
+const CYAN = '#5ccfe6';
+const GREEN = '#95e6a0';
+const WHITE = '#e7e7ea';
+const DIM_GRAY = '#c8c9cc';
+const COMMENT_GRAY = '#6b7280';
+const RED = '#ff6b6b';
+const SELECTION_BG = 'rgba(92, 207, 230, 0.25)';
+
+const baseTokenStyle = {
+  color: WHITE,
+  fontSize: '13px',
+  textShadow: 'none',
+  fontFamily:
+    'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Andale Mono", "Ubuntu Mono", "Courier New", monospace',
+  direction: 'ltr' as const,
+  textAlign: 'left' as const,
+  whiteSpace: 'pre' as const,
+  wordSpacing: 'normal',
+  wordBreak: 'normal' as const,
+  lineHeight: '1.5',
+  MozTabSize: '4',
+  OTabSize: '4',
+  tabSize: '4',
+  WebkitHyphens: 'none' as const,
+  MozHyphens: 'none' as const,
+  msHyphens: 'none' as const,
+  hyphens: 'none' as const,
+};
+
+export const vividDarkCodeTheme: Record<string, React.CSSProperties> = {
+  'pre[class*="language-"]': {
+    ...baseTokenStyle,
+    padding: '1em',
+    margin: '.5em 0',
+    overflow: 'auto',
+    background: 'transparent',
+  },
+  'code[class*="language-"]': baseTokenStyle,
+  'pre[class*="language-"]::selection': { textShadow: 'none', background: SELECTION_BG },
+  'code[class*="language-"]::selection': { textShadow: 'none', background: SELECTION_BG },
+  'pre[class*="language-"] *::selection': { textShadow: 'none', background: SELECTION_BG },
+  'code[class*="language-"] *::selection': { textShadow: 'none', background: SELECTION_BG },
+  ':not(pre) > code[class*="language-"]': {
+    padding: '.1em .3em',
+    borderRadius: '.3em',
+    color: WHITE,
+    background: 'transparent',
+  },
+  '.namespace': { opacity: '.7' },
+  'doctype.name': { color: WHITE },
+  comment: { color: COMMENT_GRAY, fontStyle: 'italic' },
+  prolog: { color: COMMENT_GRAY, fontStyle: 'italic' },
+  cdata: { color: COMMENT_GRAY, fontStyle: 'italic' },
+  punctuation: { color: DIM_GRAY },
+  'tag.punctuation': { color: DIM_GRAY },
+  'attr-value.punctuation.attr-equals': { color: DIM_GRAY },
+  property: { color: WHITE },
+  tag: { color: PINK },
+  boolean: { color: ORANGE },
+  number: { color: ORANGE },
+  unit: { color: ORANGE },
+  constant: { color: WHITE },
+  symbol: { color: WHITE },
+  inserted: { color: GREEN },
+  deleted: { color: RED },
+  selector: { color: PINK },
+  'attr-name': { color: WHITE },
+  string: { color: GREEN },
+  char: { color: GREEN },
+  builtin: { color: WHITE },
+  '.language-css .token.string.url': { textDecoration: 'underline' },
+  operator: { color: CYAN },
+  'operator.arrow': { color: CYAN },
+  entity: { color: CYAN },
+  escape: { color: CYAN },
+  'punctuation.interpolation-punctuation': { color: CYAN },
+  atrule: { color: PINK },
+  keyword: { color: PINK },
+  'keyword.module': { color: PINK },
+  'keyword.control-flow': { color: PINK },
+  important: { color: PINK },
+  function: { color: WHITE },
+  'function.maybe-class-name': { color: WHITE },
+  regex: { color: GREEN },
+  italic: { fontStyle: 'italic' },
+  'class-name': { color: WHITE },
+  'maybe-class-name': { color: WHITE },
+  console: { color: WHITE },
+  parameter: { color: WHITE },
+  interpolation: { color: WHITE },
+  variable: { color: WHITE },
+  'imports.maybe-class-name': { color: WHITE },
+  'exports.maybe-class-name': { color: WHITE },
+  namespace: { color: WHITE },
+  'attr-value': { color: GREEN },
+  'attr-value.punctuation': { color: GREEN },
+  'pre[class*="language-"] > code[class*="language-"]': { position: 'relative', zIndex: '1' },
+};
+
+/** Gutter/line-number color tuned for vividDarkCodeTheme's near-black card background. */
+export const VIVID_DARK_LINE_NUMBER_COLOR = 'rgba(255,255,255,0.34)';
+
+/** Card background (near-pure black with a whisper of the app's cool-neutral hue) — see overlayAppearance.ts codeBlockStyle dark branch. */
+export const VIVID_DARK_CODE_BG_RGB = '10, 10, 13';

--- a/src/lib/overlayAppearance.ts
+++ b/src/lib/overlayAppearance.ts
@@ -1,4 +1,5 @@
 import type React from 'react';
+import { VIVID_DARK_CODE_BG_RGB } from './codeTheme';
 
 export type OverlayTheme = 'light' | 'dark';
 
@@ -86,12 +87,12 @@ export const getOverlayAppearance = (opacity: number, theme: OverlayTheme): Over
                 backgroundColor: `rgba(248, 251, 255, ${scale(0.055, 0.88, surfaceStrength)})`,
             },
             codeBlockStyle: {
-                backgroundColor: `rgba(245, 249, 255, ${scale(0.06, 0.94, surfaceStrength)})`,
-                borderColor: `rgba(30, 64, 175, ${scale(0.07, 0.15, surfaceStrength)})`,
+                backgroundColor: `rgba(249, 250, 251, ${scale(0.06, 0.94, surfaceStrength)})`,
+                borderColor: `rgba(0, 0, 0, ${scale(0.07, 0.15, surfaceStrength)})`,
             },
             codeHeaderStyle: {
-                backgroundColor: `rgba(236, 244, 255, ${scale(0.08, 0.96, surfaceStrength)})`,
-                borderBottomColor: `rgba(30, 64, 175, ${scale(0.08, 0.16, surfaceStrength)})`,
+                backgroundColor: `rgba(243, 244, 246, ${scale(0.08, 0.96, surfaceStrength)})`,
+                borderBottomColor: `rgba(0, 0, 0, ${scale(0.08, 0.16, surfaceStrength)})`,
             },
             dividerStyle: {
                 backgroundColor: `rgba(30, 64, 175, ${scale(0.08, 0.16, surfaceStrength)})`,
@@ -140,11 +141,11 @@ export const getOverlayAppearance = (opacity: number, theme: OverlayTheme): Over
             backgroundColor: `rgba(54, 59, 71, ${scale(0.2, 0.92, surfaceStrength)})`,
         },
         codeBlockStyle: {
-            backgroundColor: `rgba(35, 40, 50, ${scale(0.24, 0.96, surfaceStrength)})`,
+            backgroundColor: `rgba(${VIVID_DARK_CODE_BG_RGB}, ${scale(0.30, 0.97, surfaceStrength)})`,
             borderColor: `rgba(255, 255, 255, ${scale(0.05, 0.1, surfaceStrength)})`,
         },
         codeHeaderStyle: {
-            backgroundColor: `rgba(48, 53, 64, ${scale(0.22, 0.94, surfaceStrength)})`,
+            backgroundColor: `rgba(45, 45, 45, ${scale(0.22, 0.94, surfaceStrength)})`,
             borderBottomColor: `rgba(255, 255, 255, ${scale(0.05, 0.1, surfaceStrength)})`,
         },
         dividerStyle: {


### PR DESCRIPTION
## Summary
- Code blocks in the meeting overlay had a blue-gray tint (RGB triplets where blue consistently outweighed red/green) instead of neutral chrome, and used the stock `vscDarkPlus` syntax theme.
- Adds a custom near-black theme (`src/lib/codeTheme.ts`): pink keywords/tags, orange numeric literals, cyan operators, green strings, everything else (identifiers, function/class names) plain white — matches a reference screenshot the user provided.
- Removes the code block's header bar for the default dark theme, replaced by a hover-revealed floating language tag + copy button. Light theme and the modern/liquid-glass interface themes keep their existing header treatment unchanged.
- Applied consistently to the live overlay (`NativelyInterface.tsx`) and the recap page's `CodeHero` (`MeetingDetails.tsx`).

## Test plan
- [x] `tsc --noEmit` passes clean on the changed files
- [ ] Manually verify code blocks render correctly in the live meeting overlay (dark, light, modern, liquid-glass themes)
- [ ] Manually verify the recap page's code blocks (`CodeHero`)
- [ ] Verify hover-reveal copy button works and copies code to clipboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)