### PR TITLE
fix(settings): use real Natively logo instead of placeholder mark

### DIFF
--- a/src/components/SettingsOverlay.tsx
+++ b/src/components/SettingsOverlay.tsx
@@ -19,7 +19,7 @@ import { PhoneMirrorSettings } from './settings/PhoneMirrorSettings';
 import { IntelligenceSettings } from './settings/IntelligenceSettings';
 import { SkillsSettings } from './settings/SkillsSettings';
 import { LocalWhisperModelPanel } from './LocalWhisperModelPanel';
-import { NativelyLogoMark } from './NativelyLogoMark';
+import nativelyLogo from '../assets/logo.webp';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useShortcuts } from '../hooks/useShortcuts';
 import { isMac } from '../utils/platformUtils';
@@ -1464,14 +1464,14 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({
                                         onClick={() => setActiveTab('natively-api')}
                                         className={`w-full text-left px-3 py-2 rounded-lg text-sm font-medium transition-colors flex items-center gap-3 relative ${activeTab === 'natively-api' ? "bg-bg-item-active text-text-primary before:absolute before:left-0 before:top-1/2 before:-translate-y-1/2 before:h-5 before:w-[2px] before:rounded-full before:bg-accent-primary" : "text-text-secondary hover:text-text-primary hover:bg-bg-item-active/50"}`}
                                     >
-                                        <NativelyLogoMark size={16} className={activeTab === 'natively-api' ? 'text-text-primary' : 'text-text-secondary'} />
+                                        <img src={nativelyLogo} alt="" className={`w-4 h-4 object-contain ${activeTab === 'natively-api' ? 'opacity-100' : 'opacity-70'}`} draggable={false} />
                                         <span>Natively API</span>
                                     </button>
                                     <button
                                         onClick={() => setActiveTab('natively-pro')}
                                         className={`w-full text-left px-3 py-2 rounded-lg text-sm font-medium transition-colors flex items-center gap-3 relative ${activeTab === 'natively-pro' ? "bg-bg-item-active text-text-primary before:absolute before:left-0 before:top-1/2 before:-translate-y-1/2 before:h-5 before:w-[2px] before:rounded-full before:bg-accent-primary" : "text-text-secondary hover:text-text-primary hover:bg-bg-item-active/50"}`}
                                     >
-                                        <NativelyLogoMark size={16} className={activeTab === 'natively-pro' ? 'text-text-primary' : 'text-text-secondary'} />
+                                        <img src={nativelyLogo} alt="" className={`w-4 h-4 object-contain ${activeTab === 'natively-pro' ? 'opacity-100' : 'opacity-70'}`} draggable={false} />
                                         <span>Natively Pro</span>
                                     </button>
                                     <button

--- a/src/components/settings/NativelyApiSettings.tsx
+++ b/src/components/settings/NativelyApiSettings.tsx
@@ -16,7 +16,7 @@ import {
 } from 'lucide-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useT } from '../../i18n';
-import { NativelyLogoMark } from '../NativelyLogoMark';
+import nativelyLogo from '../../assets/logo.webp';
 import { FreeTrialModal } from '../trial/FreeTrialModal';
 import { getMeetingInterfaceTheme, type MeetingInterfaceTheme } from '../../lib/meetingInterfaceTheme';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -1006,7 +1006,7 @@ export const NativelyApiSettings: React.FC<NativelyApiSettingsProps> = ({ initia
                 {/* Header — same layout as "Try Natively API free" start card */}
                 <div className="flex items-start gap-3.5">
                   <div className="w-10 h-10 rounded-[11px] bg-violet-500/10 border border-violet-500/20 flex items-center justify-center shrink-0">
-                    <NativelyLogoMark size={18} className="text-violet-400" />
+                    <img src={nativelyLogo} alt="Natively" className="w-[18px] h-[18px] object-contain" draggable={false} />
                   </div>
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center justify-between">
@@ -1079,11 +1079,11 @@ export const NativelyApiSettings: React.FC<NativelyApiSettingsProps> = ({ initia
               <div className="px-5 pt-5 pb-4 flex flex-col items-center justify-center text-center">
                 {/* Apple Promo Icon */}
                 <div className="w-[42px] h-[42px] mb-3 rounded-[12px] bg-bg-input border border-border-subtle shadow-[inset_0_1px_rgba(255,255,255,0.06),0_2px_8px_rgba(0,0,0,0.04)] flex items-center justify-center relative overflow-hidden">
-                  <NativelyLogoMark
-                    size={20}
-                    className={
-                      isClaimed ? 'text-text-tertiary' : 'text-text-primary drop-shadow-sm'
-                    }
+                  <img
+                    src={nativelyLogo}
+                    alt="Natively"
+                    className={`w-5 h-5 object-contain ${isClaimed ? 'opacity-50' : 'drop-shadow-sm'}`}
+                    draggable={false}
                   />
                 </div>
 
@@ -1169,7 +1169,7 @@ export const NativelyApiSettings: React.FC<NativelyApiSettingsProps> = ({ initia
         <div className="flex items-center gap-3 px-5 pt-5 pb-4">
           {/* Tinted icon well — Apple style */}
           <div className="w-9 h-9 rounded-xl bg-accent-subtle border border-accent-border flex items-center justify-center shrink-0">
-            <NativelyLogoMark size={18} className="text-accent-strong" />
+            <img src={nativelyLogo} alt="Natively" className="w-[18px] h-[18px] object-contain" draggable={false} />
           </div>
           <div className="min-w-0">
             <p className="text-[13px] font-semibold text-text-primary">API Key</p>

--- a/src/components/trial/FreeTrialModal.tsx
+++ b/src/components/trial/FreeTrialModal.tsx
@@ -10,7 +10,7 @@
 import React, { useState } from 'react';
 import { motion, useReducedMotion } from 'framer-motion';
 import { Zap, Key, ArrowRight, Loader2, CheckCircle, Brain, Mic, Flame, ShieldCheck } from 'lucide-react';
-import { NativelyLogoMark } from '../NativelyLogoMark';
+import nativelyLogo from '../../assets/logo.webp';
 
 const PLAN_STANDARD_URL = 'https://checkout.dodopayments.com/buy/pdt_0NbFixGmD8CSeawb5qvVl';
 const PLAN_PRO_URL      = 'https://checkout.dodopayments.com/buy/pdt_0NcM6Aw0IWdspbsgUeCLA';
@@ -213,7 +213,7 @@ function ChooseState({ usage, error, reduced, onPro, onMax, onUltra, onStandard,
       {/* ── Header ─── */}
       <div style={{display:'flex',alignItems:'center',gap:'10px',paddingBottom:'12px',borderBottom:`1px solid ${C.div}`}}>
         <div style={{width:'34px',height:'34px',borderRadius:'10px',background:'rgba(139,92,246,.13)',border:'1px solid rgba(139,92,246,.22)',display:'flex',alignItems:'center',justifyContent:'center',flexShrink:0}}>
-          <NativelyLogoMark size={16} className="text-violet-400" />
+          <img src={nativelyLogo} alt="Natively" style={{width:'16px',height:'16px',objectFit:'contain'}} draggable={false} />
         </div>
         <div>
           <div style={{fontSize:'14px',fontWeight:650,color:C.t1,letterSpacing:'-.02em',lineHeight:1.2}}>Keep the momentum going</div>


### PR DESCRIPTION
## Summary
- The Natively API and Natively Pro settings screens (sidebar tabs, trial card, promo card, API key card, free trial modal) rendered a hand-drawn SVG approximation (`NativelyLogoMark`) instead of the actual brand asset.
- Swapped all of those spots to `src/assets/logo.webp`, the real logo file.

## Test plan
- [x] `tsc --noEmit` passes for the touched files
- [ ] Visual check in the running app (light + dark theme) for Natively API / Natively Pro settings tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)