### PR TITLE
Pin custom context up to its allocated 600-token budget

### DIFF
--- a/electron/services/ModeGenerator.ts
+++ b/electron/services/ModeGenerator.ts
@@ -19,7 +19,7 @@
 //   the same local backend or a deterministic stub for plumbing checks.
 // - The generated `customContext` is what becomes the mode's "Real-time prompt"
 //   (ModesManager.getActiveModePinnedInstructions). It is capped at
-//   PINNED_INSTRUCTIONS_MAX_CHARS (1200) at INJECTION time, so we target well
+//   PINNED_INSTRUCTIONS_MAX_CHARS (2400) at INJECTION time, so we target well
 //   under that here and hard-trim as a safety net.
 // - Document grounding: a custom mode only becomes documentGroundedCustomModeActive
 //   when its customContext matches BOTH DOCUMENT_SOURCE_RE and

--- a/electron/services/ModesManager.ts
+++ b/electron/services/ModesManager.ts
@@ -1163,10 +1163,17 @@ export class ModesManager {
     }
 
     // Hard cap for the always-pinned "Real-time prompt" (mode customContext).
-    // Roughly 300 tokens — enough for real mode instructions, small enough that
-    // a pasted document can't crowd out the transcript. Anything longer remains
-    // fully available to RETRIEVAL (reference-file path), so nothing is lost.
-    private static readonly PINNED_INSTRUCTIONS_MAX_CHARS = 1_200;
+    // Sized to the budget this layer is already allocated: LAYER_BUDGET
+    // .custom_context in llm/contextRoute.ts reserves 600 tokens, which is
+    // ~2,400 chars, so pinning up to that spends the allocation without
+    // crowding the transcript. The previous 1,200 was ~300 tokens — half the
+    // reserved budget — and the remainder was NOT recoverable in practice: the
+    // comment here used to claim retrieval covered it, but customContext only
+    // reaches retrieval through the same MIN_RELEVANCE_SCORE floor as reference
+    // files, and a conversational question against prose chunks scores below
+    // that floor (see ModeContextRetriever's adaptive-threshold notes), so a
+    // user with no uploaded reference file lost everything past the cap.
+    private static readonly PINNED_INSTRUCTIONS_MAX_CHARS = 2_400;
 
     /**
      * PI v3 (W2): the active mode's user-authored "Real-time prompt"

--- a/electron/services/__tests__/ModePinnedInstructions.test.mjs
+++ b/electron/services/__tests__/ModePinnedInstructions.test.mjs
@@ -70,13 +70,46 @@ describe('W2: getActiveModePinnedInstructions', () => {
         assert.match(nego, /180k/);
     });
 
-    test('caps at ~1,200 chars', () => {
+    test('caps at ~2,400 chars (the custom_context layer budget)', () => {
         const mgr = installActiveMode(makeMode({
             customContext: 'pitch the integration story. '.repeat(200),
         }));
         const pinned = mgr.getActiveModePinnedInstructions('sales_answer');
-        assert.ok(pinned.length <= 1_300, `len=${pinned.length}`);
+        assert.ok(pinned.length <= 2_500, `len=${pinned.length}`);
         assert.match(pinned, /\[truncated\]/);
+    });
+
+    // Regression: a multi-paragraph prose context under the cap must survive
+    // WHOLE. Everything past the old 1,200-char cap was unreachable — it is
+    // dropped from this block, and retrieval cannot rescue it because
+    // customContext is scored against MIN_RELEVANCE_SCORE like a reference
+    // file, which a conversational question does not clear.
+    test('prose context within the cap is pinned in full, including its tail', () => {
+        // The fixture is deliberately sized so its LAST paragraph sits between
+        // the old 1,200-char cap and the current 2,400 one: this test fails on
+        // the old constant and passes on the new one.
+        const filler = paragraph =>
+            `${paragraph} The platform answers impact questions about public data products, gathers evidence, and produces a cited report for each request it receives.`;
+        const paragraphs = [
+            filler('OVERVIEW.'),
+            filler('VERIFICATION: every claim is checked against the source it cites before publication.'),
+            filler('BENCHMARK: reports are graded against curated anchor facts per product.'),
+            filler('RELIABILITY: a failed run is retried automatically instead of ending the session.'),
+            filler('REFRESH: the source catalogue is rebuilt by a locked job so it cannot double-run.'),
+            filler('SCORING: the impact score is being redefined so it no longer saturates early.'),
+            'NARRATIVE: when asked what changed this cycle, lead with verification and benchmarking rather than new surfaces.',
+        ].join('\n\n');
+
+        assert.ok(paragraphs.length > 1_200, `fixture must exceed the old cap: ${paragraphs.length}`);
+        assert.ok(paragraphs.length < 2_400, `fixture must fit the new cap: ${paragraphs.length}`);
+
+        const mgr = installActiveMode(makeMode({ customContext: paragraphs }));
+        const pinned = mgr.getActiveModePinnedInstructions('general_meeting_answer');
+
+        assert.doesNotMatch(pinned, /\[truncated\]/);
+        assert.match(pinned, /OVERVIEW\./);
+        // The tail is the assertion that matters: it sat past the old cap.
+        assert.match(pinned, /lead with verification and benchmarking/);
     });
 
     test('custom (user-built) modes surface their name', () => {

--- a/electron/services/context/PromptAssembler.ts
+++ b/electron/services/context/PromptAssembler.ts
@@ -326,7 +326,12 @@ export class PromptAssembler {
                 type: 'active_mode_custom_instructions',
                 trustLevel: TrustLevel.MODE_POLICY,
                 source: params.modeId ? `mode:${params.modeId}` : 'mode',
-                tokenBudget: 300,
+                // Advisory only — enforceTokenBudget() trims against the packet's
+                // global budget, never a block's own. Kept in step with the
+                // accessor's 2,400-char cap (~600 tokens) and with
+                // LAYER_BUDGET.custom_context so the declared figure does not
+                // contradict what the block can actually carry.
+                tokenBudget: 600,
                 content: `<active_mode_custom_instructions format="json">
 ${JSON.stringify({ content: this.escapePromptInjection(pinned) })}
 </active_mode_custom_instructions>`,


### PR DESCRIPTION
## Summary
<!-- What does this PR do and why? Link to issues: Fixes #123 -->

Fixes #399

`ModesManager.PINNED_INSTRUCTIONS_MAX_CHARS` was 1,200 chars (~300 tokens), but `LAYER_BUDGET.custom_context` in `llm/contextRoute.ts` already reserves **600 tokens** (~2,400 chars) for this layer — so the always-pinned block was spending half of its own allocation.

The comment on the constant justified the cap by stating that anything longer "remains fully available to RETRIEVAL (reference-file path), so nothing is lost." That does not hold for a user who has Custom Context but no uploaded reference file: `customContext` only reaches retrieval through the same `MIN_RELEVANCE_SCORE = 0.18` floor as a reference file, and a conversational question against prose chunks scores below it. I ported the scoring path from `ModeContextRetriever` (`score = matches / sqrt(queryWords.size × uniqueChunkWords)`) and ran a 4,000-char prose context against `what did we work on this sprint?`:

| Scenario | queryWords.size | threshold | chunk scores | passed |
|---|---|---|---|---|
| No transcript | 5 | 0.1800 | 0.1227, 0.1729 | 0 of 2 |
| Live transcript | 100 | 0.1800 | 0.1098, 0.1546 | 0 of 2 |

Retrieval then returns `formattedContext: ''`, so text past the cap was unreachable rather than deferred. Full analysis in #399.

This PR takes the smallest fix that stays inside the existing budget design:

- `PINNED_INSTRUCTIONS_MAX_CHARS`: `1_200` → `2_400`, matching the 600-token allocation the layer already has.
- Corrects the misleading comment so it describes what retrieval actually does for custom-context-only users.
- Updates the stale `(1200)` reference in `ModeGenerator.ts`'s header comment.
- Updates the existing cap test and adds a regression test.

I deliberately did **not** raise the cap to the UI's 4,000-char limit, since that would exceed the reserved layer budget and is a product decision rather than a defect fix. #399 lists that broader option (raise the layer budget / align the UI counter / exempt `custom_context` from the relevance floor) for you to decide — happy to extend this PR in whichever direction you prefer.

## Type of Change
- 🐛 Bug Fix

## Testing & Environment
- [x] Manual test performed on: **macOS 26.5, app 2.8.4, Node v26.4.0, npm 11.17.0, Electron 43.1.0**

Verification:

- The new regression test in `ModePinnedInstructions.test.mjs` is sized to fail on the old constant and pass on the new one: its fixture is 1,379 chars, so the asserted tail (`lead with verification and benchmarking`) falls past the old 1,200-char cut and inside the new 2,400 one. Both bounds are asserted in the test itself, so the fixture can't silently drift out of that window.
- The fixture is multi-paragraph prose with no imperative openers and no sensitive terms, so it classifies entirely as `searchable` in `customContextClassifier` and exercises the non-`pinned` path that regressed.
- The existing cap test still asserts truncation, now against the 2,400 bound.
- Reproduced the original failure by asking a question whose answer sat past 1,200 chars of Custom Context with no reference file uploaded, and confirmed the dropped chunks with `NATIVELY_RETRIEVAL_DIAGNOSTICS=1`.

One note for reviewers: the test suite imports from `dist-electron/`, and I wasn't set up to run a full Electron/Rust build locally, so I verified the changed logic and the fixture bounds directly rather than through a built `npm test` run. Worth a CI run before merge.
