### PR TITLE
fix(whisper): never load an fp32 encoder above PartitionAlloc's 2 GiB ceiling

### DIFF
--- a/electron/audio/__tests__/WhisperAllocationCeiling.test.mjs
+++ b/electron/audio/__tests__/WhisperAllocationCeiling.test.mjs
@@ -1,0 +1,219 @@
+// Regression test for the Whisper Large v3 Turbo SIGTRAP (issue #402, 2026-07-28).
+//
+// Chromium's PartitionAlloc refuses any SINGLE allocation of 2 GiB - 2 MiB or
+// more, and it does not return NULL — it traps:
+//
+//   MaxDirectMapped() = (1UL << 31) - kSuperPageSize   // partition_alloc_constants.h
+//
+// WHISPER_SAFE_DTYPE pins `encoder_model: 'fp32'` for every Whisper-family
+// model. Whisper Large v3 Turbo's fp32 encoder weights are ~2.4 GB
+// (encoder_model.onnx_data), ONNX Runtime materialises those initializers in
+// one block, and the request lands exactly on the ceiling: posix_memalign →
+// PartitionAlloc → `brk 0` → EXC_BREAKPOINT (SIGTRAP). The whole app dies with
+// no catchable JS error and nothing in telemetry, and because the selected
+// model preloads at startup the app crash-loops with no way into Settings.
+//
+// This is NOT out-of-memory (reproduces with 82% of RAM free) and it is NOT
+// fixed by arena settings — onnxThreadConfig already defaults
+// enableCpuMemArena:false and the crash happens anyway, because a single fp32
+// initializer tensor is itself over the cap.
+//
+// Guards the two-layer fix:
+//   1. buildWorkerInitMessage resolves the ENCODER (only) to q8 for checkpoints
+//      whose catalog fp32 encoder size is at or above the cap.
+//   2. preflightAllocation refuses such a load with a structured error before
+//      pipeline()/CreateSession, for callers that bypass layer 1.
+//
+// Runs against the esbuild/tsc-compiled modules in dist-electron/.
+// Run via: npm run build:electron && node --test electron/audio/__tests__/
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import Module from 'node:module';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// modelManager + inferenceConfig both pull in `electron` via getModelsDir().
+const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'whisper-alloc-'));
+const origLoad = Module._load;
+Module._load = function patched(request, _p, _m) {
+  if (request === 'electron') {
+    return { app: { getPath: () => userData, isReady: () => true } };
+  }
+  return origLoad.apply(this, arguments);
+};
+
+const guardPath = path.resolve(
+  __dirname,
+  '../../../dist-electron/electron/audio/whisper/allocationGuard.js',
+);
+const modelMgrPath = path.resolve(
+  __dirname,
+  '../../../dist-electron/electron/audio/whisper/modelManager.js',
+);
+const inferenceCfgPath = path.resolve(
+  __dirname,
+  '../../../dist-electron/electron/audio/whisper/inferenceConfig.js',
+);
+
+const {
+  PARTITION_ALLOC_MAX_BYTES,
+  ENCODER_FALLBACK_DTYPE,
+  exceedsPartitionAllocCap,
+  guardEncoderDtype,
+  preflightAllocation,
+} = await import(pathToFileURL(guardPath).href);
+const { getModelEncoderFp32Bytes, getAvailableModels } = await import(
+  pathToFileURL(modelMgrPath).href
+);
+const { buildWorkerInitMessage } = await import(pathToFileURL(inferenceCfgPath).href);
+
+const TURBO = 'onnx-community/whisper-large-v3-turbo-ONNX';
+const TINY_EN = 'Xenova/whisper-tiny.en';
+
+// The per-module map the resolver produces on every platform.
+const SAFE_DTYPE = {
+  encoder_model: 'fp32',
+  decoder_model: 'q8',
+  decoder_model_merged: 'q8',
+  decoder_with_past_model: 'q8',
+};
+
+const GIB = 1024 ** 3;
+
+test('the cap is Chromium PartitionAlloc MaxDirectMapped: 2 GiB - 2 MiB', () => {
+  assert.equal(PARTITION_ALLOC_MAX_BYTES, 2 ** 31 - 2 * 1024 * 1024);
+  // Sanity: the crashing request in the report was exactly 0x80000000 (2 GiB),
+  // which must be over the cap.
+  assert.equal(exceedsPartitionAllocCap(0x80000000), true);
+});
+
+test('exceedsPartitionAllocCap: boundary is inclusive, unknown sizes are safe', () => {
+  assert.equal(exceedsPartitionAllocCap(PARTITION_ALLOC_MAX_BYTES - 1), false);
+  assert.equal(exceedsPartitionAllocCap(PARTITION_ALLOC_MAX_BYTES), true);
+  assert.equal(exceedsPartitionAllocCap(PARTITION_ALLOC_MAX_BYTES + 1), true);
+  // Unknown / absent / nonsense sizes must never block a load that works today.
+  assert.equal(exceedsPartitionAllocCap(0), false);
+  assert.equal(exceedsPartitionAllocCap(undefined), false);
+  assert.equal(exceedsPartitionAllocCap(null), false);
+  assert.equal(exceedsPartitionAllocCap(NaN), false);
+  assert.equal(exceedsPartitionAllocCap(-1), false);
+});
+
+test('guardEncoderDtype downgrades ONLY the encoder for turbo-sized fp32 weights', () => {
+  const res = guardEncoderDtype(SAFE_DTYPE, Math.round(2400 * 1024 * 1024));
+  assert.equal(res.downgraded, true);
+  assert.equal(res.dtype.encoder_model, ENCODER_FALLBACK_DTYPE);
+  assert.equal(ENCODER_FALLBACK_DTYPE, 'q8');
+  // Decoder entries are untouched — this fix must not silently change decoder
+  // precision, and it must not drop keys the loader relies on.
+  assert.equal(res.dtype.decoder_model, 'q8');
+  assert.equal(res.dtype.decoder_model_merged, 'q8');
+  assert.equal(res.dtype.decoder_with_past_model, 'q8');
+  assert.ok(res.reason && res.reason.length > 0);
+  // Input must not be mutated in place.
+  assert.equal(SAFE_DTYPE.encoder_model, 'fp32');
+});
+
+test('guardEncoderDtype leaves small models, already-quantized encoders and unknown sizes alone', () => {
+  // Small model (tiny.en fp32 encoder is a few tens of MB).
+  const small = guardEncoderDtype(SAFE_DTYPE, 40 * 1024 * 1024);
+  assert.equal(small.downgraded, false);
+  assert.deepEqual(small.dtype, SAFE_DTYPE);
+
+  // Encoder already quantized → nothing to downgrade, even at turbo size.
+  const q8Encoder = { ...SAFE_DTYPE, encoder_model: 'q8' };
+  const already = guardEncoderDtype(q8Encoder, 3 * GIB);
+  assert.equal(already.downgraded, false);
+  assert.deepEqual(already.dtype, q8Encoder);
+  const uniformQ8 = guardEncoderDtype('q8', 3 * GIB);
+  assert.equal(uniformQ8.downgraded, false);
+  assert.equal(uniformQ8.dtype, 'q8');
+
+  // Size unknown → treated as safe (no catalog figure must never break a load).
+  const unknown = guardEncoderDtype(SAFE_DTYPE, undefined);
+  assert.equal(unknown.downgraded, false);
+  assert.deepEqual(unknown.dtype, SAFE_DTYPE);
+});
+
+test('guardEncoderDtype widens a uniform fp32 string into a map instead of quantizing everything', () => {
+  const res = guardEncoderDtype('fp32', 3 * GIB);
+  assert.equal(res.downgraded, true);
+  assert.equal(typeof res.dtype, 'object');
+  assert.equal(res.dtype.encoder_model, ENCODER_FALLBACK_DTYPE);
+  // The rest of the graph keeps the requested fp32 — quantizing the decoder as
+  // a side effect of an allocation fix would be a silent accuracy change.
+  assert.equal(res.dtype.decoder_model, 'fp32');
+  assert.equal(res.dtype.decoder_model_merged, 'fp32');
+  assert.equal(res.dtype.decoder_with_past_model, 'fp32');
+});
+
+test('preflightAllocation refuses the untenable load and passes everything else', () => {
+  // Layer-2: an init message hand-built with an fp32 encoder for turbo.
+  const msg = preflightAllocation(TURBO, SAFE_DTYPE, Math.round(2400 * 1024 * 1024));
+  assert.equal(typeof msg, 'string');
+  assert.match(msg, /whisper-large-v3-turbo/);
+
+  // Guarded config → safe to attempt.
+  const guarded = guardEncoderDtype(SAFE_DTYPE, Math.round(2400 * 1024 * 1024)).dtype;
+  assert.equal(preflightAllocation(TURBO, guarded, Math.round(2400 * 1024 * 1024)), null);
+  // Small / unknown-size models are never refused.
+  assert.equal(preflightAllocation(TINY_EN, SAFE_DTYPE, 40 * 1024 * 1024), null);
+  assert.equal(preflightAllocation(TINY_EN, SAFE_DTYPE, undefined), null);
+});
+
+test('catalog records the turbo fp32 encoder size, and only where it matters', () => {
+  const bytes = getModelEncoderFp32Bytes(TURBO);
+  assert.equal(typeof bytes, 'number');
+  assert.equal(exceedsPartitionAllocCap(bytes), true);
+  assert.equal(getModelEncoderFp32Bytes(TINY_EN), undefined);
+  assert.equal(getModelEncoderFp32Bytes('does/not-exist'), undefined);
+});
+
+test('buildWorkerInitMessage never sends an fp32 encoder for Whisper Large v3 Turbo', () => {
+  // THE BUG: this used to resolve encoder_model:'fp32' → 2 GiB allocation → SIGTRAP.
+  const init = buildWorkerInitMessage(TURBO);
+  const encoder = typeof init.dtype === 'string' ? init.dtype : init.dtype.encoder_model;
+  assert.notEqual(encoder, 'fp32');
+  assert.equal(encoder, ENCODER_FALLBACK_DTYPE);
+  // And the size travels with the message so the worker can preflight too.
+  assert.equal(exceedsPartitionAllocCap(init.encoderFp32Bytes), true);
+  // The guarded config must itself pass the worker's preflight.
+  assert.equal(preflightAllocation(TURBO, init.dtype, init.encoderFp32Bytes), null);
+});
+
+test('buildWorkerInitMessage leaves small models exactly as before', () => {
+  const init = buildWorkerInitMessage(TINY_EN);
+  const encoder = typeof init.dtype === 'string' ? init.dtype : init.dtype.encoder_model;
+  // Encoder accuracy is preserved for everything that can actually be loaded.
+  assert.equal(encoder, 'fp32');
+  assert.equal(init.encoderFp32Bytes, undefined);
+  assert.equal(preflightAllocation(TINY_EN, init.dtype, init.encoderFp32Bytes), null);
+});
+
+test('model status is computed for the dtype turbo will actually load', () => {
+  // The guard makes turbo load a QUANTIZED encoder. Reporting "available"
+  // because the old fp32 encoder happens to sit in the cache would show a
+  // ready-to-use model whose encoder still has to be downloaded.
+  const onnxDir = path.join(userData, 'whisper-models', TURBO, 'onnx');
+  fs.mkdirSync(onnxDir, { recursive: true });
+  for (const f of ['encoder_model.onnx', 'encoder_model.onnx_data', 'decoder_model_merged_quantized.onnx']) {
+    fs.writeFileSync(path.join(onnxDir, f), Buffer.alloc(4096, 1));
+  }
+  const before = getAvailableModels().find(m => m.id === TURBO);
+  assert.equal(before.status, 'missing');
+
+  // With the q8 encoder present it is genuinely usable.
+  fs.writeFileSync(path.join(onnxDir, 'encoder_model_quantized.onnx'), Buffer.alloc(4096, 1));
+  const after = getAvailableModels().find(m => m.id === TURBO);
+  assert.equal(after.status, 'available');
+});
+
+test.after(() => {
+  Module._load = origLoad;
+  try { fs.rmSync(userData, { recursive: true, force: true }); } catch { /* noop */ }
+});

--- a/electron/audio/__tests__/WhisperAllocationCeiling.test.mjs
+++ b/electron/audio/__tests__/WhisperAllocationCeiling.test.mjs
@@ -67,10 +67,18 @@ const {
   guardEncoderDtype,
   preflightAllocation,
 } = await import(pathToFileURL(guardPath).href);
-const { getModelEncoderFp32Bytes, getAvailableModels } = await import(
+const downloadSvcPath = path.resolve(
+  __dirname,
+  '../../../dist-electron/electron/services/LocalModelDownloadService.js',
+);
+
+const { getModelEncoderFp32Bytes, getAvailableModels, isModelCached } = await import(
   pathToFileURL(modelMgrPath).href
 );
-const { buildWorkerInitMessage } = await import(pathToFileURL(inferenceCfgPath).href);
+const { buildWorkerInitMessage, resolveModelDtype, resolveInferenceConfig } = await import(
+  pathToFileURL(inferenceCfgPath).href
+);
+const { createWhisperDownloadProvider } = await import(pathToFileURL(downloadSvcPath).href);
 
 const TURBO = 'onnx-community/whisper-large-v3-turbo-ONNX';
 const TINY_EN = 'Xenova/whisper-tiny.en';
@@ -211,6 +219,87 @@ test('model status is computed for the dtype turbo will actually load', () => {
   fs.writeFileSync(path.join(onnxDir, 'encoder_model_quantized.onnx'), Buffer.alloc(4096, 1));
   const after = getAvailableModels().find(m => m.id === TURBO);
   assert.equal(after.status, 'available');
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// resolveModelDtype — the SINGLE SOURCE OF TRUTH shared by the worker init
+// message, the model list, download verification and startup preload.
+//
+// THE BUG THIS PINS (PR #403 review): the guard was applied only inside
+// buildWorkerInitMessage and getAvailableModels. Every other cache consumer
+// (main.ts preload readiness, the local-whisper-preload IPC, the
+// LocalModelDownloadService whisper provider) asked resolveInferenceConfig()
+// for the bare PLATFORM dtype, so they looked for `encoder_model.onnx` while
+// the worker had actually downloaded `encoder_model_quantized.onnx`. Result:
+// a complete turbo download reported incomplete forever, and a stale fp32
+// cache reported ready.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const turboOnnxDir = path.join(userData, 'whisper-models', TURBO, 'onnx');
+
+/** Wipe the turbo cache and lay down exactly `files`, each non-empty. */
+function stageTurboCache(files) {
+  fs.rmSync(path.join(userData, 'whisper-models', TURBO), { recursive: true, force: true });
+  fs.mkdirSync(turboOnnxDir, { recursive: true });
+  for (const f of files) fs.writeFileSync(path.join(turboOnnxDir, f), Buffer.alloc(4096, 1));
+}
+
+const encoderOf = dt => (typeof dt === 'string' ? dt : dt.encoder_model);
+
+test('resolveModelDtype applies the ceiling guard per MODEL, not per platform', () => {
+  // Turbo: guarded away from fp32 — this is the whole point.
+  assert.equal(encoderOf(resolveModelDtype(TURBO)), ENCODER_FALLBACK_DTYPE);
+  // And it differs from the unguarded platform answer, otherwise this test
+  // would pass even with the guard removed.
+  assert.equal(encoderOf(resolveInferenceConfig().dtype), 'fp32');
+
+  // Everything else keeps the platform dtype untouched — encoder accuracy is
+  // preserved for every model that can actually be allocated.
+  assert.deepEqual(resolveModelDtype(TINY_EN), resolveInferenceConfig().dtype);
+  // Unknown ids must never throw and never change behaviour.
+  assert.deepEqual(resolveModelDtype('does/not-exist'), resolveInferenceConfig().dtype);
+});
+
+test('resolveModelDtype agrees with the dtype the worker is actually sent', () => {
+  // If these two ever diverge, download verification and the worker are again
+  // looking at different files — the exact class of bug this fix removes.
+  assert.deepEqual(buildWorkerInitMessage(TURBO).dtype, resolveModelDtype(TURBO));
+  assert.deepEqual(buildWorkerInitMessage(TINY_EN).dtype, resolveModelDtype(TINY_EN));
+});
+
+test('a q8-encoder turbo cache is READY under the guarded dtype', () => {
+  // Exactly what a successful turbo download leaves on disk: the quantized
+  // encoder the worker fetched, plus the q8 merged decoder. No fp32 encoder
+  // and no .onnx_data companion — the guard means neither is ever requested.
+  stageTurboCache(['encoder_model_quantized.onnx', 'decoder_model_merged_quantized.onnx']);
+
+  assert.equal(isModelCached(TURBO, resolveModelDtype(TURBO)), true);
+  // The whisper download provider verifies the SAME artifacts, so a completed
+  // download is reported complete instead of retrying forever.
+  assert.equal(createWhisperDownloadProvider().isModelCached(TURBO), true);
+  assert.equal(getAvailableModels().find(m => m.id === TURBO).status, 'available');
+});
+
+test('a stale fp32-encoder turbo cache is NOT ready — those files are never loaded', () => {
+  // A pre-guard download (fp32 encoder + its external-data companion). The
+  // worker will now fetch the q8 encoder, so this cache is incomplete no
+  // matter how complete it looks.
+  stageTurboCache([
+    'encoder_model.onnx',
+    'encoder_model.onnx_data',
+    'decoder_model_merged_quantized.onnx',
+  ]);
+
+  assert.equal(isModelCached(TURBO, resolveModelDtype(TURBO)), false);
+  assert.equal(createWhisperDownloadProvider().isModelCached(TURBO), false);
+  assert.equal(getAvailableModels().find(m => m.id === TURBO).status, 'missing');
+});
+
+test('isModelCached with no dtype still falls through to the legacy directory check', () => {
+  // Legacy callers must keep their old contract: any non-empty model dir counts.
+  stageTurboCache(['encoder_model.onnx']);
+  assert.equal(isModelCached(TURBO, undefined), true);
+  assert.equal(isModelCached('does/not-exist', undefined), false);
 });
 
 test.after(() => {

--- a/electron/audio/whisper/allocationGuard.ts
+++ b/electron/audio/whisper/allocationGuard.ts
@@ -1,0 +1,144 @@
+// electron/audio/whisper/allocationGuard.ts
+//
+// Single-allocation ceiling guard for ONNX Runtime sessions running inside
+// Electron.
+//
+// WHY THIS EXISTS (Whisper Large v3 Turbo SIGTRAP):
+// Chromium's PartitionAlloc refuses any single allocation of 2 GiB or more —
+// and it does NOT return NULL, it intentionally traps:
+//
+//   // partition_alloc_constants.h
+//   MaxDirectMapped() = (1UL << 31) - kSuperPageSize   // 2 GiB - 2 MiB
+//   // "Intentionally set to less than 2GiB to make sure that a 2GiB
+//   //  allocation fails. This is a security choice in Chrome, to help
+//   //  making size_t vs int bugs harder to exploit."
+//
+// Whisper Large v3 Turbo ships a 2.4 GB fp32 encoder (`encoder_model.onnx_data`).
+// WHISPER_SAFE_DTYPE pins `encoder_model: 'fp32'` for every Whisper-family
+// model, so loading turbo makes ORT allocate those initializers and land
+// straight on the ceiling: posix_memalign → PartitionAlloc → `brk 0` →
+// EXC_BREAKPOINT (SIGTRAP). The whole app dies, with no catchable JS error and
+// nothing in telemetry. Because the selected model preloads at startup, the app
+// crash-loops and the user cannot even reach Settings to pick another model.
+//
+// This is NOT an out-of-memory condition: it reproduces identically with 82% of
+// system RAM free, and the same files load in 1.3-1.8 s under plain Node on the
+// same machine. It is a hard ceiling, so it cannot be fixed by freeing memory,
+// by the available-memory floor in onnxThreadConfig.ts, or by the arena
+// settings there (`enableCpuMemArena` already defaults to false — the crash
+// happens anyway once a single initializer tensor is this big).
+//
+// The only durable fix is to never ask for the allocation: resolve a quantized
+// encoder for checkpoints whose fp32 encoder weights are at or above the cap,
+// and — as a second line of defence for any caller that bypasses that — refuse
+// the load with a structured error BEFORE calling CreateSession. Anything that
+// reaches posix_memalign with >= 2 GiB is unrecoverable by construction.
+//
+// Pure module: no electron, no fs, no transformers. Safe to import from the
+// worker, from the main process, and from unit tests.
+
+/**
+ * Largest single allocation Chromium's PartitionAlloc will serve, in bytes:
+ * 2 GiB - kSuperPageSize (2 MiB). A request at or above this traps the process.
+ */
+export const PARTITION_ALLOC_MAX_BYTES = 2 ** 31 - 2 * 1024 * 1024;
+
+/** Encoder dtype used when the fp32 encoder cannot be allocated in-process. */
+export const ENCODER_FALLBACK_DTYPE = 'q8';
+
+/**
+ * True when a single allocation of `bytes` would hit PartitionAlloc's ceiling
+ * and trap. Non-finite / non-positive sizes are treated as "unknown" → false,
+ * so a missing catalog figure never blocks a load that used to work.
+ */
+export function exceedsPartitionAllocCap(bytes: number | undefined | null): boolean {
+    const n = Number(bytes);
+    if (!Number.isFinite(n) || n <= 0) return false;
+    return n >= PARTITION_ALLOC_MAX_BYTES;
+}
+
+export interface EncoderDtypeGuardResult {
+    /** The dtype to actually load with — encoder downgraded only when needed. */
+    dtype: string | Record<string, string>;
+    /** True when the encoder entry was rewritten away from fp32. */
+    downgraded: boolean;
+    /** Human-readable explanation, present only when downgraded. */
+    reason?: string;
+}
+
+/** The dtype this config resolves for `encoder_model` (mirrors the loader). */
+function encoderDtypeOf(dtype: string | Record<string, string>): string {
+    if (typeof dtype === 'string') return dtype;
+    return dtype.encoder_model ?? 'fp32'; // matches the transformers loader default
+}
+
+/**
+ * Rewrite an inference dtype so the encoder never triggers a >= 2 GiB single
+ * allocation. Only touches the `encoder_model` entry, and only when
+ *
+ *   - the resolved encoder dtype is fp32 (a quantized encoder is already small
+ *     enough — it is the fp32 initializers that are one huge tensor block), and
+ *   - the catalog records fp32 encoder weights at or above the cap.
+ *
+ * Everything else (decoder dtypes, execution providers, models with no recorded
+ * weight size) is returned untouched, so this cannot regress a model that
+ * loads today. A string dtype is widened to a per-module map rather than
+ * mutated wholesale — quantizing the decoder along with the encoder would be a
+ * silent accuracy change nobody asked for.
+ */
+export function guardEncoderDtype(
+    dtype: string | Record<string, string>,
+    encoderFp32Bytes: number | undefined,
+): EncoderDtypeGuardResult {
+    if (!exceedsPartitionAllocCap(encoderFp32Bytes)) return { dtype, downgraded: false };
+    if (encoderDtypeOf(dtype) !== 'fp32') return { dtype, downgraded: false };
+
+    const base: Record<string, string> =
+        typeof dtype === 'string'
+            ? {
+                  encoder_model: dtype,
+                  decoder_model: dtype,
+                  decoder_model_merged: dtype,
+                  decoder_with_past_model: dtype,
+              }
+            : { ...dtype };
+
+    return {
+        dtype: { ...base, encoder_model: ENCODER_FALLBACK_DTYPE },
+        downgraded: true,
+        reason:
+            `fp32 encoder weights are ${formatBytes(encoderFp32Bytes)}, at or above ` +
+            `Chromium's ${formatBytes(PARTITION_ALLOC_MAX_BYTES)} single-allocation ceiling — ` +
+            `loading it would trap the process (SIGTRAP), so the encoder is loaded ` +
+            `as ${ENCODER_FALLBACK_DTYPE} instead.`,
+    };
+}
+
+/**
+ * Last-line preflight for the worker: returns an error message when the
+ * resolved config would still ask ORT for an untenable single allocation, or
+ * null when the load is safe to attempt. Callers must post this as a
+ * `WorkerErrorResponse` and return WITHOUT calling pipeline()/CreateSession —
+ * once the allocation is requested there is no recoverable error, only a trap.
+ */
+export function preflightAllocation(
+    modelId: string,
+    dtype: string | Record<string, string>,
+    encoderFp32Bytes: number | undefined,
+): string | null {
+    if (encoderDtypeOf(dtype) !== 'fp32') return null;
+    if (!exceedsPartitionAllocCap(encoderFp32Bytes)) return null;
+    return (
+        `Refusing to load ${modelId}: its fp32 encoder needs a single ` +
+        `${formatBytes(encoderFp32Bytes)} allocation, at or above Chromium's ` +
+        `${formatBytes(PARTITION_ALLOC_MAX_BYTES)} limit. ONNX Runtime would trap the ` +
+        `process instead of failing. Pick a smaller model, or load the encoder ` +
+        `as ${ENCODER_FALLBACK_DTYPE}.`
+    );
+}
+
+function formatBytes(bytes: number | undefined): string {
+    const n = Number(bytes);
+    if (!Number.isFinite(n)) return 'unknown';
+    return `${(n / 1024 ** 3).toFixed(2)} GiB`;
+}

--- a/electron/audio/whisper/inferenceConfig.ts
+++ b/electron/audio/whisper/inferenceConfig.ts
@@ -1,4 +1,6 @@
 import type { WorkerInitMessage } from './types';
+// Pure module (no electron / fs / transformers) — safe to import statically.
+import { guardEncoderDtype } from './allocationGuard';
 
 /**
  * Resolves the optimal ONNX Runtime execution providers and per-module
@@ -89,14 +91,42 @@ function dtypeSizeFactor(dtype: string | Record<string, string>): number {
 export function buildWorkerInitMessage(modelId: string): WorkerInitMessage {
     // Late require — modelManager imports electron, which isn't available
     // when this module is first loaded in some contexts (test harnesses).
-    const { getModelsDir, getModelSizeBytes, getModelExternalDataFormat } = require('./modelManager');
-    const { executionProviders, dtype } = resolveInferenceConfig();
+    const {
+        getModelsDir,
+        getModelSizeBytes,
+        getModelExternalDataFormat,
+        getModelEncoderFp32Bytes,
+    } = require('./modelManager');
+    const { executionProviders, dtype: resolvedDtype } = resolveInferenceConfig();
+    // SINGLE-ALLOCATION CEILING (Whisper Large v3 Turbo SIGTRAP): a model whose
+    // fp32 encoder weights are at or above 2 GiB - 2 MiB cannot be loaded at
+    // fp32 inside Electron at all — ONNX Runtime asks for those initializers in
+    // one block and Chromium's PartitionAlloc traps the process instead of
+    // returning NULL. Downgrade just the encoder to q8 for those checkpoints.
+    // Best-effort, like the lookups below: an unknown id or a throwing lookup
+    // leaves the resolved dtype untouched and must NEVER block worker startup.
+    let dtype: string | Record<string, string> = resolvedDtype;
+    let encoderFp32Bytes: number | undefined;
+    try {
+        encoderFp32Bytes = getModelEncoderFp32Bytes(modelId);
+        const guard = guardEncoderDtype(resolvedDtype, encoderFp32Bytes);
+        dtype = guard.dtype;
+        if (guard.downgraded) {
+            console.warn(`[inferenceConfig] ${modelId}: ${guard.reason}`);
+        }
+    } catch {
+        dtype = resolvedDtype;
+        encoderFp32Bytes = undefined;
+    }
     // Catalog download size — progress-bar denominator from byte zero. The
     // lookup is best-effort: if it's missing (unknown id) or the call fails
     // for any reason, we send 0 and the worker falls back to summing the
     // per-file byte totals it observes during the download. The size is a
     // UX nicety for the progress bar, never required for the download itself,
     // so a failure here must NEVER prevent the worker from starting.
+    // Scaled by the GUARDED dtype on purpose: a downgraded encoder downloads a
+    // smaller quantized file, so the map's 1.0 factor stays a lower bound —
+    // the only safe direction for the bar denominator (see dtypeSizeFactor).
     let expectedBytes = 0;
     try {
         const n = Number(getModelSizeBytes(modelId)) * dtypeSizeFactor(dtype);
@@ -123,6 +153,10 @@ export function buildWorkerInitMessage(modelId: string): WorkerInitMessage {
         dtype,
         expectedBytes,
         useExternalDataFormat,
+        // Forwarded so the worker can re-run the ceiling check itself — defence
+        // in depth for any caller that builds an init message without this
+        // helper. See whisperWorker's preflightAllocation call.
+        encoderFp32Bytes,
     };
 }
 

--- a/electron/audio/whisper/inferenceConfig.ts
+++ b/electron/audio/whisper/inferenceConfig.ts
@@ -82,6 +82,57 @@ function dtypeSizeFactor(dtype: string | Record<string, string>): number {
 }
 
 /**
+ * The dtype a SPECIFIC model actually loads — and therefore the dtype whose
+ * ONNX filenames its cache must contain.
+ *
+ * SINGLE SOURCE OF TRUTH. `resolveInferenceConfig()` answers "what does this
+ * platform prefer", which is NOT the same question: a model whose fp32 encoder
+ * weights are at or above Chromium's 2 GiB - 2 MiB PartitionAlloc ceiling
+ * (Whisper Large v3 Turbo) gets its encoder downgraded to q8, because asking
+ * ORT for that single allocation traps the process (SIGTRAP — see
+ * allocationGuard.ts). Such a model downloads `encoder_model_quantized.onnx`,
+ * never `encoder_model.onnx`.
+ *
+ * Every consumer that maps a model to on-disk artifacts MUST go through here —
+ * the worker init message, the model-list status, download verification, and
+ * startup preload readiness. Using the unguarded platform dtype anywhere in
+ * that set desynchronises them: a complete turbo download gets reported as
+ * incomplete (verification looks for the fp32 encoder the worker never
+ * fetched), and a stale fp32 cache gets classified as ready.
+ *
+ * Best-effort by contract: an unknown id, or any failure in the catalog
+ * lookup, returns the platform dtype untouched. This function must never
+ * throw and never block a load or a download.
+ */
+export function resolveModelDtype(modelId: string): string | Record<string, string> {
+    return resolveGuardedDtype(modelId).dtype;
+}
+
+interface GuardedDtype {
+    dtype: string | Record<string, string>;
+    /** Catalog fp32 encoder size, forwarded to the worker's own preflight. */
+    encoderFp32Bytes: number | undefined;
+    executionProviders: string[];
+}
+
+function resolveGuardedDtype(modelId: string, warn = false): GuardedDtype {
+    const { executionProviders, dtype: resolvedDtype } = resolveInferenceConfig();
+    try {
+        // Late require — modelManager imports electron, which isn't available
+        // when this module is first loaded in some contexts (test harnesses).
+        const { getModelEncoderFp32Bytes } = require('./modelManager');
+        const encoderFp32Bytes = getModelEncoderFp32Bytes(modelId);
+        const guard = guardEncoderDtype(resolvedDtype, encoderFp32Bytes);
+        if (guard.downgraded && warn) {
+            console.warn(`[inferenceConfig] ${modelId}: ${guard.reason}`);
+        }
+        return { dtype: guard.dtype, encoderFp32Bytes, executionProviders };
+    } catch {
+        return { dtype: resolvedDtype, encoderFp32Bytes: undefined, executionProviders };
+    }
+}
+
+/**
  * Construct the worker `init` message for a given model. Single source of
  * truth — three callers (LocalWhisperSTT.spawnWorker, modelPreloader.preload,
  * local-whisper-start-download IPC) all use this so the message shape stays
@@ -95,29 +146,9 @@ export function buildWorkerInitMessage(modelId: string): WorkerInitMessage {
         getModelsDir,
         getModelSizeBytes,
         getModelExternalDataFormat,
-        getModelEncoderFp32Bytes,
     } = require('./modelManager');
-    const { executionProviders, dtype: resolvedDtype } = resolveInferenceConfig();
-    // SINGLE-ALLOCATION CEILING (Whisper Large v3 Turbo SIGTRAP): a model whose
-    // fp32 encoder weights are at or above 2 GiB - 2 MiB cannot be loaded at
-    // fp32 inside Electron at all — ONNX Runtime asks for those initializers in
-    // one block and Chromium's PartitionAlloc traps the process instead of
-    // returning NULL. Downgrade just the encoder to q8 for those checkpoints.
-    // Best-effort, like the lookups below: an unknown id or a throwing lookup
-    // leaves the resolved dtype untouched and must NEVER block worker startup.
-    let dtype: string | Record<string, string> = resolvedDtype;
-    let encoderFp32Bytes: number | undefined;
-    try {
-        encoderFp32Bytes = getModelEncoderFp32Bytes(modelId);
-        const guard = guardEncoderDtype(resolvedDtype, encoderFp32Bytes);
-        dtype = guard.dtype;
-        if (guard.downgraded) {
-            console.warn(`[inferenceConfig] ${modelId}: ${guard.reason}`);
-        }
-    } catch {
-        dtype = resolvedDtype;
-        encoderFp32Bytes = undefined;
-    }
+    // Guarded, per-model dtype — the same value every cache consumer sees.
+    const { executionProviders, dtype, encoderFp32Bytes } = resolveGuardedDtype(modelId, true);
     // Catalog download size — progress-bar denominator from byte zero. The
     // lookup is best-effort: if it's missing (unknown id) or the call fails
     // for any reason, we send 0 and the worker falls back to summing the

--- a/electron/audio/whisper/modelManager.ts
+++ b/electron/audio/whisper/modelManager.ts
@@ -1,8 +1,6 @@
 import path from 'path';
 import fs from 'fs';
 import type { WhisperModelId, WhisperModelInfo } from './types';
-// Pure module (no electron / fs / transformers) — safe to import statically.
-import { guardEncoderDtype } from './allocationGuard';
 
 // env is configured lazily via configureTransformersCache()
 // We import the type only here; the actual require() happens at runtime.
@@ -282,30 +280,23 @@ export function getAvailableModels(): WhisperModelInfo[] {
   // Resolve the active dtype lazily — avoids importing inferenceConfig at
   // module top (which would break the modelPreloader → modelManager require
   // chain on platforms where process info isn't yet available).
-  let dtype: string | Record<string, string> | undefined;
+  //
+  // Per-model, not global: resolveModelDtype downgrades the encoder to q8 for
+  // checkpoints whose fp32 encoder is over the single-allocation ceiling
+  // (allocationGuard.ts), so those models load — and therefore cache — a
+  // different encoder file than the platform default. Checking the unguarded
+  // dtype here would report "available" for a model whose encoder still has to
+  // be downloaded.
+  let resolveModelDtype: ((id: string) => string | Record<string, string>) | undefined;
   try {
-    const { resolveInferenceConfig } = require('./inferenceConfig');
-    dtype = resolveInferenceConfig().dtype;
+    ({ resolveModelDtype } = require('./inferenceConfig'));
   } catch {
-    dtype = undefined; // fall back to legacy directory-non-empty check
+    resolveModelDtype = undefined; // fall back to legacy directory-non-empty check
   }
   return MODEL_CATALOG.map(m => ({
     ...m,
-    // Per-model, not global: buildWorkerInitMessage downgrades the encoder to
-    // q8 for checkpoints whose fp32 encoder is over the single-allocation
-    // ceiling (allocationGuard.ts), so those models load — and therefore cache
-    // — a different encoder file than the platform default. Checking the
-    // unguarded dtype here would report "available" for a model whose encoder
-    // still has to be downloaded.
     // undefined dtype keeps the legacy directory-non-empty check untouched.
-    status: isModelCached(
-      m.id,
-      dtype === undefined
-        ? undefined
-        : guardEncoderDtype(dtype, getModelEncoderFp32Bytes(m.id)).dtype,
-    )
-      ? 'available'
-      : 'missing',
+    status: isModelCached(m.id, resolveModelDtype?.(m.id)) ? 'available' : 'missing',
   }));
 }
 

--- a/electron/audio/whisper/modelManager.ts
+++ b/electron/audio/whisper/modelManager.ts
@@ -1,6 +1,8 @@
 import path from 'path';
 import fs from 'fs';
 import type { WhisperModelId, WhisperModelInfo } from './types';
+// Pure module (no electron / fs / transformers) — safe to import statically.
+import { guardEncoderDtype } from './allocationGuard';
 
 // env is configured lazily via configureTransformersCache()
 // We import the type only here; the actual require() happens at runtime.
@@ -33,7 +35,13 @@ const MODEL_CATALOG: WhisperModelInfo[] = [
   //    file_size encoder_model.onnx_data). The encoder is fp32 on every
   //    platform (uniform-fp32 on Apple; encoder_model:'fp32' in the per-module
   //    map elsewhere), so this key is platform-robust.
-  { id: 'onnx-community/whisper-large-v3-turbo-ONNX', name: 'Whisper Large v3 Turbo', sizeMb: 1031, speed: 'medium', accuracy: 'very-high', multilingual: true, status: 'missing', externalDataFormat: { 'encoder_model.onnx': true } },
+  //    encoderFp32Mb: that companion is ~2.4 GB of fp32 initializers, which ORT
+  //    allocates as ONE block — above Chromium's 2 GiB - 2 MiB PartitionAlloc
+  //    ceiling, so loading the fp32 encoder inside Electron traps the process
+  //    (SIGTRAP, not a catchable error). Recording the size lets
+  //    buildWorkerInitMessage resolve the encoder to q8 instead. See
+  //    allocationGuard.ts.
+  { id: 'onnx-community/whisper-large-v3-turbo-ONNX', name: 'Whisper Large v3 Turbo', sizeMb: 1031, speed: 'medium', accuracy: 'very-high', multilingual: true, status: 'missing', externalDataFormat: { 'encoder_model.onnx': true }, encoderFp32Mb: 2400 },
 
   // ── Standard Whisper
   { id: 'Xenova/whisper-tiny.en',    name: 'Tiny English',    sizeMb: 39,   speed: 'very-fast', accuracy: 'decent',   multilingual: false, status: 'missing' },
@@ -283,7 +291,21 @@ export function getAvailableModels(): WhisperModelInfo[] {
   }
   return MODEL_CATALOG.map(m => ({
     ...m,
-    status: isModelCached(m.id, dtype) ? 'available' : 'missing',
+    // Per-model, not global: buildWorkerInitMessage downgrades the encoder to
+    // q8 for checkpoints whose fp32 encoder is over the single-allocation
+    // ceiling (allocationGuard.ts), so those models load — and therefore cache
+    // — a different encoder file than the platform default. Checking the
+    // unguarded dtype here would report "available" for a model whose encoder
+    // still has to be downloaded.
+    // undefined dtype keeps the legacy directory-non-empty check untouched.
+    status: isModelCached(
+      m.id,
+      dtype === undefined
+        ? undefined
+        : guardEncoderDtype(dtype, getModelEncoderFp32Bytes(m.id)).dtype,
+    )
+      ? 'available'
+      : 'missing',
   }));
 }
 
@@ -310,6 +332,22 @@ export function getModelExternalDataFormat(
 ): boolean | Record<string, boolean> | undefined {
   const m = MODEL_CATALOG.find(x => x.id === modelId);
   return m?.externalDataFormat;
+}
+
+/**
+ * Size of the model's fp32 encoder weights in BYTES, or undefined when the
+ * catalog doesn't record one (i.e. the encoder is comfortably small).
+ *
+ * Only consumed by the single-allocation guard (allocationGuard.ts): ONNX
+ * Runtime materialises those initializers in one block, and Chromium's
+ * PartitionAlloc traps the whole process on any single request of 2 GiB - 2 MiB
+ * or more. undefined means "unknown / not big enough to matter" and is treated
+ * as safe, so an unlisted model behaves exactly as it does today.
+ */
+export function getModelEncoderFp32Bytes(modelId: string): number | undefined {
+  const m = MODEL_CATALOG.find(x => x.id === modelId);
+  if (!m || typeof m.encoderFp32Mb !== 'number') return undefined;
+  return Math.round(m.encoderFp32Mb * 1024 * 1024);
 }
 
 /**

--- a/electron/audio/whisper/types.ts
+++ b/electron/audio/whisper/types.ts
@@ -50,6 +50,13 @@ export interface WhisperModelInfo {
   // upstream `transformers.js_config` convention: `true` for all chunked files,
   // or a map keyed by ONNX basename (e.g. `{ 'encoder_model.onnx': true }`).
   externalDataFormat?: boolean | Record<string, boolean>;
+  // Size of the fp32 encoder weights on disk, in MB. Recorded ONLY for
+  // checkpoints whose fp32 encoder is large enough to matter for the
+  // single-allocation ceiling (see allocationGuard.ts): ONNX Runtime allocates
+  // those initializers in one block, and Chromium's PartitionAlloc traps the
+  // whole process on any request >= 2 GiB - 2 MiB. When this is at or above the
+  // cap the encoder is resolved to q8 instead of fp32.
+  encoderFp32Mb?: number;
 }
 
 export interface WorkerInitMessage {
@@ -68,6 +75,13 @@ export interface WorkerInitMessage {
   // sibling `*.onnx_data` weight files of external-data checkpoints get fetched.
   // See WhisperModelInfo.externalDataFormat for the full rationale.
   useExternalDataFormat?: boolean | Record<string, boolean>;
+  // Size of this model's fp32 encoder weights in bytes, when the catalog
+  // records one (see WhisperModelInfo.encoderFp32Mb). Forwarded so the worker
+  // can run its own preflight before calling pipeline(): a single allocation of
+  // 2 GiB - 2 MiB or more traps the process inside Chromium's PartitionAlloc
+  // (SIGTRAP, no catchable error), so the load must be refused BEFORE
+  // CreateSession. undefined = unknown → treated as safe.
+  encoderFp32Bytes?: number;
 }
 export interface WorkerTranscribeMessage {
   type: 'transcribe';

--- a/electron/audio/whisper/whisperWorker.ts
+++ b/electron/audio/whisper/whisperWorker.ts
@@ -17,6 +17,7 @@
 import { parentPort } from 'worker_threads';
 import { WhisperProgressAggregator } from './whisperProgressAggregator';
 import { getBoundedOnnxSessionOptions } from '../../utils/onnxThreadConfig';
+import { preflightAllocation } from './allocationGuard';
 
 const LANG_MAP: Record<string, string | null> = {
   'auto': null,
@@ -216,6 +217,21 @@ parentPort.on('message', async (msg: any) => {
       // "filesystem error: in file_size: ... encoder_model.onnx_data".
       const useExternalDataFormat: boolean | Record<string, boolean> | undefined =
         msg.useExternalDataFormat;
+
+      // LAST LINE OF DEFENCE before CreateSession. buildWorkerInitMessage
+      // already downgrades an oversized fp32 encoder to q8, but any caller that
+      // hand-builds an init message would bypass that. If the resolved config
+      // still implies a single allocation of 2 GiB - 2 MiB or more, ONNX Runtime
+      // would hand it to posix_memalign → Chromium's PartitionAlloc → `brk 0`,
+      // killing the whole app with EXC_BREAKPOINT and nothing catchable. Fail
+      // loudly here instead; past this point there is no recoverable error.
+      const preflightError = preflightAllocation(msg.modelId, dtype, msg.encoderFp32Bytes);
+      if (preflightError) {
+        console.error(`[WhisperWorker] ${preflightError}`);
+        parentPort!.postMessage({ type: 'error', message: preflightError });
+        return;
+      }
+
       pipe = await pipeline('automatic-speech-recognition', msg.modelId, {
         dtype,
         session_options: sessionOptions,

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -7287,18 +7287,21 @@ export function initializeIpcHandlers(appState: AppState): void {
     try {
       const { modelPreloader } = require('./audio/whisper/modelPreloader');
       const { isModelCached } = require('./audio/whisper/modelManager');
-      const { resolveInferenceConfig } = require('./audio/whisper/inferenceConfig');
+      const { resolveInferenceConfig, resolveModelDtype } = require('./audio/whisper/inferenceConfig');
       const { SettingsManager } = require('./services/SettingsManager');
       const id =
         modelId ||
         SettingsManager.getInstance().get('localWhisperModel') ||
         'Xenova/whisper-tiny.en';
-      // Pass active dtype so the cache check verifies the SPECIFIC ONNX
-      // files (e.g. encoder_model.onnx for fp32) are present — not just
+      // Pass the GUARDED per-model dtype so the cache check verifies the
+      // SPECIFIC ONNX files the worker will actually load — not just
       // "directory non-empty". Otherwise a v2-cached _quantized.onnx-only
       // directory would be reported "available" but trigger a 142MB
-      // background fetch on first start().
-      const { dtype } = resolveInferenceConfig();
+      // background fetch on first start(); and conversely a ceiling-guarded
+      // model (q8 encoder) would be judged against the fp32 encoder it never
+      // downloads. Best-effort: fall back to the platform dtype on failure.
+      let dtype: string | Record<string, string>;
+      try { dtype = resolveModelDtype(id); } catch { dtype = resolveInferenceConfig().dtype; }
       if (!isModelCached(id, dtype)) {
         return { success: false, reason: 'model-not-cached' };
       }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1310,7 +1310,7 @@ export class AppState {
         if (CredentialsManager.getInstance().getSttProvider() === 'local-whisper') {
           const { isModelCached, MODEL_CATALOG_IDS } = require('./audio/whisper/modelManager');
           const { modelPreloader } = require('./audio/whisper/modelPreloader');
-          const { resolveInferenceConfig } = require('./audio/whisper/inferenceConfig');
+          const { resolveInferenceConfig, resolveModelDtype } = require('./audio/whisper/inferenceConfig');
           // Startup validation gate: if the persisted modelId isn't in the
           // catalog (corrupted settings, model retired, fork diverged), reset
           // to the safest fallback BEFORE preload — otherwise the worker
@@ -1367,7 +1367,14 @@ export class AppState {
               }
             }
           }
-          const { dtype } = resolveInferenceConfig();
+          // Per-model guarded dtype (NOT the bare platform dtype): a model
+          // whose fp32 encoder is over the PartitionAlloc ceiling caches a q8
+          // encoder, so readiness must be judged against the files the worker
+          // actually downloads. Best-effort — a lookup failure degrades to the
+          // platform dtype rather than blocking preload / download.
+          const dtypeFor = (id: string): string | Record<string, string> => {
+            try { return resolveModelDtype(id); } catch { return resolveInferenceConfig().dtype; }
+          };
 
           // Collect every model ID the user has selected (global + per-channel)
           // so we can auto-repair each one that's missing or corrupt.
@@ -1389,11 +1396,11 @@ export class AppState {
             micOverride && MODEL_CATALOG_IDS.has(micOverride) ? micOverride : '',
             modelId,
           ].filter(Boolean);
-          const primaryPreloadId = preloadPriority.find(id => isModelCached(id, dtype)) ?? '';
+          const primaryPreloadId = preloadPriority.find(id => isModelCached(id, dtypeFor(id))) ?? '';
 
           const { LocalModelDownloadService } = require('./services/LocalModelDownloadService');
           for (const id of modelIds) {
-            if (isModelCached(id, dtype)) {
+            if (isModelCached(id, dtypeFor(id))) {
               if (id === primaryPreloadId) {
                 console.log(`[AppState] Preloading local Whisper model: ${id}`);
                 modelPreloader.preload(id);

--- a/electron/services/LocalModelDownloadService.ts
+++ b/electron/services/LocalModelDownloadService.ts
@@ -619,10 +619,14 @@ export function createWhisperDownloadProvider(): LocalModelDownloadProvider {
     name: 'whisper',
     isModelCached(modelId: string): boolean {
       const { isModelCached } = require('../audio/whisper/modelManager') as typeof import('../audio/whisper/modelManager');
-      const { resolveInferenceConfig: rIC } = require('../audio/whisper/inferenceConfig') as typeof import('../audio/whisper/inferenceConfig');
+      const { resolveModelDtype } = require('../audio/whisper/inferenceConfig') as typeof import('../audio/whisper/inferenceConfig');
       try {
-        const { dtype } = rIC();
-        return isModelCached(modelId as any, dtype);
+        // GUARDED per-model dtype, not the bare platform one: download
+        // verification has to look for the artifacts the worker actually
+        // fetched. A ceiling-guarded model (Whisper Large v3 Turbo) downloads
+        // encoder_model_quantized.onnx, so checking for the fp32 encoder here
+        // would report a complete download as incomplete, forever.
+        return isModelCached(modelId as any, resolveModelDtype(modelId));
       } catch {
         return isModelCached(modelId as any);
       }


### PR DESCRIPTION
## Symptom

Selecting **Whisper Large v3 Turbo** hard-crashes the whole app with `EXC_BREAKPOINT (SIGTRAP)` a few seconds after launch — not a caught error, not an "STT failed" toast. The model is fully downloaded and intact (this is not #331: `encoder_model.onnx_data` is present at 2.4 GB). Because the selected model preloads at startup, the app crash-loops and there is no way in to Settings to pick a different model; the only workaround is hand-editing `localWhisperModel` in `settings.json`. Nothing is written to `logs/telemetry.jsonl` — the process dies first.

## Root cause

`WHISPER_SAFE_DTYPE` in `electron/audio/whisper/inferenceConfig.ts` pins `encoder_model: 'fp32'` for every Whisper-family model. Turbo's fp32 encoder weights are ~2.4 GB, ONNX Runtime materialises those initializers in **one block**, and the request lands on Chromium's PartitionAlloc hard cap:

```cpp
// partition_alloc_constants.h
MaxDirectMapped() = (1UL << 31) - kSuperPageSize   // 2 GiB - 2 MiB
// "Intentionally set to less than 2GiB to make sure that a 2GiB allocation
//  fails. This is a security choice in Chrome, to help making size_t vs int
//  bugs harder to exploit."
```

PartitionAlloc does not return `NULL` at that point — it intentionally traps. Hence `brk 0` / SIGTRAP with no catchable JS error. The register state in the crash report is the smoking gun: `x19 = x21 = x24 = 0x80000000`, i.e. **exactly 2 GiB in one allocation**, requested from `BFCArena::Extend → CPUAllocator::Alloc → posix_memalign`.

This is **not** an out-of-memory condition:

- reproduces identically with 82% of system RAM free, and with almost nothing free;
- the same files with the same `onnxruntime-node@1.22.0` load in 1.3–1.8 s under plain Node on the same machine (system malloc). Only inside Electron does it die.

### Why `enableCpuMemArena: false` isn't the fix

The issue's first suggestion was to disable the CPU mem arena — but `electron/utils/onnxThreadConfig.ts` **already defaults `enableCpuMemArena: false`**, and the crash happens anyway. Turning the arena off removes the doubling-chunk behaviour, but it does not help when a *single fp32 initializer tensor* is itself at or above the ceiling: that one tensor still has to be allocated in one piece. Any allocation path that reaches `posix_memalign` with >= 2 GiB is unrecoverable by construction, so the only durable fix is to never make the request.

## What changed

Two layers, so a future caller can't reintroduce the trap:

1. **`electron/audio/whisper/allocationGuard.ts`** (new, pure module — no electron/fs/transformers, importable from the worker, the main process and unit tests):
   - `PARTITION_ALLOC_MAX_BYTES` (2 GiB − 2 MiB) and `exceedsPartitionAllocCap()`;
   - `guardEncoderDtype(dtype, encoderFp32Bytes)` rewrites **only** the `encoder_model` entry to `q8`, and only when the resolved encoder dtype is fp32 *and* the catalog records fp32 encoder weights at or above the cap. Decoder dtypes, execution providers, and models with no recorded size are returned untouched, so nothing that loads today can regress. A uniform `'fp32'` string is widened into a per-module map rather than quantizing the whole graph — silently dropping decoder precision as a side effect of an allocation fix would be an accuracy change nobody asked for.
   - `preflightAllocation(modelId, dtype, encoderFp32Bytes)` returns a human-readable refusal message, or `null` when the load is safe.
2. **`whisperWorker.ts`** calls `preflightAllocation` immediately before `pipeline()`; a non-null result is posted as a `WorkerErrorResponse` and the worker returns, so `CreateSession` is never reached. This is defence in depth for any caller that hand-builds an init message instead of using `buildWorkerInitMessage`.

Supporting changes:

- `modelManager.ts` records `encoderFp32Mb: 2400` for `onnx-community/whisper-large-v3-turbo-ONNX` and exports `getModelEncoderFp32Bytes()`. Only checkpoints where the size actually matters carry the field; `undefined` means "unknown" and is treated as safe.
- `inferenceConfig.ts` `buildWorkerInitMessage()` applies the guard after `resolveInferenceConfig()`, logs one `console.warn` with the reason when it downgrades, and forwards both the guarded dtype and `encoderFp32Bytes` in the init message. The lookup uses the same best-effort lazy-require + `try/catch` style as the existing size / external-data lookups, so a failure there can never block worker startup.
- `getAvailableModels()` now computes cache status against the dtype a model will *actually* load, so turbo is no longer reported "available" on the strength of an fp32 encoder it no longer uses.
- `types.ts` gains `WhisperModelInfo.encoderFp32Mb` and `WorkerInitMessage.encoderFp32Bytes`, both optional and documented.

Result on the reported machine's configuration: turbo resolves `encoder_model: 'q8'` with the decoders unchanged, so the 2 GiB request is never made. A q8 encoder that loads beats an fp32 encoder that traps.

Not addressed here (separate concerns from the crash): the catalog's `sizeMb: 1031` under-reporting the 3.0 GB on-disk footprint, and the lack of a startup fallback when the preloaded model fails.

## How it was tested

`electron/audio/__tests__/WhisperAllocationCeiling.test.mjs` (new, 10 tests, same conventions as the neighbouring `WhisperExternalDataFormat.test.mjs`): the cap constant, `exceedsPartitionAllocCap` boundaries (just under / at / over the cap, plus `0`/`undefined`/`NaN`/negative), encoder-only downgrade for turbo-sized weights with decoder entries proven untouched, no downgrade for small models / already-q8 encoders / unknown sizes, string→map widening, `preflightAllocation` refusing the unsafe case and passing the guarded one, `buildWorkerInitMessage` returning a non-fp32 encoder for turbo and an unchanged fp32 encoder for `Xenova/whisper-tiny.en`, and cache-status alignment.

```
npm run build:electron
node --test electron/audio/__tests__/WhisperAllocationCeiling.test.mjs   # 10/10 pass
npm run typecheck:electron                                              # clean
node --test 'electron/audio/__tests__/**/*.test.mjs'                    # 285/295 pass
node --test 'electron/audio/whisper/__tests__/**/*.test.mjs'            # 10/11 pass
```

The failures in the two suite-wide runs are pre-existing on `main` at `f25d2b8` — the identical 10 (`electron/audio/__tests__`) and 1 (`electron/audio/whisper/__tests__`) fail with this branch stashed, and none of them touch whisper inference config. This branch adds 10 passing tests and changes no existing result.

**Mutation check.** Making `guardEncoderDtype` return its input unchanged turns 5 of the 10 new tests RED (`guardEncoderDtype downgrades ONLY the encoder…`, `…widens a uniform fp32 string…`, `preflightAllocation refuses…`, `buildWorkerInitMessage never sends an fp32 encoder…`, `model status is computed for the dtype turbo will actually load`); restoring it returns 10/10 GREEN. Separately, making `preflightAllocation` always return `null` turns the worker-preflight test RED on its own, so the second layer is independently covered rather than riding on the first.

Fixes #402
