### PR TITLE
fix(settings): restore missing ui/AccordionSection module

### DIFF
--- a/src/components/settings/IntelligenceSettings.tsx
+++ b/src/components/settings/IntelligenceSettings.tsx
@@ -1,7 +1,8 @@
-import { AlertTriangle, Check, ChevronDown, Copy, Cpu, Loader2, Wifi, WifiOff } from 'lucide-react';
+import { AlertTriangle, Check, Copy, Cpu, Loader2, Wifi, WifiOff } from 'lucide-react';
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useT } from '../../i18n';
+import { Disclosure, DisclosureChevron } from '../ui/AccordionSection';
 
 // Label + one-line description + group + TIER for each Intelligence OS flag. Keyed by flag
 // key; an unknown key falls back to the raw key so a newly-added flag still renders.
@@ -147,36 +148,6 @@ const Toggle: React.FC<{ on: boolean; disabled?: boolean; onClick: () => void }>
   >
     <span className={`absolute top-1 left-1 w-4 h-4 rounded-full bg-white shadow-sm transition-transform duration-200 ease-spring motion-reduce:transition-none ${on ? 'translate-x-5' : 'translate-x-0'}`} />
   </button>
-);
-
-// Smooth height+opacity expand/collapse for the disclosures (Set up / Customize / Developer
-// options), matching the HelpSettings AccordionSection idiom. Height-auto is measured by
-// framer-motion; under prefers-reduced-motion we drop the height/opacity tween so nothing
-// slides or reflows — the content just appears.
-const Disclosure: React.FC<{ open: boolean; children: React.ReactNode }> = ({ open, children }) => {
-  const reduce = useReducedMotion();
-  return (
-    <AnimatePresence initial={false}>
-      {open ? (
-        <motion.div
-          key="disclosure"
-          initial={reduce ? { opacity: 0 } : { height: 0, opacity: 0 }}
-          animate={reduce ? { opacity: 1 } : { height: 'auto', opacity: 1 }}
-          exit={reduce ? { opacity: 0 } : { height: 0, opacity: 0 }}
-          transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
-          style={{ overflow: 'hidden' }}
-        >
-          {children}
-        </motion.div>
-      ) : null}
-    </AnimatePresence>
-  );
-};
-
-// A chevron that rotates between collapsed (▸) and expanded (▾) instead of swapping glyphs,
-// so the disclosure indicator turns smoothly with the panel.
-const DisclosureChevron: React.FC<{ open: boolean }> = ({ open }) => (
-  <ChevronDown size={14} className={`shrink-0 transition-transform duration-200 ease-apple-ease motion-reduce:transition-none ${open ? 'rotate-0' : '-rotate-90'}`} />
 );
 
 // Inline copyable command/snippet block — same idiom as UpdateModal's CopyBlock. Used in the

--- a/src/components/ui/AccordionSection.tsx
+++ b/src/components/ui/AccordionSection.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import { ChevronDown } from 'lucide-react';
+
+// Smooth height+opacity expand/collapse for settings disclosures (Set up / Customize /
+// Developer options), matching the HelpSettings AccordionSection idiom. Height-auto is
+// measured by framer-motion; under prefers-reduced-motion we drop the height/opacity tween
+// so nothing slides or reflows — the content just appears.
+export const Disclosure: React.FC<{ open: boolean; children: React.ReactNode }> = ({ open, children }) => {
+  const reduce = useReducedMotion();
+  return (
+    <AnimatePresence initial={false}>
+      {open ? (
+        <motion.div
+          key="disclosure"
+          initial={reduce ? { opacity: 0 } : { height: 0, opacity: 0 }}
+          animate={reduce ? { opacity: 1 } : { height: 'auto', opacity: 1 }}
+          exit={reduce ? { opacity: 0 } : { height: 0, opacity: 0 }}
+          transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
+          style={{ overflow: 'hidden' }}
+        >
+          {children}
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
+  );
+};
+
+// A chevron that rotates between collapsed (▸) and expanded (▾) instead of swapping glyphs,
+// so the disclosure indicator turns smoothly with the panel.
+export const DisclosureChevron: React.FC<{ open: boolean }> = ({ open }) => (
+  <ChevronDown size={14} className={`shrink-0 transition-transform duration-200 ease-apple-ease motion-reduce:transition-none ${open ? 'rotate-0' : '-rotate-90'}`} />
+);


### PR DESCRIPTION
## Summary
Fixes #<issue-number-once-filed>

`SettingsOverlay.tsx` imports `Disclosure`/`DisclosureChevron` from `./ui/AccordionSection`,
but that file was never committed, breaking `npm run dev` for every fresh clone
(TS2307 / Vite resolve failure). `IntelligenceSettings.tsx` already had its own local
copies of the same two components, so the shared module was clearly intended to exist.

<img width="1061" height="179" alt="Screenshot 2026-08-02 012624" src="https://github.com/user-attachments/assets/182f6c45-37e2-4a35-b9df-964976d8f634" />

This PR extracts `Disclosure`/`DisclosureChevron` into `src/components/ui/AccordionSection.tsx`
and updates `IntelligenceSettings.tsx` to import the shared version instead of duplicating it.

## Type of Change
- 🐛 Bug Fix

## Testing & Environment
- [x] Manual test performed on: **Windows 11**
- `npx tsc --noEmit` passes with no errors
- `npm run dev` starts cleanly; Settings overlay's Advanced/Customize/Developer
  disclosures in Intelligence settings still expand/collapse correctly

## Visuals (Optional)
N/A — internal build fix, no UI change.
