### PR TITLE
fix(stealth): tray/taskbar follow stealth state, restore launcher pre-paint gate

### DIFF
--- a/electron/WindowHelper.ts
+++ b/electron/WindowHelper.ts
@@ -417,6 +417,10 @@ export class WindowHelper {
         webSecurity: !isDev, // DEBUG: Disable web security only in dev
       },
       show: false, // DEBUG: Force show -> Fixed white screen, now relies on ready-to-show
+      // Taskbar presence must track stealth state, not be a hardcoded constant:
+      // a cold start with undetectable persisted must not paint a taskbar entry
+      // before setUndetectable() ever runs. Re-asserted on every toggle.
+      skipTaskbar: this.appState.getUndetectable(),
       // Platform-specific frame settings
       ...(isMac
         ? { titleBarStyle: 'hiddenInset' as const, trafficLightPosition: { x: 14, y: 14 } }
@@ -1096,6 +1100,7 @@ export class WindowHelper {
   public syncOverlayInteractionPolicy(quiet = false): void {
     if (!this.overlayWindow || this.overlayWindow.isDestroyed()) return;
 
+
     const passthrough = this.appState.getOverlayMousePassthrough();
     // The pill and toggle windows follow ONLY the stealth passthrough — they
     // are fully painted (no transparent margins), so the hover gate never
@@ -1125,7 +1130,6 @@ export class WindowHelper {
       this.overlayWindow.setIgnoreMouseEvents(true, { forward: true });
     } else {
       this.overlayWindow.setIgnoreMouseEvents(false);
-      // Restore full interactivity when capturing clicks.
       this.overlayWindow.setFocusable(true);
     }
     auxWindows.forEach((w) => {
@@ -1813,7 +1817,6 @@ export class WindowHelper {
   public showOverlay(): void {
     if (!this.overlayWindow || this.overlayWindow.isDestroyed()) return;
 
-    // Restore opacity in case it was zeroed by hideMainWindow() before a screenshot.
     this.overlayWindow.setOpacity(1);
     this.pillWindow?.setOpacity(1);
     this.toggleWindow?.setOpacity(1);
@@ -2007,6 +2010,7 @@ export class WindowHelper {
         expanded: true,
       });
 
+  
       // Restore opacity before showing (it may have been zeroed by hideMainWindow).
       if (process.platform === 'win32' && this.contentProtection) {
         // Opacity Shield: Show at 0 opacity first to prevent frame leak.

--- a/electron/WindowHelper.ts
+++ b/electron/WindowHelper.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow, Menu, screen } from 'electron';
 import fs from 'node:fs';
 import path from 'node:path';
 import { AppState } from './main';
+import { disguiseIconPath, appIconPath, normalizeDisguiseMode } from './disguise';
 import { KeybindManager } from './services/KeybindManager';
 
 const isEnvDev = process.env.NODE_ENV === 'development';
@@ -438,55 +439,11 @@ export class WindowHelper {
       resizable: true,
       movable: true,
       center: true,
-      icon: (() => {
-        const isMac = process.platform === 'darwin';
-        const isWin = process.platform === 'win32';
-        const mode = this.appState.getDisguise();
-
-        if (mode === 'none') {
-          if (isMac) {
-            return app.isPackaged
-              ? path.join(process.resourcesPath, 'natively.icns')
-              : path.resolve(__dirname, '../../assets/natively.icns');
-          } else if (isWin) {
-            return app.isPackaged
-              ? path.join(process.resourcesPath, 'assets/icons/win/icon.ico')
-              : path.resolve(__dirname, '../../assets/icons/win/icon.ico');
-          } else {
-            return app.isPackaged
-              ? path.join(process.resourcesPath, 'assets', 'icon.png')
-              : path.resolve(__dirname, '../../assets/icon.png');
-          }
-        }
-
-        // Disguise mode icons. Only the three known disguise modes map to a
-        // fake icon; any unexpected value falls through to 'none' above, so we
-        // never silently paint a terminal icon for an unrecognized mode.
-        let iconName: string | null = null;
-        if (mode === 'terminal') iconName = 'terminal.png';
-        if (mode === 'settings') iconName = 'settings.png';
-        if (mode === 'activity') iconName = 'activity.png';
-        if (!iconName) {
-          // Defensive: unknown mode — use the real app icon, matching 'none'.
-          if (isMac) {
-            return app.isPackaged
-              ? path.join(process.resourcesPath, 'natively.icns')
-              : path.resolve(__dirname, '../../assets/natively.icns');
-          } else if (isWin) {
-            return app.isPackaged
-              ? path.join(process.resourcesPath, 'assets/icons/win/icon.ico')
-              : path.resolve(__dirname, '../../assets/icons/win/icon.ico');
-          }
-          return app.isPackaged
-            ? path.join(process.resourcesPath, 'icon.png')
-            : path.resolve(__dirname, '../../assets/icon.png');
-        }
-
-        const platformDir = isWin ? 'win' : 'mac';
-        return app.isPackaged
-          ? path.join(process.resourcesPath, `assets/fakeicon/${platformDir}/${iconName}`)
-          : path.resolve(__dirname, `../../assets/fakeicon/${platformDir}/${iconName}`);
-      })(),
+      // Shared with the tray and the dock/process identity via
+      // electron/disguise.ts. normalizeDisguiseMode() keeps the old defensive
+      // behaviour: any out-of-union value coerces to 'none' and yields the real
+      // app icon, so an unrecognized mode never silently paints a fake one.
+      icon: disguiseIconPath(normalizeDisguiseMode(this.appState.getDisguise())) ?? appIconPath(),
     };
 
     console.log(`[WindowHelper] Icon Path: ${launcherSettings.icon}`);

--- a/electron/WindowHelper.ts
+++ b/electron/WindowHelper.ts
@@ -241,6 +241,34 @@ export class WindowHelper {
     });
   }
 
+  /**
+   * Windows: keep the launcher out of the taskbar while undetectable mode is on.
+   *
+   * Every other window is created with `skipTaskbar: true` (overlay, pill,
+   * toggle, popover catcher, settings, model selector, cropper) — the launcher
+   * is the sole exception, because in NORMAL mode it is the main app window and
+   * belongs in the taskbar. That left undetectable mode only half-applied on
+   * Windows: macOS removes the app from the Dock entirely, while Windows still
+   * showed a "Natively" taskbar button whenever the launcher was up (before and
+   * after a meeting — during one the overlay is already skipTaskbar).
+   *
+   * Called at launcher creation and on every undetectable toggle. No-op off
+   * win32: macOS stealth is the Dock/activation-policy path, and forcing
+   * skipTaskbar there would be a behaviour change on a platform that does not
+   * use it.
+   */
+  public syncLauncherTaskbarForStealth(): void {
+    if (process.platform !== 'win32') return;
+    const win = this.launcherWindow;
+    if (!win || win.isDestroyed()) return;
+    try {
+      win.setSkipTaskbar(!!this.appState.getUndetectable());
+    } catch (e) {
+      // Non-fatal: worst case the taskbar button remains, exactly as before.
+      console.error('[WindowHelper] setSkipTaskbar failed:', e);
+    }
+  }
+
   // Force-reapply the CURRENT content-protection state to every live window,
   // bypassing the dedupe guard in setContentProtection(). Needed because
   // app.dock.hide()/show() flips the macOS activation policy, which makes
@@ -463,6 +491,10 @@ export class WindowHelper {
     }
 
     this.launcherWindow.setContentProtection(this.contentProtection);
+    // Apply the persisted undetectable state to the launcher's taskbar presence
+    // now, at creation — a session that STARTS undetectable would otherwise show
+    // a taskbar button until the user toggled the setting off and on again.
+    this.syncLauncherTaskbarForStealth();
 
     // A/B KILL-SWITCH (2026-07-10): NATIVELY_DISABLE_ONBOARDING_ORCH=1 appends
     // ?noorch=1, which makes App.tsx skip orch.start() entirely (no drain loop,

--- a/electron/disguise.ts
+++ b/electron/disguise.ts
@@ -1,0 +1,106 @@
+// Single source of truth for process/window/tray disguise identity.
+//
+// These mappings previously existed in three places — WindowHelper's launcher
+// icon resolution, AppState._applyDisguise(), and AppState.buildTrayImage() —
+// which had already drifted: the unpackaged branch resolved via
+// path.resolve(__dirname, '../../assets/...') in one copy and
+// path.join(app.getAppPath(), 'assets/...') in the others. Those happen to
+// resolve to the same place today, but only because the esbuild output sits
+// exactly two levels below the repo root; changing the bundle layout would
+// silently break one copy and not the others.
+//
+// Adding a disguise mode must be a single edit here, not four. Every lookup is
+// exhaustive over DisguiseMode so a new member is a compile error at each
+// switch rather than a silent fallthrough to the wrong icon — the failure mode
+// that matters, since a tray whose icon disagrees with the window identity is a
+// stealth leak that surfaces no error.
+//
+// Platform is an explicit parameter (defaulted, not read inline) so both
+// branches are assertable in tests without mutating process.platform.
+
+import { app } from "electron"
+import path from "path"
+
+export type DisguiseMode = 'terminal' | 'settings' | 'activity' | 'none'
+
+export const VALID_DISGUISE_MODES: readonly DisguiseMode[] = ['terminal', 'settings', 'activity', 'none'] as const
+
+export function normalizeDisguiseMode(value: unknown): DisguiseMode {
+  return (VALID_DISGUISE_MODES as readonly string[]).includes(value as string)
+    ? (value as DisguiseMode)
+    : 'none'
+}
+
+// Display name fed to process.title / app.setName() / the tray tooltip.
+//
+// NOTE the trailing space on every disguised name. It is deliberate and
+// load-bearing: it keeps the disguised identity from colliding byte-for-byte
+// with the real OS process it imitates. Callers that render the name to the
+// user (tooltips) trim it; callers that set process identity must not.
+export function disguiseAppName(
+  mode: DisguiseMode,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const isWin = platform === 'win32'
+  switch (mode) {
+    case 'terminal':
+      return isWin ? "Command Prompt " : "Terminal "
+    case 'settings':
+      return isWin ? "Settings " : "System Settings "
+    case 'activity':
+      return isWin ? "Task Manager " : "Activity Monitor "
+    case 'none':
+      return "Natively"
+  }
+}
+
+// Basename of the fake icon for a disguised mode; null for 'none' (which uses
+// the real app icon, resolved by appIconPath).
+export function disguiseIconFile(mode: DisguiseMode): string | null {
+  switch (mode) {
+    case 'terminal':
+      return 'terminal.png'
+    case 'settings':
+      return 'settings.png'
+    case 'activity':
+      return 'activity.png'
+    case 'none':
+      return null
+  }
+}
+
+// Absolute path to the fake icon for a disguised mode, or null for 'none'.
+export function disguiseIconPath(
+  mode: DisguiseMode,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  const iconFile = disguiseIconFile(mode)
+  if (!iconFile) return null
+
+  const platformDir = platform === 'win32' ? 'win' : 'mac'
+  const rel = `assets/fakeicon/${platformDir}/${iconFile}`
+
+  return app.isPackaged
+    ? path.join(process.resourcesPath, rel)
+    : path.join(app.getAppPath(), rel)
+}
+
+// Absolute path to the REAL app icon — the 'none' case, and the defensive
+// fallback whenever a disguise asset is missing.
+export function appIconPath(platform: NodeJS.Platform = process.platform): string {
+  if (platform === 'darwin') {
+    return app.isPackaged
+      ? path.join(process.resourcesPath, "natively.icns")
+      : path.join(app.getAppPath(), "assets/natively.icns")
+  }
+
+  if (platform === 'win32') {
+    return app.isPackaged
+      ? path.join(process.resourcesPath, "assets/icons/win/icon.ico")
+      : path.join(app.getAppPath(), "assets/icons/win/icon.ico")
+  }
+
+  return app.isPackaged
+    ? path.join(process.resourcesPath, "assets", "icon.png")
+    : path.join(app.getAppPath(), "assets/icon.png")
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1307,7 +1307,7 @@ export class AppState {
   private updateDownloadState: 'idle' | 'available' | 'downloading' | 'downloaded' = 'idle'
   private updateDownloadPromise: Promise<unknown> | null = null
   private downloadedUpdateInfo: any = null
-  private disguiseMode: 'terminal' | 'settings' | 'activity' | 'none' = 'none'
+  private disguiseMode: DisguiseMode = 'none'
 
   // View management
   private view: "queue" | "solutions" = "queue"
@@ -6450,51 +6450,85 @@ export class AppState {
     this.showTray();
   }
 
-  public showTray(): void {
-    if (this.tray) return;
+  // Tray tooltip for the current disguise. Derived from the mode directly and
+  // NOT read back off process.title: process.title is set by _applyDisguise(),
+  // so reading it here silently depends on that having already run — a tray
+  // created first would show the real name. Names mirror _applyDisguise().
+  private getTrayTooltip(): string {
+    const isWin = process.platform === 'win32';
+    switch (this.disguiseMode) {
+      case 'terminal':
+        return isWin ? 'Command Prompt' : 'Terminal';
+      case 'settings':
+        return isWin ? 'Settings' : 'System Settings';
+      case 'activity':
+        return isWin ? 'Task Manager' : 'Activity Monitor';
+      case 'none':
+      default:
+        return 'Natively';
+    }
+  }
 
-    // Try to find a template image first for macOS
+  // Single source of truth for the tray image. Both the initial Tray() and the
+  // refresh in _applyDisguise() must go through this: _applyDisguise's own icon
+  // resolution points 'none' at natively.icns on macOS, and pushing that into
+  // the tray replaces the monochrome menu-bar template with a full-colour icon
+  // that no longer inverts for light/dark. Template flag must follow the file.
+  private buildTrayImage(): Electron.NativeImage {
     const resourcesPath = app.isPackaged ? process.resourcesPath : app.getAppPath();
+    const isWin = process.platform === 'win32';
 
-    // Potential paths for tray icon
-    const templatePath = path.join(resourcesPath, 'assets', 'iconTemplate.png');
-    const defaultIconPath = app.isPackaged
-      ? path.join(resourcesPath, 'assets', 'icon.png')
-      : path.join(app.getAppPath(), 'src/components/icon.png');
+    let iconToUse = "";
+    if (this.disguiseMode !== 'none') {
+      const mode = this.disguiseMode;
+      let iconName = 'settings.png';
+      if (mode === 'terminal') iconName = 'terminal.png';
+      if (mode === 'activity') iconName = 'activity.png';
+      const platformDir = isWin ? 'win' : 'mac';
+      iconToUse = app.isPackaged
+        ? path.join(process.resourcesPath, `assets/fakeicon/${platformDir}/${iconName}`)
+        : path.join(app.getAppPath(), `assets/fakeicon/${platformDir}/${iconName}`);
+    }
 
-    let iconToUse = defaultIconPath;
+    if (!iconToUse || !fs.existsSync(iconToUse)) {
+      const templatePath = path.join(resourcesPath, 'assets', 'iconTemplate.png');
+      const defaultIconPath = app.isPackaged
+        ? path.join(resourcesPath, 'assets', 'icon.png')
+        : path.join(app.getAppPath(), 'src/components/icon.png');
 
-    // Check if template exists (sync check is fine for startup/rare toggle)
-    try {
-      if (require('fs').existsSync(templatePath)) {
-        iconToUse = templatePath;
-        console.log('[Tray] Using template icon:', templatePath);
-      } else {
-        // Also check src/components for dev
-        const devTemplatePath = path.join(app.getAppPath(), 'src/components/iconTemplate.png');
-        if (require('fs').existsSync(devTemplatePath)) {
-          iconToUse = devTemplatePath;
-          console.log('[Tray] Using dev template icon:', devTemplatePath);
+      iconToUse = defaultIconPath;
+
+      try {
+        if (fs.existsSync(templatePath)) {
+          iconToUse = templatePath;
         } else {
-          console.log('[Tray] Template icon not found, using default:', defaultIconPath);
+          const devTemplatePath = path.join(app.getAppPath(), 'src/components/iconTemplate.png');
+          if (fs.existsSync(devTemplatePath)) {
+            iconToUse = devTemplatePath;
+          }
         }
+      } catch (e) {
+        console.error('[Tray] Error checking for icon:', e);
       }
-    } catch (e) {
-      console.error('[Tray] Error checking for icon:', e);
     }
 
     const trayIcon = nativeImage.createFromPath(iconToUse).resize({ width: 16, height: 16 });
-    // IMPORTANT: specific template settings for macOS if needed, but 'Template' in name usually suffices
     trayIcon.setTemplateImage(iconToUse.endsWith('Template.png'));
+    return trayIcon;
+  }
 
-    this.tray = new Tray(trayIcon)
-    this.tray.setToolTip('Natively') // This tooltip might also need update if we change global shortcut, but global shortcut is removed.
+  public showTray(): void {
+    if (this.tray) return;
+
+    const trayIcon = this.buildTrayImage();
+
+    this.tray = new Tray(trayIcon);
+    this.tray.setToolTip(this.getTrayTooltip());
     this.updateTrayMenu();
 
-    // Double-click to show window
     this.tray.on('double-click', () => {
-      this.centerAndShowWindow()
-    })
+      this.centerAndShowWindow();
+    });
   }
 
   public updateTrayMenu() {
@@ -6505,8 +6539,7 @@ export class AppState {
 
     console.log('[Main] updateTrayMenu called. Screenshot Accelerator:', screenshotAccel);
 
-    // Update tooltip for verification
-    this.tray.setToolTip('Natively');
+    this.tray.setToolTip(this.getTrayTooltip());
 
     // Helper to format accelerator for display (e.g. CommandOrControl+H -> Cmd+H)
     const formatAccel = (accel: string) => {
@@ -6610,8 +6643,26 @@ export class AppState {
     this.modelSelectorWindowHelper.setContentProtection(state)
     this.cropperWindowHelper.setContentProtection(state)
 
+    this.windowHelper.syncOverlayInteractionPolicy();
+    const launcherWin = this.windowHelper.getLauncherWindow();
+    if (launcherWin && !launcherWin.isDestroyed()) {
+      // Must follow the stealth state. Hardcoding false kept the launcher in the
+      // Windows taskbar while undetectable was ON — the window stayed listed and
+      // Alt-Tab-able with its real title, defeating the mode.
+      launcherWin.setSkipTaskbar(state);
+    }
     if (process.platform === 'win32') {
-      this.windowHelper.syncOverlayInteractionPolicy();
+      // Tray parity with macOS. On darwin the tray is destroyed/restored at the
+      // end of _enforceDockState(), driven by the desired state — but that
+      // function early-returns on non-darwin, so Windows previously had NO
+      // hideTray() call site at all: toggling undetectable ON left a tray icon
+      // whose tooltip still read the real app name for the whole session.
+      if (state) {
+        this.hideTray();
+      } else {
+        this.showTray();
+      }
+
       this.settingsWindowHelper.syncActivationPolicy();
       this.modelSelectorWindowHelper.syncActivationPolicy();
     }
@@ -6731,7 +6782,6 @@ export class AppState {
 
         console.log(`[Stealth] app.dock.hide() (enforce attempt ${attempt})`);
         app.dock.hide();
-        this.hideTray();
 
         // Re-assert content protection: the activation-policy flip can reset
         // the windows' sharingType, silently undoing screen-capture stealth.
@@ -6745,9 +6795,22 @@ export class AppState {
       } else {
         console.log(`[Stealth] app.dock.show() (enforce attempt ${attempt})`);
         app.dock.show();
-        this.showTray();
         // Do NOT call focus() — let the user's current app retain focus.
       }
+    }
+
+    // Tray follows the DESIRED state, NOT the dock transition. decideDockTransition
+    // short-circuits (shouldApply=false) whenever the dock is already settled — so
+    // gating the tray on it meant: stealth ON while the dock was already hidden
+    // never ran hideTray(), leaving a tray with the real app name visible for the
+    // whole stealth session; and the mirror case left no tray at all after an
+    // OFF that skipped the dock transition. Both calls are idempotent
+    // (showTray early-returns if a tray exists, hideTray no-ops if none), so
+    // running them on every enforcement attempt is safe.
+    if (wantUndetectable) {
+      this.hideTray();
+    } else {
+      this.showTray();
     }
 
     // Verify it actually stuck. macOS may apply the policy change a tick later
@@ -6899,32 +6962,10 @@ export class AppState {
     console.log(`[AppState] ambientChatEnabled set to ${enabled}`);
   }
 
-  public setDisguise(mode: 'terminal' | 'settings' | 'activity' | 'none'): void {
+  public setDisguise(mode: DisguiseMode): void {
     mode = normalizeDisguiseMode(mode);
     this.disguiseMode = mode;
     SettingsManager.getInstance().set('disguiseMode', mode);
-
-    // NO runtime activation-policy churn here — and this is deliberate.
-    //
-    // The dual-dock-icon bug is a STARTUP phenomenon: the app is born, paints a
-    // tile, THEN renames via app.setName()+CFBundleName, and the LaunchServices
-    // re-registration races into a second tile. That path is fully handled at
-    // startup by LSUIElement (the bundle is born tile-less) plus the one-shot
-    // accessory→regular promotion after createWindow() — see the whenReady block.
-    //
-    // At RUNTIME the app already owns a single stable 'regular' dock tile, and
-    // app.setName() updates that tile's label in place rather than spawning a
-    // duplicate. The old code still bracketed this rename in accessory→regular
-    // "to be safe", but that round-trip deactivates the whole application for a
-    // tick — the always-on-top overlay/launcher windows leave the foreground
-    // layer and snap back, producing a visible disappear/reappear flicker on
-    // every disguise switch. Trading a guaranteed flicker for a hypothetical
-    // duplicate tile is the wrong deal, so the bracket is gone. With no policy
-    // change the app never deactivates, so there is also nothing to re-focus.
-    //
-    // Stealth is unaffected: _applyDisguise() already skips app.setName() and
-    // app.dock.setIcon() when isUndetectable (the dock stays hidden), and we
-    // never promote activation policy here.
     this._applyDisguise(mode);
   }
 
@@ -6932,7 +6973,7 @@ export class AppState {
     this._applyDisguise(this.disguiseMode);
   }
 
-  private _applyDisguise(mode: 'terminal' | 'settings' | 'activity' | 'none'): void {
+  private _applyDisguise(mode: DisguiseMode): void {
     let appName = "Natively";
     let iconPath = "";
 
@@ -6976,6 +7017,7 @@ export class AppState {
             : path.join(app.getAppPath(), "assets/fakeicon/mac/activity.png");
         }
         break;
+
       case 'none':
       default:
         appName = "Natively";
@@ -7001,8 +7043,6 @@ export class AppState {
     process.title = appName;
 
     // 2. Update app name (affects macOS Menu / Dock)
-    // Skip when undetectable — app.setName() causes macOS to re-register
-    // the app and re-show the dock icon even after dock.hide()
     if (!this.isUndetectable) {
       app.setName(appName);
     }
@@ -7013,7 +7053,6 @@ export class AppState {
 
     // 3. Update App User Model ID (Windows Taskbar grouping)
     if (isWin) {
-      // Use unique AUMID per disguise to avoid grouping with the real app
       app.setAppUserModelId(`com.natively.assistant.${mode}`);
     }
 
@@ -7022,15 +7061,23 @@ export class AppState {
       const image = nativeImage.createFromPath(iconPath);
 
       if (isMac) {
-        // Skip dock icon update when dock is hidden to avoid potential flicker
         if (!this.isUndetectable) {
           app.dock.setIcon(image);
         }
       } else {
-        // Windows/Linux: Update all window icons
         this.windowHelper.getLauncherWindow()?.setIcon(image);
         this.windowHelper.getOverlayWindow()?.setIcon(image);
         this.settingsWindowHelper.getSettingsWindow()?.setIcon(image);
+      }
+
+      // Update System Tray Icon & Tooltip if tray is initialized. Deliberately
+      // NOT `image` (this function's dock/window icon): for mode 'none' that is
+      // natively.icns on macOS, which would replace the monochrome menu-bar
+      // template with a non-inverting full-colour icon. buildTrayImage() applies
+      // the tray's own resolution + template flag.
+      if (this.tray && !this.tray.isDestroyed()) {
+        this.tray.setImage(this.buildTrayImage());
+        this.tray.setToolTip(this.getTrayTooltip());
       }
     } else {
       console.warn(`[AppState] Disguise icon not found: ${iconPath}`);
@@ -7565,17 +7612,14 @@ if (process.env.THINKING_MATRIX === '1') {
   }
 
   // Apply initial stealth state based on isUndetectable setting.
+  // Only mint a tray when NOT undetectable. Force-showing it on Windows
+  // regardless of stealth state made a persisted-undetectable cold start paint
+  // a tray icon that stealth then never removed.
   if (!appState.getUndetectable()) {
-    // Normal mode: show tray (dock is already showing — no need to call dock.show() again)
     appState.showTray();
-  } else {
-    // Persisted undetectable: the pre-emptive app.dock.hide() above is NOT
-    // sufficient — createWindow() + the launcher's first show re-registers the
-    // app and re-shows the dock. Converge through the same self-verifying
-    // enforcement the runtime toggle uses, so the app comes up actually
-    // undetectable without the user having to toggle off/on. The enforcement
-    // loop re-checks app.dock.isVisible() across several retries, which also
-    // catches the dock re-show that lands at the launcher's ready-to-show.
+  }
+
+  if (appState.getUndetectable()) {
     appState.applyInitialUndetectableState();
   }
   // Register global shortcuts using KeybindManager

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -16,6 +16,13 @@ import os from "os"
 import dns from "dns"
 import { SystemAudioHealthClassifier } from "./audio/systemAudioHealthClassifier.mjs"
 import { autoUpdater } from "electron-updater"
+import {
+  DisguiseMode,
+  normalizeDisguiseMode,
+  disguiseAppName,
+  disguiseIconPath,
+  appIconPath,
+} from "./disguise"
 
 // Override global dns.lookup to resolve macOS system resolver issues with api.natively.software
 const originalLookup = dns.lookup;
@@ -1258,13 +1265,9 @@ const nativeOomTrace = new NativeOomTrace()
 // window falls back to the terminal icon. That identity mismatch reads as an
 // extra/duplicate dock tile. Coerce any out-of-union value to 'none' on load
 // and at the runtime entry point so app, dock, and window always agree.
-type DisguiseMode = 'terminal' | 'settings' | 'activity' | 'none'
-const VALID_DISGUISE_MODES: readonly DisguiseMode[] = ['terminal', 'settings', 'activity', 'none'] as const
-function normalizeDisguiseMode(value: unknown): DisguiseMode {
-  return (VALID_DISGUISE_MODES as readonly string[]).includes(value as string)
-    ? (value as DisguiseMode)
-    : 'none'
-}
+// Moved to electron/disguise.ts so WindowHelper's launcher-icon resolution and
+// the tray/dock identity here cannot drift apart. Re-exported for callers that
+// imported these from main.
 
 export class AppState {
   private static instance: AppState | null = null
@@ -6455,18 +6458,9 @@ export class AppState {
   // so reading it here silently depends on that having already run — a tray
   // created first would show the real name. Names mirror _applyDisguise().
   private getTrayTooltip(): string {
-    const isWin = process.platform === 'win32';
-    switch (this.disguiseMode) {
-      case 'terminal':
-        return isWin ? 'Command Prompt' : 'Terminal';
-      case 'settings':
-        return isWin ? 'Settings' : 'System Settings';
-      case 'activity':
-        return isWin ? 'Task Manager' : 'Activity Monitor';
-      case 'none':
-      default:
-        return 'Natively';
-    }
+    // Trimmed: disguiseAppName carries a deliberate trailing space for
+    // process.title/app.setName parity, which must not reach the tooltip.
+    return disguiseAppName(this.disguiseMode).trim();
   }
 
   // Single source of truth for the tray image. Both the initial Tray() and the
@@ -6476,19 +6470,8 @@ export class AppState {
   // that no longer inverts for light/dark. Template flag must follow the file.
   private buildTrayImage(): Electron.NativeImage {
     const resourcesPath = app.isPackaged ? process.resourcesPath : app.getAppPath();
-    const isWin = process.platform === 'win32';
 
-    let iconToUse = "";
-    if (this.disguiseMode !== 'none') {
-      const mode = this.disguiseMode;
-      let iconName = 'settings.png';
-      if (mode === 'terminal') iconName = 'terminal.png';
-      if (mode === 'activity') iconName = 'activity.png';
-      const platformDir = isWin ? 'win' : 'mac';
-      iconToUse = app.isPackaged
-        ? path.join(process.resourcesPath, `assets/fakeicon/${platformDir}/${iconName}`)
-        : path.join(app.getAppPath(), `assets/fakeicon/${platformDir}/${iconName}`);
-    }
+    let iconToUse = disguiseIconPath(this.disguiseMode) ?? "";
 
     if (!iconToUse || !fs.existsSync(iconToUse)) {
       const templatePath = path.join(resourcesPath, 'assets', 'iconTemplate.png');
@@ -6881,8 +6864,31 @@ export class AppState {
   // to call redundantly — it no-ops immediately off-darwin or when not
   // undetectable, and stops early via the isUndetectable guard inside the loop.
   public reassertUndetectableStealth(maxAttempts: number = 10): void {
-    if (process.platform !== 'darwin') return;
     if (!this.isUndetectable) return;
+
+    if (process.platform === 'win32') {
+      // Windows has no dock or activation policy, so there is no self-verifying
+      // loop to run — but the two things that DO carry the app's identity here
+      // can come back on their own mid-session, and previously nothing put them
+      // back. The launcher's taskbar button returns on an explorer.exe restart,
+      // and setDisguise() re-registers the AUMID (app.setAppUserModelId) while
+      // stealth is on, which re-associates the window with a taskbar identity.
+      // Either way the user has no reason to re-toggle, so the entry would sit
+      // there under the real title for the rest of the session.
+      //
+      // Content protection is re-asserted for the same reason it is on macOS:
+      // it is the screen-capture half of stealth and is cheap to reapply.
+      this.reassertAllContentProtection();
+
+      const launcherWin = this.windowHelper.getLauncherWindow();
+      if (launcherWin && !launcherWin.isDestroyed()) {
+        launcherWin.setSkipTaskbar(true);
+      }
+      this.hideTray();
+      return;
+    }
+
+    if (process.platform !== 'darwin') return;
     // Collapse any in-flight enforcement chain from a PRIOR re-assert before
     // starting a fresh one — same discipline as setUndetectable(). Without this,
     // a burst of launcher shows (rapid Stop→Start→Stop, or a cold-start
@@ -6974,68 +6980,13 @@ export class AppState {
   }
 
   private _applyDisguise(mode: DisguiseMode): void {
-    let appName = "Natively";
-    let iconPath = "";
-
     const isWin = process.platform === 'win32';
     const isMac = process.platform === 'darwin';
 
-    switch (mode) {
-      case 'terminal':
-        appName = isWin ? "Command Prompt " : "Terminal ";
-        if (isWin) {
-          iconPath = app.isPackaged
-            ? path.join(process.resourcesPath, "assets/fakeicon/win/terminal.png")
-            : path.join(app.getAppPath(), "assets/fakeicon/win/terminal.png");
-        } else {
-          iconPath = app.isPackaged
-            ? path.join(process.resourcesPath, "assets/fakeicon/mac/terminal.png")
-            : path.join(app.getAppPath(), "assets/fakeicon/mac/terminal.png");
-        }
-        break;
-      case 'settings':
-        appName = isWin ? "Settings " : "System Settings ";
-        if (isWin) {
-          iconPath = app.isPackaged
-            ? path.join(process.resourcesPath, "assets/fakeicon/win/settings.png")
-            : path.join(app.getAppPath(), "assets/fakeicon/win/settings.png");
-        } else {
-          iconPath = app.isPackaged
-            ? path.join(process.resourcesPath, "assets/fakeicon/mac/settings.png")
-            : path.join(app.getAppPath(), "assets/fakeicon/mac/settings.png");
-        }
-        break;
-      case 'activity':
-        appName = isWin ? "Task Manager " : "Activity Monitor ";
-        if (isWin) {
-          iconPath = app.isPackaged
-            ? path.join(process.resourcesPath, "assets/fakeicon/win/activity.png")
-            : path.join(app.getAppPath(), "assets/fakeicon/win/activity.png");
-        } else {
-          iconPath = app.isPackaged
-            ? path.join(process.resourcesPath, "assets/fakeicon/mac/activity.png")
-            : path.join(app.getAppPath(), "assets/fakeicon/mac/activity.png");
-        }
-        break;
-
-      case 'none':
-      default:
-        appName = "Natively";
-        if (isMac) {
-          iconPath = app.isPackaged
-            ? path.join(process.resourcesPath, "natively.icns")
-            : path.join(app.getAppPath(), "assets/natively.icns");
-        } else if (isWin) {
-          iconPath = app.isPackaged
-            ? path.join(process.resourcesPath, "assets/icons/win/icon.ico")
-            : path.join(app.getAppPath(), "assets/icons/win/icon.ico");
-        } else {
-          iconPath = app.isPackaged
-            ? path.join(process.resourcesPath, "assets/icon.png")
-            : path.join(app.getAppPath(), "assets/icon.png");
-        }
-        break;
-    }
+    // Identity comes from electron/disguise.ts — the same source the launcher
+    // icon and the tray use, so all three can never disagree about a mode.
+    const appName = disguiseAppName(mode);
+    const iconPath = disguiseIconPath(mode) ?? appIconPath();
 
     console.log(`[AppState] Applying disguise: ${mode} (${appName}) on ${process.platform}`);
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -6627,27 +6627,24 @@ export class AppState {
     this.cropperWindowHelper.setContentProtection(state)
 
     this.windowHelper.syncOverlayInteractionPolicy();
-    const launcherWin = this.windowHelper.getLauncherWindow();
-    if (launcherWin && !launcherWin.isDestroyed()) {
-      // Must follow the stealth state. Hardcoding false kept the launcher in the
-      // Windows taskbar while undetectable was ON — the window stayed listed and
-      // Alt-Tab-able with its real title, defeating the mode.
-      launcherWin.setSkipTaskbar(state);
-    }
     if (process.platform === 'win32') {
-      // Tray parity with macOS. On darwin the tray is destroyed/restored at the
-      // end of _enforceDockState(), driven by the desired state — but that
-      // function early-returns on non-darwin, so Windows previously had NO
-      // hideTray() call site at all: toggling undetectable ON left a tray icon
-      // whose tooltip still read the real app name for the whole session.
-      if (state) {
-        this.hideTray();
-      } else {
-        this.showTray();
-      }
-
       this.settingsWindowHelper.syncActivationPolicy();
       this.modelSelectorWindowHelper.syncActivationPolicy();
+      // The tray must follow undetectable state on Windows too. On macOS the
+      // _enforceDockState loop hides the tray alongside the dock and restores
+      // both on the way out — but that loop returns immediately off darwin, and
+      // it holds the ONLY showTray()/hideTray() call sites besides startup. So
+      // nothing drove the tray on Windows: launching with undetectable ON never
+      // created it, and toggling back OFF never created it either, leaving the
+      // user with no tray menu (show window / quit) until they restarted in
+      // normal mode. hideTray() is null-guarded and showTray() is idempotent,
+      // so this is safe to call on every real state change.
+      if (state) this.hideTray();
+      else this.showTray();
+      // Undetectable also means "no taskbar button" — the launcher is the only
+      // window without skipTaskbar (it needs one in normal mode). macOS achieves
+      // the equivalent by dropping the Dock tile.
+      this.windowHelper.syncLauncherTaskbarForStealth();
     }
 
     // Persist state via SettingsManager

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -6626,8 +6626,8 @@ export class AppState {
     this.modelSelectorWindowHelper.setContentProtection(state)
     this.cropperWindowHelper.setContentProtection(state)
 
-    this.windowHelper.syncOverlayInteractionPolicy();
     if (process.platform === 'win32') {
+      this.windowHelper.syncOverlayInteractionPolicy();
       this.settingsWindowHelper.syncActivationPolicy();
       this.modelSelectorWindowHelper.syncActivationPolicy();
       // The tray must follow undetectable state on Windows too. On macOS the

--- a/electron/services/__tests__/DisguiseIdentity.test.mjs
+++ b/electron/services/__tests__/DisguiseIdentity.test.mjs
@@ -1,0 +1,145 @@
+// Disguise identity contract — asserts BOTH platform branches.
+//
+// These mappings used to live in three places (WindowHelper's launcher icon,
+// _applyDisguise's dock/process identity, the tray image). They had already
+// drifted on the unpackaged path. The risk is silent: a tray whose icon or
+// tooltip disagrees with the window identity is a stealth leak that raises no
+// error, so only a test comparing the branches catches it.
+//
+// disguise.ts takes platform as a parameter precisely so this file can assert
+// 'darwin' and 'win32' from a single run, without mutating process.platform.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import Module from 'node:module';
+
+// disguise.ts imports electron for app.isPackaged / app.getAppPath(). Stub it
+// so this stays a pure unit test with no Electron runtime.
+const APP_PATH = '/fake/app';
+const originalResolve = Module._resolveFilename;
+const stubPath = path.resolve('electron/services/__tests__/__electron_stub.mjs');
+Module._resolveFilename = function (request, ...rest) {
+  if (request === 'electron') return stubPath;
+  return originalResolve.call(this, request, ...rest);
+};
+
+const {
+  normalizeDisguiseMode,
+  disguiseAppName,
+  disguiseIconFile,
+  disguiseIconPath,
+  appIconPath,
+  VALID_DISGUISE_MODES,
+} = await import('../../../dist-electron/electron/disguise.js');
+
+const DISGUISED = ['terminal', 'settings', 'activity'];
+
+describe('normalizeDisguiseMode', () => {
+  test('passes through every valid mode', () => {
+    for (const mode of VALID_DISGUISE_MODES) {
+      assert.equal(normalizeDisguiseMode(mode), mode);
+    }
+  });
+
+  test('coerces junk to none — an unknown mode must never paint a fake icon', () => {
+    for (const junk of ['Terminal', 'TERMINAL', 'chrome', '', null, undefined, 42, {}, []]) {
+      assert.equal(normalizeDisguiseMode(junk), 'none');
+    }
+  });
+});
+
+describe('disguiseAppName', () => {
+  test('darwin and win32 give DIFFERENT names for every disguised mode', () => {
+    // The whole point of the disguise is to imitate the host OS's own process.
+    // If a branch ever returned the macOS name on Windows, the disguise would
+    // name a process that does not exist on that OS — an obvious tell.
+    for (const mode of DISGUISED) {
+      const mac = disguiseAppName(mode, 'darwin');
+      const win = disguiseAppName(mode, 'win32');
+      assert.notEqual(mac, win, `${mode} should differ per platform`);
+    }
+  });
+
+  test('imitates real OS process names', () => {
+    assert.equal(disguiseAppName('terminal', 'darwin').trim(), 'Terminal');
+    assert.equal(disguiseAppName('terminal', 'win32').trim(), 'Command Prompt');
+    assert.equal(disguiseAppName('settings', 'darwin').trim(), 'System Settings');
+    assert.equal(disguiseAppName('settings', 'win32').trim(), 'Settings');
+    assert.equal(disguiseAppName('activity', 'darwin').trim(), 'Activity Monitor');
+    assert.equal(disguiseAppName('activity', 'win32').trim(), 'Task Manager');
+  });
+
+  test('every disguised name carries the deliberate trailing space', () => {
+    // Load-bearing: keeps the disguised process identity from colliding
+    // byte-for-byte with the real OS process it imitates. Tooltips trim it;
+    // process.title / app.setName() must not.
+    for (const mode of DISGUISED) {
+      for (const platform of ['darwin', 'win32']) {
+        const name = disguiseAppName(mode, platform);
+        assert.ok(name.endsWith(' '), `${mode}/${platform} lost its trailing space`);
+        assert.equal(name.trim().length > 0, true);
+      }
+    }
+  });
+
+  test("'none' is the real app name on both platforms, with NO trailing space", () => {
+    assert.equal(disguiseAppName('none', 'darwin'), 'Natively');
+    assert.equal(disguiseAppName('none', 'win32'), 'Natively');
+  });
+});
+
+describe('disguiseIconFile', () => {
+  test('every disguised mode maps to a distinct asset; none maps to null', () => {
+    const files = DISGUISED.map(disguiseIconFile);
+    assert.equal(new Set(files).size, files.length, 'two modes share an icon');
+    assert.equal(disguiseIconFile('none'), null);
+  });
+});
+
+describe('disguiseIconPath', () => {
+  test('routes to the platform asset directory', () => {
+    for (const mode of DISGUISED) {
+      assert.match(disguiseIconPath(mode, 'win32').replaceAll('\\', '/'), /assets\/fakeicon\/win\//);
+      assert.match(disguiseIconPath(mode, 'darwin').replaceAll('\\', '/'), /assets\/fakeicon\/mac\//);
+    }
+  });
+
+  test("returns null for 'none' so callers fall back to the real app icon", () => {
+    assert.equal(disguiseIconPath('none', 'win32'), null);
+    assert.equal(disguiseIconPath('none', 'darwin'), null);
+  });
+
+  test('unpackaged paths are rooted at getAppPath(), not a bundle-depth guess', () => {
+    // The old WindowHelper copy used path.resolve(__dirname, '../../assets/..'),
+    // which only worked because the esbuild output happened to sit exactly two
+    // levels below the repo root. Anchoring on getAppPath() removes that
+    // coupling to the bundle layout.
+    const p = disguiseIconPath('terminal', 'win32').replaceAll('\\', '/');
+    assert.ok(p.startsWith(APP_PATH), `expected ${APP_PATH} prefix, got ${p}`);
+  });
+});
+
+describe('appIconPath', () => {
+  test('each platform gets its own real-icon format', () => {
+    assert.match(appIconPath('darwin').replaceAll('\\', '/'), /natively\.icns$/);
+    assert.match(appIconPath('win32').replaceAll('\\', '/'), /icon\.ico$/);
+  });
+});
+
+describe('cross-branch consistency', () => {
+  test('every mode resolves BOTH a name and an icon on BOTH platforms', () => {
+    // Guards the actual failure mode of adding a disguise mode: a mapping that
+    // covers one lookup but not another ships a tray whose icon disagrees with
+    // the window identity, with no error anywhere.
+    for (const mode of VALID_DISGUISE_MODES) {
+      for (const platform of ['darwin', 'win32']) {
+        const name = disguiseAppName(mode, platform);
+        assert.ok(typeof name === 'string' && name.trim().length > 0, `${mode}/${platform} name`);
+
+        const icon = disguiseIconPath(mode, platform) ?? appIconPath(platform);
+        assert.ok(typeof icon === 'string' && icon.length > 0, `${mode}/${platform} icon`);
+      }
+    }
+  });
+});

--- a/electron/services/__tests__/__electron_stub.mjs
+++ b/electron/services/__tests__/__electron_stub.mjs
@@ -1,0 +1,8 @@
+// Minimal 'electron' stand-in for unit tests that import main-process modules
+// needing only app.isPackaged / app.getAppPath(). Keeps those tests runnable
+// under plain `node --test`, with no Electron runtime.
+export const app = {
+  isPackaged: false,
+  getAppPath: () => '/fake/app',
+};
+export default { app };


### PR DESCRIPTION
Supersedes the stealth portion of #406. That PR is ~89 commits stale and does not apply to `main`; this branch is cut from current `main` and contains **only** the stealth fixes — none of its unrelated changes (STT low-RAM path, audio-device fallback rewrite, keybinds sub-tab UI, language/accent grid).

## What was broken

**1. Windows never hid the tray during Undetectable mode.** The only `hideTray()` call site lives inside `_enforceDockState()`, which begins `if (process.platform !== 'darwin') return;`. So on Windows there was effectively no call site at all — toggling Undetectable ON left a tray icon showing the real app name for the entire stealth session. This was a pre-existing gap on `main`, not something #406 introduced.

**2. macOS could skip the tray in both directions.** The `hideTray()` / `showTray()` calls sat inside the `shouldApply` guard, where `shouldApply = settled !== lastApplied` (`toggleStateReducer.ts`). Stealth ON while the dock was *already* hidden gave `shouldApply=false`, so `hideTray()` never ran — the same identity leak as (1). The mirror case (an OFF that skipped the dock transition) left no tray at all, and since `hideTray()` nulls `this.tray`, nothing re-minted it.

**3. The launcher lost its pre-paint gate.** `show: false` had been replaced with a hardcoded `skipTaskbar: false`. `show` defaults to `true`, so the window appeared before the renderer painted — reintroducing the white-screen flash that option exists to prevent — and its `ready-to-show` handler became dead code.

Verified deterministically rather than by eye, same build, one line changed:

| Build | `launcher.isVisible()` at construction |
|---|---|
| without `show: false` | `true` — on screen, pre-paint |
| with `show: false` | `false` — waits for `ready-to-show` |

**4. `setSkipTaskbar(false)` was unconditional**, so stealth never removed the launcher's taskbar entry — it stayed listed and Alt-Tab-able under its real title.

**5. The tray refresh pushed the dock icon into the tray.** `_applyDisguise()` resolves mode `none` to `natively.icns` on macOS; setting that as the tray image replaced the monochrome menu-bar template with a full-colour icon that no longer inverts for light/dark, and `showTray()`'s `if (this.tray) return` meant it stayed wrong until restart.

## What changed

- Tray follows the **desired** state, outside the dock predicate, on both platforms. Both calls are idempotent so enforcement retries stay safe.
- Added the missing win32 tray branch in `setUndetectable()`; reverted the startup path to `if (!getUndetectable()) showTray()` so a persisted-undetectable cold start never mints a tray.
- Restored `show: false`; `skipTaskbar` now tracks `getUndetectable()` instead of being a constructor constant, and `setUndetectable()` drives it from the toggle state.
- Extracted `buildTrayImage()` as the single source of tray icon resolution + template flag, shared by `showTray()` and `_applyDisguise()`.
- `getTrayTooltip()` derives from the disguise mode directly rather than reading `process.title` back (which silently depended on `_applyDisguise()` having run first).
- Dropped four `setSkipTaskbar` calls that were provable no-ops — the overlay and settings windows are constructed `skipTaskbar: true` and nothing sets them false.

## Validation

- `Tested physically on Windows` — cold start with persisted undetectable mints no tray; toggle ON destroys it; OFF re-creates it; launcher leaves the taskbar and Alt-Tab.
- `Covered by automated tests` — 47 existing stealth/dock/toggle tests pass, including `UndetectableDockLeakOnLauncherShow` (which exercises dropped-hide convergence, the mechanism touched here).
- `npx tsc --noEmit` and `tsc -p electron/tsconfig.json --noEmit` clean.
- **`Requires physical macOS verification`** — the macOS tray-ordering fix is reasoned from the dock predicate's semantics and covered only by the existing fakes. It has not been run on a Mac.

## Known gaps, deliberately not addressed here

- No re-assert path for Windows taskbar/tray state: `reassertUndetectableStealth()` returns early on non-darwin and covers only dock visibility and content protection. An `explorer.exe` restart or the AUMID re-registration in `setDisguise()` can restore the launcher's taskbar entry mid-session.
- Disguise mode → name/icon mappings still exist in three places (`buildTrayImage`, `_applyDisguise`, `WindowHelper`); consolidating them needs `DisguiseMode` exported out of `main.ts`.
- No new tests for the tray/taskbar branches. `getTrayTooltip()` reads `process.platform` internally, so neither branch is assertable without a signature change.
