### PR TITLE
fix(ui): renderer polish — markdown tables, gate-wall copy, panel flash, pill layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import { AlertCircle, RefreshCw } from "lucide-react"
 import { clampOverlayOpacity, OVERLAY_OPACITY_DEFAULT, getDefaultOverlayOpacity } from "./lib/overlayAppearance"
 import { getMeetingInterfaceTheme, type MeetingInterfaceTheme } from './lib/meetingInterfaceTheme'
 import { isMac } from "./utils/platformUtils"
+import { useResolvedTheme } from "./hooks/useResolvedTheme"
 import { trackAppOpen } from "./lib/toasterGating"
 import {
   JDAwarenessToaster,
@@ -200,6 +201,9 @@ const App: React.FC = () => {
   const managerDialogRef = useRef<HTMLDivElement>(null);
   const managerOpenerRef = useRef<HTMLElement | null>(null);
   const reduceManagerMotion = useReducedMotion() ?? false;
+  // mode="wait" below leaves this shell exposed between panels — it must track
+  // theme or light mode flashes the shell's dark base color during the swap.
+  const managerPanelTheme = useResolvedTheme();
 
   const rememberManagerOpener = useCallback(() => {
     const activeElement = document.activeElement;
@@ -1056,8 +1060,9 @@ const App: React.FC = () => {
                           willChange: 'transform, opacity',
                           transformOrigin: 'center',
                           boxShadow: '0 24px 64px -24px rgba(0,0,0,0.72), 0 8px 24px -16px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.05)',
+                          background: managerPanelTheme === 'light' ? '#ffffff' : '#141414',
                         }}
-                        className="w-[820px] h-[600px] max-w-[95vw] max-h-[90vh] rounded-2xl overflow-hidden border border-white/10 bg-[#141414]"
+                        className="w-[820px] h-[600px] max-w-[95vw] max-h-[90vh] rounded-2xl overflow-hidden border border-white/10"
                       >
                         <AnimatePresence mode="wait" initial={false}>
                         <motion.div

--- a/src/components/FeatureSpotlight.tsx
+++ b/src/components/FeatureSpotlight.tsx
@@ -180,7 +180,7 @@ export const FeatureSpotlight: React.FC = () => {
                                 <h2
                                     className={`drop-shadow-sm tracking-tight mb-0 transition-all duration-300 group-hover:brightness-105 ${isSupport ? 'translate-y-1.5' : ''}`}
                                     style={{
-                                        fontFamily: '-apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text"',
+                                        fontFamily: 'var(--font-system)',
                                         fontSize: (isPremium || isSupport) ? '30px' : '26px',
                                         fontWeight: 500,
                                         lineHeight: 1.1,
@@ -195,7 +195,7 @@ export const FeatureSpotlight: React.FC = () => {
                                 <p
                                     className={`antialiased mb-2 ${isSupport ? 'translate-y-1.5' : ''}`} // Standardized mb-2 for equal spacing
                                     style={{
-                                        fontFamily: '-apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text"',
+                                        fontFamily: 'var(--font-system)',
                                         fontSize: (isPremium || isSupport) ? '16px' : '15px',
                                         fontWeight: 400,
                                         lineHeight: 1.4,

--- a/src/components/Launcher.tsx
+++ b/src/components/Launcher.tsx
@@ -764,12 +764,12 @@ const Launcher: React.FC<LauncherProps> = ({ onStartMeeting, onOpenSettings, onO
                                             </button>
 
                                             {/* Detectable Toggle Pill */}
-                                            <div className={`flex items-center gap-3 border rounded-full px-3 py-1.5 min-w-[140px] transition-colors ${isLight ? 'bg-bg-elevated border-border-muted shadow-sm' : 'bg-[#101011] border-border-muted'}`}>
+                                            <div className={`flex items-center gap-3 border rounded-full px-3 py-1.5 min-w-[140px] shrink-0 transition-colors ${isLight ? 'bg-bg-elevated border-border-muted shadow-sm' : 'bg-[#101011] border-border-muted'}`}>
                                                 {isDetectable ? (
                                                     <Ghost
                                                         size={14}
                                                         strokeWidth={2}
-                                                        className="text-text-secondary transition-colors"
+                                                        className="text-text-secondary transition-colors shrink-0"
                                                     />
                                                 ) : (
                                                     <svg
@@ -778,7 +778,7 @@ const Launcher: React.FC<LauncherProps> = ({ onStartMeeting, onOpenSettings, onO
                                                         viewBox="0 0 24 24"
                                                         fill="none"
                                                         xmlns="http://www.w3.org/2000/svg"
-                                                        className="transition-colors"
+                                                        className="transition-colors shrink-0"
                                                     >
                                                         <path
                                                             d="M12 2C7.58172 2 4 5.58172 4 10V22L7 19L9.5 21.5L12 19L14.5 21.5L17 19L20 22V10C20 5.58172 16.4183 2 12 2Z"
@@ -790,13 +790,13 @@ const Launcher: React.FC<LauncherProps> = ({ onStartMeeting, onOpenSettings, onO
                                                 )}
                                                 <span className="text-xs font-medium flex-1 transition-colors text-text-secondary">
                                                     {isDetectable ? t("Detectable") : t("Undetectable")}
-                                                 </span>
-                                                 <div
-                                                     className={`w-8 h-4 rounded-full relative transition-colors cursor-pointer ${!isDetectable ? 'bg-accent-primary' : 'bg-bg-toggle-switch'}`}
-                                                     onClick={toggleDetectable}
-                                                 >
-                                                     <div className={`absolute top-0.5 w-3 h-3 rounded-full bg-white shadow-sm transition-all ${!isDetectable ? 'left-[18px]' : 'left-0.5'}`} />
-                                                 </div>
+                                                </span>
+                                                <div
+                                                    className={`w-8 h-4 rounded-full p-0.5 flex items-center shrink-0 transition-colors cursor-pointer ${!isDetectable ? 'bg-accent-primary' : 'bg-bg-toggle-switch'}`}
+                                                    onClick={toggleDetectable}
+                                                >
+                                                    <div className={`w-3 h-3 rounded-full bg-white shadow-sm transition-transform ${!isDetectable ? 'translate-x-4' : 'translate-x-0'}`} />
+                                                </div>
                                              </div>
 
                                              {/* What's New Pill */}

--- a/src/components/MeetingDetails.tsx
+++ b/src/components/MeetingDetails.tsx
@@ -345,6 +345,17 @@ const mdComponents = {
     ol: ({ node, ...props }: any) => <ol className="list-decimal ml-4 mb-2 space-y-1.5" {...props} />,
     li: ({ node, ...props }: any) => <li className="text-[15px] text-text-secondary font-normal leading-relaxed" {...props} />,
     strong: ({ node, ...props }: any) => <strong className="font-semibold text-text-primary" {...props} />,
+    // GFM tables (dry-run traces): preflight zeroes cell padding, so columns
+    // butt together without these. Gaps via right padding, hairline under the
+    // header; wide tables scroll inside the min-w-0 wrapper instead of
+    // stretching the answer column (same trick as CodeHero below).
+    table: ({ node, ...props }: any) => (
+        <div className="w-full min-w-0 overflow-x-auto mb-2 last:mb-0">
+            <table className="border-collapse text-[13.5px] leading-relaxed" {...props} />
+        </div>
+    ),
+    th: ({ node, ...props }: any) => <th className="text-left align-top font-semibold text-text-primary pr-5 last:pr-0 pb-1.5 border-b border-border-muted" {...props} />,
+    td: ({ node, ...props }: any) => <td className="text-left align-top text-text-secondary tabular-nums pr-5 last:pr-0 py-1" {...props} />,
     a: ({ node, ...props }: any) => <a target="_blank" rel="noopener noreferrer" className="text-accent-primary hover:text-accent-hover underline underline-offset-2 transition-colors duration-150" {...props} />,
     pre: ({ children }: any) => <div className="mb-3 last:mb-0">{children}</div>,
     code: ({ node, className, children, ...props }: any) => {
@@ -591,13 +602,6 @@ const CodingAnswerBlock: React.FC<{ sections: CodingSection[]; firstView?: boole
                                             />
                                         )}
                                         <span className="relative z-10">{pill.label}</span>
-                                        {/* Chevron signals panel OPEN vs closed (not which pill) */}
-                                        {isActive && (
-                                            <ChevronDown
-                                                className="relative z-10 w-3 h-3 text-text-tertiary transition-transform duration-200 ease-out rotate-180"
-                                                strokeWidth={2.5}
-                                            />
-                                        )}
                                     </button>
                                 );
                             })}
@@ -1270,6 +1274,15 @@ ${meeting.detailedSummary.keyPoints?.map(item => `- ${item}`).join('\n') || 'Non
                                             li: ({ node, ...props }) => <li className="text-sm text-text-secondary" {...props} />,
                                             strong: ({ node, ...props }) => <strong className="font-semibold text-text-primary" {...props} />,
                                             a: ({ node, ...props }) => <a className="text-accent-primary hover:underline" {...props} />,
+                                            // GFM tables: preflight zeroes cell padding (`prose` is a
+                                            // no-op — no typography plugin), so columns need real gaps.
+                                            table: ({ node, ...props }) => (
+                                                <div className="w-full min-w-0 overflow-x-auto mb-2 last:mb-0">
+                                                    <table className="border-collapse text-sm leading-relaxed" {...props} />
+                                                </div>
+                                            ),
+                                            th: ({ node, ...props }) => <th className="text-left align-top font-semibold text-text-primary pr-5 last:pr-0 pb-1.5 border-b border-border-muted" {...props} />,
+                                            td: ({ node, ...props }) => <td className="text-left align-top text-text-secondary tabular-nums pr-5 last:pr-0 py-1" {...props} />,
                                         }}
                                     >
                                         {meeting.detailedSummary?.overview || ''}

--- a/src/components/ProfileIntelligenceSettings.tsx
+++ b/src/components/ProfileIntelligenceSettings.tsx
@@ -8,6 +8,15 @@ import {
 import { PremiumUpgradeModal } from '../premium';
 import { useResolvedTheme } from '../hooks/useResolvedTheme';
 import { truncateResumeSummary } from '../utils/resumeSummary.mjs';
+import { CHECKOUT_URLS } from '../config/urls';
+
+const openExternal = (url: string) => {
+    if ((window as any).electronAPI?.openExternal) {
+        (window as any).electronAPI.openExternal(url);
+    } else {
+        window.open(url, '_blank', 'noopener,noreferrer');
+    }
+};
 
 // ─── CSS ──────────────────────────────────────────────────────────────────────
 const PI_CSS = `
@@ -791,8 +800,7 @@ const PI_GATE_CSS = `
     }
 `;
 
-function ProfileIntelligenceProGate({ onUnlock, onOpenNativelyAPI, onClose }: {
-    onUnlock: () => void;
+function ProfileIntelligenceProGate({ onOpenNativelyAPI, onClose }: {
     onOpenNativelyAPI?: () => void;
     onClose?: () => void;
 }) {
@@ -966,7 +974,7 @@ function ProfileIntelligenceProGate({ onUnlock, onOpenNativelyAPI, onClose }: {
                 </div>
 
                 <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-                    <button className="pig-cta-group" onClick={onUnlock}>
+                    <button className="pig-cta-group" onClick={() => openExternal(CHECKOUT_URLS.apiMax)}>
                         Unlock Pro
                         <div className="pig-cta-icon-ring">
                             <ArrowUpRight size={14} strokeWidth={2.5} />
@@ -2633,20 +2641,10 @@ export function ProfileIntelligenceSettings({
     if (!hasProfileAccess) {
         if (!licenseLoaded) return null;
         return (
-            <>
-                <ProfileIntelligenceProGate
-                    onUnlock={() => setIsPremiumModalOpen(true)}
-                    onOpenNativelyAPI={onOpenNativelyAPI}
-                    onClose={onClose}
-                />
-                <PremiumUpgradeModal
-                    isOpen={isPremiumModalOpen}
-                    onClose={() => setIsPremiumModalOpen(false)}
-                    isPremium={isPremium}
-                    onActivated={handlePremiumActivated}
-                    onDeactivated={handlePremiumDeactivated}
-                />
-            </>
+            <ProfileIntelligenceProGate
+                onOpenNativelyAPI={onOpenNativelyAPI}
+                onClose={onClose}
+            />
         );
     }
 

--- a/src/components/ProfileIntelligenceSettings.tsx
+++ b/src/components/ProfileIntelligenceSettings.tsx
@@ -613,10 +613,10 @@ const PI_GATE_FEATURES: Array<{
     // ellipsize instead of crowding the card). Keep these short; verify with
     // the pi-gate screenshot/measurement script before lengthening any of them
     // again.
-    { key: 'profile', label: 'Profile', desc: 'Every skill and role — mapped.', hex: '#34d399', Icon: FileText, col: '3 / 5', row: '1 / 2', type: 'wide' },
+    { key: 'profile', label: 'Profile', desc: 'Every skill and role mapped.', hex: '#34d399', Icon: FileText, col: '3 / 5', row: '1 / 2', type: 'wide' },
     { key: 'company', label: 'Company Intel', hex: '#fbbf24', Icon: Building2, col: '3 / 4', row: '2 / 3', type: 'small' },
     { key: 'cover', label: 'Cover Letter', hex: '#fb7185', Icon: Mail, col: '4 / 5', row: '2 / 3', type: 'small' },
-    { key: 'talking', label: 'Talking Points', desc: 'Every fit gap — answered.', hex: '#f472b6', Icon: MessageSquare, col: '1 / 3', row: '3 / 4', type: 'wide' },
+    { key: 'talking', label: 'Talking Points', desc: 'Every fit gap answered.', hex: '#f472b6', Icon: MessageSquare, col: '1 / 3', row: '3 / 4', type: 'wide' },
     { key: 'search', label: 'Web Search', desc: 'Live research, on demand.', hex: '#38bdf8', Icon: Globe, col: '3 / 5', row: '3 / 4', type: 'wide' },
 ];
 

--- a/src/index.css
+++ b/src/index.css
@@ -6184,16 +6184,57 @@ html[data-platform="linux"] body {
 .markdown-content pre:first-child {
   margin-top: 0 !important;
 }
-.markdown-content h1, 
-.markdown-content h2, 
-.markdown-content h3, 
-.markdown-content h4, 
-.markdown-content h5, 
+.markdown-content h1,
+.markdown-content h2,
+.markdown-content h3,
+.markdown-content h4,
+.markdown-content h5,
 .markdown-content h6 {
   margin-top: 8px !important;
   margin-bottom: 4.5px !important;
   line-height: 1.6 !important;
   font-weight: 700 !important;
+}
+/* GFM tables (dry-run traces etc.): Tailwind's preflight collapses borders
+   and zeroes cell padding, so ReactMarkdown tables rendered columns butted
+   together. Column gaps come from right padding; a hairline under the header
+   row separates it from data. Wide tables scroll inside the bubble instead
+   of stretching it. --border-muted is the table border token — visible in
+   both themes, whereas --border-subtle is transparent in dark. */
+.markdown-content table {
+  display: block;
+  width: fit-content;
+  max-width: 100%;
+  overflow-x: auto;
+  border-collapse: collapse;
+  margin: 8px 0;
+  line-height: 1.5;
+}
+.markdown-content table:first-child {
+  margin-top: 0;
+}
+.markdown-content table:last-child {
+  margin-bottom: 0;
+}
+.markdown-content th,
+.markdown-content td {
+  padding: 3px 18px 3px 0;
+  text-align: left;
+  vertical-align: top;
+}
+.markdown-content th:last-child,
+.markdown-content td:last-child {
+  padding-right: 0;
+}
+.markdown-content thead th {
+  padding-bottom: 5px;
+  border-bottom: 1px solid var(--border-muted);
+}
+.markdown-content tbody tr:first-child td {
+  padding-top: 5px;
+}
+.markdown-content td {
+  font-variant-numeric: tabular-nums;
 }
 /* ── Usage-section code block: thin horizontal scrollbar, revealed on hover ──
    The global scrollbar is hidden (width:0). The code hero needs a discreet


### PR DESCRIPTION
**Stack 1 of 7.** Base: `main`.

## Change summary

Seven renderer-only commits. Touches `src/` exclusively — no `electron/`, no native module, no build config.

| Commit | Change |
|---|---|
| `a022a80e` | Use the app-wide font token in the support-development card |
| `44b37215` | Route the Profile Intelligence paywall gate CTA to the Max checkout link |
| `3deec7e5` | Drop em dashes from gate wall feature copy |
| `b83ffea8` | Stop the dark shell flash when switching manager panels in light mode |
| `45bf756c` | Remove the redundant open-state chevron from answer detail pills |
| `6e51e65f` | Give GFM tables real column spacing in overlay surfaces |
| `4da73985` | Stop the Detectable pill toggle squishing under flex pressure |

Files: `FeatureSpotlight.tsx`, `ProfileIntelligenceSettings.tsx`, `App.tsx`, `MeetingDetails.tsx`, `index.css`, `Launcher.tsx`.

## Cross-platform analysis

- **Expected macOS behavior:** all seven changes apply identically.
- **Expected Windows behavior:** identical.
- No `process.platform` branch is introduced or touched. This is one of the few PRs in the stack that genuinely moves both platforms — most of the rest bring Windows up to existing macOS behavior.
- **Impact radius:** presentation only. No IPC, no window management, no state contracts.

## Validation

- `Reviewed but not executed on macOS`
- `Reviewed but not executed on Windows` — these are visual changes; the branch typechecks and builds, but the rendering was not physically inspected on this branch tip.
- `Requires physical macOS verification`
- `Requires physical Windows verification`

## Commands executed

```
git cherry-pick -x   # 7 commits, zero conflicts
```

## Remaining risks

Visual regressions in light mode and in overlay markdown rendering are not covered by automated tests. Worth an eyeball on both platforms before merge.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWCt3EHyDEzRYhZXJwudSf