### PR TITLE
feat(settings): LiteLLM model selector, shortcut-conflict surfacing, Windows opacity preview

### DIFF
--- a/electron/WindowHelper.ts
+++ b/electron/WindowHelper.ts
@@ -424,11 +424,18 @@ export class WindowHelper {
       ...(isMac
         ? { vibrancy: 'under-window' as const, visualEffectState: 'followWindow' as const }
         : {}),
-      transparent: isMac,
+      // `transparent` is a creation-time-only BrowserWindow option, so it must
+      // be true on every platform (not just macOS) for the Interface Opacity
+      // preview to be able to punch through the window at runtime later — see
+      // setLauncherOpacityPreview(). The window still starts fully opaque via
+      // the solid `backgroundColor` below; only the mac vibrancy path used a
+      // translucent material by default.
+      transparent: true,
       hasShadow: true,
       // The launcher starts with the black logo splash. Use a black native
-      // background too so macOS doesn't show a grey/white transparent-window
-      // flash before the renderer paints.
+      // background too so the OS doesn't show a grey/white transparent-window
+      // flash before the renderer paints (applies on macOS and Windows, both
+      // of which now create the window with `transparent: true`).
       backgroundColor: '#000000',
       focusable: true,
       resizable: true,
@@ -1860,18 +1867,15 @@ export class WindowHelper {
   // the "empty" areas behind the hidden DOM still rendered as an opaque-ish
   // dark surface instead of the real desktop, defeating the point of a live
   // preview. `transparent` itself is a creation-time-only BrowserWindow
-  // option (Electron cannot toggle it after construction), but vibrancy and
-  // backgroundColor ARE mutable at runtime, so this flips only those two for
-  // the duration of the hold.
+  // option (Electron cannot toggle it after construction) — createWindow()
+  // now always passes `transparent: true` on every platform so this handler
+  // has something to work with — but vibrancy and backgroundColor ARE
+  // mutable at runtime, so this flips those for the duration of the hold.
   //
-  // macOS-only: on Windows/Linux the launcher window is created with
-  // `transparent: false` (see createWindow()), so there is no runtime call
-  // that makes it see-through — the preview there stays boxed in the
-  // window's opaque backgroundColor. Fixing that would require creating the
-  // launcher as an always-transparent window, which the product wants only
-  // for the in-meeting overlay, not the main dashboard.
+  // Windows/Linux have no vibrancy API, so the `setVibrancy` calls are
+  // guarded to macOS only; there `setBackgroundColor('#00000000')` alone is
+  // enough to let the real desktop show through the frameless window.
   public setLauncherOpacityPreview(active: boolean): void {
-    if (process.platform !== 'darwin') return;
     if (!this.launcherWindow || this.launcherWindow.isDestroyed()) return;
     // Only short-circuit the "start previewing" case when already previewing
     // — that branch is the one worth deduping (60fps drag ticks etc. never
@@ -1884,8 +1888,10 @@ export class WindowHelper {
     // mid-drag — see that handler's comment).
     if (active && this.launcherOpacityPreviewActive) return;
 
+    const isMac = process.platform === 'darwin';
+
     if (active) {
-      this.launcherWindow.setVibrancy(null);
+      if (isMac) this.launcherWindow.setVibrancy(null);
       this.launcherWindow.setBackgroundColor('#00000000');
       // macOS renders a native drop shadow from the transparent window's own
       // painted alpha. With vibrancy off, the mockup preview's rgba surfaces
@@ -1898,7 +1904,7 @@ export class WindowHelper {
       this.launcherWindow.setHasShadow(false);
     } else {
       // Must match the values createWindow() applies at construction.
-      this.launcherWindow.setVibrancy('under-window');
+      if (isMac) this.launcherWindow.setVibrancy('under-window');
       this.launcherWindow.setBackgroundColor('#000000');
       this.launcherWindow.setHasShadow(true);
     }

--- a/electron/services/__tests__/AIProvidersSettingsState.test.mjs
+++ b/electron/services/__tests__/AIProvidersSettingsState.test.mjs
@@ -37,7 +37,11 @@ describe('AIProvidersSettings credential synchronization', () => {
     assert.match(source, /const \[litellmModels, setLitellmModels\] = useState<string\[\]>\(\[\]\)/, 'LiteLLM model list state should exist');
     assert.match(source, /if\s*\(!hasStoredKey\.litellm\)\s*\{\s*setLitellmModels\(\[\]\);\s*return;/, 'LiteLLM models should clear when proxy is removed');
     assert.match(source, /getAvailableLiteLLMModels/, 'configured LiteLLM proxy should populate selectable models');
-    assert.match(source, /id: `litellm\/\$\{model\}`/, 'LiteLLM options should use the runtime litellm/<model> id shape');
+    // Matches the id SHAPE, not the statement it sits in: the id is built on its own
+    // line now so the allow-list filter can test it before the push. Pinning the
+    // `id: ...` property form made this fail on a refactor that never changed the id.
+    assert.match(source, /`litellm\/\$\{model\}`/, 'LiteLLM options should use the runtime litellm/<model> id shape');
+    assert.match(source, /if \(!isModelEnabled\('litellm', id\)\) return;/, 'LiteLLM options should honour the cloudEnabledModels allow-list');
   });
 
   test('loadCredentials clears LiteLLM form fields when another window removes the proxy', () => {

--- a/src/components/SettingsOverlay.tsx
+++ b/src/components/SettingsOverlay.tsx
@@ -689,17 +689,13 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({
         }
     }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
 
-    // Only macOS can actually make the launcher window see-through during
-    // the preview (setLauncherOpacityPreview is a no-op elsewhere — see its
-    // doc comment in WindowHelper.ts: Windows/Linux launcher windows are
-    // created with `transparent: false`). On those platforms, hiding the
-    // Settings backdrop/panel/banners gains nothing — there's no real
-    // desktop showing through regardless — and instead leaves the mockup
-    // floating over a flat opaque background with no context, which reads as
-    // more broken than just leaving the normal (non-transparent) Settings
-    // backdrop visible behind it. So the DOM hide/restore below is itself
-    // macOS-only; non-macOS keeps its backdrop and only toggles the mockup.
-    const canPreviewTransparency = document.documentElement.getAttribute('data-platform') === 'darwin';
+    // The launcher window is created with `transparent: true` on every
+    // platform (see createWindow() in WindowHelper.ts) so setLauncherOpacityPreview
+    // can punch through it at runtime everywhere, not just macOS. Windows/Linux
+    // have no vibrancy API, but stripping the native backgroundColor alone is
+    // enough there to reveal the real desktop, so the DOM hide/restore below
+    // runs on all platforms.
+    const canPreviewTransparency = true;
 
     const startPreviewingOpacity = () => {
         // Bug fix #5: guard against rapid repeated calls (double pointerDown / touch events)

--- a/src/components/SettingsOverlay.tsx
+++ b/src/components/SettingsOverlay.tsx
@@ -498,7 +498,22 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({
         }
     }, [isOpen, initialTab]);
 
-    const { shortcuts, updateShortcut, resetShortcuts } = useShortcuts();
+    const { shortcuts, updateShortcut, resetShortcuts, conflicts } = useShortcuts();
+    // Small badge shown next to a shortcut row when globalShortcut.register()
+    // failed for it (another app/OS already owns that key combo). The
+    // KeyRecorder right next to it is the fix — recording a new combo
+    // re-registers and clears the flag.
+    const renderShortcutConflictBadge = (actionId: keyof typeof shortcuts) => (
+        conflicts.has(actionId) ? (
+            <span
+                className="flex items-center gap-1 text-[10px] font-medium text-amber-400 bg-amber-500/15 border border-amber-500/20 px-1.5 py-0.5 rounded-full shrink-0"
+                title={t('Another app on your system is already using this shortcut. Record a new key combo to fix it.')}
+            >
+                <AlertCircle size={11} />
+                {t('In use')}
+            </span>
+        ) : null
+    );
     const [isUndetectable, setIsUndetectable] = useState(false);
     const [isMousePassthrough, setIsMousePassthrough] = useState(false);
     const [disguiseMode, setDisguiseMode] = useState<'terminal' | 'settings' | 'activity' | 'none'>('none');
@@ -2405,6 +2420,19 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({
                                         </button>
                                     </div>
 
+                                    {/* Surfaces globalShortcut.register() failures in bulk — e.g. on
+                                        Windows, another running app (screenshot tool, clipboard
+                                        manager, IME) can silently claim a combo Natively wants,
+                                        which otherwise looks like "the hotkey just doesn't work". */}
+                                    {conflicts.size > 0 && (
+                                        <div className="flex items-start gap-2.5 px-3 py-2.5 rounded-xl bg-amber-500/10 border border-amber-500/20">
+                                            <AlertCircle size={14} className="text-amber-400 shrink-0 mt-0.5" />
+                                            <p className="text-xs text-amber-200/90 leading-snug">
+                                                {t("Some shortcuts below (marked \"In use\") are claimed by another app on your system and won't fire. Record a new key combo for each to fix it.")}
+                                            </p>
+                                        </div>
+                                    )}
+
                                     <div className="grid gap-6" data-settings-stagger>
                                         {/* General Category */}
                                         <div>
@@ -2415,80 +2443,104 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({
                                                         <span className="text-text-tertiary group-hover:text-text-primary transition-colors w-5 flex justify-center"><Eye size={14} /></span>
                                                         <span className="text-sm text-text-secondary font-medium group-hover:text-text-primary transition-colors">{t('Toggle Visibility')}</span>
                                                     </div>
-                                                    <KeyRecorder
-                                                        currentKeys={shortcuts.toggleVisibility}
-                                                        onSave={(keys) => updateShortcut('toggleVisibility', keys)}
-                                                    />
+                                                    <div className="flex items-center gap-2">
+                                                        {renderShortcutConflictBadge('toggleVisibility')}
+                                                        <KeyRecorder
+                                                            currentKeys={shortcuts.toggleVisibility}
+                                                            onSave={(keys) => updateShortcut('toggleVisibility', keys)}
+                                                        />
+                                                    </div>
                                                 </div>
                                                 <div className="flex items-center justify-between py-1.5 group">
                                                     <div className="flex items-center gap-3">
                                                         <span className="text-text-tertiary group-hover:text-text-primary transition-colors w-5 flex justify-center"><PointerOff size={14} /></span>
                                                         <span className="text-sm text-text-secondary font-medium group-hover:text-text-primary transition-colors">{t('Toggle Mouse Passthrough')}</span>
                                                     </div>
-                                                    <KeyRecorder
-                                                        currentKeys={shortcuts.toggleMousePassthrough}
-                                                        onSave={(keys) => updateShortcut('toggleMousePassthrough', keys)}
-                                                    />
+                                                    <div className="flex items-center gap-2">
+                                                        {renderShortcutConflictBadge('toggleMousePassthrough')}
+                                                        <KeyRecorder
+                                                            currentKeys={shortcuts.toggleMousePassthrough}
+                                                            onSave={(keys) => updateShortcut('toggleMousePassthrough', keys)}
+                                                        />
+                                                    </div>
                                                 </div>
                                                 <div className="flex items-center justify-between py-1.5 group">
                                                     <div className="flex items-center gap-3">
                                                         <span className="text-text-tertiary group-hover:text-text-primary transition-colors w-5 flex justify-center"><MessageSquare size={14} /></span>
                                                         <span className="text-sm text-text-secondary font-medium group-hover:text-text-primary transition-colors">{t('Process Screenshots')}</span>
                                                     </div>
-                                                    <KeyRecorder
-                                                        currentKeys={shortcuts.processScreenshots}
-                                                        onSave={(keys) => updateShortcut('processScreenshots', keys)}
-                                                    />
+                                                    <div className="flex items-center gap-2">
+                                                        {renderShortcutConflictBadge('processScreenshots')}
+                                                        <KeyRecorder
+                                                            currentKeys={shortcuts.processScreenshots}
+                                                            onSave={(keys) => updateShortcut('processScreenshots', keys)}
+                                                        />
+                                                    </div>
                                                 </div>
                                                 <div className="flex items-center justify-between py-1.5 group">
                                                     <div className="flex items-center gap-3">
                                                         <span className="text-text-tertiary group-hover:text-text-primary transition-colors w-5 flex justify-center"><Sparkles size={14} /></span>
                                                         <span className="text-sm text-text-secondary font-medium group-hover:text-text-primary transition-colors">{t('Capture Screen & Ask AI')}</span>
                                                     </div>
-                                                    <KeyRecorder
-                                                        currentKeys={shortcuts.captureAndProcess}
-                                                        onSave={(keys) => updateShortcut('captureAndProcess', keys)}
-                                                    />
+                                                    <div className="flex items-center gap-2">
+                                                        {renderShortcutConflictBadge('captureAndProcess')}
+                                                        <KeyRecorder
+                                                            currentKeys={shortcuts.captureAndProcess}
+                                                            onSave={(keys) => updateShortcut('captureAndProcess', keys)}
+                                                        />
+                                                    </div>
                                                 </div>
                                                 <div className="flex items-center justify-between py-1.5 group">
                                                     <div className="flex items-center gap-3">
                                                         <span className="text-text-tertiary group-hover:text-text-primary transition-colors w-5 flex justify-center"><Globe size={14} /></span>
                                                         <span className="text-sm text-text-secondary font-medium group-hover:text-text-primary transition-colors">{t('Capture Page (Browser)')}</span>
                                                     </div>
-                                                    <KeyRecorder
-                                                        currentKeys={shortcuts.capturePage}
-                                                        onSave={(keys) => updateShortcut('capturePage', keys)}
-                                                    />
+                                                    <div className="flex items-center gap-2">
+                                                        {renderShortcutConflictBadge('capturePage')}
+                                                        <KeyRecorder
+                                                            currentKeys={shortcuts.capturePage}
+                                                            onSave={(keys) => updateShortcut('capturePage', keys)}
+                                                        />
+                                                    </div>
                                                 </div>
                                                 <div className="flex items-center justify-between py-1.5 group">
                                                     <div className="flex items-center gap-3">
                                                         <span className="text-text-tertiary group-hover:text-text-primary transition-colors w-5 flex justify-center"><RotateCcw size={14} /></span>
                                                         <span className="text-sm text-text-secondary font-medium group-hover:text-text-primary transition-colors">{t('Reset / Cancel')}</span>
                                                     </div>
-                                                    <KeyRecorder
-                                                        currentKeys={shortcuts.resetCancel}
-                                                        onSave={(keys) => updateShortcut('resetCancel', keys)}
-                                                    />
+                                                    <div className="flex items-center gap-2">
+                                                        {renderShortcutConflictBadge('resetCancel')}
+                                                        <KeyRecorder
+                                                            currentKeys={shortcuts.resetCancel}
+                                                            onSave={(keys) => updateShortcut('resetCancel', keys)}
+                                                        />
+                                                    </div>
                                                 </div>
                                                 <div className="flex items-center justify-between py-1.5 group">
                                                     <div className="flex items-center gap-3">
                                                         <span className="text-text-tertiary group-hover:text-text-primary transition-colors w-5 flex justify-center"><Camera size={14} /></span>
                                                         <span className="text-sm text-text-secondary font-medium group-hover:text-text-primary transition-colors">{t('Take Screenshot')}</span>
                                                     </div>
-                                                    <KeyRecorder
-                                                        currentKeys={shortcuts.takeScreenshot}
-                                                        onSave={(keys) => updateShortcut('takeScreenshot', keys)}
-                                                    />
+                                                    <div className="flex items-center gap-2">
+                                                        {renderShortcutConflictBadge('takeScreenshot')}
+                                                        <KeyRecorder
+                                                            currentKeys={shortcuts.takeScreenshot}
+                                                            onSave={(keys) => updateShortcut('takeScreenshot', keys)}
+                                                        />
+                                                    </div>
                                                 </div>
                                                 <div className="flex items-center justify-between py-1.5 group">
                                                     <div className="flex items-center gap-3">
                                                         <span className="text-text-tertiary group-hover:text-text-primary transition-colors w-5 flex justify-center"><Crop size={14} /></span>
                                                         <span className="text-sm text-text-secondary font-medium group-hover:text-text-primary transition-colors">{t('Selective Screenshot')}</span>
                                                     </div>
-                                                    <KeyRecorder
-                                                        currentKeys={shortcuts.selectiveScreenshot}
-                                                        onSave={(keys) => updateShortcut('selectiveScreenshot', keys)}
-                                                    />
+                                                    <div className="flex items-center gap-2">
+                                                        {renderShortcutConflictBadge('selectiveScreenshot')}
+                                                        <KeyRecorder
+                                                            currentKeys={shortcuts.selectiveScreenshot}
+                                                            onSave={(keys) => updateShortcut('selectiveScreenshot', keys)}
+                                                        />
+                                                    </div>
                                                 </div>
                                             </div>
                                         </div>
@@ -2518,10 +2570,13 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({
                                                             <span className="text-text-tertiary group-hover:text-text-primary transition-colors w-5 flex justify-center">{item.icon}</span>
                                                             <span className="text-sm text-text-secondary font-medium group-hover:text-text-primary transition-colors">{t(item.label)}</span>
                                                         </div>
-                                                        <KeyRecorder
-                                                            currentKeys={shortcuts[item.id as keyof typeof shortcuts]}
-                                                            onSave={(keys) => updateShortcut(item.id as any, keys)}
-                                                        />
+                                                        <div className="flex items-center gap-2">
+                                                            {renderShortcutConflictBadge(item.id as keyof typeof shortcuts)}
+                                                            <KeyRecorder
+                                                                currentKeys={shortcuts[item.id as keyof typeof shortcuts]}
+                                                                onSave={(keys) => updateShortcut(item.id as any, keys)}
+                                                            />
+                                                        </div>
                                                     </div>
                                                 ))}
                                             </div>
@@ -2542,10 +2597,13 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({
                                                             <span className="text-text-tertiary group-hover:text-text-primary transition-colors w-5 flex justify-center">{item.icon}</span>
                                                             <span className="text-sm text-text-secondary font-medium group-hover:text-text-primary transition-colors">{t(item.label)}</span>
                                                         </div>
-                                                        <KeyRecorder
-                                                            currentKeys={shortcuts[item.id as keyof typeof shortcuts]}
-                                                            onSave={(keys) => updateShortcut(item.id as any, keys)}
-                                                        />
+                                                        <div className="flex items-center gap-2">
+                                                            {renderShortcutConflictBadge(item.id as keyof typeof shortcuts)}
+                                                            <KeyRecorder
+                                                                currentKeys={shortcuts[item.id as keyof typeof shortcuts]}
+                                                                onSave={(keys) => updateShortcut(item.id as any, keys)}
+                                                            />
+                                                        </div>
                                                     </div>
                                                 ))}
                                             </div>

--- a/src/components/settings/AIProvidersSettings.tsx
+++ b/src/components/settings/AIProvidersSettings.tsx
@@ -2102,11 +2102,17 @@ export const AIProvidersSettings: React.FC<AIProvidersSettingsProps> = ({
             out.push({ id, label });
         };
         preset?.ids.forEach((id, i) => push(id, preset.names[i] || id));
+        // LiteLLM has no preset table and no `cloudFetchedModels` entry — its universe
+        // is whatever the proxy reported, held UNPREFIXED in `litellmModels`. Prefix it
+        // here so the allow-list stores the same `litellm/<model>` ids that
+        // modelAvailable() in ipcHandlers.ts compares against; storing the bare name
+        // would make the two surfaces disagree and the filter would silently no-op.
+        if (provider === 'litellm') litellmModels.forEach(m => push(`litellm/${m}`, prettifyModelId(m)));
         (cloudFetchedModels[provider] || []).forEach(m => push(m.id, m.label || m.id));
         // Allow-listed ids with no catalog entry still get a row, labelled as best we can.
         (cloudEnabledModels[provider] || []).forEach(id => push(id, prettifyModelId(id)));
         return out;
-    }, [cloudFetchedModels, cloudEnabledModels]);
+    }, [cloudFetchedModels, cloudEnabledModels, litellmModels]);
 
     const buildAvailableModelOptions = (): { id: string; name: string }[] => {
         const opts: { id: string; name: string }[] = [];
@@ -2143,7 +2149,15 @@ export const AIProvidersSettings: React.FC<AIProvidersSettingsProps> = ({
             });
         }
         if (hasStoredKey.litellm && isProviderEnabled('litellm')) {
-            litellmModels.forEach(model => opts.push({ id: `litellm/${model}`, name: `${prettifyModelId(model)} (LiteLLM)` }));
+            // Same allow-list gate the cloud providers get above. Without it the proxy's
+            // full catalogue reaches the picker while modelAvailable() filters it, and
+            // the two surfaces disagree — the exact drift the comment at isProviderEnabled
+            // warns about.
+            litellmModels.forEach(model => {
+                const id = `litellm/${model}`;
+                if (!isModelEnabled('litellm', id)) return;
+                opts.push({ id, name: `${prettifyModelId(model)} (LiteLLM)` });
+            });
         }
         if (isProviderEnabled('custom')) {
             customProviders.forEach(p => opts.push({ id: p.id, name: p.name }));
@@ -3364,26 +3378,10 @@ export const AIProvidersSettings: React.FC<AIProvidersSettingsProps> = ({
                             </div>
                             {hasStoredKey.litellm && (
                                 <div className="flex items-center gap-2 shrink-0">
-                                    {/* tabular-nums so the digit does not twitch as the
-                                        count changes. No odometer, no flash, no pulse. */}
-                                    <span className="aip-count">
-                                        {litellmModels.length === 1
-                                            ? t('1 model')
-                                            : `${litellmModels.length} ${t('models')}`}
-                                    </span>
-                                    {/* Discovery is explicit now — the model picker reads a
-                                        cache so it never blocks on the proxy. */}
-                                    <button
-                                        type="button"
-                                        onClick={handleRefreshLitellmModels}
-                                        disabled={isRefreshingLitellm}
-                                        className="aip-btn"
-                                        data-size="sm"
-                                        title={t('Re-discover models from the proxy')}
-                                    >
-                                        <RefreshCw size={10} strokeWidth={1.75} className={isRefreshingLitellm ? 'aip-spinner' : ''} />
-                                        {isRefreshingLitellm ? t('Refreshing...') : t('Refresh')}
-                                    </button>
+                                    {/* Model count and re-discovery both live in the
+                                        <AipModelList> below now — same as every cloud card.
+                                        Keeping a second Refresh up here would give the card
+                                        two controls for one action. */}
                                     <AipBadge tone="ok" label={t('Configured')} />
                                     <AipSwitch
                                         checked={!disabledProviders.includes('litellm')}
@@ -3458,6 +3456,32 @@ export const AIProvidersSettings: React.FC<AIProvidersSettingsProps> = ({
                                 </button>
                             )}
                         </div>
+
+                        {/* The proxy can expose dozens of models; without this the Active
+                            Model dropdown gets all of them. Reuses the cloud providers'
+                            allow-list wholesale — `cloudEnabledModels` is keyed by provider
+                            string, so 'litellm' needs no dedicated store or IPC channel.
+                            No `onSetDefault`/`defaultId`: there is no litellmPreferredModel
+                            credential, and STANDARD_CLOUD_MODELS has no litellm pmKey, so a
+                            per-provider default would write a key nothing reads. */}
+                        {hasStoredKey.litellm && (
+                            <AipModelList
+                                models={effectiveModels('litellm')}
+                                enabled={cloudEnabledModels['litellm'] || []}
+                                onToggle={(modelId) => handleToggleModel('litellm', modelId)}
+                                onReset={() => handleResetModels('litellm')}
+                                error={modelSaveError['litellm'] ? 'save-failed' : null}
+                                refreshing={isRefreshingLitellm}
+                                onRefresh={handleRefreshLitellmModels}
+                                // Deliberately NOT gated on litellmModels.length: an empty
+                                // catalogue (proxy down at save time, or the cache cleared)
+                                // is exactly when the user needs Refresh, and this list is
+                                // now the only place it lives.
+                                onFirstOpen={() => {
+                                    if (litellmModels.length === 0) handleRefreshLitellmModels();
+                                }}
+                            />
+                        )}
                     </div>
                 </div>
             </div>

--- a/src/components/settings/AIProvidersSettings.tsx
+++ b/src/components/settings/AIProvidersSettings.tsx
@@ -3431,7 +3431,12 @@ export const AIProvidersSettings: React.FC<AIProvidersSettingsProps> = ({
                             </p>
                         </div>
 
-                        <div className="flex items-center gap-2">
+                        {/* flex-wrap, not plain flex: <AipModelList> is a fragment whose
+                            summary is `order-2` (so it lands after these order-0 buttons)
+                            and whose panel is `basis-full order-4` (so it wraps onto its
+                            own line). Both only work as direct children of a wrapping flex
+                            row — outside one the classes are inert and the panel squeezes. */}
+                        <div className="flex flex-wrap items-center gap-2">
                             <button
                                 type="button"
                                 onClick={handleSaveLitellm}
@@ -3455,33 +3460,33 @@ export const AIProvidersSettings: React.FC<AIProvidersSettingsProps> = ({
                                     {t('Remove')}
                                 </button>
                             )}
-                        </div>
 
-                        {/* The proxy can expose dozens of models; without this the Active
-                            Model dropdown gets all of them. Reuses the cloud providers'
-                            allow-list wholesale — `cloudEnabledModels` is keyed by provider
-                            string, so 'litellm' needs no dedicated store or IPC channel.
-                            No `onSetDefault`/`defaultId`: there is no litellmPreferredModel
-                            credential, and STANDARD_CLOUD_MODELS has no litellm pmKey, so a
-                            per-provider default would write a key nothing reads. */}
-                        {hasStoredKey.litellm && (
-                            <AipModelList
-                                models={effectiveModels('litellm')}
-                                enabled={cloudEnabledModels['litellm'] || []}
-                                onToggle={(modelId) => handleToggleModel('litellm', modelId)}
-                                onReset={() => handleResetModels('litellm')}
-                                error={modelSaveError['litellm'] ? 'save-failed' : null}
-                                refreshing={isRefreshingLitellm}
-                                onRefresh={handleRefreshLitellmModels}
-                                // Deliberately NOT gated on litellmModels.length: an empty
-                                // catalogue (proxy down at save time, or the cache cleared)
-                                // is exactly when the user needs Refresh, and this list is
-                                // now the only place it lives.
-                                onFirstOpen={() => {
-                                    if (litellmModels.length === 0) handleRefreshLitellmModels();
-                                }}
-                            />
-                        )}
+                            {/* The proxy can expose dozens of models; without this the Active
+                                Model dropdown gets all of them. Reuses the cloud providers'
+                                allow-list wholesale — `cloudEnabledModels` is keyed by provider
+                                string, so 'litellm' needs no dedicated store or IPC channel.
+                                No `onSetDefault`/`defaultId`: there is no litellmPreferredModel
+                                credential, and STANDARD_CLOUD_MODELS has no litellm pmKey, so a
+                                per-provider default would write a key nothing reads. */}
+                            {hasStoredKey.litellm && (
+                                <AipModelList
+                                    models={effectiveModels('litellm')}
+                                    enabled={cloudEnabledModels['litellm'] || []}
+                                    onToggle={(modelId) => handleToggleModel('litellm', modelId)}
+                                    onReset={() => handleResetModels('litellm')}
+                                    error={modelSaveError['litellm'] ? 'save-failed' : null}
+                                    refreshing={isRefreshingLitellm}
+                                    onRefresh={handleRefreshLitellmModels}
+                                    // Deliberately NOT gated on litellmModels.length: an empty
+                                    // catalogue (proxy down at save time, or the cache cleared)
+                                    // is exactly when the user needs Refresh, and this list is
+                                    // now the only place it lives.
+                                    onFirstOpen={() => {
+                                        if (litellmModels.length === 0) handleRefreshLitellmModels();
+                                    }}
+                                />
+                            )}
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/hooks/useShortcuts.ts
+++ b/src/hooks/useShortcuts.ts
@@ -83,9 +83,49 @@ function buildDefaultShortcuts(): ShortcutConfig {
  */
 export const DEFAULT_SHORTCUTS: ShortcutConfig = buildDefaultShortcuts();
 
+// Backend keybind id -> frontend ShortcutConfig key. Shared between the
+// backend->frontend state mapper and the registration-failure listener below
+// so both stay in sync as new keybinds are added.
+const BACKEND_ID_TO_ACTION: Partial<Record<string, keyof ShortcutConfig>> = {
+    'chat:whatToAnswer': 'whatToAnswer',
+    'chat:followUp': 'followUp',
+    'chat:followup': 'followUp', // backwards compat
+    'chat:clarify': 'clarify',
+    'chat:dynamicAction4': 'dynamicAction4',
+    'chat:answer': 'answer',
+    'chat:codeHint': 'codeHint',
+    'chat:brainstorm': 'brainstorm',
+    'chat:shorten': 'shorten',
+    'chat:recap': 'recap',
+    'chat:scrollUp': 'scrollUp',
+    'chat:scrollDown': 'scrollDown',
+    'chat:scrollLeft': 'scrollLeft',
+    'chat:scrollRight': 'scrollRight',
+    'chat:focusInput': 'focusInput',
+    'chat:auto-answer-mode': 'autoAnswerMode',
+    // Window
+    'window:move-up': 'moveWindowUp',
+    'window:move-down': 'moveWindowDown',
+    'window:move-left': 'moveWindowLeft',
+    'window:move-right': 'moveWindowRight',
+    // General
+    'general:toggle-visibility': 'toggleVisibility',
+    'general:toggle-mouse-passthrough': 'toggleMousePassthrough',
+    'general:process-screenshots': 'processScreenshots',
+    'general:capture-and-process': 'captureAndProcess',
+    'general:capture-dom': 'capturePage',
+    'general:reset-cancel': 'resetCancel',
+    'general:take-screenshot': 'takeScreenshot',
+    'general:selective-screenshot': 'selectiveScreenshot',
+};
+
 export const useShortcuts = () => {
     // Initialize state with platform-aware defaults
     const [shortcuts, setShortcuts] = useState<ShortcutConfig>(buildDefaultShortcuts);
+    // Backend ids whose globalShortcut.register() call failed (OS or another
+    // app already owns that accelerator) — surfaced in Settings so the user
+    // knows to rebind rather than assuming the feature is broken.
+    const [conflicts, setConflicts] = useState<Set<keyof ShortcutConfig>>(new Set());
 
     // Map backend keybinds (array of objects) to frontend state (ShortcutConfig)
     const mapBackendToFrontend = useCallback((backendKeybinds: any[]) => {
@@ -93,44 +133,46 @@ export const useShortcuts = () => {
             const newShortcuts: any = { ...prev };
 
             backendKeybinds.forEach(kb => {
-                const keys = acceleratorToKeys(kb.accelerator);
-
-                // Map backend IDs to frontend keys
-                if (kb.id === 'chat:whatToAnswer') newShortcuts.whatToAnswer = keys;
-                else if (kb.id === 'app:toggle-global-overlay') newShortcuts.toggleGlobalOverlay = keys;
-                else if (kb.id === 'chat:followUp') newShortcuts.followUp = keys;
-                else if (kb.id === 'chat:followup') newShortcuts.followUp = keys; // backwards compat
-                else if (kb.id === 'chat:clarify') newShortcuts.clarify = keys;
-                else if (kb.id === 'chat:dynamicAction4') newShortcuts.dynamicAction4 = keys;
-                else if (kb.id === 'chat:answer') newShortcuts.answer = keys;
-                else if (kb.id === 'chat:codeHint') newShortcuts.codeHint = keys;
-                else if (kb.id === 'chat:brainstorm') newShortcuts.brainstorm = keys;
-                else if (kb.id === 'chat:shorten') newShortcuts.shorten = keys;
-                else if (kb.id === 'chat:recap') newShortcuts.recap = keys;
-                else if (kb.id === 'chat:scrollUp') newShortcuts.scrollUp = keys;
-                else if (kb.id === 'chat:scrollDown') newShortcuts.scrollDown = keys;
-                else if (kb.id === 'chat:scrollLeft') newShortcuts.scrollLeft = keys;
-                else if (kb.id === 'chat:scrollRight') newShortcuts.scrollRight = keys;
-                else if (kb.id === 'chat:focusInput') newShortcuts.focusInput = keys;
-                else if (kb.id === 'chat:auto-answer-mode') newShortcuts.autoAnswerMode = keys;
-                // Window
-                else if (kb.id === 'window:move-up') newShortcuts.moveWindowUp = keys;
-                else if (kb.id === 'window:move-down') newShortcuts.moveWindowDown = keys;
-                else if (kb.id === 'window:move-left') newShortcuts.moveWindowLeft = keys;
-                else if (kb.id === 'window:move-right') newShortcuts.moveWindowRight = keys;
-                // General
-                else if (kb.id === 'general:toggle-visibility') newShortcuts.toggleVisibility = keys;
-                else if (kb.id === 'general:toggle-mouse-passthrough') newShortcuts.toggleMousePassthrough = keys;
-                else if (kb.id === 'general:process-screenshots') newShortcuts.processScreenshots = keys;
-                else if (kb.id === 'general:capture-and-process') newShortcuts.captureAndProcess = keys;
-                else if (kb.id === 'general:capture-dom') newShortcuts.capturePage = keys;
-                else if (kb.id === 'general:reset-cancel') newShortcuts.resetCancel = keys;
-                else if (kb.id === 'general:take-screenshot') newShortcuts.takeScreenshot = keys;
-                else if (kb.id === 'general:selective-screenshot') newShortcuts.selectiveScreenshot = keys;
+                const action = BACKEND_ID_TO_ACTION[kb.id];
+                if (action) newShortcuts[action] = acceleratorToKeys(kb.accelerator);
             });
 
             return newShortcuts;
         });
+    }, []);
+
+    // Track shortcuts the OS/another app is refusing to hand over, so
+    // Settings can flag them instead of leaving a silently dead hotkey.
+    useEffect(() => {
+        if (!window.electronAPI?.onKeybindRegistrationFailed) return;
+        const unsubscribe = window.electronAPI.onKeybindRegistrationFailed(({ id }) => {
+            const action = BACKEND_ID_TO_ACTION[id];
+            if (!action) return;
+            setConflicts(prev => {
+                if (prev.has(action)) return prev;
+                const next = new Set(prev);
+                next.add(action);
+                return next;
+            });
+        });
+        return unsubscribe;
+    }, []);
+
+    // Clear the flag once a shortcut re-registers successfully (e.g. right
+    // after the user records a new combo for it).
+    useEffect(() => {
+        if (!window.electronAPI?.onKeybindRegistrationSucceeded) return;
+        const unsubscribe = window.electronAPI.onKeybindRegistrationSucceeded(({ id }) => {
+            const action = BACKEND_ID_TO_ACTION[id];
+            if (!action) return;
+            setConflicts(prev => {
+                if (!prev.has(action)) return prev;
+                const next = new Set(prev);
+                next.delete(action);
+                return next;
+            });
+        });
+        return unsubscribe;
     }, []);
 
     // Load from Main Process on mount
@@ -158,6 +200,14 @@ export const useShortcuts = () => {
     const updateShortcut = useCallback(async (actionId: keyof ShortcutConfig, keys: string[]) => {
         // Optimistic update
         setShortcuts(prev => ({ ...prev, [actionId]: keys }));
+        // Give the conflict badge a chance to clear right away instead of
+        // waiting on the round-trip to main and back.
+        setConflicts(prev => {
+            if (!prev.has(actionId)) return prev;
+            const next = new Set(prev);
+            next.delete(actionId);
+            return next;
+        });
 
         const accelerator = keysToAccelerator(keys);
         let backendId = '';
@@ -278,6 +328,7 @@ export const useShortcuts = () => {
         shortcuts,
         updateShortcut,
         resetShortcuts,
-        isShortcutPressed
+        isShortcutPressed,
+        conflicts
     };
 };


### PR DESCRIPTION
**Stack 2 of 7.** Base: `pr/ui-polish` — merge that first.

## Change summary

| Commit | Change |
|---|---|
| `7181df49` | Make the launcher opacity preview work on Windows/Linux |
| `a48b8ed5` | Add a model selector to the LiteLLM proxy card |
| `609ce2f8` | Move the LiteLLM Models trigger into the card action row |
| `8f5daad8` | Surface global-shortcut registration conflicts in Settings |

Files: `electron/WindowHelper.ts`, `src/components/SettingsOverlay.tsx`, `src/components/settings/AIProvidersSettings.tsx`, `src/hooks/useShortcuts.ts`, plus `AIProvidersSettingsState.test.mjs`.

## Why `7181df49` is here rather than in a Windows-specific PR

Its renderer half lives in `SettingsOverlay.tsx`, which `8f5daad8` substantially rewrites (+140/−0). Splitting them creates a conflict for no reviewer benefit. Its `WindowHelper.ts` half is the platform branch for opacity preview.

## Cross-platform analysis

- **Expected macOS behavior:** LiteLLM selector and shortcut-conflict surfacing are shared and apply identically. The opacity-preview change is a Windows/Linux code path; macOS keeps its existing behavior.
- **Expected Windows behavior:** all four apply; opacity preview starts working where it previously did not.
- **Existing implementations reviewed:** `WindowHelper.ts` opacity handling on both platform branches.
- **Impact radius:** Settings surface + launcher window opacity. No native module, no IPC contract change.

## Validation

- `Covered by automated Windows branch tests` — `AIProvidersSettingsState.test.mjs`.
- `Reviewed but not executed on macOS`
- `Requires physical macOS verification` — specifically that the opacity-preview refactor did not disturb the macOS branch.
- `Requires physical Windows verification` — opacity preview visual behavior.

## Commands executed

```
git cherry-pick -x   # 4 commits, zero conflicts
```

## Remaining risks

`WindowHelper.ts` is touched by four PRs in this stack. This is the first of them; the macOS opacity path was reviewed but not executed.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWCt3EHyDEzRYhZXJwudSf