### PR TITLE
fix(windows): packaged preflight asset check + capture the meeting's monitor

### DIFF
--- a/electron/ScreenshotHelper.ts
+++ b/electron/ScreenshotHelper.ts
@@ -673,10 +673,16 @@ export class ScreenshotHelper {
       if (this.view === "queue") {
         screenshotPath = path.join(this.screenshotDir, `${uuidv4()}.png`)
         console.log(`[ScreenshotHelper] Using queue directory: ${screenshotPath}`);
-        if (process.platform === 'darwin') {
+        // Both desktop platforms capture via desktopCapturer, and BOTH must
+        // forward preferredDisplay. main.ts already resolves the display the
+        // overlay / meeting is on (getTargetDisplayForFullScreenshot) and passes
+        // it in; the old win32 branch dropped the argument, so the capture fell
+        // through to screen.getPrimaryDisplay() and a multi-monitor Windows user
+        // silently sent the model their PRIMARY screen instead of the one the
+        // meeting was on. (Selective/cropper capture was unaffected — it passes
+        // an explicit area, which routes through getDisplayContainingRect.)
+        if (process.platform === 'darwin' || process.platform === 'win32') {
           await this.captureWithDesktopCapturer(screenshotPath, undefined, preferredDisplay);
-        } else if (process.platform === 'win32') {
-          await this.captureWithDesktopCapturer(screenshotPath);
         } else {
           await shellExecAsync(this.getScreenshotCommand(screenshotPath, false))
         }
@@ -696,10 +702,16 @@ export class ScreenshotHelper {
       } else {
         screenshotPath = path.join(this.extraScreenshotDir, `${uuidv4()}.png`)
         console.log(`[ScreenshotHelper] Using extra screenshots directory: ${screenshotPath}`);
-        if (process.platform === 'darwin') {
+        // Both desktop platforms capture via desktopCapturer, and BOTH must
+        // forward preferredDisplay. main.ts already resolves the display the
+        // overlay / meeting is on (getTargetDisplayForFullScreenshot) and passes
+        // it in; the old win32 branch dropped the argument, so the capture fell
+        // through to screen.getPrimaryDisplay() and a multi-monitor Windows user
+        // silently sent the model their PRIMARY screen instead of the one the
+        // meeting was on. (Selective/cropper capture was unaffected — it passes
+        // an explicit area, which routes through getDisplayContainingRect.)
+        if (process.platform === 'darwin' || process.platform === 'win32') {
           await this.captureWithDesktopCapturer(screenshotPath, undefined, preferredDisplay);
-        } else if (process.platform === 'win32') {
-          await this.captureWithDesktopCapturer(screenshotPath);
         } else {
           await shellExecAsync(this.getScreenshotCommand(screenshotPath, false))
         }

--- a/electron/services/LocalFallbackPreflight.ts
+++ b/electron/services/LocalFallbackPreflight.ts
@@ -161,6 +161,41 @@ function checkNativeModuleUnpacked(): { ok: boolean; message: string } {
   return { ok: false, message: `Native module binary missing under resources/app.asar.unpacked/native-module/` };
 }
 
+/**
+ * Like checkUnpackedNativeDir, but satisfied by ANY entry under `dirRel` whose
+ * name starts with `prefix`.
+ *
+ * Used for the platform-specific native packages (sharp, sqlite-vec) whose
+ * directory name embeds the CPU arch — `sharp-win32-x64` vs `sharp-win32-ia32`
+ * vs `sharp-win32-arm64`. Windows ships both x64 and ia32 installers, so
+ * pinning one arch would fail the other. Matching on the platform prefix
+ * verifies "a native binary for this OS was packaged" without hardcoding an
+ * arch that may legitimately not be the one installed.
+ */
+function checkUnpackedNativePrefix(
+  dirRel: string,
+  prefix: string,
+  label: string,
+): { ok: boolean; message: string } {
+  if (!isPackagedSafe()) {
+    return { ok: true, message: `Dev mode: skipping unpacked check (${dirRel}/${prefix}*)` };
+  }
+  if (!process.resourcesPath) {
+    return {
+      ok: false,
+      message: `Cannot validate packaged path: process.resourcesPath is undefined (rel=${dirRel})`,
+    };
+  }
+  const dir = path.join(process.resourcesPath, 'app.asar.unpacked', dirRel);
+  try {
+    const hit = fs.readdirSync(dir).find((entry) => entry.startsWith(prefix));
+    if (hit) return { ok: true, message: `Found app.asar.unpacked/${dirRel}/${hit}` };
+    return { ok: false, message: `Missing ${label}: no ${dirRel}/${prefix}* in app.asar.unpacked` };
+  } catch {
+    return { ok: false, message: `Missing ${label}: cannot read app.asar.unpacked/${dirRel}` };
+  }
+}
+
 function checkUnpackedNativeDir(rel: string): { ok: boolean; message: string } {
   if (!isPackagedSafe()) {
     return { ok: true, message: `Dev mode: skipping unpacked check (${rel})` };
@@ -242,10 +277,30 @@ export async function runLocalFallbackPreflight(options: { ollamaSelected?: bool
     checks.push(await timedCheck('rust native audio module', async () => checkNativeModuleUnpacked()));
     checks.push(await timedCheck('rust native audio module loadable', async () => tryRequireNativeModule()));
     checks.push(await timedCheck('better-sqlite3 native', async () => checkUnpackedNativeDir('node_modules/better-sqlite3/build/Release/better_sqlite3.node')));
-    checks.push(await timedCheck('sharp darwin-arm64 native', async () => checkUnpackedNativeDir('node_modules/@img/sharp-darwin-arm64/lib')));
-    checks.push(await timedCheck('sharp darwin-x64 native', async () => checkUnpackedNativeDir('node_modules/@img/sharp-darwin-x64/lib')));
-    checks.push(await timedCheck('sqlite-vec darwin-arm64 dylib', async () => checkUnpackedNativeDir('node_modules/sqlite-vec-darwin-arm64/vec0.dylib')));
-    checks.push(await timedCheck('sqlite-vec darwin-x64 dylib', async () => checkUnpackedNativeDir('node_modules/sqlite-vec-darwin-x64/vec0.dylib')));
+    // sharp / sqlite-vec ship as per-OS packages, so these checks MUST be
+    // platform-scoped. They used to be darwin-only paths run unconditionally,
+    // which meant every packaged WINDOWS build failed four checks for binaries
+    // that are never installed there — flipping `nativeOk` false and telling the
+    // user "Please reinstall Natively" on a perfectly good install. (Dev mode
+    // short-circuits checkUnpacked*, which is why it never showed up locally.)
+    //
+    // The darwin branch is byte-for-byte what shipped before; only the win32
+    // branch is new. Linux gets neither (as before) rather than a guess.
+    if (process.platform === 'darwin') {
+      checks.push(await timedCheck('sharp darwin-arm64 native', async () => checkUnpackedNativeDir('node_modules/@img/sharp-darwin-arm64/lib')));
+      checks.push(await timedCheck('sharp darwin-x64 native', async () => checkUnpackedNativeDir('node_modules/@img/sharp-darwin-x64/lib')));
+      checks.push(await timedCheck('sqlite-vec darwin-arm64 dylib', async () => checkUnpackedNativeDir('node_modules/sqlite-vec-darwin-arm64/vec0.dylib')));
+      checks.push(await timedCheck('sqlite-vec darwin-x64 dylib', async () => checkUnpackedNativeDir('node_modules/sqlite-vec-darwin-x64/vec0.dylib')));
+    } else if (process.platform === 'win32') {
+      // Prefix-matched: Windows ships x64 AND ia32 installers (and arm64 is
+      // possible), so the arch suffix cannot be hardcoded. Both directories are
+      // covered by asarUnpack (`**/node_modules/@img/**`,
+      // `**/node_modules/sqlite-vec-*/**`).
+      // The 'sharp ' / 'sqlite-vec ' id prefixes are load-bearing — `nativeOk`
+      // below selects these checks by exactly those prefixes.
+      checks.push(await timedCheck('sharp win32 native', async () => checkUnpackedNativePrefix('node_modules/@img', 'sharp-win32-', 'sharp Windows binary')));
+      checks.push(await timedCheck('sqlite-vec windows extension', async () => checkUnpackedNativePrefix('node_modules', 'sqlite-vec-windows-', 'sqlite-vec Windows extension')));
+    }
 
     // 4. Ollama optional path.
     if (options.ollamaSelected) {

--- a/electron/services/__tests__/WindowsPlatformParity.test.mjs
+++ b/electron/services/__tests__/WindowsPlatformParity.test.mjs
@@ -75,6 +75,37 @@ test('preflight: Windows has its own sharp / sqlite-vec checks, arch-agnostic', 
   );
 });
 
+// ── 2. Full-screen screenshots captured the wrong monitor on Windows ─────────
+// main.ts resolves the display the overlay/meeting is on and passes it down,
+// but the win32 branch dropped the argument, so capture fell through to
+// screen.getPrimaryDisplay() — a multi-monitor user silently sent the model
+// their primary screen instead of the meeting's.
+
+test('screenshot: BOTH desktop platforms forward preferredDisplay', () => {
+  const src = read('electron/ScreenshotHelper.ts');
+  // Every full-screen desktopCapturer call (i.e. not the area/cropper one) must
+  // pass preferredDisplay.
+  const fullScreenCalls = src
+    .split('\n')
+    .filter((l) => l.includes('captureWithDesktopCapturer(screenshotPath'));
+  assert.ok(fullScreenCalls.length >= 2, 'expected the queue + extra full-screen capture calls');
+  for (const call of fullScreenCalls) {
+    if (call.includes('captureArea')) continue; // selective capture resolves its own display
+    assert.match(
+      call,
+      /preferredDisplay/,
+      'BUG: a full-screen capture dropped preferredDisplay — it will fall through to ' +
+        'screen.getPrimaryDisplay() and capture the wrong monitor on multi-display setups.',
+    );
+  }
+  // And there must be no win32 branch that calls it without the display.
+  assert.doesNotMatch(
+    src,
+    /process\.platform === 'win32'\) \{\s*\n\s*await this\.captureWithDesktopCapturer\(screenshotPath\);/,
+    'BUG: the win32-only capture branch that omitted preferredDisplay is back.',
+  );
+});
+
 test('preflight: the new Windows check ids are still selected by nativeOk', () => {
   // `nativeOk` picks checks by id prefix; renaming an id silently drops it from
   // the aggregate, which would make the gate pass while the asset is missing.

--- a/electron/services/__tests__/WindowsPlatformParity.test.mjs
+++ b/electron/services/__tests__/WindowsPlatformParity.test.mjs
@@ -1,0 +1,99 @@
+// Windows/macOS parity for platform-gated behaviour that was macOS-only.
+//
+// Each test pins one gap found in a cross-platform audit, where a feature
+// existed on macOS and was missing, stubbed, or degraded on Windows. Source
+// assertions: these are wiring/branching contracts, and the code they guard
+// touches Electron singletons (tray, app.isPackaged, screen) that cannot be
+// instantiated in a plain node test.
+//
+// The rule every fix follows: the darwin path must stay byte-for-byte what
+// shipped, so a Windows fix can never regress macOS.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+const read = (rel) => fs.readFileSync(path.join(repoRoot, rel), 'utf8');
+
+// ── 1. Packaged Windows builds failed their own asset preflight ──────────────
+// sharp / sqlite-vec ship as per-OS packages. The four darwin paths used to run
+// unconditionally, so every packaged Windows build failed them, flipped
+// `nativeOk` false, and told the user "Please reinstall Natively" on a good
+// install. Dev mode short-circuits the check, hiding it locally.
+
+test('preflight: the darwin-only native asset checks are gated to darwin', () => {
+  const src = read('electron/services/LocalFallbackPreflight.ts');
+  const block = src.slice(
+    src.indexOf('// sharp / sqlite-vec ship as per-OS packages'),
+    src.indexOf('// 4. Ollama optional path.'),
+  );
+  assert.ok(block.length > 0, 'platform-scoped native-asset block not found');
+  assert.match(
+    block,
+    /if \(process\.platform === 'darwin'\) \{[\s\S]*?sharp darwin-arm64 native/,
+    'BUG: the darwin sharp/sqlite-vec checks must sit behind a darwin gate — running them on ' +
+      'Windows fails four checks for binaries that are never installed there.',
+  );
+  // Every darwin check must still be present and unchanged (no macOS regression).
+  for (const id of [
+    'sharp darwin-arm64 native',
+    'sharp darwin-x64 native',
+    'sqlite-vec darwin-arm64 dylib',
+    'sqlite-vec darwin-x64 dylib',
+  ]) {
+    assert.ok(block.includes(id), `BUG: macOS regression — the "${id}" check disappeared.`);
+  }
+});
+
+test('preflight: Windows has its own sharp / sqlite-vec checks, arch-agnostic', () => {
+  const src = read('electron/services/LocalFallbackPreflight.ts');
+  const block = src.slice(
+    src.indexOf("} else if (process.platform === 'win32') {"),
+    src.indexOf('// 4. Ollama optional path.'),
+  );
+  assert.ok(block.length > 0, 'win32 native-asset branch not found');
+  assert.match(
+    block,
+    /checkUnpackedNativePrefix\('node_modules\/@img', 'sharp-win32-'/,
+    'BUG: Windows must verify a sharp win32 binary was packaged.',
+  );
+  assert.match(
+    block,
+    /checkUnpackedNativePrefix\('node_modules', 'sqlite-vec-windows-'/,
+    'BUG: Windows must verify the sqlite-vec Windows extension was packaged.',
+  );
+  // Arch must NOT be hardcoded: Windows ships x64 AND ia32 installers, so
+  // pinning one arch would fail the other with the same false "reinstall" alarm.
+  assert.doesNotMatch(
+    block,
+    /sharp-win32-x64|sharp-win32-ia32|sqlite-vec-windows-x64/,
+    'BUG: do not hardcode a Windows arch — prefix-match so x64/ia32/arm64 all pass.',
+  );
+});
+
+test('preflight: the new Windows check ids are still selected by nativeOk', () => {
+  // `nativeOk` picks checks by id prefix; renaming an id silently drops it from
+  // the aggregate, which would make the gate pass while the asset is missing.
+  const src = read('electron/services/LocalFallbackPreflight.ts');
+  const line = src.split('\n').find((l) => l.includes('const nativeOk ='));
+  assert.ok(line, 'nativeOk aggregate not found');
+  const selects = (id) =>
+    id.startsWith('rust native') ||
+    id.includes('better-sqlite3') ||
+    id.startsWith('sharp ') ||
+    id.startsWith('sqlite-vec ');
+  for (const id of ['sharp win32 native', 'sqlite-vec windows extension']) {
+    assert.ok(
+      selects(id),
+      `BUG: "${id}" is not matched by the nativeOk selector — the check would run but never ` +
+        'count, so a genuinely missing binary would report healthy.',
+    );
+  }
+  // And the selector itself must still use those prefixes.
+  assert.match(line, /startsWith\('sharp '\)/);
+  assert.match(line, /startsWith\('sqlite-vec '\)/);
+});


### PR DESCRIPTION
**Stack 3 of 7.** Base: `pr/settings-and-shortcuts` — merge that first.

## Change summary

| Commit | Change |
|---|---|
| `e0c6ae2c` | Stop packaged Windows builds failing their own asset check |
| `c42b28ef` | Capture the meeting's monitor on Windows, not the primary one |

Files: `electron/services/LocalFallbackPreflight.ts`, `electron/ScreenshotHelper.ts`, and a new `electron/services/__tests__/WindowsPlatformParity.test.mjs`.

## Ordering note for reviewers

This PR **must land before** `pr/windows-stealth-typing`. It creates `WindowsPlatformParity.test.mjs`, which five commits in that PR then append to. An earlier arrangement placed this group after the stealth chain and produced add/add plus modify/delete conflicts on that file; moving it earlier makes the whole stack apply cleanly.

## Cross-platform analysis

- **Expected macOS behavior:** unchanged. `e0c6ae2c` gates the darwin-only native asset checks to darwin and adds separate Windows sharp/sqlite-vec checks; the darwin path is preserved as-is. `c42b28ef` makes **both** desktop platforms forward `preferredDisplay` — macOS already resolved the correct display, this aligns the Windows path with it.
- **Expected Windows behavior:** packaged builds stop failing preflight on assets that are macOS-only; screenshots capture the display the meeting overlay is on rather than always the primary.
- **Existing implementations reviewed:** the darwin branches in `LocalFallbackPreflight.ts` and `ScreenshotHelper.ts`.
- **Impact radius:** packaged-app startup preflight and the screenshot capture path.

## Validation

- `Covered by automated Windows branch tests` — `WindowsPlatformParity.test.mjs`, 4 pass / 0 fail at this branch tip.
- `Covered by automated macOS branch tests` — the same file asserts the darwin-only checks stay gated to darwin and that both platforms forward `preferredDisplay`.
- `Tested physically on Windows` — typecheck, electron build, and the test suite were run at this exact branch tip.
- `Requires physical macOS verification` — packaged macOS preflight not executed.

## Commands executed

```
npx tsc --noEmit -p tsconfig.json                              # exit 0
npx tsc -p electron/tsconfig.json --noEmit                     # exit 0
npm run build:electron                                         # ok
node --test electron/services/__tests__/WindowsPlatformParity.test.mjs   # 4 pass / 0 fail
```

## Remaining risks

Packaging itself was not validated — the preflight logic was tested, but no packaged macOS or Windows build was produced from this tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWCt3EHyDEzRYhZXJwudSf
