### PR TITLE
docs(bugs): answering pipeline bug reports — Aug 2026 (Telegram user issues)

### DIFF
--- a/docs/bugs/README.md
+++ b/docs/bugs/README.md
@@ -1,0 +1,65 @@
+# Answering Pipeline Bug Report — August 2026
+
+## Overview
+
+This PR documents **three user-reported bugs** in the answering pipeline (v2.8.5).  
+All bugs were discovered from Telegram user reports and validated against the source code  
+with static analysis + jcodemunch blast-radius assessment.
+
+**No source-code changes are in this PR** — these are documentation-only fixes for developer review.
+
+---
+
+## Bug Index
+
+| ID | Title | Severity | Files to Fix |
+|---|---|---|---|
+| [Bug 001](./bug-001-document-grounded-refusal.md) | Document-Grounded Refusal on General Questions | 🔴 High | `AnswerPlanner.ts`, `contextRoute.ts` |
+| [Bug 002](./bug-002-screenshot-code-generation.md) | Screenshot Attached but Code Not Generated | 🟠 Medium | `ipcHandlers.ts`, `IntelligenceEngine.ts` |
+| [Bug 003](./bug-003-skill-injection-failure.md) | Skill Injection Ignored in V3 Engine | 🟠 Medium | `WhatToAnswerLLM.ts` |
+
+---
+
+## Blast Radius Summary (jcodemunch analysis)
+
+All three bugs touch the core answering loop. Risk is **concentrated** in a small set of files
+but the flag `documentGroundedCustomModeActive` fans out to 26 dependent files.
+
+```
+documentGroundedCustomModeActive (AnswerPlanner.ts)
+  ├── WhatToAnswerLLM.ts            [6 refs — also affected by Bug 003]
+  ├── contextRoute.ts               [5 refs — secondary fix site for Bug 001]
+  ├── ModesManager.ts               [8 refs]
+  ├── conversationHistoryPolicy.ts  [1 ref]
+  └── modeProfiles.ts               [1 ref]
+
+buildCustomModeExecutionContract
+  ├── IntelligenceEngine.ts         [5 refs — fix site for Bug 002]
+  └── ipcHandlers.ts                [6 refs — fix site for Bug 002]
+
+WhatToAnswerLLM (class)
+  └── llm/index.ts                  [2 refs]
+```
+
+> **⚠️ All confirmed dependents have `has_test_reach: false`** — meaning none of the above files  
+> are currently covered by a test that verifies end-to-end answering behaviour.  
+> Each bug doc includes a checklist of tests to add or update.
+
+---
+
+## Key Additional Finding (Bug 001)
+
+`documentGroundedFromContract()` in [`modeSourceContract.ts`](../../electron/services/modeSourceContract.ts)  
+**already implements the correct guard** (`if (!hasReferenceFiles) return false`).  
+It has **zero call-sites** in the entire codebase.  
+
+The recommended fix for Bug 001 is to wire this function in rather than adding a new inline check.
+
+---
+
+## How to Review
+
+1. Read each bug file in [`docs/bugs/`](./) for full root-cause analysis, diffs, and safe-change checklists.
+2. Fixes are **surgical** — each change is a single guard condition or a 3-line append.
+3. Run `ModePolicyShadowDivergence2026_07_26.test.mjs` and `Issue303SkillInvocation.test.mjs`  
+   after implementing fixes to catch regressions early.

--- a/docs/bugs/bug-001-document-grounded-refusal.md
+++ b/docs/bugs/bug-001-document-grounded-refusal.md
@@ -1,0 +1,142 @@
+# Bug 001 — Document-Grounded Refusal on General / YouTube Questions
+
+## User Reports (Telegram)
+
+> *"I just asked a random question from a YouTube, and it answers: 'This is not directly uploaded document.'"*  
+> *"I noticed that instead of generating an answer based on the conversation context, it keeps saying 'no document has been uploaded.'"*
+
+---
+
+## Root Cause
+
+### 1. `documentGroundedCustomModeActive` ignores `hasReferenceFiles`
+
+**File:** [`electron/llm/AnswerPlanner.ts`](../../electron/llm/AnswerPlanner.ts) — line 2335
+
+```typescript
+// CURRENT (broken)
+const documentGroundedCustomModeActive =
+  input.activeMode?.documentGroundedCustomModeActive === true;
+```
+
+This reads the pre-computed flag directly from the mode object. The flag is set by `ModesManager` for any mode whose `sourceAuthority` is `reference_files_primary` (or similar) — **even when no files have been uploaded**.  
+
+### 2. The safe guard function exists but is never called
+
+**File:** [`electron/services/modeSourceContract.ts`](../../electron/services/modeSourceContract.ts) — line 730
+
+```typescript
+function documentGroundedFromContract(
+  contract: ModeSourceContract,
+  hasReferenceFiles: boolean,   // ← correctly short-circuits
+): boolean {
+  if (!hasReferenceFiles) return false;   // ← guard we need
+  return contract.sourceAuthority === 'reference_files_only'
+    || contract.sourceAuthority === 'reference_files_primary'
+    || contract.sourceAuthority === 'reference_files_plus_transcript';
+}
+```
+
+> **This function has 0 call-sites in the entire codebase** (confirmed via `find_references`).  
+> It was built to solve exactly this problem but was never wired in.
+
+### 3. Forced document-grounded routing with empty context
+
+**File:** [`electron/llm/AnswerPlanner.ts`](../../electron/llm/AnswerPlanner.ts) — line 2822
+
+```typescript
+if (documentGroundedCustomModeActive && !explicitDocumentModeCodingAsk && !explicitDocumentModeProfileAsk) {
+  const docShape = classifyDocumentQuestionShape(question, ...);
+  answerType = docShape === 'broad_overview' ? 'lecture_answer' : docShape;
+}
+```
+
+Because the flag is `true` (incorrectly), the turn is classified as `lecture_answer` / `definitional_answer` / etc.
+
+### 4. Validation fails against empty `docContextBlock`
+
+**Files:** [`electron/ipcHandlers.ts`](../../electron/ipcHandlers.ts) (line 4029) and [`electron/IntelligenceEngine.ts`](../../electron/IntelligenceEngine.ts) (line 3156)
+
+The WTA gate checks that a non-empty `docContextBlock` exists for document-grounded answer types. Since no files were uploaded, the block is empty → validation fails → refusal message returned.
+
+---
+
+## Also Affected: `contextRoute.ts`
+
+**File:** [`electron/llm/contextRoute.ts`](../../electron/llm/contextRoute.ts) — line 76
+
+```typescript
+// Same pattern, same bug:
+const documentGroundedCustomModeActive = plan.documentGroundedCustomModeActive === true;
+```
+
+This copy of the flag is used for conversation-history routing and WhatToAnswerLLM prompt shaping — it inherits the same incorrect `true` value.
+
+---
+
+## Proposed Fix
+
+### Fix A — `AnswerPlanner.ts` (primary routing gate)
+
+```diff
+- const documentGroundedCustomModeActive =
+-   input.activeMode?.documentGroundedCustomModeActive === true;
++ const hasReferenceFiles = input.activeMode?.hasReferenceFiles === true;
++ const documentGroundedCustomModeActive =
++   input.activeMode?.documentGroundedCustomModeActive === true && hasReferenceFiles;
+```
+
+**Alternative (preferred):** wire in the already-existing safe utility:
+
+```diff
++ import { documentGroundedFromContract } from '../services/modeSourceContract';
+  // …
+  const documentGroundedCustomModeActive =
+-   input.activeMode?.documentGroundedCustomModeActive === true;
++   documentGroundedFromContract(
++     input.activeMode?.sourceContract,
++     input.activeMode?.hasReferenceFiles === true,
++   );
+```
+
+### Fix B — `contextRoute.ts` (conversation-history / WTA routing)
+
+Apply the same guard so that the `plan` object propagated to WhatToAnswerLLM is consistent:
+
+```diff
+- const documentGroundedCustomModeActive = plan.documentGroundedCustomModeActive === true;
++ const documentGroundedCustomModeActive =
++   plan.documentGroundedCustomModeActive === true && (plan.hasReferenceFiles === true);
+```
+
+---
+
+## Blast Radius
+
+| Symbol | Confirmed Dependents | Potential (namespace import) |
+|---|---|---|
+| `documentGroundedCustomModeActive` (AnswerPlanner) | 5 files | 21 files |
+| `classifyDocumentQuestionShape` | 3 files | 6 files |
+| `buildCustomModeExecutionContract` | 2 files | 4 files |
+
+**High-blast files that must be regression-tested after this fix:**
+- `electron/llm/WhatToAnswerLLM.ts` (6 references to the flag)
+- `electron/llm/contextRoute.ts` (5 references)
+- `electron/services/ModesManager.ts` (8 references)
+- `electron/llm/conversationHistoryPolicy.ts`
+- `electron/llm/modeProfiles.ts`
+
+**Files with no test coverage flagged by jcodemunch:**
+- All confirmed dependents listed above have `has_test_reach: false`
+- Recommendation: add a dedicated Jest test for the `documentGroundedFromContract` path with `hasReferenceFiles: false`
+
+---
+
+## Safe-Change Checklist
+
+- [ ] Fix A applied in `AnswerPlanner.ts`
+- [ ] Fix B applied in `contextRoute.ts`
+- [ ] `documentGroundedFromContract` verified to return `false` when `hasReferenceFiles` is falsy
+- [ ] Manual smoke-test: open "General" mode, ask a question, verify no refusal
+- [ ] Existing doc-grounded tests still pass when files are uploaded
+- [ ] No regression in `ModePolicyShadowDivergence2026_07_26.test.mjs` (tests the `documentGroundedCustomModeActive` flag parity)

--- a/docs/bugs/bug-001-document-grounded-refusal.md
+++ b/docs/bugs/bug-001-document-grounded-refusal.md
@@ -91,13 +91,18 @@ This copy of the flag is used for conversation-history routing and WhatToAnswerL
 ```diff
 + import { documentGroundedFromContract } from '../services/modeSourceContract';
   // …
-  const documentGroundedCustomModeActive =
+- const documentGroundedCustomModeActive =
 -   input.activeMode?.documentGroundedCustomModeActive === true;
-+   documentGroundedFromContract(
-+     input.activeMode?.sourceContract,
-+     input.activeMode?.hasReferenceFiles === true,
-+   );
++ const documentGroundedCustomModeActive =
++   input.activeMode?.sourceContract != null
++     ? documentGroundedFromContract(
++         input.activeMode.sourceContract,         // non-optional after the null check
++         input.activeMode?.hasReferenceFiles === true,
++       )
++     : false;   // no contract → treat as not doc-grounded
 ```
+
+> **Why the null guard?** `input.activeMode?.sourceContract` has type `ModeSourceContract | undefined`. `documentGroundedFromContract` requires a concrete `ModeSourceContract` as its first argument and immediately reads `.sourceAuthority`, which would throw at runtime (or fail TypeScript checking) when the contract is absent. The ternary ensures the safe-guard function is only invoked when the contract exists.
 
 ### Fix B — `contextRoute.ts` (conversation-history / WTA routing)
 

--- a/docs/bugs/bug-002-screenshot-code-generation.md
+++ b/docs/bugs/bug-002-screenshot-code-generation.md
@@ -1,0 +1,122 @@
+# Bug 002 — Screenshot Attached but Code Not Generated
+
+## User Report (Telegram)
+
+> *"when i take a screenshot and chat shows screenshot attached, and i ask to give me the code, it doesn't give me the code"*
+
+---
+
+## Root Cause Chain
+
+### 1. `hasScreenContext` omitted in manual-chat IPC handler
+
+**File:** [`electron/ipcHandlers.ts`](../../electron/ipcHandlers.ts) — inside `_geminiChatStreamHandler` (~line 1163)
+
+When `buildV3Prompt` is called for the `gemini-chat-stream` IPC path, `hasScreenContext` is **completely absent** from the argument object:
+
+```typescript
+const composed = await buildV3Prompt({
+  surface: 'manual-chat',
+  pathTag: 'ipc',
+  question: String(message || ''),
+  modeTemplateType: rawMode,
+  modeUniqueId: modeInfo?.id ?? null,
+  attachedSourceCount: files.length,
+  // … other fields …
+  // hasScreenContext: ← MISSING
+});
+```
+
+The field defaults to `undefined` / `false` inside `buildV3Prompt`.
+
+### 2. `IntelligenceEngine` only checks `options.screenContext`, not `imagePaths`
+
+**File:** [`electron/IntelligenceEngine.ts`](../../electron/IntelligenceEngine.ts) — inside `runWhatShouldISay` (~line 2494)
+
+```typescript
+// CURRENT (broken):
+hasScreenContext: Boolean(options?.screenContext),
+```
+
+`options.screenContext` is the **OCR object** built from the periodic screen-capture service — it is not set for manually-attached screenshots sent through `imagePaths`. When a user attaches a screenshot through the chat UI, `imagePaths` is populated but `screenContext` is `null`, so `hasScreenContext` is `false`.
+
+### 3. Turn classifier misses `SCREEN_SPECIFIC` / `SCREEN_FACT`
+
+**File:** [`electron/context-intelligence/question/turn-classifier.ts`](../../electron/context-intelligence/question/turn-classifier.ts)
+
+The classifier uses `hasScreenContext` to mark turns as screen-anchored. With `hasScreenContext: false`, a query like *"give me the code"* receives no screen-related label.
+
+### 4. Coding persona never activated
+
+**File:** [`electron/llm/AnswerPlanner.ts`](../../electron/llm/AnswerPlanner.ts)
+
+Without a `SCREEN_SPECIFIC` or `CODING_TASK_RE` match, the orchestrator falls through to a generic `general_meeting_answer` type and never activates the coding persona or code-extraction prompt.
+
+> **Note:** the phrase *"give me the code"* does not match `CODING_TASK_RE` (which requires verbs like write / implement / solve). The primary fix must therefore be at the `hasScreenContext` propagation level, not keyword-tuning.
+
+---
+
+## Proposed Fixes
+
+### Fix A — `electron/ipcHandlers.ts`
+
+Inside `_geminiChatStreamHandler`, pass `hasScreenContext` from `imagePaths`:
+
+```diff
+  const composed = await buildV3Prompt({
+    surface: 'manual-chat',
+    pathTag: 'ipc',
+    question: String(message || ''),
+    modeTemplateType: rawMode,
+    modeUniqueId: modeInfo?.id ?? null,
+    attachedSourceCount: files.length,
+    attachedFileNames: (files as Array<{ fileName?: string }>)
+      .map((f) => f.fileName ?? '').filter(Boolean),
+    profileSourceCount: v3ProfileCounts.profileResume + ...,
+    resolvedProfileSources: v3ProfileResolved,
+    extraAllowedSourceTypes: extraSourceTypes,
+    debugSources: v3DebugSources as never,
+    deferDebugCompletion: true,
+    requestId: `v3-${myStreamId}`,
+    requestSequence: myStreamId,
++   hasScreenContext: Boolean(imagePaths && imagePaths.length > 0),
+  });
+```
+
+### Fix B — `electron/IntelligenceEngine.ts`
+
+Expand the `hasScreenContext` guard to cover the `imagePaths` channel:
+
+```diff
+- hasScreenContext: Boolean(options?.screenContext),
++ hasScreenContext: Boolean(
++   options?.screenContext || (imagePaths && imagePaths.length > 0)
++ ),
+```
+
+---
+
+## Blast Radius
+
+| Symbol / File | Confirmed Dependents | Risk |
+|---|---|---|
+| `ScreenContextService` | `IntelligenceEngine`, `IntelligenceManager`, `WhatToAnswerLLM` | Low — existing callers only read `captureScreen()`, not `imagePaths` |
+| `buildCustomModeExecutionContract` | `IntelligenceEngine` (×5), `ipcHandlers` (×6) | Medium — touches both primary entry points |
+| `ipcHandlers.ts` change | Only `gemini-chat-stream` handler | Low — scoped to manual-chat surface |
+| `IntelligenceEngine.ts` change | All `runWhatShouldISay` callers | Medium — also affects overlay auto-answer flow |
+
+**Regression risk for overlay auto-answer:**  
+The overlay path sends both `options.screenContext` (OCR object) and `imagePaths`. After Fix B, both still resolve to `true` — no behaviour change for the existing overlay path.
+
+**Test file to update:**  
+- [`electron/services/__tests__/IntelligenceEngineScreenContext.test.mjs`](../../electron/services/__tests__/IntelligenceEngineScreenContext.test.mjs) — add a case where `screenContext` is `null` but `imagePaths` is non-empty, assert `hasScreenContext === true`.
+
+---
+
+## Safe-Change Checklist
+
+- [ ] Fix A applied in `ipcHandlers.ts`
+- [ ] Fix B applied in `IntelligenceEngine.ts`
+- [ ] Manual smoke-test: attach a screenshot in manual chat, type "give me the code", verify coding response
+- [ ] Overlay auto-answer with screen capture still works (no regression)
+- [ ] `IntelligenceEngineScreenContext.test.mjs` updated with new `imagePaths`-only case

--- a/docs/bugs/bug-003-skill-injection-failure.md
+++ b/docs/bugs/bug-003-skill-injection-failure.md
@@ -1,0 +1,79 @@
+# Bug 003 — Skill Injection Ignored in V3 Engine (v2.8.5+)
+
+## User Report (Telegram)
+
+> *"Did anyone try skill injection in 2.8.5? Does it work? For me it just goes like plain prompt like instead of the skill"*
+
+---
+
+## Root Cause
+
+### V3 system prompt silently discards the active skill block
+
+**File:** [`electron/llm/WhatToAnswerLLM.ts`](../../electron/llm/WhatToAnswerLLM.ts) — line 813
+
+```typescript
+// CURRENT (broken):
+const _wtaSystemPrompt = _v3p?.system ?? finalPromptOverride;
+```
+
+**Execution path:**
+
+1. A skill is selected → its `promptBlock` is appended to `finalPromptOverride` earlier in the flow.
+2. The V3 Context Intelligence engine runs and sets `_v3p` (a structured prompt object that includes `_v3p.system`).
+3. The line above prefers `_v3p.system` via `??` — because `_v3p` is defined (not nullish), `finalPromptOverride` (which contains the skill instructions) is **silently discarded**.
+4. The LLM receives a generic V3 system prompt with no skill instructions.
+
+### Why `??` is wrong here
+
+`??` (nullish coalescing) only falls back when the left side is `null` or `undefined`. Since `_v3p` is always a truthy object when V3 is active, the right-hand side (`finalPromptOverride` with the skill) is never reached.
+
+---
+
+## Proposed Fix
+
+**File:** [`electron/llm/WhatToAnswerLLM.ts`](../../electron/llm/WhatToAnswerLLM.ts) — line 813
+
+```diff
+- const _wtaSystemPrompt = _v3p?.system ?? finalPromptOverride;
++ let _wtaSystemPrompt = _v3p?.system ?? finalPromptOverride;
++ if (_v3p && activeSkill) {
++   // Append the skill block after the V3 system prompt so V3 routing
++   // context is preserved while skill instructions still reach the LLM.
++   _wtaSystemPrompt = `${_v3p.system}\n\n## ACTIVE SKILL\n${activeSkill.promptBlock}`;
++ }
+```
+
+**Why append instead of replace:**  
+`_v3p.system` carries routing context (source authority, evidence pack summaries) that the LLM needs to answer correctly. Replacing it entirely with `finalPromptOverride` would regress V3 source-authority routing. Appending the skill as a clearly-delimited section preserves both.
+
+---
+
+## Additional Risk: Skill Block in `finalPromptOverride` Missed in Non-V3 Path
+
+When `_v3p` is `undefined` (V3 disabled), the `??` correctly falls back to `finalPromptOverride`. This path works today but should be verified to still include `activeSkill.promptBlock` — confirm the upstream code that builds `finalPromptOverride` always appends the skill before this point.
+
+---
+
+## Blast Radius
+
+| Symbol | Confirmed Dependents | Notes |
+|---|---|---|
+| `WhatToAnswerLLM` class | `electron/llm/index.ts` (×2 refs) | Only 1 confirmed importer — low blast radius |
+| `_wtaSystemPrompt` (local variable) | Scoped to `WhatToAnswerLLM` class | No external exposure |
+| `activeSkill` parameter | Internal to `WhatToAnswerLLM.generateStream` | Already propagated correctly to the call site |
+
+**Existing test to validate:**  
+- [`electron/services/__tests__/Issue303SkillInvocation.test.mjs`](../../electron/services/__tests__/Issue303SkillInvocation.test.mjs)
+  - Currently checks `source.indexOf('skillPromptBlock')` 
+  - Must be extended or verified to cover the V3-active path (i.e., when `_v3p` is defined)
+
+---
+
+## Safe-Change Checklist
+
+- [ ] Fix applied in `WhatToAnswerLLM.ts` (append skill block when both `_v3p` and `activeSkill` are present)
+- [ ] Confirm `finalPromptOverride` still has skill block for non-V3 path
+- [ ] `Issue303SkillInvocation.test.mjs` extended to cover V3-active scenario
+- [ ] Manual smoke-test: create a skill, enable it, ask a question → verify skill instructions appear in response
+- [ ] Verify no regression for non-skill V3 answers (V3 system prompt should be unchanged when `activeSkill` is null)

--- a/docs/tech-debt/README.md
+++ b/docs/tech-debt/README.md
@@ -33,9 +33,22 @@ Covers:
 - Why token-overlap similarity fails on semantically opposite questions (strengths/weaknesses, success/failure)
 - Why stop words inflate scores on interview questions
 - Recommended fix: Sentence-BERT (`all-MiniLM-L6-v2`, 22MB) hybrid — Jaccard fast-exit for clear cases, SBERT for the ambiguous zone
-- Implementation sketch reusing the existing `IntentClassifier.ts` worker pattern
+- Implementation sketch reusing the existing `LocalEmbeddingProvider` worker infrastructure
 
 **Priority fix**: Hybrid Jaccard + SBERT gate · Calibrate thresholds against a test set of interview question antonym pairs
+
+---
+
+### 3. [`replace-placeholder-corruption-bug.md`](./replace-placeholder-corruption-bug.md)
+**Scope**: `electron/llm/answerPolish.ts` (line 480) and `electron/llm/postProcessor.ts` (lines 85, 88, 133, 134)
+
+Covers:
+- How post-processing restores code and math segments using `.replace()` with raw string replacements.
+- The Javascript string replacement parsing vulnerability for untrusted outputs containing `$` symbols (like bash arguments `$1`, jQuery/regex `$&`, and math tokens).
+- How it causes wrong answers by corrupting code/math formatting and leaking internal tokens.
+- Trivial fix: wrap string variables in callback functions `() => value` in `replace()` calls.
+
+**Priority fix**: Update all post-processing restoration loops to callback-based replacements.
 
 ---
 
@@ -54,6 +67,7 @@ The documents are intentionally **read-only findings** — no production code wa
 
 | Issue | Severity | Document |
 |-------|----------|----------|
+| Unsafe String Replacement / Code Placeholder Corruption | 🔴 Critical | Placeholder Corruption Bug |
 | Post-stream repair cascade (up to 14s added latency) | 🔴 Critical | Architecture Critique §1.2 |
 | `runWhatShouldISay` ~2,400 lines, untestable | 🔴 Critical | Architecture Critique §1.1 |
 | Disabled relevance guard still runs NLI on every answer | 🟡 Medium | Architecture Critique §2.1 |

--- a/docs/tech-debt/README.md
+++ b/docs/tech-debt/README.md
@@ -1,0 +1,66 @@
+# Tech Debt — Architecture Review Notes
+
+This directory contains architecture review findings that **do not change any code**. Each document describes a problem, explains why it is a problem, and proposes a concrete fix for the implementing developer.
+
+> These documents are the output of a focused review session on the `IntelligenceEngine` answering pipeline (August 2026).
+
+---
+
+## Documents
+
+### 1. [`intelligence-engine-architecture-critique.md`](./intelligence-engine-architecture-critique.md)
+**Scope**: `electron/IntelligenceEngine.ts` (5,094 lines) and `electron/llm/`
+
+Covers:
+- The God-file problem (`runWhatShouldISay` at ~2,400 lines)
+- The post-stream repair cascade (up to 3 sequential blocking LLM calls after the answer already streams to the UI)
+- `AnswerPlanner.ts` at 211KB — no internal module split
+- Manual path / WTA path post-processing duplication (`ipcHandlers.ts` "mirrors" pattern)
+- Disabled answer relevance guard that still runs NLI classification on every answer
+- `detectRefinementIntent` — possibly dead code
+- Dynamic `require()` in the hot path
+- Per-call-site context sanitization with inconsistent limits
+
+**Priority fixes**: Delete disabled Phase 8 guard · Extract `WtaPipeline` stages · Unify post-processing · Move constraints into primary prompt
+
+---
+
+### 2. [`speculative-similarity-jaccard-critique.md`](./speculative-similarity-jaccard-critique.md)
+**Scope**: `jaccardSimilarity()` and `handleSuggestionTrigger()` in `IntelligenceEngine.ts`
+
+Covers:
+- What Jaccard is doing (speculative pre-fetch reuse gate)
+- Why token-overlap similarity fails on semantically opposite questions (strengths/weaknesses, success/failure)
+- Why stop words inflate scores on interview questions
+- Recommended fix: Sentence-BERT (`all-MiniLM-L6-v2`, 22MB) hybrid — Jaccard fast-exit for clear cases, SBERT for the ambiguous zone
+- Implementation sketch reusing the existing `IntentClassifier.ts` worker pattern
+
+**Priority fix**: Hybrid Jaccard + SBERT gate · Calibrate thresholds against a test set of interview question antonym pairs
+
+---
+
+## How to Use These Documents
+
+Each document follows this structure:
+1. **What it is** — describes the current code behavior
+2. **What's wrong** — concrete failure modes with examples
+3. **Recommended fix** — specific, implementable solution with code sketches where applicable
+
+The documents are intentionally **read-only findings** — no production code was changed to produce this PR. The implementing developer should read the relevant section, verify the finding in the live code at the cited line numbers, and implement the recommended fix on a feature branch.
+
+---
+
+## Severity at a Glance
+
+| Issue | Severity | Document |
+|-------|----------|----------|
+| Post-stream repair cascade (up to 14s added latency) | 🔴 Critical | Architecture Critique §1.2 |
+| `runWhatShouldISay` ~2,400 lines, untestable | 🔴 Critical | Architecture Critique §1.1 |
+| Disabled relevance guard still runs NLI on every answer | 🟡 Medium | Architecture Critique §2.1 |
+| `AnswerPlanner.ts` 211KB monolith | 🟡 Medium | Architecture Critique §1.3 |
+| Regex failure detectors per model/provider | 🟡 Medium | Architecture Critique §3.2 |
+| Manual/WTA path post-processing duplicated | 🟡 Medium | Architecture Critique §1.4 |
+| Dynamic `require()` in hot path | 🟡 Medium | Architecture Critique §3.3 |
+| Jaccard antonym false-positive (strengths/weaknesses) | 🟡 Medium | Jaccard Critique |
+| `detectRefinementIntent` possibly unwired | 🟠 Low | Architecture Critique §2.2 |
+| Sanitization limits copy-pasted at 3 sites | 🟠 Low | Architecture Critique §3.4 |

--- a/docs/tech-debt/intelligence-engine-architecture-critique.md
+++ b/docs/tech-debt/intelligence-engine-architecture-critique.md
@@ -1,0 +1,359 @@
+# IntelligenceEngine — Architecture Critique & Recommended Fixes
+
+> **Scope**: `electron/IntelligenceEngine.ts` (5,094 lines) and `electron/llm/` module  
+> **Author**: Architecture review, August 2026  
+> **Status**: Findings only — no code changed in this PR
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#executive-summary)
+2. [Unnecessary Complexity](#1-unnecessary-complexity)
+3. [Unneeded / Dead Features](#2-unneeded--dead-features)
+4. [Features with the Wrong Approach](#3-features-with-the-wrong-approach)
+5. [Severity Summary Table](#severity-summary-table)
+6. [Recommended Refactor Direction](#recommended-refactor-direction)
+
+---
+
+## Executive Summary
+
+`IntelligenceEngine.ts` suffers from **progressive defensive accumulation**: every time the model produced a bad output, a new post-stream repair pass was bolted on. After many iterations this has produced:
+
+- A 5,094-line file containing what should be 6–8 separate modules
+- A single function (`runWhatShouldISay`) that is ~2,400 lines long
+- Up to 3 sequential blocking LLM regeneration calls *after* an answer has already streamed to the UI
+- Regex-based failure detectors that break with each new model provider
+- Disabled features that still run classifiers and consume CPU on every request
+
+The core insight: **the repair cascade is compensating for a weak primary prompt.** The right fix is upstream (stronger prompt constraints, structured output) not downstream (regex + LLM repair passes).
+
+---
+
+## 1. Unnecessary Complexity
+
+### 1.1 God File: `IntelligenceEngine.ts` is 5,094 lines
+
+**File**: [`electron/IntelligenceEngine.ts`](../../electron/IntelligenceEngine.ts)
+
+One file contains all of:
+- Mode routing and lifecycle (`idle`, `assist`, `what_to_say`, `follow_up`, `recap`, `clarify`, `manual`, `follow_up_questions`, `code_hint`, `brainstorm`)
+- Speculative pre-fetch logic + debouncing
+- Context assembly (profile, transcript, JD, screen, docs, custom mode contract)
+- Streaming + AbortController cancellation
+- 7+ distinct post-stream validation and repair passes, each with their own LLM calls
+- Telemetry marking (`PiLatencyTrace`)
+- Session persistence (`session.addAssistantMessage`)
+
+**Impact**: Impossible to unit-test individual stages. A change to the profile repair logic requires understanding 2,400 lines of context. Onboarding a new developer onto this file is a multi-day task.
+
+**Recommended Fix**:
+
+Extract into purpose-built modules:
+```
+electron/intelligence/
+  WtaPipeline.ts          ← orchestrator only (~200 lines)
+  stages/
+    PlanStage.ts          ← planAnswer(), answerPlan
+    ContextStage.ts       ← candidateProfile, docContext, JD assembly
+    GenerateStage.ts      ← raceStreamWithDeadline, streaming tokens
+    ValidateStage.ts      ← all post-stream guards (no LLM calls)
+    RepairStage.ts        ← bounded LLM repair (if needed at all)
+    PersistStage.ts       ← session.addAssistantMessage, emit
+```
+
+Each stage takes a `WtaContext` object and returns an updated one. Independently testable.
+
+---
+
+### 1.2 The Post-Stream Repair Cascade
+
+**File**: [`electron/IntelligenceEngine.ts`](../../electron/IntelligenceEngine.ts), lines ~2800–3800
+
+After the initial answer streams to the UI, the pipeline runs **8+ sequential passes**:
+
+| Phase | Gate | Extra LLM call? | Worst-case latency added |
+|-------|------|-----------------|--------------------------|
+| 1 | Leaked schema stubs / JSON envelopes | ❌ regex | ~0ms |
+| 2 | Scaffold misfire detection | ❌ regex | ~0ms |
+| 3 | Document-grounded answer validation | ✅ full regen | 4–7s |
+| 4 | Profile evidence validation (hallucinated metrics, identity leaks) | ✅ full regen | 4–7s |
+| 5 | `sanitizeCandidateAnswer` | ❌ regex | ~0ms |
+| 6 | Assistant voice misfire guard | ❌ regex | ~0ms |
+| 7 | False-no-content-claim guard | ❌ regex | ~0ms |
+| 8 | Answer relevance guard (NLI, **currently disabled**) | ✅ full regen | 4–7s |
+| Always | `cleanAnswerArtifacts`, `compressToSpeakable` | ❌ | ~0ms |
+
+In the worst case (Phase 3 + Phase 4 both trigger), **14 additional seconds of latency** accrue after the answer the user already saw starts streaming. The regenerated text then silently replaces the streamed row.
+
+**The UX problem**: The user sees a bad answer streaming in. The system detects it, regenerates behind the scenes, then swaps the row. This is jarring and untrustworthy.
+
+**The code smell**: After every repair, `isLeakedAnswerArtifact()` is re-checked:
+```ts
+// From lines 3249, 3443, 3790 — the same check, three times:
+&& !isLeakedAnswerArtifact(repairedTrim)
+```
+This is the clearest symptom that each repair can reintroduce the same class of failures as the original generation. The validation logic has no stable foundation.
+
+**Recommended Fix**:
+
+1. **Move profile and identity constraints into the primary prompt** as hard-formatted instructions. Most of Phase 4 (identity leak, false refusal) should never reach post-stream — the model should be unable to produce these shapes if the primary prompt is correctly specified.
+2. **Use structured output / `response_format: json_schema`** where the provider supports it (OpenAI, Gemini) to eliminate the schema-stub / JSON-envelope repair gates entirely (Phases 1 & 2).
+3. **Reduce post-stream repair to one optional LLM pass** that only fires if the output fails a deterministic structural check — and only runs for the doc-grounded path where factual accuracy checking is genuinely needed post-generation.
+
+---
+
+### 1.3 `AnswerPlanner.ts` is 211KB
+
+**File**: [`electron/llm/AnswerPlanner.ts`](../../electron/llm/AnswerPlanner.ts) — 211,175 bytes
+
+A single file containing prompt templates, routing logic, policy rules, type definitions, and business logic all mixed together. No individual component can be imported, tested, or modified without loading the entire 211KB module.
+
+**Recommended Fix**: Split into a directory:
+```
+electron/llm/answerPlanner/
+  index.ts                    ← re-exports public surface
+  types.ts                    ← AnswerPlan, DocumentQuestionShape, etc.
+  router.ts                   ← planAnswer(), routing decisions
+  policy.ts                   ← profileContextPolicy, voicePerspective rules
+  templates/
+    candidate/                ← interview answer templates
+    document/                 ← doc-grounded templates
+    assistant/                ← meeting/lecture/sales templates
+    coding/                   ← DSA/system design templates
+```
+
+---
+
+### 1.4 Manual Path / WTA Path Code Duplication
+
+**Files**: [`electron/IntelligenceEngine.ts`](../../electron/IntelligenceEngine.ts), [`electron/ipcHandlers.ts`](../../electron/ipcHandlers.ts), [`electron/llm/manualProfileIntelligence.ts`](../../electron/llm/manualProfileIntelligence.ts) (89KB)
+
+Throughout `IntelligenceEngine.ts`, comments repeatedly say *"mirrors the same guard added to ipcHandlers.ts"* — indicating that every bug fix must be applied in two places:
+
+```
+// From line 3239:
+// NON-REGRESSION LENGTH FLOOR (root-cause fix, 2026-07-23,
+// mirrors the same guard added to ipcHandlers.ts's manual-chat regen path)
+```
+
+```
+// From line 3476:
+// Campaign 2 longsession run-023 finding (2026-07-18): ...
+// The manual path (ipcHandlers.ts, same sanitizer) already has this
+// exact `needsFallback` branch — mirrored here.
+```
+
+This is textbook maintenance debt. Both paths share identical post-processing needs but don't share code.
+
+**Recommended Fix**: Extract a shared `AnswerPostProcessor` class that both the WTA auto-trigger path and the manual chat path call. Post-processing logic lives in one place.
+
+---
+
+## 2. Unneeded / Dead Features
+
+### 2.1 Answer Relevance Guard (Phase 8) — Disabled in Production, Still Runs Classifier
+
+**File**: [`electron/IntelligenceEngine.ts`](../../electron/IntelligenceEngine.ts), lines ~3617–3804  
+**Flag**: `isIntelligenceFlagEnabled('answerRelevanceGuardLive')` — **OFF by default**
+
+```ts
+if (!isIntelligenceFlagEnabled('answerRelevanceGuardLive')) {
+    // observe-only: classifier still runs, result is logged, fullAnswer never mutated
+    trace.mark('validation_completed', { reason: 'answer_relevance_observe_only' });
+} else {
+    // ... hundreds of lines of repair logic ...
+}
+```
+
+The guard was disabled because validation (run-032) proved it *made correct answers worse* — it flagged correct answers as irrelevant and regenerated them into worse versions. Despite being disabled, it still:
+- Runs `checkAnswerRelevance()` (NLI inference via `IntentClassifier.ts`) on **every** non-speculative, non-coding answer
+- Emits a trace mark
+- The full repair code path (repair prompt, `raceStreamWithDeadline`, re-check, acceptance logic) sits in the live file, misleading readers into thinking it's active
+
+**Recommended Fix**: 
+- Delete the entire Phase 8 repair block
+- If telemetry is still needed, move the `checkAnswerRelevance` call to a background analytics path that never touches `fullAnswer`
+- Recalibrate the classifier against real score distributions before re-enabling
+
+---
+
+### 2.2 `detectRefinementIntent` — Possibly Dead Code in Main WTA Flow
+
+**File**: [`electron/IntelligenceEngine.ts`](../../electron/IntelligenceEngine.ts), lines 81–100
+
+```ts
+function detectRefinementIntent(userText: string): { isRefinement: boolean; intent: string } {
+    const refinementPatterns = [
+        { pattern: /make it longer|expand on this|elaborate more/i, intent: 'expand' },
+        { pattern: /rephrase that|say it differently|put it another way/i, intent: 'rephrase' },
+        // ...5 more patterns
+    ];
+    ...
+}
+```
+
+This function is called in `handleTranscript` at line 559 (on the user's speaker segment), which triggers `runFollowUp`. However, it is:
+- **Not connected to the WTA path** at all
+- Triggered on the raw STT token-by-token transcript, which means it fires on "make it longer" only if the user says that *exact phrase* aloud in the meeting
+- The `intent` string it returns is passed to `runFollowUp(intent, ...)` but `runFollowUp` does not appear to actually use the intent string to modify its behavior
+
+**Recommended Action**: Audit whether `runFollowUp` uses the `intent` parameter. If not, remove `detectRefinementIntent` and the intent passing. If yes, document the feature and add a test — it's currently invisible.
+
+---
+
+### 2.3 Multiple Single-Shot Modes Are Thin Duplicates
+
+**File**: [`electron/IntelligenceEngine.ts`](../../electron/IntelligenceEngine.ts)
+
+`runBrainstorm`, `runCodeHint`, `runClarify`, `runFollowUpQuestions` are all `IntelligenceMode` variants that each:
+- Set up their own `AbortController`
+- Have their own error handling boilerplate
+- Call a single LLM function and emit the result
+
+They could be unified into a single `runOneshot(mode: IntelligenceMode, prompt: string)` helper, reducing ~300 lines to ~60.
+
+---
+
+## 3. Features with the Wrong Approach
+
+### 3.1 Post-Stream Repair is the Wrong UX Model
+
+Already covered in §1.2 above. To summarize the UX impact clearly:
+
+```
+Timeline (worst case, Phase 3 + 4 both fire):
+
+0ms    → Answer starts streaming to user
+2000ms → Stream completes. User reads the answer.
+2001ms → Phase 3 (doc-grounded validation) starts LLM call
+7000ms → Phase 3 repair completes. User still reading.
+7001ms → Phase 4 (profile validation) starts LLM call
+14000ms→ Phase 4 repair completes. Row is silently swapped.
+```
+
+The user is reading and possibly acting on the first version of the answer while the system is swapping it out under them. This is worse than showing nothing while a correct answer generates.
+
+**Recommended Fix**: Show a loading skeleton ("Thinking…") and only render the final, validated answer. One generation, one render. This is what every major AI assistant does.
+
+---
+
+### 3.2 Regex-Based LLM Failure Detection
+
+**File**: [`electron/llm/`](../../electron/llm/) — multiple files
+
+Functions like `isLeakedSchemaStub`, `isLeakedJsonEnvelope`, `isLeakedInternalTagBlock`, `isFalseNoContentClaim`, `detectAssistantVoiceMisfire` are regex-based detectors for specific failure phrasings from specific model versions.
+
+Each was added to fix a specific observed regression:
+- `isLeakedJsonEnvelope` — added when a specific provider started wrapping answers in JSON
+- `detectAssistantVoiceMisfire` — added because *"smaller models over-apply the prompt's identity reply"*
+- `isFalseNoContentClaim` — added because *"M3 over-applies the system-prompt refusal"*
+
+**Why this fails**: Each new model or model version produces different failure phrasings. The guard list grows with every provider integration. These are per-model bugs, not general solutions.
+
+**Recommended Fix**:
+1. **Use `response_format: { type: "json_schema", ... }`** for providers that support it (OpenAI, Gemini). Constrain the output shape at the API level — the model *cannot* produce JSON envelopes or schema stubs if it's required to emit a specific schema.
+2. For providers without structured output: write **one general-purpose output validator** that checks structural invariants (is it valid prose? does it start with a refusal phrase?) rather than a growing list of named pattern guards.
+3. **Model-specific quirks belong in the provider adapter layer** (`ProviderRouter.ts`), not scattered as top-level flags in the answer pipeline.
+
+---
+
+### 3.3 Dynamic `require()` in the Hot Answer Path
+
+**File**: [`electron/IntelligenceEngine.ts`](../../electron/IntelligenceEngine.ts), line ~3298
+
+```ts
+const { allowsEvidence } = require('./intelligence/context-os') as typeof import('./intelligence/context-os');
+```
+
+This is a synchronous dynamic `require()` inside the hot WTA path, wrapped in a `try/catch` that fails open (`return true`). Problems:
+- Bypasses TypeScript's module graph analysis
+- Prevents tree-shaking
+- The `try/catch` silently grants permission if the require fails — a security-adjacent default that should be the opposite
+
+**Recommended Fix**: Convert to a static import at the top of the file. The module is always needed when Context OS is active; there's no legitimate reason for it to be dynamic.
+
+---
+
+### 3.4 `sanitizeManualContextText` Called Per-Field with Inconsistent Limits
+
+**File**: [`electron/IntelligenceEngine.ts`](../../electron/IntelligenceEngine.ts), lines ~3354, ~3368, ~3734
+
+```ts
+// Doc-grounded repair:
+IntelligenceEngine.sanitizeManualContextText(candidateProfile, 8000)
+IntelligenceEngine.sanitizeManualContextText(question, 1000)
+
+// Profile repair:
+IntelligenceEngine.sanitizeManualContextText(candidateProfile, 8000)
+IntelligenceEngine.sanitizeManualContextText(question, 1000)
+
+// Relevance repair:
+IntelligenceEngine.sanitizeManualContextText(candidateProfile, 8000)  // 8000
+IntelligenceEngine.sanitizeManualContextText(relevanceQuestion, 1000) // 1000
+```
+
+The same sanitization is copy-pasted at 3 repair call sites with manually typed limits. If the profile limit changes, it must be updated in 3 places.
+
+**Recommended Fix**: Assemble the context object once at the start of `runWhatShouldISay`:
+
+```ts
+const sanitizedCtx = {
+    profile: sanitize(candidateProfile, MAX_PROFILE_CHARS),
+    question: sanitize(resolvedQuestion, MAX_QUESTION_CHARS),
+    docContext: sanitize(docContextBlock, MAX_DOC_CHARS),
+};
+```
+
+Pass `sanitizedCtx` through to all repair sites. One assembly, zero drift.
+
+---
+
+## Severity Summary Table
+
+| Problem | Severity | File(s) |
+|---------|----------|---------|
+| `runWhatShouldISay` is ~2,400 lines | 🔴 Critical | `IntelligenceEngine.ts` |
+| Post-stream repair cascade with 2–3 sequential LLM calls | 🔴 Critical | `IntelligenceEngine.ts` |
+| Answer relevance guard disabled but classifier still runs on every call | 🟡 Medium | `IntelligenceEngine.ts` |
+| `AnswerPlanner.ts` at 211KB, no internal module split | 🟡 Medium | `llm/AnswerPlanner.ts` |
+| Regex-based LLM failure detection growing per provider/version | 🟡 Medium | `llm/` (multiple files) |
+| Manual path / WTA path post-processing duplicated | 🟡 Medium | `IntelligenceEngine.ts`, `ipcHandlers.ts` |
+| Dynamic `require()` in hot path with fail-open catch | 🟡 Medium | `IntelligenceEngine.ts` |
+| `detectRefinementIntent` possibly unused / unverified | 🟠 Low-Medium | `IntelligenceEngine.ts` |
+| Sanitization limits copy-pasted at 3 repair call sites | 🟠 Low | `IntelligenceEngine.ts` |
+| `runBrainstorm` / `runCodeHint` / `runClarify` boilerplate duplication | 🟠 Low | `IntelligenceEngine.ts` |
+
+---
+
+## Recommended Refactor Direction
+
+The following is a prioritized sequence — each step is independently mergeable:
+
+### Step 1 (Highest ROI): Delete the disabled relevance guard (Phase 8)
+- Remove ~200 lines from the hot path
+- Stop running NLI classification on every answer
+- Zero risk: it's already disabled
+
+### Step 2: Extract `WtaPipeline` with explicit named stages
+- Move the 2,400-line function into a class with stage methods
+- Each stage becomes independently unit-testable
+- No behavior change required at this step
+
+### Step 3: Unify post-processing into `AnswerPostProcessor`
+- Both `IntelligenceEngine.ts` (WTA) and `ipcHandlers.ts` (manual) call the same class
+- Eliminates all "mirrors the same guard" comment patterns
+
+### Step 4: Replace post-stream repair with pre-generation constraints
+- Move profile/identity rules into the primary prompt template
+- Enable `response_format` structured output for OpenAI/Gemini providers
+- Target: reduce post-stream repair to **zero LLM calls** on the happy path
+
+### Step 5: Split `AnswerPlanner.ts`
+- Pure refactor, no behavior change
+- Enables per-template unit tests
+
+### Step 6: Replace per-model regex guards with provider-adapter pattern
+- Each provider adapter handles its own output normalization
+- Core pipeline sees clean, normalized strings only

--- a/docs/tech-debt/replace-placeholder-corruption-bug.md
+++ b/docs/tech-debt/replace-placeholder-corruption-bug.md
@@ -42,49 +42,59 @@ inline.forEach((c, i) => { s = s.replace(`  INL${i}  `, c); });
 When the first argument to `String.prototype.replace()` is a string and the second argument is a **replacement string**, JavaScript searches for special **dollar-sign replacement patterns** in that replacement string:
 
 - `$&` — Replaced by the matched substring (in this case, the placeholder token itself, e.g. `FENCE0`).
-- `$`` — Replaced by the portion of the string preceding the matched substring.
-- `$'` — Replaced by the portion of the string following the matched substring.
-- `$n` (where `n` is a digit) — Replaced by capturing groups.
+- `` $` `` — Replaced by the portion of the string **preceding** the matched substring.
+- `$'` — Replaced by the portion of the string **following** the matched substring.
+- `$n` (where `n` is a digit) — **Only expands when the search pattern is a regex with capturing groups.** With a literal string search there are no capturing groups, so `$1`, `$2`, etc. are left as-is and are **not** a vulnerability here.
 
 Because the code blocks (`f`, `c`) and math blocks (`m`) are **untrusted LLM outputs**, they frequently contain `$` characters. When these blocks contain dollar-sign patterns, JavaScript expands them during the replacement, corrupting the code block.
 
 ### Concrete Failure Examples
 
-#### 1. Shell Script / Bash Variables (`$1`, `$2`, `$n`)
-If the model outputs a Bash script containing command line arguments:
-```bash
-#!/bin/bash
-echo "First arg: $1"
-echo "Second arg: $2"
-```
-Because the replacement pattern is a literal string, `$1` and `$2` are interpreted as capture groups. Since there are no capturing groups in the literal string matches (`"FENCE0"`), `$1` and `$2` are replaced by **empty strings** or left partially unresolved depending on the engine context, corrupting the script:
-```bash
-#!/bin/bash
-echo "First arg: "
-echo "Second arg: "
+#### 1. jQuery / Code using `$&` (matched-substring expansion)
+
+If the model outputs JavaScript that uses `$&` — for example as a literal symbol in a regex explanation or a jQuery snippet:
+
+```javascript
+// LLM output inside a fenced code block:
+let result = str.replace(/foo/, "matched: $& done");
 ```
 
-#### 2. jQuery / Regex / Bash Run-in-Background (`$&`)
-If the model outputs Javascript regex code or jQuery operations using `$&` (which denotes the last match):
+When the pipeline restores ` CODE0 ` via `result.replace(" CODE0 ", block)`, JavaScript
+exands `$&` in `block` to the match string (` CODE0 ` itself), leaking the internal token
+into the rendered answer:
+
 ```javascript
-let pattern = /foo/;
-let replaced = text.replace(pattern, "bar $& baz");
-```
-During restoration, the JS engine replaces `$&` in the replacement string with the matched pattern (` CODE0 `). The output becomes corrupted, leaking the internal template marker:
-```javascript
-let pattern = /foo/;
-let replaced = text.replace(pattern, "bar  CODE0  baz");
+// Corrupted output:
+let result = str.replace(/foo/, "matched:  CODE0  done");
 ```
 
-#### 3. Math Formulas containing multiple `$` symbols
-If a math block contains variable names like `$x_1` or expressions with sub-scripts:
-```markdown
-We can see that $x_1 = a$ and $y_2 = b$.
+#### 2. Preceding-context expansion with `` $` ``
+
+If the model outputs a code block containing `` $` `` (the backtick form of the pre-match pattern),
+the replacement inserts everything in the output string that appears **before** the placeholder.
+This causes arbitrary text from the surrounding prose to be injected into the middle of the code block:
+
+```ts
+// LLM output:
+const s = `hello $\`world\``;
 ```
-The `$1` in `$x_1` is stripped, rendering the math incorrectly in the UI:
-```markdown
-We can see that $x_ = a$ and $y_2 = b$.
+
+```ts
+// Corrupted — preceding prose bled into the code block:
+const s = `hello The answer to your question is...world`;
 ```
+
+#### 3. Following-context expansion with `$'`
+
+Similarly, `$'` expands to everything **after** the matched placeholder, injecting the
+remainder of the answer string into the code block — a mirror image of the `` $` `` vulnerability.
+
+> **Note on `$n` patterns (Bash variables, math subscripts):** When `.replace()` is called
+> with a **literal string** as the first argument (as in this code), there are no regex
+> capturing groups. Per the ECMAScript specification, `$1`, `$2`, `$x_1`, etc. are therefore
+> left **entirely literal** in the replacement output. Bash scripts with `$1` / `$2` and math
+> formulas with `$x_1` are **not** corrupted by this mechanism. The only real danger patterns
+> are `$&`, `` $` ``, and `$'`.
 
 ---
 

--- a/docs/tech-debt/replace-placeholder-corruption-bug.md
+++ b/docs/tech-debt/replace-placeholder-corruption-bug.md
@@ -1,0 +1,130 @@
+# Unsafe String Replacement: Code and Math Placeholder Corruption Bug
+
+> **Scope**: `electron/llm/answerPolish.ts` (line 480) and `electron/llm/postProcessor.ts` (lines 85, 88, 133, 134)  
+> **Author**: Architecture review, August 2026  
+> **Status**: Findings only — no code changed in this PR
+
+---
+
+## The Bug: Restoring Fenced Templates via Unsafe `.replace()`
+
+To protect code blocks, inline code, and mathematical formulas from prose post-processing (such as dash reduction or bullet cleaning), the pipeline temporarily extracts them and replaces them with unique tokens (e.g. `FENCE0`, ` CODE0 `, ` INL0 `, ` MATH0 `).
+
+After post-processing completes, the tokens are restored to the final answer string using JavaScript's `String.prototype.replace()`.
+
+### The Vulnerable Code
+
+In `electron/llm/answerPolish.ts`:
+```ts
+// Line 480: Unsafe replacement of fence tokens
+fences.forEach((f, i) => { out = out.replace(`FENCE${i}`, f); });
+```
+
+In `electron/llm/postProcessor.ts`:
+```ts
+// Lines 84-89: Unsafe replacement of code blocks and inline code
+inlineCodes.forEach((c, i) => {
+    result = result.replace(` INL${i} `, c);
+});
+codeBlocks.forEach((c, i) => {
+    result = result.replace(` CODE${i} `, c);
+});
+
+// Lines 133-134: Unsafe replacement of inline math and inline code
+math.forEach((m, i) => { s = s.replace(`  MATH${i}  `, m); });
+inline.forEach((c, i) => { s = s.replace(`  INL${i}  `, c); });
+```
+
+---
+
+## Why This Causes Wrong Answers / Code Corruption
+
+When the first argument to `String.prototype.replace()` is a string and the second argument is a **replacement string**, JavaScript searches for special **dollar-sign replacement patterns** in that replacement string:
+
+- `$&` — Replaced by the matched substring (in this case, the placeholder token itself, e.g. `FENCE0`).
+- `$`` — Replaced by the portion of the string preceding the matched substring.
+- `$'` — Replaced by the portion of the string following the matched substring.
+- `$n` (where `n` is a digit) — Replaced by capturing groups.
+
+Because the code blocks (`f`, `c`) and math blocks (`m`) are **untrusted LLM outputs**, they frequently contain `$` characters. When these blocks contain dollar-sign patterns, JavaScript expands them during the replacement, corrupting the code block.
+
+### Concrete Failure Examples
+
+#### 1. Shell Script / Bash Variables (`$1`, `$2`, `$n`)
+If the model outputs a Bash script containing command line arguments:
+```bash
+#!/bin/bash
+echo "First arg: $1"
+echo "Second arg: $2"
+```
+Because the replacement pattern is a literal string, `$1` and `$2` are interpreted as capture groups. Since there are no capturing groups in the literal string matches (`"FENCE0"`), `$1` and `$2` are replaced by **empty strings** or left partially unresolved depending on the engine context, corrupting the script:
+```bash
+#!/bin/bash
+echo "First arg: "
+echo "Second arg: "
+```
+
+#### 2. jQuery / Regex / Bash Run-in-Background (`$&`)
+If the model outputs Javascript regex code or jQuery operations using `$&` (which denotes the last match):
+```javascript
+let pattern = /foo/;
+let replaced = text.replace(pattern, "bar $& baz");
+```
+During restoration, the JS engine replaces `$&` in the replacement string with the matched pattern (` CODE0 `). The output becomes corrupted, leaking the internal template marker:
+```javascript
+let pattern = /foo/;
+let replaced = text.replace(pattern, "bar  CODE0  baz");
+```
+
+#### 3. Math Formulas containing multiple `$` symbols
+If a math block contains variable names like `$x_1` or expressions with sub-scripts:
+```markdown
+We can see that $x_1 = a$ and $y_2 = b$.
+```
+The `$1` in `$x_1` is stripped, rendering the math incorrectly in the UI:
+```markdown
+We can see that $x_ = a$ and $y_2 = b$.
+```
+
+---
+
+## The Solution: Callback-Based Replacement
+
+To prevent JavaScript from parsing dollar-sign patterns in the replacement string, the second argument to `replace()` must be a **callback function** that returns the string. 
+
+When a function is provided, JavaScript does **not** evaluate dollar-sign replacement patterns; the return value of the function is inserted exactly as-is.
+
+### Recommended Fix
+
+Update the restoration loops to use callback functions:
+
+#### In `electron/llm/answerPolish.ts` (line 480):
+```diff
+-fences.forEach((f, i) => { out = out.replace(`FENCE${i}`, f); });
++fences.forEach((f, i) => { out = out.replace(`FENCE${i}`, () => f); });
+```
+
+#### In `electron/llm/postProcessor.ts` (lines 84-89 and 133-134):
+```diff
+-inlineCodes.forEach((c, i) => {
+-    result = result.replace(` INL${i} `, c);
+-});
+-codeBlocks.forEach((c, i) => {
+-    result = result.replace(` CODE${i} `, c);
+-});
++inlineCodes.forEach((c, i) => {
++    result = result.replace(` INL${i} `, () => c);
++});
++codeBlocks.forEach((c, i) => {
++    result = result.replace(` CODE${i} `, () => c);
++});
+```
+
+```diff
+-math.forEach((m, i) => { s = s.replace(`  MATH${i}  `, m); });
+-inline.forEach((c, i) => { s = s.replace(`  INL${i}  `, c); });
++math.forEach((m, i) => { s = s.replace(`  MATH${i}  `, () => m); });
++inline.forEach((c, i) => { s = s.replace(`  INL${i}  `, () => c); });
+```
+
+This single character change (`f` → `() => f`) completely neutralizes the placeholder corruption vulnerability across all coding and mathematical outputs.

--- a/docs/tech-debt/speculative-similarity-jaccard-critique.md
+++ b/docs/tech-debt/speculative-similarity-jaccard-critique.md
@@ -97,7 +97,10 @@ embed("Tell me about a project you led") · embed("Tell me about a time you show
   → cosine ≈ 0.82  ← correctly HIGH (synonymous intent, Jaccard would miss this)
 ```
 
----
+> **⚠️ Illustrative values only.** The cosine scores above (`≈ 0.31`, `≈ 0.89`, `≈ 0.82`) are
+> indicative estimates based on the model's known semantic geometry, not measurements against
+> this repository's production data. They should be validated against a labelled set of real
+> interview question pairs before being used to set thresholds. See *Threshold Calibration* below.
 
 ## Recommended Implementation: Hybrid Approach
 
@@ -137,6 +140,7 @@ export async function speculativeSimilarity(
         embeddingWorker.embed(finalQuestion),
     ]);
     const cosine = cosineSimilarity(embA, embB);
+    // ILLUSTRATIVE threshold — calibrate against real question pairs before shipping
     const SBERT_THRESHOLD = 0.65;
     return { accepted: cosine >= SBERT_THRESHOLD, score: cosine, method: 'sbert' };
 }
@@ -160,9 +164,14 @@ if (accepted) {
 
 ---
 
-## Threshold Calibration
+## Threshold Calibration ⚠️ (values below are illustrative — not yet measured)
 
-The current `SPECULATIVE_SIMILARITY_THRESHOLD` constant should be audited. If it's ≥ 0.7, Jaccard-inflated stop-word matches may be passing the gate. With the hybrid approach:
+The figures in this section are **starting-point estimates** derived from the illustrative
+cosine examples above. They must be validated against a representative corpus of real interview
+question pairs before being used in production. Treat `0.65` and `0.92` as hypotheses, not policy.
+
+The current `SPECULATIVE_SIMILARITY_THRESHOLD` constant should also be audited. If it's ≥ 0.7,
+Jaccard-inflated stop-word matches may be passing the gate. With the hybrid approach:
 
 - **Jaccard fast-accept threshold**: 0.92 (very conservative — only obvious prefix completions bypass SBERT)
 - **SBERT acceptance threshold**: 0.65 (raw cosine similarity)
@@ -193,9 +202,9 @@ The only thing that needs to change is how the similarity score is computed in t
 
 | Aspect | Current (Jaccard) | Recommended (Hybrid) |
 |--------|------------------|----------------------|
-| Antonym pairs (strengths/weaknesses) | ❌ ~0.72 — close to threshold | ✅ ~0.31 SBERT — correct reject |
+| Antonym pairs (strengths/weaknesses) | ❌ ~0.72 — close to threshold | ✅ ~0.31 SBERT — correct reject *(illustrative)* |
 | Prefix completion (partial → full) | ✅ Handled by containment blend | ✅ Still handled at fast-exit tier |
-| Synonymous rephrasing | ❌ ~0.42 — may incorrectly reject | ✅ ~0.82 SBERT — correct accept |
+| Synonymous rephrasing | ❌ ~0.42 — may incorrectly reject | ✅ ~0.82 SBERT — correct accept *(illustrative)* |
 | Latency (fast cases) | µs | µs (Jaccard fast exit) |
 | Latency (ambiguous zone) | µs | ~5–10ms (SBERT) |
 | Model size overhead | 0MB | +22MB (`all-MiniLM-L6-v2`) |

--- a/docs/tech-debt/speculative-similarity-jaccard-critique.md
+++ b/docs/tech-debt/speculative-similarity-jaccard-critique.md
@@ -54,12 +54,12 @@ Jaccard compares raw word-token sets. This means two questions can score high de
 | Speculative text | Final text | Jaccard score | Should reuse? |
 |---|---|---|---|
 | `"Can you walk me through"` | `"Can you walk me through your design process?"` | ~0.90 (containment) | ✅ Yes |
-| `"What are your greatest strengths"` | `"What are your greatest weaknesses"` | **~0.75** | ❌ No — opposite |
-| `"Tell me about a time you succeeded"` | `"Tell me about a time you failed"` | **~0.64** | ❌ No — opposite |
+| `"What are your greatest strengths"` | `"What are your greatest weaknesses"` | **~0.72** | ❌ No — opposite (but dangerously close to threshold) |
+| `"Tell me about a time you succeeded"` | `"Tell me about a time you failed"` | **~0.77** | ❌ No — opposite (false accept under 0.75 threshold) |
 | `"Can you describe your leadership style"` | `"Can you describe your biggest mistake"` | ~0.55 | ❌ Likely rejected but close |
 | `"Tell me about a project you led"` | `"Tell me about a time you showed leadership"` | ~0.42 | ✅ Should reuse — same intent |
 
-**The critical failure class** for this app is row 2 and row 3. In interview contexts, "strengths/weaknesses", "success/failure", "led/followed" are extremely common antonym pairs. An answer about the candidate's strengths played in response to a weaknesses question is the **single worst possible failure mode** — it gives the candidate the wrong answer to speak aloud.
+**The critical failure class** for this app is row 2 and row 3. In interview contexts, "strengths/weaknesses", "success/failure", "led/followed" are extremely common antonym pairs. Under the current `SPECULATIVE_SIMILARITY_THRESHOLD = 0.75` check, the succeeded/failed comparison (scoring ~0.77 due to containment blend) results in a **false accept**, which is the **single worst possible failure mode** — it serves the candidate the wrong answer (success details) to speak aloud in response to a failure question. The strengths/weaknesses comparison (scoring ~0.72) is rejected under 0.75 but is dangerously close, and would be accepted if a user slightly rephrases either prompt.
 
 ### Why stop words inflate the score
 
@@ -137,7 +137,7 @@ export async function speculativeSimilarity(
         embeddingWorker.embed(finalQuestion),
     ]);
     const cosine = cosineSimilarity(embA, embB);
-    return { score: (cosine + 1) / 2, method: 'sbert' }; // normalize to [0,1]
+    return { score: cosine, method: 'sbert' };
 }
 ```
 
@@ -155,7 +155,7 @@ if (score >= SPECULATIVE_SIMILARITY_THRESHOLD) {
 
 ### Worker reuse
 
-`IntentClassifier.ts` already maintains a warmed transformer worker. The embedding worker can share the same infrastructure — no new model-loading overhead on startup. The worker is already warm by the time a speculative check fires.
+`LocalEmbeddingProvider` already loads `all-MiniLM-L6-v2` in a background worker thread for normalized feature extraction and RAG indexing. The speculative similarity gate should reuse this existing worker infrastructure to retrieve embeddings, avoiding any new model-loading overhead on startup.
 
 ---
 
@@ -164,7 +164,7 @@ if (score >= SPECULATIVE_SIMILARITY_THRESHOLD) {
 The current `SPECULATIVE_SIMILARITY_THRESHOLD` constant should be audited. If it's ≥ 0.7, Jaccard-inflated stop-word matches may be passing the gate. With the hybrid approach:
 
 - **Jaccard fast-accept threshold**: 0.92 (very conservative — only obvious prefix completions bypass SBERT)
-- **SBERT acceptance threshold**: 0.65 (cosine normalized to [0,1])
+- **SBERT acceptance threshold**: 0.65 (raw cosine similarity)
 
 These values should be validated against a test set of real interview question pairs covering:
 - Clear prefixes ("Can you walk me through" → "Can you walk me through your architecture")
@@ -192,10 +192,10 @@ The only thing that needs to change is how the similarity score is computed in t
 
 | Aspect | Current (Jaccard) | Recommended (Hybrid) |
 |--------|------------------|----------------------|
-| Antonym pairs (strengths/weaknesses) | ❌ ~0.75 — often wrong accept | ✅ ~0.31 SBERT — correct reject |
+| Antonym pairs (strengths/weaknesses) | ❌ ~0.72 — close to threshold | ✅ ~0.31 SBERT — correct reject |
 | Prefix completion (partial → full) | ✅ Handled by containment blend | ✅ Still handled at fast-exit tier |
 | Synonymous rephrasing | ❌ ~0.42 — may incorrectly reject | ✅ ~0.82 SBERT — correct accept |
 | Latency (fast cases) | µs | µs (Jaccard fast exit) |
 | Latency (ambiguous zone) | µs | ~5–10ms (SBERT) |
 | Model size overhead | 0MB | +22MB (`all-MiniLM-L6-v2`) |
-| Infrastructure needed | None | Worker thread (reuse IntentClassifier pattern) |
+| Infrastructure needed | None | Worker thread (reuse LocalEmbeddingProvider worker) |

--- a/docs/tech-debt/speculative-similarity-jaccard-critique.md
+++ b/docs/tech-debt/speculative-similarity-jaccard-critique.md
@@ -1,0 +1,201 @@
+# Speculative Pre-fetch: Jaccard Similarity Critique & Recommended Fix
+
+> **Scope**: `electron/IntelligenceEngine.ts` — `jaccardSimilarity()` and `handleSuggestionTrigger()`  
+> **Author**: Architecture review, August 2026  
+> **Status**: Findings only — no code changed in this PR
+
+---
+
+## What the Jaccard Check Does
+
+When the STT system detects a high-confidence interviewer question mid-sentence, the engine speculatively fires an LLM call before the sentence is finished (`maybeSpeculate`, line ~496). When the final, complete transcript arrives, `handleSuggestionTrigger` must decide: **is the question the model speculated on close enough to the final question to reuse the answer — or does it need to re-run?**
+
+```
+Interviewer mid-sentence (partial):   "Can you walk me through"
+→ speculative LLM call fires
+
+Interviewer finishes:                 "Can you walk me through your system design?"
+→ Jaccard check: partial ↔ final
+→ score ≥ threshold → reuse speculative answer, skip re-generation
+```
+
+The implementation is at lines 477–486:
+
+```ts
+private static jaccardSimilarity(a: string, b: string): number {
+    const setA = IntelligenceEngine.wordsOf(a); // raw word tokens, lowercased
+    const setB = IntelligenceEngine.wordsOf(b);
+    if (setA.size === 0 && setB.size === 0) return 1;
+    let intersection = 0;
+    setA.forEach(w => { if (setB.has(w)) intersection++; });
+    const jaccard = intersection / (setA.size + setB.size - intersection);
+    // Containment: fraction of speculative words covered by final
+    const containment = setA.size > 0 ? intersection / setA.size : 0;
+    return Math.max(jaccard, containment * 0.9);
+}
+```
+
+The **containment blend** (`Math.max(jaccard, containment * 0.9)`) was added because pure Jaccard underestimates prefix-to-full matches. The comment explicitly acknowledges this limitation.
+
+---
+
+## What Works
+
+- Computationally free — runs in microseconds, no model load
+- The containment blend is a correct and thoughtful fix for the intended prefix-completion case
+- Works well for the common case: partial sentence vs. complete sentence on the same topic
+
+---
+
+## The Core Problem: Token Overlap ≠ Semantic Similarity
+
+Jaccard compares raw word-token sets. This means two questions can score high despite being **semantically opposite**:
+
+| Speculative text | Final text | Jaccard score | Should reuse? |
+|---|---|---|---|
+| `"Can you walk me through"` | `"Can you walk me through your design process?"` | ~0.90 (containment) | ✅ Yes |
+| `"What are your greatest strengths"` | `"What are your greatest weaknesses"` | **~0.75** | ❌ No — opposite |
+| `"Tell me about a time you succeeded"` | `"Tell me about a time you failed"` | **~0.64** | ❌ No — opposite |
+| `"Can you describe your leadership style"` | `"Can you describe your biggest mistake"` | ~0.55 | ❌ Likely rejected but close |
+| `"Tell me about a project you led"` | `"Tell me about a time you showed leadership"` | ~0.42 | ✅ Should reuse — same intent |
+
+**The critical failure class** for this app is row 2 and row 3. In interview contexts, "strengths/weaknesses", "success/failure", "led/followed" are extremely common antonym pairs. An answer about the candidate's strengths played in response to a weaknesses question is the **single worst possible failure mode** — it gives the candidate the wrong answer to speak aloud.
+
+### Why stop words inflate the score
+
+`wordsOf` uses `\b\w+\b` with no stop-word filtering. Words like `"what"`, `"are"`, `"your"`, `"can"`, `"you"`, `"a"`, `"the"`, `"tell"`, `"me"`, `"about"` appear in almost every interview question. They inflate the intersection, making questions look more similar than they are.
+
+---
+
+## The Right Fix: Semantic Embedding Similarity
+
+### The Model: Sentence-BERT (`all-MiniLM-L6-v2`)
+
+Raw BERT (`[CLS]` pooling) is **not appropriate for sentence similarity** — it wasn't trained for it. The correct model is Sentence-BERT (SBERT), specifically fine-tuned on paraphrase and NLI tasks.
+
+| Model | Size | CPU latency | Quality |
+|-------|------|-------------|---------|
+| `paraphrase-MiniLM-L3-v2` | 17MB | ~3ms | Good |
+| **`all-MiniLM-L6-v2`** | **22MB** | **~5–10ms** | **Best for size** |
+| `all-MiniLM-L12-v2` | 34MB | ~15ms | Better |
+| `all-mpnet-base-v2` | 420MB | ~50ms | Best overall |
+
+**`all-MiniLM-L6-v2` is the right pick** — 22MB, ~5–10ms on CPU, trained specifically on semantic similarity tasks. The codebase already has the infrastructure for this: `IntentClassifier.ts` (34KB) runs a transformer model in a `Worker` thread. The same worker pattern applies.
+
+### How it fixes the antonym problem
+
+Under cosine similarity of SBERT embeddings:
+
+```
+embed("What are your greatest strengths") · embed("What are your greatest weaknesses")
+  → cosine ≈ 0.31  ← correctly LOW (antonyms)
+
+embed("Can you walk me through") · embed("Can you walk me through your system design?")  
+  → cosine ≈ 0.89  ← correctly HIGH (prefix completion)
+
+embed("Tell me about a project you led") · embed("Tell me about a time you showed leadership")
+  → cosine ≈ 0.82  ← correctly HIGH (synonymous intent, Jaccard would miss this)
+```
+
+---
+
+## Recommended Implementation: Hybrid Approach
+
+Running SBERT on every speculative check would add 5–10ms even for trivially obvious cases. The optimal design runs it **only when Jaccard is in the ambiguous zone**:
+
+```
+1. Jaccard containment check (µs, always):
+   → score < 0.3  → reject immediately (clearly different topic, don't call SBERT)
+   → score > 0.92 → accept immediately (obvious prefix/synonym, don't call SBERT)
+   → score 0.3–0.92 → ambiguous → proceed to step 2
+
+2. SBERT cosine similarity (only in ambiguous zone, ~5–10ms):
+   → cosine < 0.65 → reject, re-run generation
+   → cosine ≥ 0.65 → accept speculative answer
+```
+
+This keeps the fast path (clear prefix match, clearly different topic) at zero cost, and only pays the embedding cost for the genuinely ambiguous middle where Jaccard makes mistakes — which is exactly where the strengths/weaknesses failure class lives.
+
+### Implementation sketch
+
+```ts
+// electron/llm/speculativeSimilarity.ts
+
+export async function speculativeSimilarity(
+    speculativeQuestion: string,
+    finalQuestion: string,
+): Promise<{ score: number; method: 'jaccard' | 'sbert' }> {
+    const jScore = jaccardWithContainment(speculativeQuestion, finalQuestion);
+
+    // Fast exits — no embedding needed
+    if (jScore < 0.3)  return { score: jScore, method: 'jaccard' };
+    if (jScore > 0.92) return { score: jScore, method: 'jaccard' };
+
+    // Ambiguous zone — run semantic check
+    const [embA, embB] = await Promise.all([
+        embeddingWorker.embed(speculativeQuestion),
+        embeddingWorker.embed(finalQuestion),
+    ]);
+    const cosine = cosineSimilarity(embA, embB);
+    return { score: (cosine + 1) / 2, method: 'sbert' }; // normalize to [0,1]
+}
+```
+
+```ts
+// In handleSuggestionTrigger (IntelligenceEngine.ts):
+const { score, method } = await speculativeSimilarity(this.speculativeText, trigger.lastQuestion);
+console.log(`[IntelligenceEngine] Speculative check (${method}): ${score.toFixed(2)}`);
+
+if (score >= SPECULATIVE_SIMILARITY_THRESHOLD) {
+    // accept
+} else {
+    // restart generation
+}
+```
+
+### Worker reuse
+
+`IntentClassifier.ts` already maintains a warmed transformer worker. The embedding worker can share the same infrastructure — no new model-loading overhead on startup. The worker is already warm by the time a speculative check fires.
+
+---
+
+## Threshold Calibration
+
+The current `SPECULATIVE_SIMILARITY_THRESHOLD` constant should be audited. If it's ≥ 0.7, Jaccard-inflated stop-word matches may be passing the gate. With the hybrid approach:
+
+- **Jaccard fast-accept threshold**: 0.92 (very conservative — only obvious prefix completions bypass SBERT)
+- **SBERT acceptance threshold**: 0.65 (cosine normalized to [0,1])
+
+These values should be validated against a test set of real interview question pairs covering:
+- Clear prefixes ("Can you walk me through" → "Can you walk me through your architecture")
+- Antonym pairs (strengths/weaknesses, success/failure, led/followed)
+- Synonymous rephrasing ("Tell me about a project" → "Walk me through something you built")
+- Completely different topics
+
+---
+
+## Is the Speculative Pre-fetch Concept Worth Keeping?
+
+**Yes.** The underlying idea is sound — firing an LLM call on a high-confidence partial transcript so the answer is ready when the question finishes is a legitimate latency optimization. The Jaccard gate is the right *type* of solution (a similarity check to avoid wrong-answer reuse). The problem is purely the implementation of that gate.
+
+The speculative system is also well-designed in other respects:
+- `SPECULATIVE_DEBOUNCE_MS` prevents flooding on rapid partials
+- `speculativeTextExpiry` prevents stale answers from being served
+- `forceFresh` correctly bypasses the gate on explicit user button presses
+- `AbortController` cancellation is correctly wired
+
+The only thing that needs to change is how the similarity score is computed in the ambiguous zone.
+
+---
+
+## Summary
+
+| Aspect | Current (Jaccard) | Recommended (Hybrid) |
+|--------|------------------|----------------------|
+| Antonym pairs (strengths/weaknesses) | ❌ ~0.75 — often wrong accept | ✅ ~0.31 SBERT — correct reject |
+| Prefix completion (partial → full) | ✅ Handled by containment blend | ✅ Still handled at fast-exit tier |
+| Synonymous rephrasing | ❌ ~0.42 — may incorrectly reject | ✅ ~0.82 SBERT — correct accept |
+| Latency (fast cases) | µs | µs (Jaccard fast exit) |
+| Latency (ambiguous zone) | µs | ~5–10ms (SBERT) |
+| Model size overhead | 0MB | +22MB (`all-MiniLM-L6-v2`) |
+| Infrastructure needed | None | Worker thread (reuse IntentClassifier pattern) |

--- a/docs/tech-debt/speculative-similarity-jaccard-critique.md
+++ b/docs/tech-debt/speculative-similarity-jaccard-critique.md
@@ -124,12 +124,12 @@ This keeps the fast path (clear prefix match, clearly different topic) at zero c
 export async function speculativeSimilarity(
     speculativeQuestion: string,
     finalQuestion: string,
-): Promise<{ score: number; method: 'jaccard' | 'sbert' }> {
+): Promise<{ accepted: boolean; score: number; method: 'jaccard' | 'sbert' }> {
     const jScore = jaccardWithContainment(speculativeQuestion, finalQuestion);
 
     // Fast exits — no embedding needed
-    if (jScore < 0.3)  return { score: jScore, method: 'jaccard' };
-    if (jScore > 0.92) return { score: jScore, method: 'jaccard' };
+    if (jScore < 0.3)  return { accepted: false, score: jScore, method: 'jaccard' };
+    if (jScore > 0.92) return { accepted: true, score: jScore, method: 'jaccard' };
 
     // Ambiguous zone — run semantic check
     const [embA, embB] = await Promise.all([
@@ -137,16 +137,17 @@ export async function speculativeSimilarity(
         embeddingWorker.embed(finalQuestion),
     ]);
     const cosine = cosineSimilarity(embA, embB);
-    return { score: cosine, method: 'sbert' };
+    const SBERT_THRESHOLD = 0.65;
+    return { accepted: cosine >= SBERT_THRESHOLD, score: cosine, method: 'sbert' };
 }
 ```
 
 ```ts
 // In handleSuggestionTrigger (IntelligenceEngine.ts):
-const { score, method } = await speculativeSimilarity(this.speculativeText, trigger.lastQuestion);
-console.log(`[IntelligenceEngine] Speculative check (${method}): ${score.toFixed(2)}`);
+const { accepted, score, method } = await speculativeSimilarity(this.speculativeText, trigger.lastQuestion);
+console.log(`[IntelligenceEngine] Speculative check (${method}): score=${score.toFixed(2)} accepted=${accepted}`);
 
-if (score >= SPECULATIVE_SIMILARITY_THRESHOLD) {
+if (accepted) {
     // accept
 } else {
     // restart generation


### PR DESCRIPTION
## Summary

This PR documents **three bugs** in the answering pipeline surfaced by Telegram user reports in v2.8.5. No source-code changes — docs only, for dev review and targeted fix.

> Related to: general-question refusals, screenshot code-generation failure, skill injection being ignored.

---

## Bug 001 — Document-Grounded Refusal on General Questions 🔴

**Root cause:** `documentGroundedCustomModeActive` is read directly from the mode object without checking `hasReferenceFiles`. Modes seeded with `reference_files_primary` authority fire the doc-grounded routing even when no files are uploaded, causing the WTA gate to fail against an empty `docContextBlock` and return a refusal message.

**Key finding:** `documentGroundedFromContract()` in `modeSourceContract.ts` already implements the correct `if (!hasReferenceFiles) return false` guard — it has **zero call-sites**.

**Fix surface:** `AnswerPlanner.ts` line 2335 (guard condition) + `contextRoute.ts` line 76 (secondary site).

---

## Bug 002 — Screenshot Attached but Code Not Generated 🟠

**Root cause:** `hasScreenContext` is omitted from `buildV3Prompt()` in the `gemini-chat-stream` IPC handler, and `IntelligenceEngine.ts` only checks `options.screenContext` (the OCR object from the periodic capture service) — not `imagePaths`. Manually-attached screenshots never set `options.screenContext`, so `hasScreenContext` is always `false` in manual chat.

**Fix surface:** Single-line addition in `ipcHandlers.ts` + one-line guard expansion in `IntelligenceEngine.ts`.

---

## Bug 003 — Skill Injection Ignored in V3 Engine 🟠

**Root cause:** `WhatToAnswerLLM.ts` composes the system prompt as `_v3p?.system ?? finalPromptOverride`. When V3 is active, `_v3p` is always defined (non-nullish), so `finalPromptOverride` — which carries `activeSkill.promptBlock` — is silently discarded. Skills appear to have no effect in v2.8.5.

**Fix surface:** 3-line change in `WhatToAnswerLLM.ts` — append skill block after V3 system prompt when `activeSkill` is present.

---

## Files in this PR

| File | Purpose |
|---|---|
| `docs/bugs/README.md` | Index + blast-radius summary |
| `docs/bugs/bug-001-document-grounded-refusal.md` | Full root cause, diffs, checklist |
| `docs/bugs/bug-002-screenshot-code-generation.md` | Full root cause, diffs, checklist |
| `docs/bugs/bug-003-skill-injection-failure.md` | Full root cause, diffs, checklist |

## Blast Radius (jcodemunch)

`documentGroundedCustomModeActive` fans into **26 dependent files** — all with `has_test_reach: false`. Each bug doc includes a checklist of tests to add/update before merging the actual code fix.
