### PR TITLE
fix(codex,stt): Codex CLI vision payload + Google service-account validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,11 @@ GROQ_API_KEY=your_groq_api_key_here
 OPENAI_API_KEY=your_openai_api_key_here
 CLAUDE_API_KEY=your_claude_api_key_here
 GEMINI_API_KEY=your_gemini_api_key_here
-GOOGLE_APPLICATION_CREDENTIALS=/path/to/your/service-account.json
+# Google Speech-to-Text service-account key. Leave this COMMENTED OUT unless you
+# have a real key file — the app persists whatever is set here into the
+# credential store, and a non-existent path makes the Google Speech SDK throw
+# ENOENT on every STT start and on quit.
+# GOOGLE_APPLICATION_CREDENTIALS=/absolute/path/to/service-account.json
 
 # Speech Providers (Optional - only one needed)
 DEEPGRAM_API_KEY=your_deepgram_key_here

--- a/electron/LLMHelper.ts
+++ b/electron/LLMHelper.ts
@@ -1493,6 +1493,14 @@ export class LLMHelper {
 
   private async generateWithCodexCli(userContent: string, systemPrompt?: string, fastMode = false, imagePaths?: string[], signal?: AbortSignal): Promise<string> {
     if (!this.isCodexAvailable()) throw new Error('Codex CLI transport is disabled or ChatGPT is signed out.');
+    // Codex routes to chatgpt.com/backend-api — it is a CLOUD provider, and it
+    // needs the same local-only last boundary every other cloud provider has.
+    // The vision chain already omits it when isLocalOnlyMode is set, but that
+    // is a list-BUILD exclusion; this is the boundary that holds for any path
+    // reaching the transport another way. (VisionProviderRegistry marks Codex
+    // isLocal:true as a routing hint meaning "no API key" — that hint must
+    // never be mistaken for "stays on this device". See visionPolicy.ts.)
+    if (this.isLocalOnlyMode) throw new Error("Cloud providers disabled in local-only mode");
     // Codex had NO boundary at all. It is the sharpest case: visionPolicy.ts
     // keeps it out of isLocalVisionProvider precisely because it routes to
     // chatgpt.com/backend-api, so a screenshot going out here is a cloud send
@@ -1523,6 +1531,14 @@ export class LLMHelper {
 
   private async *streamWithCodexCli(userContent: string, systemPrompt?: string, fastMode = false, imagePaths?: string[], signal?: AbortSignal): AsyncGenerator<string, void, unknown> {
     if (!this.isCodexAvailable()) throw new Error('Codex CLI transport is disabled or ChatGPT is signed out.');
+    // Codex routes to chatgpt.com/backend-api — it is a CLOUD provider, and it
+    // needs the same local-only last boundary every other cloud provider has.
+    // The vision chain already omits it when isLocalOnlyMode is set, but that
+    // is a list-BUILD exclusion; this is the boundary that holds for any path
+    // reaching the transport another way. (VisionProviderRegistry marks Codex
+    // isLocal:true as a routing hint meaning "no API key" — that hint must
+    // never be mistaken for "stays on this device". See visionPolicy.ts.)
+    if (this.isLocalOnlyMode) throw new Error("Cloud providers disabled in local-only mode");
     // See generateWithCodexCli. This is a generator, so the check runs on the
     // first next() rather than at call time — still strictly before any byte
     // reaches CodexCliService.stream, which is the property that matters.
@@ -4949,6 +4965,22 @@ let isMultimodal = !!(imagePaths?.length);
         cloud.push({ id: 'natively', name: 'Natively API', isLocal: false, priority: prio++, ttftTimeoutMs: FLASH_TTFT_MS,
           open: (sig) => this.streamWithNatively(userContent, systemPrompt, imagePaths, sig) });
       }
+      // isCodexAvailable() — NOT `codexCliConfig.enabled` — is the gate every
+      // other Codex call site uses. It additionally covers the disabled-provider
+      // kill switch and "is ChatGPT actually signed in". streamWithCodexCli
+      // throws on both, so a looser gate here would not leak anything, but it
+      // would seat a provider that is guaranteed to fail: one wasted attempt
+      // per request, a bogus unhealthy mark in visionHealth, and a misleading
+      // "Codex CLI failed" line in the logs.
+      //
+      // TTFT: Codex is a reasoning model behind an OAuth hop, so it gets the
+      // Pro budget rather than the flash one. A timeout still records it
+      // unhealthy and deprioritizes it on later requests — see the note in
+      // orderVisionByHealth if that proves too tight in practice.
+      if (this.isCodexAvailable()) {
+        cloud.push({ id: 'codex-cli', name: `Codex CLI (${this.codexCliConfig.model})`, isLocal: false, priority: prio++, ttftTimeoutMs: PRO_TTFT_MS,
+          open: (sig) => this.streamWithCodexCli(userContent, systemPrompt, false, imagePaths, sig) });
+      }
     }
 
     // Local providers (always available, including in local-only mode).
@@ -4989,8 +5021,10 @@ let isMultimodal = !!(imagePaths?.length);
       const front: VisionStreamProvider[] = [];
       if (this.useOllama) { const o = local.find(p => p.id === 'ollama'); if (o) front.push(o); }
       if (this.customProvider) { const c = local.find(p => p.id === 'custom'); if (c) front.push(c); }
+      if (this.isCodexCliModel(this.currentModelId)) { const cdx = cloud.find(p => p.id === 'codex-cli'); if (cdx) front.push(cdx); }
       const backLocal = local.filter(p => !front.includes(p));
-      ordered = [...front, ...orderVisionByHealth(cloud, this.visionHealth, nowMs), ...backLocal];
+      const backCloud = cloud.filter(p => !front.includes(p));
+      ordered = [...front, ...orderVisionByHealth(backCloud, this.visionHealth, nowMs), ...backLocal];
     }
 
     if (ordered.length === 0) {

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -8,7 +8,8 @@ import * as path from 'path';
 import { AudioDevices } from './audio/AudioDevices';
 import { DatabaseManager } from './db/DatabaseManager'; // Import Database Manager
 import { AppState } from './main';
-import { CodexCliService } from './services/CodexCliService';
+import { CodexCliService, isCodexAuthError } from './services/CodexCliService';
+import { describeServiceAccountRejection } from './services/googleServiceAccount';
 import { PhoneMirrorService } from './services/PhoneMirrorService';
 import { sanitizeContextEnvelope } from './services/browser-context/sanitize';
 import { formatEnvelopeForPrompt } from './services/browser-context/formatEnvelopeForPrompt';
@@ -5096,7 +5097,14 @@ export function initializeIpcHandlers(appState: AppState): void {
             piTelemetry.emit('pi_provider_error_classified', { kind: klass.kind, outage: klass.isOutage, retryable: klass.retryable, surface: 'manual' });
             if (answerPlan.profileContextPolicy === 'required' && !fullResponse.trim()
                 && _chatStreamsBySender.get(senderId)?.streamId === myStreamId) {
-              const safe = "The model failed before generating an answer, so I won't guess from your profile. Please try again.";
+              // Codex auth failures are the one provider error the user can act
+              // on directly, and the generic text below sends them looking for a
+              // model problem instead of a sign-in. Surfaced verbatim because
+              // both strings are app-authored (isCodexAuthError matches the
+              // exported constants) — never echo arbitrary provider text here.
+              const safe = isCodexAuthError(streamError)
+                ? streamError.message
+                : "The model failed before generating an answer, so I won't guess from your profile. Please try again.";
               finalGenerationMode = 'provider_error_no_answer';
               sessionWriteDecision = decideSessionWritePolicy({
                 finalGenerationMode,
@@ -9776,12 +9784,25 @@ export function initializeIpcHandlers(appState: AppState): void {
 
       const filePath = result.filePaths[0];
 
-      // Update backend state immediately
-      appState.updateGoogleCredentials(filePath);
+      // Update backend state immediately. Persist ONLY if the file validated —
+      // storing an unusable path is what produced the ENOENT crash loop, since
+      // the failure surfaces later from inside the Speech SDK.
+      const verdict = appState.updateGoogleCredentials(filePath);
+      if (!verdict.usable) {
+        return { success: false, error: describeServiceAccountRejection(verdict.reason) };
+      }
 
-      // Persist the path for future sessions
+      // Persist the path for future sessions. setGoogleServiceAccountPath
+      // returns whether the write reached disk — reporting success on a failed
+      // write would show the filename as saved and lose it on restart.
       const { CredentialsManager } = require('./services/CredentialsManager');
-      CredentialsManager.getInstance().setGoogleServiceAccountPath(filePath);
+      if (!CredentialsManager.getInstance().setGoogleServiceAccountPath(filePath)) {
+        return {
+          success: false,
+          error: 'The key file is valid, but saving it failed. It will work until you quit. '
+            + 'Check that the app can write to its data folder, then try again.',
+        };
+      }
 
       return { success: true, path: filePath };
     } catch (error: any) {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -17,6 +17,12 @@ import dns from "dns"
 import { SystemAudioHealthClassifier } from "./audio/systemAudioHealthClassifier.mjs"
 import { autoUpdater } from "electron-updater"
 
+import {
+  classifyServiceAccountFile,
+  describeServiceAccountRejection,
+  type ServiceAccountVerdict,
+} from "./services/googleServiceAccount"
+
 // Override global dns.lookup to resolve macOS system resolver issues with api.natively.software
 const originalLookup = dns.lookup;
 dns.lookup = function(hostname: any, options: any, callback: any) {
@@ -6146,7 +6152,32 @@ export class AppState {
 
 
 
-  public updateGoogleCredentials(keyPath: string): void {
+  /**
+   * Adopt a Google service-account key file for Speech-to-Text.
+   *
+   * Adopts NOTHING unless the file parses as a real service-account key.
+   * `new SpeechClient({ keyFilename })` does not validate at construction — a
+   * bad path throws later, from inside the STT stream and again from the
+   * `before-quit` teardown, which reads as a fatal app crash rather than a bad
+   * setting. Validating here keeps a stale, mistyped or wrong-JSON path from
+   * ever reaching the SDK, and leaves any previously-working credential in
+   * place instead of clobbering it with a broken one.
+   *
+   * The verdict is returned rather than a bare boolean so callers can tell a
+   * POSITIVE rejection ("this json is an OAuth client secret") from a failure
+   * to read ("the volume is not mounted"). Callers must not delete persisted
+   * state on the latter — see googleServiceAccount.ts.
+   */
+  public updateGoogleCredentials(keyPath: string): ServiceAccountVerdict {
+    const verdict = classifyServiceAccountFile(keyPath);
+    if (!verdict.usable) {
+      console.error(
+        `[AppState] Ignoring Google Service Account path (${verdict.reason}`
+        + `${verdict.detail ? `: ${verdict.detail}` : ''}): ${keyPath}`,
+      );
+      return verdict;
+    }
+
     console.log(`[AppState] Updating Google Credentials to: ${keyPath}`);
     // Set global environment variable so new instances pick it up
     process.env.GOOGLE_APPLICATION_CREDENTIALS = keyPath;
@@ -6158,6 +6189,7 @@ export class AppState {
     if (this.googleSTT_User) {
       this.googleSTT_User.setCredentials(keyPath);
     }
+    return verdict;
   }
 
   public setRecognitionLanguage(key: string): void {
@@ -7479,16 +7511,67 @@ async function initializeApp() {
   const { sendAnonymousInstallPing } = require('./services/InstallPingManager');
   sendAnonymousInstallPing();
 
-  // Load stored Google Service Account path (for Speech-to-Text)
-  // Fall back to GOOGLE_APPLICATION_CREDENTIALS env var (set in terminal but not Spotlight)
-  const storedServiceAccountPath = CredentialsManager.getInstance().getGoogleServiceAccountPath()
-    || process.env.GOOGLE_APPLICATION_CREDENTIALS;
-  if (storedServiceAccountPath) {
-    console.log("[Init] Loading stored Google Service Account path");
-    appState.updateGoogleCredentials(storedServiceAccountPath);
-    // Persist env-var path so Spotlight launches also work going forward
-    if (!CredentialsManager.getInstance().getGoogleServiceAccountPath()) {
-      CredentialsManager.getInstance().setGoogleServiceAccountPath(storedServiceAccountPath);
+  // Load the Google Service Account key for Speech-to-Text: the persisted path
+  // first, then GOOGLE_APPLICATION_CREDENTIALS (set in a terminal but not for a
+  // Spotlight launch).
+  //
+  // Each candidate is tried IN TURN, not picked with `||` and then validated.
+  // A `||` picks the store's value whenever it is non-empty — including when it
+  // is stale — so a user with a moved key file and a WORKING env var would have
+  // the env var never evaluated and (worse, in the previous revision of this
+  // block) deleted. Trying them in order means a bad first candidate costs
+  // nothing.
+  //
+  // Eviction is limited to DEFINITE rejections. "Cannot read it" is not "it is
+  // gone": a key on an unmounted external volume or an unconnected network share
+  // reports ENOENT exactly like a deleted file, and deleting the stored path
+  // there would destroy a credential that comes back when the volume mounts.
+  // See googleServiceAccount.ts.
+  {
+    const cm = () => CredentialsManager.getInstance();
+    const candidates: Array<{ source: 'store' | 'env'; path: string }> = [];
+    const storedPath = cm().getGoogleServiceAccountPath();
+    const envPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    if (storedPath) candidates.push({ source: 'store', path: storedPath });
+    if (envPath && envPath !== storedPath) candidates.push({ source: 'env', path: envPath });
+
+    let adoptedPath: string | null = null;
+    for (const candidate of candidates) {
+      const verdict = appState.updateGoogleCredentials(candidate.path);
+      if (verdict.usable) {
+        console.log(`[Init] Loaded Google Service Account path from the ${candidate.source}`);
+        adoptedPath = candidate.path;
+        break;
+      }
+      // Definite rejection → drop it so the next boot doesn't retry a path we
+      // KNOW is wrong (this is what evicts the .env.example placeholder that
+      // older builds persisted). Indefinite → leave everything alone.
+      if (verdict.definite) {
+        console.warn(
+          `[Init] Discarding unusable Google Service Account path from the ${candidate.source} `
+          + `(${verdict.reason}): ${describeServiceAccountRejection(verdict.reason)}`,
+        );
+        if (candidate.source === 'store') {
+          cm().setGoogleServiceAccountPath('');
+        } else {
+          delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+        }
+      } else {
+        console.warn(
+          `[Init] Google Service Account path from the ${candidate.source} is not readable right now; `
+          + 'keeping it for the next launch (it may be on a volume that is not mounted yet)',
+        );
+      }
+    }
+
+    if (adoptedPath) {
+      // Persist an env-var-sourced path so Spotlight launches also work later.
+      if (cm().getGoogleServiceAccountPath() !== adoptedPath) {
+        cm().setGoogleServiceAccountPath(adoptedPath);
+      }
+      // Keep the env var in sync with what we actually adopted, so the Google
+      // SDK's own ADC lookup cannot pick a different (rejected) file.
+      process.env.GOOGLE_APPLICATION_CREDENTIALS = adoptedPath;
     }
   }
 

--- a/electron/services/CodexCliService.ts
+++ b/electron/services/CodexCliService.ts
@@ -39,7 +39,51 @@
  *     stream consumer; partial deltas yielded so far are NOT lost.
  */
 
+import fs from 'fs';
+import path from 'path';
+import sharp from 'sharp';
 import { CodexOAuthService } from './CodexOAuthService';
+
+// Extension → MIME for the RAW fallback path only (the normal path re-encodes
+// to JPEG via sharp, so its MIME is fixed). PNG/JPEG/WebP/GIF are the four
+// formats the Responses API accepts in `input_image` items — the same set as
+// the Chat Completions vision endpoint. Default to PNG for unknown extensions;
+// the backend rejects truly unsupported formats with a clear error.
+const IMAGE_MIME_BY_EXT: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.gif': 'image/gif',
+};
+
+// Cap for the raw (sharp-failed) fallback. Matches the LLMHelper cloud-vision
+// providers, which skip rather than ship an oversized raw image.
+const RAW_IMAGE_MAX_BYTES = 500 * 1024;
+
+// Floor for the same fallback. sharp has already failed to decode by the time
+// this applies, so anything this small is a 0-byte or truncated capture rather
+// than a real image. (The smallest valid PNG is ~67 bytes; a JPEG header alone
+// is ~125. 64 is below any real image and above an empty/near-empty file.)
+const RAW_IMAGE_MIN_BYTES = 64;
+
+// The two auth failures that are ACTIONABLE by the user, so callers may show
+// them verbatim instead of a generic "the model failed" message. Exported and
+// matched via isCodexAuthError() rather than re-typed as string literals at
+// each call site — a reword here would otherwise silently stop matching and
+// users would be back to the generic text with no test catching it.
+export const CODEX_NOT_SIGNED_IN_MESSAGE =
+  'Not signed in to ChatGPT. Please complete Codex OAuth login from Settings → AI Providers.';
+export const CODEX_SESSION_EXPIRED_MESSAGE =
+  'Codex session expired. Please sign in again from Settings → AI Providers.';
+
+/** True when `err` is one of the actionable Codex auth failures above. */
+export function isCodexAuthError(err: unknown): boolean {
+  const message = (err as { message?: unknown } | null | undefined)?.message;
+  if (typeof message !== 'string') return false;
+  return message.includes(CODEX_NOT_SIGNED_IN_MESSAGE)
+    || message.includes(CODEX_SESSION_EXPIRED_MESSAGE);
+}
 
 export type CodexSandboxMode = 'read-only' | 'workspace-write' | 'danger-full-access';
 export type CodexServiceTier = 'default' | 'fast' | 'flex';
@@ -300,12 +344,12 @@ export class CodexCliService {
     const oauth = CodexOAuthService.getInstance();
     const status = oauth.getStatus();
     if (!status.signedIn) {
-      throw new Error('Not signed in to ChatGPT. Please complete Codex OAuth login from Settings → AI Providers.');
+      throw new Error(CODEX_NOT_SIGNED_IN_MESSAGE);
     }
 
     // Build the request body ONCE outside the retry loop — refreshing
     // tokens doesn't change the prompt.
-    const body = this.buildRequestBody(options);
+    const body = await this.buildRequestBody(options);
     const headers = this.buildHeaders();
 
     // Idle-timeout guard: aborts the HTTP connection if no bytes arrive for
@@ -365,22 +409,119 @@ export class CodexCliService {
    *  - `prompt_cache_key` is a stable session id so the backend can
    *    cache the prompt prefix (codex.md:428-430)
    */
-  private static buildRequestBody(options: CodexCliRunOptions): Record<string, unknown> {
+  /**
+   * Encode one screenshot as a data URL for an `input_image` item, or return
+   * null to skip it.
+   *
+   * Downscale-then-JPEG mirrors what every other cloud vision provider in
+   * LLMHelper does (resize 1920 inside / quality 85). It is not cosmetic:
+   * a raw Retina PNG is routinely 5-15 MB, which base64 inflates by ~33% into
+   * a single JSON body, and the extra pixels buy nothing above the model's
+   * tile budget. Reads are async so the main process is not blocked on the
+   * read plus the base64 encode.
+   *
+   * If sharp fails (unsupported/corrupt input) we fall back to the raw bytes,
+   * but only under RAW_IMAGE_MAX_BYTES — an uncapped raw send is how a request
+   * silently exceeds the API's image limit and comes back as an opaque error.
+   */
+  private static async encodeImageForRequest(imagePath: string): Promise<string | null> {
+    try {
+      const compressed = await sharp(imagePath)
+        .resize(1920, 1920, { fit: 'inside', withoutEnlargement: true })
+        .jpeg({ quality: 85 })
+        .toBuffer();
+      return `data:image/jpeg;base64,${compressed.toString('base64')}`;
+    } catch (compressErr: any) {
+      console.warn(`[CodexCliService] Image compression failed, trying raw: ${imagePath}`, compressErr?.message);
+    }
+
+    try {
+      const raw = await fs.promises.readFile(imagePath);
+      if (raw.length > RAW_IMAGE_MAX_BYTES) {
+        console.warn(`[CodexCliService] Raw image too large to send (${raw.length} bytes), skipping: ${imagePath}`);
+        return null;
+      }
+      // Lower bound too. sharp already failed to decode this file, so a
+      // suspiciously small payload is a 0-byte or truncated capture — exactly
+      // the tmp-file race the catch below exists for. Shipping it would put
+      // `data:image/png;base64,` (or a fragment) on the wire, and the backend
+      // rejects the WHOLE turn with an opaque 400 because every content item
+      // fails together. Skipping degrades to a text answer instead.
+      if (raw.length < RAW_IMAGE_MIN_BYTES) {
+        console.warn(`[CodexCliService] Image is empty or truncated (${raw.length} bytes), skipping: ${imagePath}`);
+        return null;
+      }
+      const mimeType = IMAGE_MIME_BY_EXT[path.extname(imagePath).toLowerCase()] || 'image/png';
+      return `data:${mimeType};base64,${raw.toString('base64')}`;
+    } catch (e: any) {
+      // Non-fatal: skip unreadable images (already validated at the IPC
+      // layer, so this is a belt-and-suspenders guard for race conditions
+      // like tmp-file cleanup between capture and send).
+      console.warn(`[CodexCliService] Failed to read image, skipping: ${imagePath}`, e?.message);
+      return null;
+    }
+  }
+
+  private static async buildRequestBody(options: CodexCliRunOptions): Promise<Record<string, unknown>> {
     const resolvedEffort = resolveCodexReasoningEffort(options.model, options.modelReasoningEffort);
 
-    // Image inputs: Responses API wants `type: "input_image"` items.
-    // We don't yet support image-bearing Codex calls in this rewrite
-    // (LLMHelper.buildCodexCliPrompt only passes text) — the imagePaths
-    // arg is accepted for backward-compat but ignored at the wire level.
-    // Future: encode as data URLs the same way LocalWhisperSTT does.
+    // Build the user message content array. Always starts with the text
+    // prompt; image paths (screenshots) are encoded as data-URL
+    // `input_image` items so the Codex backend can process them with
+    // vision-capable models (gpt-5.4, gpt-5.5-codex, etc.).
+    const contentItems: Array<Record<string, unknown>> = [
+      { type: 'input_text', text: options.prompt },
+    ];
+
+    if (options.imagePaths?.length) {
+      let encodedCount = 0;
+      for (const imagePath of options.imagePaths) {
+        const encoded = await CodexCliService.encodeImageForRequest(imagePath);
+        if (!encoded) continue;
+        encodedCount++;
+        contentItems.push({
+          type: 'input_image',
+          image_url: encoded,
+          // 'auto' lets the backend pick the tile budget. Left explicit
+          // (rather than omitted) so the value is greppable when tuning
+          // vision cost — 'original' is the high-fidelity alternative.
+          detail: 'auto',
+        });
+      }
+
+      // Images were requested and NONE survived encoding. Throwing beats
+      // sending the prompt alone: a text-only turn returns HTTP 200 with a
+      // confident answer that never saw the screenshot ("I don't see an image"
+      // — the very symptom this vision work was written to fix), and the
+      // fallback chain records Codex as HEALTHY.
+      //
+      // HONEST LIMITS of this throw, measured against visionStreamFallback.ts:
+      //   • classifyVisionError() maps this message to 'unknown' → treated as
+      //     TRANSIENT, so the chain retries up to maxAttempts (3) before moving
+      //     on, and then marks Codex unhealthy for transientCooldownMs (30s).
+      //     The retries are cheap (a local re-read, no network) and do recover
+      //     the case where a file reappears, but the unhealthy mark is
+      //     misattributed — the fault is the file's, not the provider's.
+      //   • Failing over does NOT guarantee the screenshot gets seen: the
+      //     sibling cloud providers (LLMHelper.ts ~3505, ~6709) skip unreadable
+      //     images and answer text-only, so a chain with other providers may
+      //     still end up blind, just later.
+      // It is still the better default: for the case that actually matters —
+      // the user explicitly selected the codex-cli model, so the chain has ONE
+      // entry — this turns a confidently-wrong blind answer into a real error.
+      if (encodedCount === 0) {
+        throw new Error(
+          `Codex could not read any of the ${options.imagePaths.length} attached image(s). `
+          + 'They may have been cleaned up, be empty, or exceed the size limit.',
+        );
+      }
+    }
 
     const input: Array<Record<string, unknown>> = [
       {
         type: 'message',
         role: 'user',
-        content: [
-          { type: 'input_text', text: options.prompt },
-        ],
+        content: contentItems,
       },
     ];
 
@@ -433,7 +574,7 @@ export class CodexCliService {
     const oauth = CodexOAuthService.getInstance();
     const accessToken = await oauth.getAccessToken();
     if (!accessToken) {
-      throw new Error('Not signed in to ChatGPT. Please complete Codex OAuth login from Settings → AI Providers.');
+      throw new Error(CODEX_NOT_SIGNED_IN_MESSAGE);
     }
     const tokens = oauth.getCachedTokens();
     const headers: Record<string, string> = {
@@ -467,7 +608,7 @@ export class CodexCliService {
     const oauth = CodexOAuthService.getInstance();
     const tokens = oauth.getCachedTokens();
     if (!tokens || !tokens.accessToken) {
-      throw new Error('Not signed in to ChatGPT. Please complete Codex OAuth login from Settings → AI Providers.');
+      throw new Error(CODEX_NOT_SIGNED_IN_MESSAGE);
     }
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -551,7 +692,7 @@ export class CodexCliService {
         const oauth = CodexOAuthService.getInstance();
         const refreshed = await oauth.refreshTokens();
         if (!refreshed) {
-          throw new Error('Codex session expired. Please sign in again from Settings → AI Providers.');
+          throw new Error(CODEX_SESSION_EXPIRED_MESSAGE);
         }
         continue;
       }

--- a/electron/services/CredentialsManager.ts
+++ b/electron/services/CredentialsManager.ts
@@ -159,6 +159,26 @@ export class CredentialsManager {
     /** Memoized AES-256 key for the app-managed fallback (derived once per process). */
     private fallbackKey?: Buffer;
 
+    /**
+     * Set when a keyring file EXISTS but would not decrypt/parse at load, so
+     * `this.credentials` does not reflect what is on disk.
+     *
+     * This is the load→save half of the guard. Skipping the boot-time migrate-up
+     * is not enough on its own: `saveCredentials()` writes the WHOLE credential
+     * object, so the first ordinary write of a degraded session (a Codex OAuth
+     * refresh, any settings write) would re-encrypt an empty-or-partial object
+     * over the intact keyring file and destroy every stored key. The failure is
+     * silent and unrecoverable when no fallback exists.
+     *
+     * decryptString throws for TRANSIENT reasons too — a locked macOS keychain,
+     * a denied access prompt, a roaming DPAPI profile that has not synced — so
+     * the right move is to preserve the file and let the next healthy launch
+     * read it, not to overwrite it from a degraded in-memory view.
+     *
+     * Cleared by an explicit user-initiated overwrite (see allowDegradedOverwrite).
+     */
+    private keyringUnreadable = false;
+
     private constructor() {
         // Load on construction after app ready
     }
@@ -571,10 +591,22 @@ export class CredentialsManager {
         console.log('[CredentialsManager] LiteLLM config updated');
     }
 
-    public setGoogleServiceAccountPath(filePath: string): void {
-        this.credentials.googleServiceAccountPath = filePath;
-        this.saveCredentials();
-        console.log('[CredentialsManager] Google Service Account path updated');
+    /**
+     * Returns saveCredentials()'s boolean (true = the write actually reached
+     * disk), per the convention documented on the STT key setters below, so the
+     * IPC layer can surface a REAL error instead of a false "Saved".
+     */
+    public setGoogleServiceAccountPath(filePath: string): boolean {
+        // Empty/whitespace normalizes to `undefined`, not `''` — same convention as
+        // the STT key setters below, so the key is absent from the persisted JSON
+        // rather than present-and-empty. Callers clear the path by passing ''.
+        const trimmed = (filePath || '').trim();
+        this.credentials.googleServiceAccountPath = trimmed || undefined;
+        const persisted = this.saveCredentials();
+        console.log(trimmed
+            ? `[CredentialsManager] Google Service Account path updated (persisted=${persisted})`
+            : `[CredentialsManager] Google Service Account path cleared (persisted=${persisted})`);
+        return persisted;
     }
 
     public setSttProvider(provider: 'none' | 'google' | 'groq' | 'openai' | 'deepgram' | 'elevenlabs' | 'azure' | 'ibmwatson' | 'soniox' | 'natively' | 'local-whisper'): boolean {
@@ -992,6 +1024,25 @@ export class CredentialsManager {
      * to decide whether to warn.
      */
     private saveCredentials(): boolean {
+        // REFUSE to write over a keyring file we could not read at load.
+        // `this.credentials` is empty-or-partial in that state, and this method
+        // serializes the whole object, so writing would replace intact stored
+        // keys with nothing. The read failure may well be transient (locked
+        // keychain, denied prompt, unsynced roaming profile), so the file is
+        // preserved for the next launch instead. See `keyringUnreadable`.
+        //
+        // Returns false — the same contract as an unwritable disk — so the STT
+        // key handlers surface a real error rather than a false "Saved".
+        if (this.keyringUnreadable) {
+            console.error(
+                '[CredentialsManager] Refusing to save: the stored credential file could not be read this '
+                + 'session, so saving would overwrite it with an incomplete set. RECOVERY: quit and reopen the '
+                + 'app with your keychain unlocked (on Windows, signed in to the profile that saved the keys) — '
+                + 'a launch that can read the file clears this automatically and nothing is lost.',
+            );
+            return false;
+        }
+
         // Try the OS keyring first. When safeStorage is available, this is the
         // preferred path. On Windows the underlying DPAPI can still throw after
         // isEncryptionAvailable() returns true (e.g. policy restrictions, roaming
@@ -1081,7 +1132,42 @@ export class CredentialsManager {
         }
     }
 
+    /**
+     * Deliberately discard an unreadable keyring file and start fresh.
+     *
+     * Kept explicit and user-initiated because it destroys whatever the
+     * unreadable file held — the automatic behaviour is always to preserve it,
+     * since the read failure is often transient.
+     *
+     * NOT YET WIRED TO ANY UI. There is deliberately no IPC handler for this: a
+     * one-click "wipe my credentials" is the wrong first thing to hand someone
+     * whose keychain is merely locked, and the recovery that loses nothing is a
+     * restart. It exists so the escape hatch is a decision already made (and
+     * tested) if a support case ever needs it. `isCredentialStoreDegraded()` is
+     * the read-only half and is the one to surface first if this state ever
+     * shows up in the wild — a Settings banner explaining why saving is off.
+     */
+    public resetDegradedCredentialStore(): void {
+        if (!this.keyringUnreadable) return;
+        console.warn('[CredentialsManager] Discarding the unreadable keyring file at explicit user request');
+        this.removeKeyringFile();
+        this.keyringUnreadable = false;
+    }
+
+    /** True when the credential store could not be read this session and writes are being refused. */
+    public isCredentialStoreDegraded(): boolean {
+        return this.keyringUnreadable;
+    }
+
     private loadCredentials(): void {
+        // True when the keyring reported itself AVAILABLE but the keyring file
+        // still failed to decrypt/parse. Distinct from "keyring unavailable":
+        // an unavailable keyring is a stable platform state, whereas a failed
+        // decrypt may be transient, so the two lead to different write-back
+        // behaviour in step 2. See the migrate-up comment there.
+        let keyringReadFailed = false;
+        // Recomputed from scratch on every load (init() may run more than once).
+        this.keyringUnreadable = false;
         try {
             // 1) Encrypted keyring file is authoritative when the keyring is available.
             //    However, if a previous saveCredentials() hit the fallback path AND the
@@ -1143,27 +1229,38 @@ export class CredentialsManager {
 
                 if (keyringAvailable && fs.existsSync(CREDENTIALS_PATH)) {
                     const encrypted = fs.readFileSync(CREDENTIALS_PATH);
-                    const decrypted = safeStorage.decryptString(encrypted);
+                    let keyringSuccess = false;
                     try {
+                        const decrypted = safeStorage.decryptString(encrypted);
                         const parsed = JSON.parse(decrypted);
                         if (typeof parsed === 'object' && parsed !== null) {
                             this.credentials = parsed;
                             console.log('[CredentialsManager] Loaded encrypted credentials');
+                            keyringSuccess = true;
                         } else {
                             throw new Error('Decrypted credentials is not a valid object');
                         }
-                    } catch (parseError) {
-                        console.error('[CredentialsManager] Failed to parse decrypted credentials — file may be corrupted. Starting fresh:', parseError);
-                        this.credentials = {};
+                    } catch (keyringReadError) {
+                        console.error('[CredentialsManager] Failed to read/decrypt keyring credentials. Falling through to app-managed fallback:', keyringReadError);
+                        keyringReadFailed = true;
                     }
-                    // Keyring is authoritative — clean up any stale fallback + plaintext.
-                    this.removeFallbackFile();
-                    this.removePlaintextFile();
-                    return;
+
+                    if (keyringSuccess) {
+                        // Keyring is authoritative — clean up any stale fallback + plaintext.
+                        this.removeFallbackFile();
+                        this.removePlaintextFile();
+                        return;
+                    }
                 }
-                // Keyring file exists but keyring is unavailable: fall through to try
-                // the app-managed fallback below (we cannot decrypt the keyring file).
-                console.warn('[CredentialsManager] Encrypted credentials present but keyring unavailable; trying app-managed fallback');
+                // Either the keyring is unavailable, or it is available but the file
+                // would not decrypt/parse. Both fall through to the app-managed
+                // fallback below; `keyringReadFailed` distinguishes them for the
+                // migrate-up decision in step 2.
+                console.warn(
+                    keyringReadFailed
+                        ? '[CredentialsManager] Encrypted credentials present but unreadable; trying app-managed fallback'
+                        : '[CredentialsManager] Encrypted credentials present but keyring unavailable; trying app-managed fallback',
+                );
             }
 
             // 2) App-managed encrypted fallback.
@@ -1185,9 +1282,35 @@ export class CredentialsManager {
 
                 // Migrate up: if the keyring is now available, re-persist via safeStorage
                 // (saveCredentials prefers the keyring and deletes the fallback).
+                //
+                // NOT when we got here because the keyring file failed to decrypt.
+                // safeStorage.decryptString can throw for reasons that are TRANSIENT
+                // and have nothing to do with the file being corrupt — a locked
+                // macOS keychain, a denied keychain-access prompt, a roaming DPAPI
+                // profile that has not synced yet. Migrating up in that state would
+                // overwrite intact keyring data with whatever the fallback holds,
+                // which may be older (the staleness guard above only removes the
+                // keyring when the fallback is NEWER, so an older fallback reaches
+                // here untouched). Silently reverting a user to a previous set of
+                // credentials is worse than running this session off the fallback
+                // and leaving the keyring alone: the next successful boot recovers
+                // everything.
+                //
+                // Writes are then refused for the rest of the session
+                // (`keyringUnreadable` → saveCredentials returns false). Note this
+                // has to be a FULL refusal, not "write to the fallback only and
+                // leave the keyring alone": the mtime staleness guard at the top of
+                // this method removes the keyring whenever the fallback is NEWER, so
+                // a fallback-only write would make the NEXT boot delete the very
+                // keyring file we are preserving here.
                 let keyringNow = false;
                 try { keyringNow = safeStorage.isEncryptionAvailable(); } catch { keyringNow = false; }
-                if (keyringNow && Object.keys(this.credentials).length > 0) {
+                if (keyringReadFailed) {
+                    this.keyringUnreadable = true;
+                    console.warn('[CredentialsManager] Running from the app-managed fallback because the keyring file would not decrypt. '
+                        + 'Leaving the keyring file untouched in case the failure was transient — some recently-saved credentials may be missing '
+                        + 'this session, and saves are disabled until a launch that can read it.');
+                } else if (keyringNow && Object.keys(this.credentials).length > 0) {
                     console.log('[CredentialsManager] Keyring now available — migrating fallback credentials to keyring');
                     this.saveCredentials();
                 }
@@ -1197,10 +1320,34 @@ export class CredentialsManager {
 
             // 3) Nothing stored. Clean up any legacy plaintext file regardless.
             this.removePlaintextFile();
-            console.log('[CredentialsManager] No stored credentials found');
+            if (keyringReadFailed) {
+                // NOT a fresh install: there IS a keyring file, it just would not
+                // decrypt, and there is no fallback to recover from. This is the
+                // most dangerous shape of the degraded state — `credentials` is
+                // EMPTY, so an unguarded save would replace every stored key with
+                // nothing and leave no copy anywhere. Refuse writes and keep the
+                // file for a launch that can read it.
+                this.keyringUnreadable = true;
+                console.warn(
+                    '[CredentialsManager] Keyring credentials unreadable and no fallback present — starting with empty '
+                    + 'credentials this session. The existing credential file is preserved and saves are DISABLED so it '
+                    + 'cannot be overwritten; restart after unlocking your keychain / signing in to your profile.',
+                );
+            } else {
+                console.log('[CredentialsManager] No stored credentials found');
+            }
         } catch (error) {
+            // The catch-all also lands here with a partial/empty `credentials`
+            // while a credential file may still exist on disk. Same reasoning as
+            // above: refuse writes rather than risk overwriting it.
             console.error('[CredentialsManager] Failed to load credentials:', error);
             this.credentials = {};
+            try {
+                if (fs.existsSync(CREDENTIALS_PATH) || fs.existsSync(FALLBACK_PATH)) {
+                    this.keyringUnreadable = true;
+                    console.warn('[CredentialsManager] A credential file exists but the load failed — saves are DISABLED this session to protect it');
+                }
+            } catch { /* best-effort */ }
         }
     }
 }

--- a/electron/services/CredentialsManager.ts
+++ b/electron/services/CredentialsManager.ts
@@ -304,12 +304,18 @@ export class CredentialsManager {
     }
 
     public setCodexOAuthTokens(tokens: { accessToken: string; refreshToken: string; idToken?: string; expiresAt: number; email?: string; accountId?: string; lastRefreshAt?: number }): void {
+        // ChatGPT OAuth ROTATES the refresh token on every refresh. If we accept
+        // a rotation in memory but fail to persist it, the session keeps working
+        // off CodexOAuthService's own cache and the loss only surfaces at the
+        // next launch as an invalid_grant re-auth. Refuse up front instead.
+        if (this.refuseWriteWhileDegraded('set Codex OAuth tokens')) return;
         this.credentials.codexOAuthTokens = { ...tokens };
         this.saveCredentials();
         console.log('[CredentialsManager] Codex OAuth tokens updated');
     }
 
     public clearCodexOAuthTokens(): void {
+        if (this.refuseWriteWhileDegraded('clear Codex OAuth tokens')) return;
         this.credentials.codexOAuthTokens = undefined;
         this.saveCredentials();
         console.log('[CredentialsManager] Codex OAuth tokens cleared');
@@ -421,6 +427,7 @@ export class CredentialsManager {
     }
 
     public setDisabledProviders(providers: string[]): void {
+        if (this.refuseWriteWhileDegraded('set disabled providers')) return;
         this.credentials.disabledProviders = providers;
         this.saveCredentials();
         console.log(`[CredentialsManager] Disabled providers updated (${providers.length})`);
@@ -432,6 +439,7 @@ export class CredentialsManager {
     }
 
     public setCloudEnabledModels(provider: string, models: string[]): boolean {
+        if (this.refuseWriteWhileDegraded('set cloud enabled models')) return false;
         if (!this.credentials.cloudEnabledModels) this.credentials.cloudEnabledModels = {};
         this.credentials.cloudEnabledModels[provider] = models;
         const persisted = this.saveCredentials();
@@ -453,6 +461,7 @@ export class CredentialsManager {
     }
 
     public setCloudFetchedModels(provider: string, models: { id: string; label: string }[], fetchedAt: number): boolean {
+        if (this.refuseWriteWhileDegraded('set cloud fetched models')) return false;
         if (!this.credentials.cloudFetchedModels) this.credentials.cloudFetchedModels = {};
         if (!this.credentials.cloudFetchedAt) this.credentials.cloudFetchedAt = {};
         this.credentials.cloudFetchedModels[provider] = models;
@@ -467,6 +476,7 @@ export class CredentialsManager {
     }
 
     public setLitellmModels(models: string[]): void {
+        if (this.refuseWriteWhileDegraded('set litellm models')) return;
         this.credentials.litellmModels = models;
         this.saveCredentials();
         console.log(`[CredentialsManager] LiteLLM model cache updated (${models.length} model(s))`);
@@ -517,6 +527,7 @@ export class CredentialsManager {
     // =========================================================================
 
     public setGeminiApiKey(key: string): void {
+        if (this.refuseWriteWhileDegraded('set gemini api key')) return;
         const trimmed = (key || '').trim();
         this.credentials.geminiApiKey = trimmed || undefined;
         this.saveCredentials();
@@ -524,6 +535,7 @@ export class CredentialsManager {
     }
 
     public setGroqApiKey(key: string): void {
+        if (this.refuseWriteWhileDegraded('set groq api key')) return;
         const trimmed = (key || '').trim();
         this.credentials.groqApiKey = trimmed || undefined;
         this.saveCredentials();
@@ -531,6 +543,7 @@ export class CredentialsManager {
     }
 
     public setOpenaiApiKey(key: string): void {
+        if (this.refuseWriteWhileDegraded('set openai api key')) return;
         const trimmed = (key || '').trim();
         this.credentials.openaiApiKey = trimmed || undefined;
         this.saveCredentials();
@@ -538,6 +551,7 @@ export class CredentialsManager {
     }
 
     public setClaudeApiKey(key: string): void {
+        if (this.refuseWriteWhileDegraded('set claude api key')) return;
         const trimmed = (key || '').trim();
         this.credentials.claudeApiKey = trimmed || undefined;
         this.saveCredentials();
@@ -545,6 +559,7 @@ export class CredentialsManager {
     }
 
     public setDeepseekApiKey(key: string): void {
+        if (this.refuseWriteWhileDegraded('set deepseek api key')) return;
         const trimmed = key.trim();
         this.credentials.deepseekApiKey = trimmed || undefined;
         this.saveCredentials();
@@ -558,6 +573,7 @@ export class CredentialsManager {
      * NOT persisted (per-session, LAN-exposed) and is intentionally separate.
      */
     public setPhoneMirrorToken(token: string): void {
+        if (this.refuseWriteWhileDegraded('set phone mirror token')) return;
         this.credentials.phoneMirrorToken = token || undefined;
         this.saveCredentials();
         console.log('[CredentialsManager] Extension pairing token updated');
@@ -570,6 +586,7 @@ export class CredentialsManager {
      * Passing an empty baseURL clears everything, disabling the provider.
      */
     public setLitellmConfig(apiKey: string, baseURL: string, maxTokens?: number): void {
+        if (this.refuseWriteWhileDegraded('set litellm config')) return;
         const trimmedURL = (baseURL || '').trim();
         const trimmedKey = (apiKey || '').trim();
         if (!trimmedURL) {
@@ -597,6 +614,7 @@ export class CredentialsManager {
      * IPC layer can surface a REAL error instead of a false "Saved".
      */
     public setGoogleServiceAccountPath(filePath: string): boolean {
+        if (this.refuseWriteWhileDegraded('set google service account path')) return false;
         // Empty/whitespace normalizes to `undefined`, not `''` — same convention as
         // the STT key setters below, so the key is absent from the persisted JSON
         // rather than present-and-empty. Callers clear the path by passing ''.
@@ -610,6 +628,7 @@ export class CredentialsManager {
     }
 
     public setSttProvider(provider: 'none' | 'google' | 'groq' | 'openai' | 'deepgram' | 'elevenlabs' | 'azure' | 'ibmwatson' | 'soniox' | 'natively' | 'local-whisper'): boolean {
+        if (this.refuseWriteWhileDegraded('set stt provider')) return false;
         this.credentials.sttProvider = provider;
         const persisted = this.saveCredentials();
         console.log(`[CredentialsManager] STT Provider set to: ${provider}`);
@@ -625,6 +644,7 @@ export class CredentialsManager {
     // reload — matching `setNativelyApiKey` / `setDeepseekApiKey`. The Remove button
     // (which calls these with `''`) still correctly clears the stored key.
     public setDeepgramApiKey(key: string): boolean {
+        if (this.refuseWriteWhileDegraded('set deepgram api key')) return false;
         const trimmed = (key || '').trim();
         this.credentials.deepgramApiKey = trimmed || undefined;
         const persisted = this.saveCredentials();
@@ -633,6 +653,7 @@ export class CredentialsManager {
     }
 
     public setGroqSttApiKey(key: string): boolean {
+        if (this.refuseWriteWhileDegraded('set groq stt api key')) return false;
         const trimmed = (key || '').trim();
         this.credentials.groqSttApiKey = trimmed || undefined;
         const persisted = this.saveCredentials();
@@ -641,6 +662,7 @@ export class CredentialsManager {
     }
 
     public setOpenAiSttApiKey(key: string): boolean {
+        if (this.refuseWriteWhileDegraded('set open ai stt api key')) return false;
         const trimmed = (key || '').trim();
         this.credentials.openAiSttApiKey = trimmed || undefined;
         const persisted = this.saveCredentials();
@@ -649,6 +671,7 @@ export class CredentialsManager {
     }
 
     public setOpenAiSttBaseUrl(url: string): void {
+        if (this.refuseWriteWhileDegraded('set open ai stt base url')) return;
         // Store undefined (not empty string) when clearing, so callers can fall back
         // to the default api.openai.com endpoint with a simple truthiness check.
         const trimmed = url.trim();
@@ -658,12 +681,14 @@ export class CredentialsManager {
     }
 
     public setGroqSttModel(model: string): void {
+        if (this.refuseWriteWhileDegraded('set groq stt model')) return;
         this.credentials.groqSttModel = model;
         this.saveCredentials();
         console.log(`[CredentialsManager] Groq STT Model set to: ${model}`);
     }
 
     public setElevenLabsApiKey(key: string): boolean {
+        if (this.refuseWriteWhileDegraded('set eleven labs api key')) return false;
         const trimmed = (key || '').trim();
         this.credentials.elevenLabsApiKey = trimmed || undefined;
         const persisted = this.saveCredentials();
@@ -672,6 +697,7 @@ export class CredentialsManager {
     }
 
     public setAzureApiKey(key: string): boolean {
+        if (this.refuseWriteWhileDegraded('set azure api key')) return false;
         const trimmed = (key || '').trim();
         this.credentials.azureApiKey = trimmed || undefined;
         const persisted = this.saveCredentials();
@@ -680,12 +706,14 @@ export class CredentialsManager {
     }
 
     public setAzureRegion(region: string): void {
+        if (this.refuseWriteWhileDegraded('set azure region')) return;
         this.credentials.azureRegion = region;
         this.saveCredentials();
         console.log(`[CredentialsManager] Azure Region set to: ${region}`);
     }
 
     public setIbmWatsonApiKey(key: string): boolean {
+        if (this.refuseWriteWhileDegraded('set ibm watson api key')) return false;
         const trimmed = (key || '').trim();
         this.credentials.ibmWatsonApiKey = trimmed || undefined;
         const persisted = this.saveCredentials();
@@ -694,12 +722,14 @@ export class CredentialsManager {
     }
 
     public setIbmWatsonRegion(region: string): void {
+        if (this.refuseWriteWhileDegraded('set ibm watson region')) return;
         this.credentials.ibmWatsonRegion = region;
         this.saveCredentials();
         console.log(`[CredentialsManager] IBM Watson Region set to: ${region}`);
     }
 
     public setSonioxApiKey(key: string): boolean {
+        if (this.refuseWriteWhileDegraded('set soniox api key')) return false;
         const trimmed = (key || '').trim();
         this.credentials.sonioxApiKey = trimmed || undefined;
         const persisted = this.saveCredentials();
@@ -708,6 +738,7 @@ export class CredentialsManager {
     }
 
     public setTavilyApiKey(key: string): void {
+        if (this.refuseWriteWhileDegraded('set tavily api key')) return;
         // Store undefined (not empty string) when removing, so hasKey() checks stay consistent
         this.credentials.tavilyApiKey = key.trim() || undefined;
         this.saveCredentials();
@@ -715,6 +746,7 @@ export class CredentialsManager {
     }
 
     public setSttLanguage(language: string): void {
+        if (this.refuseWriteWhileDegraded('set stt language')) return;
         this.credentials.sttLanguage = language;
         this.saveCredentials();
         console.log(`[CredentialsManager] STT Language set to: ${language}`);
@@ -745,17 +777,20 @@ export class CredentialsManager {
     }
 
     public setAiResponseLanguage(language: string): void {
+        if (this.refuseWriteWhileDegraded('set ai response language')) return;
         this.credentials.aiResponseLanguage = language;
         this.saveCredentials();
         console.log(`[CredentialsManager] AI Response Language set to: ${language}`);
     }
     public setDefaultModel(model: string): void {
+        if (this.refuseWriteWhileDegraded('set default model')) return;
         this.credentials.defaultModel = model;
         this.saveCredentials();
         console.log(`[CredentialsManager] Default Model set to: ${model}`);
     }
 
     public setNativelyApiKey(key: string): void {
+        if (this.refuseWriteWhileDegraded('set natively api key')) return;
         const trimmed = key.trim();
         this.credentials.nativelyApiKey = trimmed || undefined;
 
@@ -801,6 +836,7 @@ export class CredentialsManager {
     }
 
     public setPreferredModel(provider: 'gemini' | 'groq' | 'openai' | 'claude' | 'deepseek', modelId: string): void {
+        if (this.refuseWriteWhileDegraded('set preferred model')) return;
         const key = `${provider}PreferredModel` as keyof StoredCredentials;
         (this.credentials as any)[key] = modelId;
         this.saveCredentials();
@@ -872,6 +908,7 @@ export class CredentialsManager {
     }
 
     public setTrialToken(token: string, expiresAt: string, startedAt: string): void {
+        if (this.refuseWriteWhileDegraded('set trial token')) return;
         this.credentials.trialToken = token;
         this.credentials.trialExpiresAt = expiresAt;
         this.credentials.trialStartedAt = startedAt;
@@ -881,6 +918,7 @@ export class CredentialsManager {
     }
 
     public clearTrialToken(): void {
+        if (this.refuseWriteWhileDegraded('clear trial token')) return;
         delete this.credentials.trialToken;
         delete this.credentials.trialExpiresAt;
         delete this.credentials.trialStartedAt;
@@ -1042,6 +1080,40 @@ export class CredentialsManager {
             );
             return false;
         }
+        return this.writeCredentials();
+    }
+
+    /**
+     * Reject a mutation BEFORE it touches `this.credentials`.
+     *
+     * 21 of the setters on this class are `void` — they mutate in-memory state,
+     * call saveCredentials(), and discard the result. Before the degraded-store
+     * guard existed, saveCredentials() effectively always succeeded, so that was
+     * harmless. Now it can refuse, and a `void` setter would leave the in-memory
+     * value diverged from disk: Settings would show a key as saved that vanishes
+     * on restart, and worse, CodexOAuthService caches its own copy of a rotated
+     * refresh token in memory — so an unpersisted rotation reads as fine until
+     * the next launch forces a re-auth.
+     *
+     * Every setter therefore calls this FIRST and returns without mutating when
+     * it says no. Rejecting before the mutation (rather than reporting after) is
+     * what keeps memory and disk in agreement on every path, including the ones
+     * that cannot report a failure.
+     */
+    private refuseWriteWhileDegraded(op: string): boolean {
+        if (!this.keyringUnreadable) return false;
+        console.error(
+            `[CredentialsManager] Refusing "${op}": the stored credential file could not be read this session. `
+            + 'The change was NOT applied in memory either, so what you see still matches what is on disk. '
+            + 'RECOVERY: quit and reopen the app with your keychain unlocked (on Windows, signed in to the '
+            + 'profile that saved the keys).',
+        );
+        return true;
+    }
+
+    /** The actual write. Split from saveCredentials() so the degraded check has
+     *  exactly one home and cannot be bypassed by a future caller. */
+    private writeCredentials(): boolean {
 
         // Try the OS keyring first. When safeStorage is available, this is the
         // preferred path. On Windows the underlying DPAPI can still throw after

--- a/electron/services/CredentialsManager.ts
+++ b/electron/services/CredentialsManager.ts
@@ -347,9 +347,19 @@ export class CredentialsManager {
         // broken state (key cleared then re-entered via a path that skipped auto-promote,
         // or credentials restored from backup). Silently restore to 'natively' so STT works.
         if (provider === 'none' && this.credentials.nativelyApiKey) {
+            // The in-memory heal is safe and useful even when the store is
+            // degraded (STT works this session), so it is NOT gated. Only the
+            // PERSIST is skipped — writing would either be refused anyway or,
+            // worse, log a success the disk never saw. Deliberately not routed
+            // through refuseWriteWhileDegraded(): this is a derived value, not
+            // a user edit, so there is nothing to report and nothing lost.
             this.credentials.sttProvider = 'natively';
-            this.saveCredentials();
-            console.log('[CredentialsManager] Self-healed sttProvider: none→natively (Natively key present)');
+            if (this.keyringUnreadable) {
+                console.log('[CredentialsManager] Self-healed sttProvider in memory only (credential store is degraded)');
+            } else {
+                this.saveCredentials();
+                console.log('[CredentialsManager] Self-healed sttProvider: none→natively (Natively key present)');
+            }
             return 'natively';
         }
         return provider;
@@ -844,6 +854,7 @@ export class CredentialsManager {
     }
 
     public saveCustomProvider(provider: CustomProvider): void {
+        if (this.refuseWriteWhileDegraded('save custom provider')) return;
         if (!this.credentials.customProviders) {
             this.credentials.customProviders = [];
         }
@@ -859,6 +870,7 @@ export class CredentialsManager {
     }
 
     public deleteCustomProvider(id: string): void {
+        if (this.refuseWriteWhileDegraded('delete custom provider')) return;
         if (!this.credentials.customProviders) return;
         this.credentials.customProviders = this.credentials.customProviders.filter(p => p.id !== id);
         this.saveCredentials();
@@ -870,6 +882,7 @@ export class CredentialsManager {
     }
 
     public saveCurlProvider(provider: CurlProvider): void {
+        if (this.refuseWriteWhileDegraded('save curl provider')) return;
         if (!this.credentials.curlProviders) {
             this.credentials.curlProviders = [];
         }
@@ -884,6 +897,7 @@ export class CredentialsManager {
     }
 
     public deleteCurlProvider(id: string): void {
+        if (this.refuseWriteWhileDegraded('delete curl provider')) return;
         if (!this.credentials.curlProviders) return;
         this.credentials.curlProviders = this.credentials.curlProviders.filter(p => p.id !== id);
         this.saveCredentials();

--- a/electron/services/__tests__/CodexVisionPayload2026_08_05.test.mjs
+++ b/electron/services/__tests__/CodexVisionPayload2026_08_05.test.mjs
@@ -1,0 +1,365 @@
+// electron/services/__tests__/CodexVisionPayload2026_08_05.test.mjs
+//
+// Codex CLI vision: wire shape + the boundaries that must still hold now that
+// screenshots ACTUALLY leave through this transport.
+//
+// BACKGROUND
+// buildRequestBody used to drop `imagePaths` on the floor with a comment saying
+// image-bearing Codex calls were unsupported. The user-visible symptom was the
+// model replying "I am not an image model" — the image never reached it. The
+// fix encodes each screenshot as a Responses-API `input_image` item.
+//
+// THE REGRESSION THESE TESTS PIN
+// The Responses API and the Chat Completions API disagree on the shape:
+//     Responses         { type: 'input_image',  image_url: '<data URL string>' }
+//     Chat Completions  { type: 'image_url',    image_url: { url: '<data URL>' } }
+// This endpoint is /v1/responses. Sending the Chat Completions shape does NOT
+// error — the backend ignores the unknown item and the model answers as if no
+// image were attached, which is exactly the bug being fixed. The first commit
+// on this branch shipped the wrong one, so `image_url` being a STRING is a
+// load-bearing assertion, not a style preference.
+//
+// AND THE BOUNDARIES
+// Codex routes to chatgpt.com/backend-api. visionPolicy.ts deliberately keeps
+// it out of isLocalVisionProvider(), and CodexNotLocalVisionGuard pins the
+// registry entry. Those guard the REGISTRY path; the tests at the bottom guard
+// the LLMHelper path (streamVisionWithFallback → streamWithCodexCli), which is
+// the one this change newly wired for images.
+//
+// Run via: npm run build:electron && ELECTRON_RUN_AS_NODE=1 npx electron --test electron/services/__tests__/CodexVisionPayload2026_08_05.test.mjs
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import os from 'node:os';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const dist = (p) => path.join(__dirname, '../../../dist-electron/electron', p);
+
+// `electron` is an esbuild external; SettingsManager/CredentialsManager touch
+// `app` at module scope. Without this shim the live policy readers fail open
+// and the private_vision assertions below would be vacuous.
+const electronPath = require.resolve('electron');
+require.cache[electronPath] = {
+  id: electronPath, filename: electronPath, loaded: true,
+  exports: {
+    app: { isReady: () => true, getPath: () => os.tmpdir(), getVersion: () => '0.0.0-test' },
+    safeStorage: { isEncryptionAvailable: () => false },
+  },
+};
+
+const { CodexCliService } = require(dist('services/CodexCliService.js'));
+// NOTE: deliberately NOT requiring dist/services/CodexOAuthService.js — see
+// seedSignedIn() for why that instance is the wrong one.
+const { LLMHelper } = require(dist('LLMHelper.js'));
+const { SettingsManager } = require(dist('services/SettingsManager.js'));
+
+const sharp = require('sharp');
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-vision-'));
+
+/** A real, decodable PNG. 2400px wide so the 1920 downscale is observable. */
+async function makeBigPng(name = 'shot.png') {
+  const file = path.join(TMP, name);
+  const buf = await sharp({
+    create: { width: 2400, height: 1400, channels: 3, background: { r: 200, g: 30, b: 90 } },
+  }).png().toBuffer();
+  fs.writeFileSync(file, buf);
+  return { file, bytes: buf.length };
+}
+
+const CRED_SLOT = '__nativelyCredentialsManagerV1__';
+
+/**
+ * Make Codex look signed in to the CodexOAuthService copy that is INLINED into
+ * the CodexCliService bundle.
+ *
+ * `__setCachedTokensForTest` on the standalone dist/services/CodexOAuthService.js
+ * does NOT work here: esbuild inlines that module per entry bundle, so the
+ * instance the test would touch is a different object from the one
+ * CodexCliService.stream() calls. The seam that IS shared is
+ * getCredentialsManager() — a LAZY runtime require, which resolves through the
+ * `__nativelyCredentialsManagerV1__` global slot from whichever bundle asks.
+ */
+function seedSignedIn() {
+  globalThis[CRED_SLOT] = {
+    getCodexOAuthTokens: () => ({
+      accessToken: 'test-access-token',
+      refreshToken: 'test-refresh-token',
+      accountId: 'acct_test',
+      expiresAt: Date.now() + 3_600_000,
+    }),
+    getDisabledProviders: () => [],
+    anyVisionProviderConfigured: () => true,
+    anyLocalVisionProviderConfigured: () => false,
+  };
+}
+
+const SSE_OK = [
+  'event: response.output_text.delta',
+  'data: {"type":"response.output_text.delta","delta":"ok"}',
+  '',
+  'event: response.completed',
+  'data: {"type":"response.completed"}',
+  '',
+  '',
+].join('\n');
+
+/**
+ * Drive CodexCliService.stream with a stubbed fetch and return the parsed
+ * request body. This is the only way to observe buildRequestBody — it is a
+ * private static, and asserting on the SERIALIZED payload is the point anyway:
+ * that is what the backend actually receives.
+ */
+async function captureRequestBody(options) {
+  seedSignedIn();
+  const realFetch = globalThis.fetch;
+  let captured = null;
+  globalThis.fetch = async (_url, init) => {
+    captured = JSON.parse(init.body);
+    return new Response(SSE_OK, {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    });
+  };
+  try {
+    let out = '';
+    for await (const chunk of CodexCliService.stream('', { model: 'gpt-5.4', timeoutMs: 30_000, ...options })) {
+      out += chunk;
+    }
+    return { body: captured, out };
+  } finally {
+    globalThis.fetch = realFetch;
+    delete globalThis[CRED_SLOT];
+  }
+}
+
+const userContent = (body) => body.input.find((i) => i.role === 'user').content;
+
+// ── 1. wire shape ───────────────────────────────────────────────────────────
+
+describe('Codex vision payload — Responses API wire shape', () => {
+  test('a screenshot becomes an input_image item with a STRING image_url', async () => {
+    const { file } = await makeBigPng();
+    const { body } = await captureRequestBody({ prompt: 'what is this?', imagePaths: [file] });
+
+    const content = userContent(body);
+    assert.equal(content[0].type, 'input_text', 'the text prompt must lead the content array');
+    assert.equal(content[0].text, 'what is this?');
+
+    const image = content[1];
+    assert.equal(image.type, 'input_image',
+      'Responses API uses input_image. `image_url` (the Chat Completions type) is silently '
+      + 'ignored by this endpoint and the model answers as if no screenshot were attached.');
+    assert.equal(typeof image.image_url, 'string',
+      'Responses API takes image_url as a data-URL STRING. The Chat Completions object form '
+      + '{ url: ... } is the exact bug this branch was opened to fix — do not "fix" it back.');
+    assert.match(image.image_url, /^data:image\/(jpeg|png|webp|gif);base64,/);
+    assert.equal(image.detail, 'auto');
+  });
+
+  test('multiple screenshots each get their own item, in order, after the text', async () => {
+    const a = await makeBigPng('a.png');
+    const b = await makeBigPng('b.png');
+    const { body } = await captureRequestBody({ prompt: 'compare', imagePaths: [a.file, b.file] });
+
+    const content = userContent(body);
+    assert.equal(content.length, 3);
+    assert.equal(content[0].type, 'input_text');
+    assert.equal(content[1].type, 'input_image');
+    assert.equal(content[2].type, 'input_image');
+  });
+
+  test('a text-only call carries no image items (the non-vision path is unchanged)', async () => {
+    const { body } = await captureRequestBody({ prompt: 'hello' });
+    const content = userContent(body);
+    assert.equal(content.length, 1);
+    assert.equal(content[0].type, 'input_text');
+  });
+});
+
+// ── 2. size policy ──────────────────────────────────────────────────────────
+
+describe('Codex vision payload — size policy matches the other cloud providers', () => {
+  test('a 2400px screenshot is downscaled and re-encoded, not shipped raw', async () => {
+    const { file, bytes } = await makeBigPng('huge.png');
+    const { body } = await captureRequestBody({ prompt: 'x', imagePaths: [file] });
+
+    const image = userContent(body)[1];
+    assert.match(image.image_url, /^data:image\/jpeg;base64,/,
+      'sharp re-encodes to JPEG (resize 1920 inside / quality 85), same as the LLMHelper '
+      + 'cloud vision providers');
+
+    const encodedBytes = Buffer.from(image.image_url.split(',')[1], 'base64').length;
+    assert.ok(encodedBytes < bytes,
+      `re-encoded image (${encodedBytes}B) should be smaller than the raw PNG (${bytes}B)`);
+
+    // The decoded image must actually be capped at 1920 on its long edge.
+    const meta = await sharp(Buffer.from(image.image_url.split(',')[1], 'base64')).metadata();
+    assert.equal(meta.width, 1920, 'long edge should be clamped to 1920');
+  });
+
+  test('one bad image among good ones is dropped; the good ones still go', async () => {
+    const good = await makeBigPng('good.png');
+    const { body } = await captureRequestBody({
+      prompt: 'compare',
+      imagePaths: [path.join(TMP, 'does-not-exist.png'), good.file],
+    });
+    const content = userContent(body);
+    assert.equal(content.length, 2, 'the missing image is dropped, the readable one survives');
+    assert.equal(content[1].type, 'input_image');
+  });
+
+  test('a 0-byte screenshot is skipped, NOT sent as an empty data URL', async () => {
+    // sharp cannot decode it, and the raw fallback must reject it on the LOWER
+    // bound. Shipping `data:image/png;base64,` makes the backend 400 the whole
+    // turn (every content item fails together), which is strictly worse than
+    // dropping the image.
+    const empty = path.join(TMP, 'empty.png');
+    fs.writeFileSync(empty, Buffer.alloc(0));
+    const good = await makeBigPng('with-empty.png');
+    const { body } = await captureRequestBody({ prompt: 'x', imagePaths: [empty, good.file] });
+    const images = userContent(body).filter((c) => c.type === 'input_image');
+    assert.equal(images.length, 1, 'the 0-byte file must not produce an item');
+    for (const img of images) {
+      assert.ok(img.image_url.split(',')[1]?.length > 0, 'no item may carry an empty base64 payload');
+    }
+  });
+
+  test('a truncated screenshot is skipped, NOT sent as a corrupt data URL', async () => {
+    const truncated = path.join(TMP, 'truncated.png');
+    fs.writeFileSync(truncated, Buffer.from('89504e470d0a1a0a0000000d49484452', 'hex')); // 16-byte PNG header
+    const good = await makeBigPng('with-truncated.png');
+    const { body } = await captureRequestBody({ prompt: 'x', imagePaths: [truncated, good.file] });
+    const images = userContent(body).filter((c) => c.type === 'input_image');
+    assert.equal(images.length, 1, 'the truncated file must not produce an item');
+  });
+
+  test('a readable-but-undecodable oversized file is skipped rather than shipped raw', async () => {
+    // sharp cannot decode this; the raw fallback then applies its byte cap.
+    const junk = path.join(TMP, 'not-an-image.png');
+    fs.writeFileSync(junk, Buffer.alloc(600 * 1024, 0x41)); // over RAW_IMAGE_MAX_BYTES
+    const good = await makeBigPng('with-junk.png');
+    const { body } = await captureRequestBody({ prompt: 'x', imagePaths: [junk, good.file] });
+    const images = userContent(body).filter((c) => c.type === 'input_image');
+    assert.equal(images.length, 1, 'oversized raw fallback must be skipped, not sent');
+  });
+});
+
+// ── 2b. all-images-dropped must FAIL, not answer blind ──────────────────────
+
+describe('a vision turn whose images all fail to encode does not degrade to text', () => {
+  // Sending the prompt alone returns HTTP 200 with a confident answer that never
+  // saw the screenshot ("I don't see an image" — the symptom this whole change
+  // was written to fix), AND marks Codex healthy in VisionProviderFallbackChain
+  // so no other provider is tried. Throwing lets the chain fail over.
+  const expectNoRequest = async (imagePaths, label) => {
+    seedSignedIn();
+    const realFetch = globalThis.fetch;
+    let fetched = false;
+    globalThis.fetch = async () => { fetched = true; throw new Error('unreachable'); };
+    try {
+      await assert.rejects(async () => {
+        for await (const _ of CodexCliService.stream('', {
+          prompt: 'what is on my screen?', model: 'gpt-5.4', timeoutMs: 30_000, imagePaths,
+        })) { /* drain */ }
+      }, /could not read any of the/i, label);
+      assert.equal(fetched, false, 'no request may be sent at all — a text-only turn would answer blind');
+    } finally {
+      globalThis.fetch = realFetch;
+      delete globalThis[CRED_SLOT];
+    }
+  };
+
+  test('every path missing → throws instead of sending a text-only turn', async () => {
+    await expectNoRequest(
+      [path.join(TMP, 'gone-a.png'), path.join(TMP, 'gone-b.png')],
+      'a screenshot turn with no readable screenshot must not silently become a text turn',
+    );
+  });
+
+  test('the sole image being 0-byte → throws', async () => {
+    const empty = path.join(TMP, 'only-empty.png');
+    fs.writeFileSync(empty, Buffer.alloc(0));
+    await expectNoRequest([empty], 'a 0-byte capture must fail the turn, not answer blind');
+  });
+});
+
+// ── 3. boundaries on the newly-wired path ───────────────────────────────────
+
+const SETTINGS_SLOT = '__nativelySettingsManagerV1__';
+const setMode = (mode) => SettingsManager.getInstance().setScreenUnderstandingMode(mode);
+
+/** A bare LLMHelper with Codex reachable — everything else left real. */
+function codexHelper({ localOnly = false } = {}) {
+  const h = Object.create(LLMHelper.prototype);
+  h.isCodexAvailable = () => true;
+  h.isLocalOnlyMode = localOnly;
+  h.codexCliConfig = { path: 'codex', model: 'gpt-5.4', fastModel: 'gpt-5.3-codex', timeoutMs: 60_000 };
+  h.currentModelId = 'codex-cli';
+  return h;
+}
+
+describe('streamWithCodexCli refuses before any byte leaves', () => {
+  test('private_vision blocks a screenshot bound for Codex', async () => {
+    const before = globalThis[SETTINGS_SLOT];
+    setMode('private_vision');
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = async () => { throw new Error('fetch must not be reached'); };
+    try {
+      const gen = LLMHelper.prototype.streamWithCodexCli.call(
+        codexHelper(), 'describe this', 'SYS', false, ['/tmp/screenshot-under-test.png'],
+      );
+      // Match on `.name` + `.userMessage`, not `instanceof` — visionPolicy.ts is
+      // inlined per entry bundle, so the error class identity differs here.
+      await assert.rejects(() => gen.next(), (err) => {
+        assert.equal(err.name, 'VisionPolicyError',
+          'Codex is a CLOUD destination; "Keep screenshots on this device" must block it. '
+          + 'The registry marks it isLocal:true as a ROUTING hint (no API key) — that hint is '
+          + 'not a privacy claim. See visionPolicy.ts.');
+        assert.equal(err.provider, 'codex');
+        assert.match(err.userMessage, /not sent anywhere/i,
+          'the user must be told the screenshot did NOT leave the device');
+        return true;
+      });
+    } finally {
+      globalThis.fetch = realFetch;
+      setMode('vision_first');
+      if (before === undefined) delete globalThis[SETTINGS_SLOT]; else globalThis[SETTINGS_SLOT] = before;
+    }
+  });
+
+  // SCOPE OF THE TWO TESTS BELOW — read before trusting them.
+  //
+  // They set `isLocalOnlyMode` on the instance DIRECTLY, because nothing in the
+  // shipped app ever turns it on: `setLocalOnlyMode()` has no production caller
+  // (grep finds only its definition at LLMHelper.ts:1108 and test files), so
+  // the field is permanently false and these throws cannot fire in production
+  // today.
+  //
+  // So these are CONSISTENCY tests, not privacy guarantees: they assert Codex
+  // carries the same local-only boundary as the eight other cloud providers, so
+  // that whenever local-only mode is actually wired up Codex is not the one
+  // provider that silently ignores it. The privacy control that IS live is
+  // `screenUnderstandingMode === 'private_vision'`, covered by the test above —
+  // do not read a green run here as "Codex is boundaried".
+  test('local-only mode blocks Codex — consistency with the other cloud providers (see scope note)', async () => {
+    const gen = LLMHelper.prototype.streamWithCodexCli.call(
+      codexHelper({ localOnly: true }), 'hi', 'SYS', false, undefined,
+    );
+    await assert.rejects(() => gen.next(), /local-only mode/i);
+  });
+
+  test('generateWithCodexCli enforces the same local-only boundary (see scope note)', async () => {
+    await assert.rejects(
+      () => LLMHelper.prototype.generateWithCodexCli.call(codexHelper({ localOnly: true }), 'hi'),
+      /local-only mode/i,
+    );
+  });
+});

--- a/electron/services/__tests__/CredentialDegradedStoreGuard2026_08_05.test.mjs
+++ b/electron/services/__tests__/CredentialDegradedStoreGuard2026_08_05.test.mjs
@@ -224,6 +224,52 @@ test('a refused Codex token rotation does not stick in memory', () => {
   assert.equal(cm3.getCodexOAuthTokens()?.refreshToken, 'refresh-ORIGINAL');
 });
 
+// ── structural: no future mutator may skip the guard ────────────────────────
+
+test('EVERY method that calls saveCredentials() checks the degraded guard first', () => {
+  // A per-method behavioural test cannot cover a setter that does not exist yet,
+  // and the first pass at this fix missed four real mutators (saveCustomProvider,
+  // deleteCustomProvider, saveCurlProvider, deleteCurlProvider) precisely because
+  // they are not named set*/clear*. This walks the source instead, so a NEW
+  // mutator added later fails here rather than silently reintroducing the
+  // memory/disk divergence.
+  const src = fs.readFileSync(
+    path.resolve(path.dirname(new URL(import.meta.url).pathname), '../CredentialsManager.ts'),
+    'utf8',
+  );
+  const lines = src.split('\n');
+  const unguarded = [];
+  let i = 0;
+  while (i < lines.length) {
+    const m = /^\s*(?:public|private|protected)?\s*(\w+)\(/.exec(lines[i]);
+    if (m && lines[i].includes('{')) {
+      const name = m[1];
+      let depth = (lines[i].match(/\{/g) || []).length - (lines[i].match(/\}/g) || []).length;
+      let j = i + 1;
+      const body = [];
+      while (j < lines.length && depth > 0) {
+        depth += (lines[j].match(/\{/g) || []).length - (lines[j].match(/\}/g) || []).length;
+        body.push(lines[j]);
+        j++;
+      }
+      const b = body.join('\n');
+      // loadCredentials legitimately calls save() for the migrate-up, and it is
+      // the thing that SETS the flag; the two write primitives are the guard's home.
+      const exempt = ['saveCredentials', 'writeCredentials', 'loadCredentials'];
+      if (b.includes('this.saveCredentials()') && !exempt.includes(name)
+          && !b.includes('refuseWriteWhileDegraded') && !b.includes('keyringUnreadable')) {
+        unguarded.push(name);
+      }
+      i = j;
+      continue;
+    }
+    i++;
+  }
+  assert.deepEqual(unguarded, [],
+    'these methods write credentials without checking the degraded guard, so in a degraded session '
+    + 'they mutate in-memory state that never reaches disk: ' + unguarded.join(', '));
+});
+
 // ── the escape hatch ────────────────────────────────────────────────────────
 
 test('resetDegradedCredentialStore() is the only thing that discards the preserved file', () => {

--- a/electron/services/__tests__/CredentialDegradedStoreGuard2026_08_05.test.mjs
+++ b/electron/services/__tests__/CredentialDegradedStoreGuard2026_08_05.test.mjs
@@ -168,6 +168,62 @@ test('keyring unreadable + an OLDER fallback: saves refuse, and neither file is 
   assert.equal(cm4.getDeepgramApiKey(), SECRET, 'the newer keyring value wins once it is readable again');
 });
 
+// ── memory must not diverge from disk (Greptile P1 on PR #435) ──────────────
+
+test('a refused write does not mutate in-memory state either', () => {
+  // The first cut of this guard refused inside saveCredentials(), i.e. AFTER
+  // the setter had already mutated `this.credentials`. 21 of the setters on
+  // this class return void and discard the save result, so the value stayed
+  // live in memory while never reaching disk: Settings would show a key as
+  // saved that vanishes on restart. Reject BEFORE mutating instead.
+  const env = makeEnv();
+  const cm1 = freshManager(env);
+  cm1.setDeepgramApiKey(SECRET);
+  cm1.setGeminiApiKey('sk-gemini-ORIGINAL');
+
+  env.state.decryptShouldThrow = true;
+  const cm2 = freshManager(env);
+  assert.equal(cm2.isCredentialStoreDegraded(), true);
+
+  // A void setter (no way to report failure) must leave memory untouched.
+  cm2.setGeminiApiKey('sk-gemini-SHOULD-NOT-STICK');
+  assert.notEqual(cm2.getGeminiApiKey(), 'sk-gemini-SHOULD-NOT-STICK',
+    'a void setter must not leave an unpersisted value live in memory — the UI reads this back '
+    + 'and would report a save that never reached disk');
+
+  // A boolean setter must report false AND not mutate.
+  assert.equal(cm2.setSonioxApiKey('sk-soniox-SHOULD-NOT-STICK'), false);
+  assert.notEqual(cm2.getSonioxApiKey(), 'sk-soniox-SHOULD-NOT-STICK');
+});
+
+test('a refused Codex token rotation does not stick in memory', () => {
+  // ChatGPT OAuth rotates the refresh token on every refresh, and
+  // CodexOAuthService caches its own copy. Accepting a rotation that never
+  // reaches disk means the session works until the next launch, which then
+  // hits invalid_grant and forces a re-auth.
+  const env = makeEnv();
+  const cm1 = freshManager(env);
+  cm1.setCodexOAuthTokens({
+    accessToken: 'access-ORIGINAL', refreshToken: 'refresh-ORIGINAL', expiresAt: Date.now() + 3600_000,
+  });
+
+  env.state.decryptShouldThrow = true;
+  const cm2 = freshManager(env);
+  assert.equal(cm2.isCredentialStoreDegraded(), true);
+
+  cm2.setCodexOAuthTokens({
+    accessToken: 'access-ROTATED', refreshToken: 'refresh-ROTATED', expiresAt: Date.now() + 3600_000,
+  });
+  const live = cm2.getCodexOAuthTokens();
+  assert.notEqual(live?.refreshToken, 'refresh-ROTATED',
+    'an unpersisted rotation must not be accepted in memory');
+
+  // And the original is intact once the keychain unlocks.
+  env.state.decryptShouldThrow = false;
+  const cm3 = freshManager(env);
+  assert.equal(cm3.getCodexOAuthTokens()?.refreshToken, 'refresh-ORIGINAL');
+});
+
 // ── the escape hatch ────────────────────────────────────────────────────────
 
 test('resetDegradedCredentialStore() is the only thing that discards the preserved file', () => {

--- a/electron/services/__tests__/CredentialDegradedStoreGuard2026_08_05.test.mjs
+++ b/electron/services/__tests__/CredentialDegradedStoreGuard2026_08_05.test.mjs
@@ -1,0 +1,214 @@
+// electron/services/__tests__/CredentialDegradedStoreGuard2026_08_05.test.mjs
+//
+// The credential store must never overwrite a keyring file it could not READ.
+//
+// THE BUG THIS PINS
+// loadCredentials() falls through to the app-managed fallback when the keyring
+// file will not decrypt, and (correctly) skips the boot-time migrate-up so it
+// does not clobber the keyring from a possibly-older fallback. That guard was
+// first written as a function-LOCAL, so it protected only the boot write. But
+// saveCredentials() serializes the WHOLE credential object, so the first
+// ordinary write of the session — a Codex OAuth token refresh, any settings
+// write — re-encrypted an empty-or-partial object straight over the intact
+// keyring file. With no fallback present, `credentials` is EMPTY and every
+// stored key is destroyed with no copy anywhere.
+//
+// WHY REFUSING IS RIGHT
+// safeStorage.decryptString throws for TRANSIENT reasons: a locked macOS
+// keychain, a denied keychain-access prompt, a Windows roaming DPAPI profile
+// that has not synced. The data is usually fine and comes back next launch. So
+// the degraded session refuses writes and preserves the file.
+//
+// WHY IT MUST BE A FULL REFUSAL, not "write to the fallback only"
+// The mtime staleness guard at the top of loadCredentials() deletes the keyring
+// whenever the fallback is NEWER. A fallback-only write would therefore make
+// the NEXT boot delete the very keyring file being preserved. Covered below.
+//
+// Both platforms: keyringAvailable=true + decryptString throwing is exactly the
+// shape of a locked macOS Keychain AND of a Windows DPAPI failure, so these
+// tests exercise the same branch that both platforms take.
+//
+// Run via: npm run build:electron && node --test electron/services/__tests__/CredentialDegradedStoreGuard2026_08_05.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import Module from 'node:module';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const COMPILED = path.resolve(
+  path.dirname(new URL(import.meta.url).pathname),
+  '../../../dist-electron/electron/services/CredentialsManager.js',
+);
+
+function makeEnv() {
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'cred-degraded-'));
+  const state = { keyringAvailable: true, userData, decryptShouldThrow: false };
+  const fakeElectron = {
+    app: { getPath: () => state.userData, isPackaged: false, getVersion: () => '0.0.0-test' },
+    safeStorage: {
+      isEncryptionAvailable: () => state.keyringAvailable,
+      encryptString: (s) => Buffer.concat([Buffer.from('KR'), Buffer.from(s, 'utf8')]),
+      decryptString: (b) => {
+        // Models a locked keychain / denied prompt / unsynced DPAPI profile:
+        // isEncryptionAvailable() says yes, the actual decrypt throws.
+        if (state.decryptShouldThrow) throw new Error('could not decrypt: keychain is locked');
+        return Buffer.from(b).subarray(2).toString('utf8');
+      },
+      getSelectedStorageBackend: () => 'basic_text',
+    },
+  };
+  return { state, fakeElectron, userData };
+}
+
+let CURRENT = null;
+const origLoad = Module._load;
+Module._load = function patched(request) {
+  if (request === 'electron') {
+    if (!CURRENT) throw new Error('no electron env active');
+    return CURRENT.fakeElectron;
+  }
+  return origLoad.apply(this, arguments);
+};
+test.after(() => { Module._load = origLoad; });
+
+/** Cold start: fresh class, reset singleton, re-read disk. */
+function freshManager(env) {
+  CURRENT = env;
+  delete require.cache[require.resolve(COMPILED)];
+  const mod = require(COMPILED);
+  if (mod.CredentialsManager.instance) mod.CredentialsManager.instance = undefined;
+  const g = globalThis;
+  delete g.__nativelyCredentialsManagerV1__;
+  const cm = mod.CredentialsManager.getInstance();
+  cm.init();
+  return cm;
+}
+
+const SECRET = 'sk-deepgram-LIVE-SENTINEL-abc123XYZ';
+const keyringPath = (env) => path.join(env.userData, 'credentials.enc');
+const fallbackPath = (env) => path.join(env.userData, 'credentials.fallback.enc');
+
+// ── the headline case: no fallback to fall back to ──────────────────────────
+
+test('keyring unreadable + NO fallback: a later save must not wipe the keyring file', () => {
+  const env = makeEnv();
+
+  // Session 1: healthy. Store a key via the keyring.
+  const cm1 = freshManager(env);
+  assert.equal(cm1.setDeepgramApiKey(SECRET), true);
+  assert.ok(fs.existsSync(keyringPath(env)), 'keyring file should exist');
+  const intact = fs.readFileSync(keyringPath(env));
+  assert.ok(!fs.existsSync(fallbackPath(env)), 'no fallback — this is the dangerous shape');
+
+  // Session 2: keychain locked. Load yields EMPTY credentials.
+  env.state.decryptShouldThrow = true;
+  const cm2 = freshManager(env);
+  assert.equal(cm2.getDeepgramApiKey(), undefined, 'the key is not readable this session (expected)');
+  assert.equal(cm2.isCredentialStoreDegraded(), true, 'the manager must know it is degraded');
+
+  // The write that used to destroy everything.
+  const saved = cm2.setSonioxApiKey('sk-soniox-new');
+  assert.equal(saved, false, 'a degraded session must report the write as FAILED, not a false "Saved"');
+
+  assert.deepEqual(
+    fs.readFileSync(keyringPath(env)), intact,
+    'the keyring file must be byte-identical — overwriting it here destroys every stored key with no copy anywhere',
+  );
+
+  // Session 3: keychain unlocked again. Everything is still there.
+  env.state.decryptShouldThrow = false;
+  const cm3 = freshManager(env);
+  assert.equal(cm3.getDeepgramApiKey(), SECRET, 'the original key must survive the degraded session');
+  assert.equal(cm3.isCredentialStoreDegraded(), false, 'a healthy load clears the degraded flag');
+});
+
+// ── the fallback-present variant ────────────────────────────────────────────
+
+test('keyring unreadable + an OLDER fallback: saves refuse, and neither file is corrupted', () => {
+  const env = makeEnv();
+
+  // Build an older fallback (keyring unavailable), then a newer keyring.
+  env.state.keyringAvailable = false;
+  const cm1 = freshManager(env);
+  cm1.setDeepgramApiKey('sk-OLD-fallback-value');
+  assert.ok(fs.existsSync(fallbackPath(env)), 'fallback should exist');
+  const oldFallback = fs.readFileSync(fallbackPath(env));
+
+  env.state.keyringAvailable = true;
+  const cm2 = freshManager(env);
+  cm2.setDeepgramApiKey(SECRET);
+  const intactKeyring = fs.readFileSync(keyringPath(env));
+
+  // Re-create the older fallback next to the newer keyring.
+  fs.writeFileSync(fallbackPath(env), oldFallback);
+  const past = Date.now() - 60_000;
+  fs.utimesSync(fallbackPath(env), past / 1000, past / 1000);
+
+  // Keychain locks. Load falls through to the older fallback.
+  env.state.decryptShouldThrow = true;
+  const cm3 = freshManager(env);
+  assert.equal(cm3.isCredentialStoreDegraded(), true);
+
+  assert.equal(cm3.setSonioxApiKey('sk-soniox-new'), false, 'writes must be refused while degraded');
+  assert.deepEqual(
+    fs.readFileSync(keyringPath(env)), intactKeyring,
+    'the newer keyring must not be overwritten from the older fallback',
+  );
+
+  // The full-refusal requirement: a fallback-only write would have made the
+  // fallback NEWER than the keyring, and the mtime staleness guard would then
+  // DELETE the keyring on this next boot.
+  env.state.decryptShouldThrow = false;
+  const cm4 = freshManager(env);
+  assert.ok(fs.existsSync(keyringPath(env)), 'the keyring must survive to the next boot');
+  assert.equal(cm4.getDeepgramApiKey(), SECRET, 'the newer keyring value wins once it is readable again');
+});
+
+// ── the escape hatch ────────────────────────────────────────────────────────
+
+test('resetDegradedCredentialStore() is the only thing that discards the preserved file', () => {
+  const env = makeEnv();
+  const cm1 = freshManager(env);
+  cm1.setDeepgramApiKey(SECRET);
+
+  env.state.decryptShouldThrow = true;
+  const cm2 = freshManager(env);
+  assert.equal(cm2.isCredentialStoreDegraded(), true);
+  assert.equal(cm2.setDeepgramApiKey('nope'), false);
+
+  cm2.resetDegradedCredentialStore();
+  assert.equal(cm2.isCredentialStoreDegraded(), false, 'the explicit reset clears the degraded state');
+  assert.ok(!fs.existsSync(keyringPath(env)), 'the unreadable file is discarded on explicit request');
+
+  // Writes work again afterwards.
+  assert.equal(cm2.setDeepgramApiKey('sk-fresh-start'), true);
+});
+
+// ── the healthy path is untouched ───────────────────────────────────────────
+
+test('a normal session is unaffected — writes still persist', () => {
+  const env = makeEnv();
+  const cm1 = freshManager(env);
+  assert.equal(cm1.isCredentialStoreDegraded(), false);
+  assert.equal(cm1.setDeepgramApiKey(SECRET), true);
+
+  const cm2 = freshManager(env);
+  assert.equal(cm2.getDeepgramApiKey(), SECRET);
+  assert.equal(cm2.setSonioxApiKey('sk-soniox'), true, 'ordinary writes must keep working');
+
+  const cm3 = freshManager(env);
+  assert.equal(cm3.getSonioxApiKey(), 'sk-soniox');
+  assert.equal(cm3.getDeepgramApiKey(), SECRET);
+});
+
+test('a fresh install (no credential files at all) is not treated as degraded', () => {
+  const env = makeEnv();
+  const cm = freshManager(env);
+  assert.equal(cm.isCredentialStoreDegraded(), false,
+    'no keyring file means nothing to protect — writes must work on a first run');
+  assert.equal(cm.setDeepgramApiKey(SECRET), true);
+});

--- a/electron/services/__tests__/GoogleServiceAccountValidation2026_08_05.test.mjs
+++ b/electron/services/__tests__/GoogleServiceAccountValidation2026_08_05.test.mjs
@@ -1,0 +1,194 @@
+// electron/services/__tests__/GoogleServiceAccountValidation2026_08_05.test.mjs
+//
+// The service-account classifier, and specifically the DEFINITE / INDEFINITE
+// split that decides whether the boot path is allowed to delete a persisted
+// credential.
+//
+// WHY THIS SPLIT EXISTS
+// A first cut of this fix validated with `fs.statSync(p).isFile()` and evicted
+// the stored path whenever that returned false. Two ways that destroys a
+// working credential:
+//   1. The key lives on an external volume / network share that is not mounted
+//      at launch, or in a macOS TCC-protected folder. statSync throws exactly
+//      like a deleted file — on macOS an unmounted /Volumes/X path reports
+//      ENOENT — so a recoverable condition looked identical to a gone one.
+//   2. statSync passes for ANY file, so the common mistake (the file dialog
+//      filters to *.json, so users pick an OAuth client-secret json) was
+//      adopted and persisted, then crashed the Speech SDK later — the same
+//      deferred-crash symptom the validation was added to remove.
+//
+// So the contract is: `definite` true ONLY when we positively read the file and
+// determined it is not a usable key. Callers may evict on definite; never on
+// indefinite. These tests pin exactly that.
+//
+// Platform note: the classifier takes injectable IO and does no path parsing,
+// so it is platform-agnostic by construction. The Windows-shaped cases below
+// run on every OS precisely because nothing in the unit depends on the host
+// filesystem — see the 'paths are treated as opaque' block.
+//
+// Run via: npm run build:electron && ELECTRON_RUN_AS_NODE=1 npx electron --test electron/services/__tests__/GoogleServiceAccountValidation2026_08_05.test.mjs
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import os from 'node:os';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const dist = (p) => path.join(__dirname, '../../../dist-electron/electron', p);
+
+const electronPath = require.resolve('electron');
+require.cache[electronPath] = {
+  id: electronPath, filename: electronPath, loaded: true,
+  exports: {
+    app: { isReady: () => true, getPath: () => os.tmpdir(), getVersion: () => '0.0.0-test' },
+    safeStorage: { isEncryptionAvailable: () => false },
+  },
+};
+
+const {
+  classifyServiceAccountFile,
+  describeServiceAccountRejection,
+  DUMMY_SERVICE_ACCOUNT_PATH,
+} = require(dist('services/googleServiceAccount.js'));
+
+/** A structurally valid service-account key (fake credentials). */
+const VALID_KEY = JSON.stringify({
+  type: 'service_account',
+  project_id: 'test-project',
+  private_key_id: 'abc123',
+  private_key: '-----BEGIN PRIVATE KEY-----\nFAKE\n-----END PRIVATE KEY-----\n',
+  client_email: 'svc@test-project.iam.gserviceaccount.com',
+  client_id: '123',
+});
+
+/** IO stub: `files` maps path → contents; anything else throws like ENOENT. */
+const io = (files, { dirs = [], throwCode } = {}) => ({
+  statSync: (p) => {
+    if (throwCode && files[p] === undefined) { const e = new Error(throwCode); e.code = throwCode; throw e; }
+    if (dirs.includes(p)) return { isFile: () => false };
+    if (files[p] === undefined) { const e = new Error('ENOENT'); e.code = 'ENOENT'; throw e; }
+    return { isFile: () => true };
+  },
+  readFileSync: (p) => {
+    if (files[p] === undefined) { const e = new Error('ENOENT'); e.code = 'ENOENT'; throw e; }
+    if (files[p] instanceof Error) throw files[p];
+    return files[p];
+  },
+});
+
+describe('a usable key is accepted', () => {
+  test('a well-formed service-account json', () => {
+    const v = classifyServiceAccountFile('/k/sa.json', io({ '/k/sa.json': VALID_KEY }));
+    assert.equal(v.usable, true);
+  });
+});
+
+describe('DEFINITE rejections — safe to evict the stored path', () => {
+  const cases = [
+    ['empty string', '', {}, 'empty'],
+    ['the .env.example placeholder', DUMMY_SERVICE_ACCOUNT_PATH, {}, 'placeholder'],
+    ['a directory', '/k/dir', { files: {}, dirs: ['/k/dir'] }, 'not_a_file'],
+    ['not json at all', '/k/x.json', { files: { '/k/x.json': 'not json {{{' } }, 'not_json'],
+    // The realistic mis-pick: the dialog filters to *.json.
+    ['an OAuth client-secret json', '/k/client.json',
+      { files: { '/k/client.json': JSON.stringify({ installed: { client_id: 'x', client_secret: 'y' } }) } },
+      'not_service_account'],
+    ['a package.json', '/k/package.json',
+      { files: { '/k/package.json': JSON.stringify({ name: 'natively', version: '1.0.0' }) } },
+      'not_service_account'],
+    ['service_account type but no private_key', '/k/partial.json',
+      { files: { '/k/partial.json': JSON.stringify({ type: 'service_account', client_email: 'a@b.com' }) } },
+      'not_service_account'],
+    ['json null', '/k/null.json', { files: { '/k/null.json': 'null' } }, 'not_service_account'],
+  ];
+
+  for (const [label, p, opts, expectedReason] of cases) {
+    test(`${label} → definite`, () => {
+      const v = classifyServiceAccountFile(p, io(opts.files || {}, opts));
+      assert.equal(v.usable, false);
+      assert.equal(v.reason, expectedReason);
+      assert.equal(v.definite, true,
+        `"${label}" is a positive determination — the boot path is allowed to evict it`);
+      assert.ok(describeServiceAccountRejection(v.reason).length > 0, 'every reason needs user-facing text');
+    });
+  }
+});
+
+describe('INDEFINITE rejections — MUST NOT evict (the file may come back)', () => {
+  // Each of these is a real user setup where the credential is fine and merely
+  // invisible right now. Evicting would destroy it permanently.
+  const transient = [
+    ['unmounted external volume (reports ENOENT on macOS)', '/Volumes/KeyDrive/sa.json', 'ENOENT'],
+    ['permission denied / macOS TCC-protected folder', '/Users/x/Documents/sa.json', 'EACCES'],
+    ['unreachable network share', '//fileserver/keys/sa.json', 'EIO'],
+    ['disconnected Windows mapped drive', 'Z:\\keys\\sa.json', 'ENOENT'],
+  ];
+
+  for (const [label, p, code] of transient) {
+    test(`${label} → indefinite`, () => {
+      const v = classifyServiceAccountFile(p, io({}, { throwCode: code }));
+      assert.equal(v.usable, false);
+      assert.equal(v.reason, 'unreadable');
+      assert.equal(v.definite, false,
+        `"${label}" is a visibility failure, not proof the key is gone. Evicting the stored path here `
+        + 'destroys a credential that returns as soon as the volume/share/permission is available.');
+    });
+  }
+
+  test('a read that throws AFTER a successful stat is also indefinite', () => {
+    // stat says it is a file, then the read fails (permissions, IO error).
+    const err = new Error('EACCES'); err.code = 'EACCES';
+    const v = classifyServiceAccountFile('/k/sa.json', io({ '/k/sa.json': err }));
+    assert.equal(v.definite, false);
+  });
+});
+
+describe('the verdict never carries key material', () => {
+  // `detail` is logged by both callers (main.ts boot path, ipcHandlers picker).
+  // JSON.parse embeds a snippet of its INPUT in the thrown message — e.g.
+  //   Unexpected token 'p', "private_ke"... is not valid JSON
+  // — and the input here is a PRIVATE KEY file. Passing that through would
+  // print key bytes into the app log, which is a worse outcome than the bad
+  // pick it is describing.
+  test('a malformed key file does not leak its contents via detail', () => {
+    const secret = 'SUPERSECRET_PRIVATE_KEY_MATERIAL';
+    const malformed = `{"type":"service_account","private_key":"${secret}" TRAILING GARBAGE`;
+    const v = classifyServiceAccountFile('/k/broken.json', io({ '/k/broken.json': malformed }));
+
+    assert.equal(v.usable, false);
+    assert.equal(v.reason, 'not_json');
+    const serialized = JSON.stringify(v);
+    assert.ok(!serialized.includes(secret), 'the verdict must not contain key material');
+    assert.ok(!serialized.includes('private_key'), 'not even the field name should round-trip');
+    assert.equal(v.detail, undefined, 'not_json must carry NO detail — the parser message quotes the input');
+  });
+
+  test('a wrong-but-valid json reports only its type, never its values', () => {
+    const v = classifyServiceAccountFile('/k/oauth.json', io({
+      '/k/oauth.json': JSON.stringify({ type: 'authorized_user', client_secret: 'SHOULD_NOT_APPEAR' }),
+    }));
+    assert.equal(v.reason, 'not_service_account');
+    assert.ok(!JSON.stringify(v).includes('SHOULD_NOT_APPEAR'), 'secret values must not reach the log');
+    assert.equal(v.detail, 'type=authorized_user', 'the type alone is the useful, safe hint');
+  });
+});
+
+describe('paths are treated as opaque strings (cross-platform by construction)', () => {
+  // The classifier does no path parsing — no separator handling, no drive-letter
+  // logic — so a Windows path behaves exactly like a POSIX one on every host.
+  // That is why the Windows cases above are meaningful when run on macOS.
+  const windowsish = [
+    'C:\\Users\\Sam\\keys\\sa.json',
+    '\\\\server\\share\\sa.json',
+    'C:/Users/Sam/keys/sa.json',
+    'C:\\Users\\Sam Smith\\My Keys\\sa.json', // spaces
+  ];
+  for (const p of windowsish) {
+    test(`accepts a valid key at ${p}`, () => {
+      assert.equal(classifyServiceAccountFile(p, io({ [p]: VALID_KEY })).usable, true);
+    });
+  }
+});

--- a/electron/services/googleServiceAccount.ts
+++ b/electron/services/googleServiceAccount.ts
@@ -1,0 +1,167 @@
+// electron/services/googleServiceAccount.ts
+//
+// One decision: "is this path a usable Google service-account key file, and if
+// not, do we KNOW that or merely fail to see it right now?"
+//
+// WHY THE SECOND HALF MATTERS
+// `new SpeechClient({ keyFilename })` does not validate at construction. A bad
+// path surfaces later as ENOENT from inside the STT stream and again from the
+// `before-quit` teardown, which reads to the user as a fatal app crash rather
+// than a bad setting. So we validate up front.
+//
+// But "cannot read it" is NOT the same as "it is not there". A key file on an
+// unmounted external volume, a not-yet-connected network share, or a folder the
+// app has not been granted access to (macOS TCC) all fail exactly like a deleted
+// file — on macOS an unmounted /Volumes/X path reports ENOENT, not EIO. Treating
+// those as "gone" and evicting the stored path would destroy a working
+// credential the user gets back the moment the volume mounts.
+//
+// Hence `definite`: true only when we positively read the file and it is not a
+// service-account key. Callers may report a `definite` failure to the user as a
+// bad pick; they must NOT delete persisted state on an indefinite one.
+
+import fs from 'fs';
+
+/**
+ * The placeholder shipped in `.env.example`. Older builds persisted it into the
+ * credential store verbatim, producing an ENOENT crash loop that survived
+ * removing the line from `.env` (by then the dummy lived in the keychain).
+ * `.env.example` now ships it commented out; this constant lets the boot path
+ * evict a copy an earlier build already persisted.
+ *
+ * This is the ONE literal that is ever evicted automatically. Everything else
+ * is handled by classification above — see the note about `definite`.
+ */
+export const DUMMY_SERVICE_ACCOUNT_PATH = '/path/to/your/service-account.json';
+
+export type ServiceAccountRejection =
+    | 'empty'
+    | 'placeholder'
+    | 'not_a_file'
+    | 'unreadable'
+    | 'not_json'
+    | 'not_service_account';
+
+/**
+ * NOTE: deliberately ONE shape with optional fields rather than a discriminated
+ * union on `usable`. `electron/tsconfig.json` does not enable `strict`, so
+ * narrowing a boolean-literal discriminant does not apply there and every
+ * `verdict.reason` read after an `if (!verdict.usable)` would be a type error.
+ * A single interface keeps the call sites honest under both configs.
+ */
+export interface ServiceAccountVerdict {
+    usable: boolean;
+    /** Present whenever `usable` is false. */
+    reason?: ServiceAccountRejection;
+    /**
+     * True when we positively determined the file is not a usable key.
+     * False when we simply could not read it right now (which may be
+     * transient) — callers must not treat this as "the credential is gone".
+     * Only meaningful when `usable` is false.
+     */
+    definite?: boolean;
+    detail?: string;
+}
+
+/** Injectable IO so the classifier is unit-testable without touching a disk. */
+export interface ServiceAccountIO {
+    statSync(p: string): { isFile(): boolean };
+    readFileSync(p: string, enc: 'utf8'): string;
+}
+
+const DEFAULT_IO: ServiceAccountIO = {
+    statSync: (p) => fs.statSync(p),
+    readFileSync: (p, enc) => fs.readFileSync(p, enc),
+};
+
+/**
+ * Classify a candidate service-account key path.
+ *
+ * Deliberately reads and parses rather than stopping at `statSync().isFile()`.
+ * The file dialog filters to `*.json`, so the realistic mistake is picking the
+ * WRONG json — a downloaded OAuth client secret, an api-key export, a
+ * package.json. Those all pass an existence check and then fail inside the
+ * Speech SDK with the same deferred crash an absent file produces.
+ */
+export function classifyServiceAccountFile(
+    keyPath: string | undefined | null,
+    io: ServiceAccountIO = DEFAULT_IO,
+): ServiceAccountVerdict {
+    if (!keyPath || !keyPath.trim()) {
+        return { usable: false, reason: 'empty', definite: true };
+    }
+    if (keyPath === DUMMY_SERVICE_ACCOUNT_PATH) {
+        return { usable: false, reason: 'placeholder', definite: true };
+    }
+
+    let raw: string;
+    try {
+        if (!io.statSync(keyPath).isFile()) {
+            // We READ the directory entry and it is not a regular file. That is
+            // a positive determination, not a visibility problem.
+            return { usable: false, reason: 'not_a_file', definite: true };
+        }
+        raw = io.readFileSync(keyPath, 'utf8');
+    } catch (err: any) {
+        // ENOENT / EACCES / EIO / ENOTCONN are NOT distinguishable here in a way
+        // that is safe to act on: an unmounted volume yields ENOENT. Indefinite.
+        return {
+            usable: false,
+            reason: 'unreadable',
+            definite: false,
+            detail: err?.code || err?.message || String(err),
+        };
+    }
+
+    let parsed: any;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        // NO detail. `JSON.parse` embeds a snippet of the INPUT in its message
+        // ("Unexpected token 'p', \"private_ke\"... is not valid JSON"), and this
+        // file is a private key — callers log `detail`, so passing it through
+        // would print key material into the app log. The reason code alone is
+        // enough to tell the user what to do.
+        return { usable: false, reason: 'not_json', definite: true };
+    }
+
+    // Google service-account keys carry `type: "service_account"` plus the two
+    // fields the SDK actually signs with. Checking all three keeps an OAuth
+    // client-secret json (which has none of them) from being adopted.
+    if (!parsed || typeof parsed !== 'object'
+        || parsed.type !== 'service_account'
+        || typeof parsed.client_email !== 'string'
+        || typeof parsed.private_key !== 'string') {
+        return {
+            usable: false,
+            reason: 'not_service_account',
+            definite: true,
+            detail: parsed && typeof parsed === 'object' && typeof parsed.type === 'string'
+                ? `type=${parsed.type}`
+                : undefined,
+        };
+    }
+
+    return { usable: true };
+}
+
+/** User-facing explanation for a rejection. Kept next to the reasons so the
+ *  Settings picker and the boot log stay in agreement. */
+export function describeServiceAccountRejection(reason: ServiceAccountRejection | undefined): string {
+    switch (reason) {
+        case 'empty':
+            return 'No file was selected.';
+        case 'placeholder':
+            return 'That is the example path from .env.example, not a real key file.';
+        case 'not_a_file':
+            return 'That path is not a file.';
+        case 'unreadable':
+            return 'That file could not be read right now. If it lives on an external drive or network share, connect it and try again.';
+        case 'not_json':
+            return 'That file is not valid JSON.';
+        case 'not_service_account':
+            return 'That JSON is not a Google service-account key. Download the key for a service account (it contains "type": "service_account").';
+        default:
+            return 'That file is not a usable Google service-account key.';
+    }
+}

--- a/src/components/SettingsOverlay.tsx
+++ b/src/components/SettingsOverlay.tsx
@@ -1031,6 +1031,9 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({
     const [sttSaving, setSttSaving] = useState(false);
     const [sttSaved, setSttSaved] = useState(false);
     const [googleServiceAccountPath, setGoogleServiceAccountPath] = useState<string | null>(null);
+    // Why the picker rejected the last pick. Without this a rejected file is
+    // indistinguishable from a cancelled dialog — the field just stays empty.
+    const [googleServiceAccountError, setGoogleServiceAccountError] = useState('');
     const [hasNativelyKey, setHasNativelyKey] = useState(initialHasNativelyKey);
     const [hasStoredSttGroqKey, setHasStoredSttGroqKey] = useState(false);
     const [hasStoredSttOpenaiKey, setHasStoredSttOpenaiKey] = useState(false);
@@ -2692,6 +2695,12 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({
                                                                 const result = await window.electronAPI?.selectServiceAccount?.();
                                                                 if (result?.success && result.path) {
                                                                     setGoogleServiceAccountPath(result.path);
+                                                                    setGoogleServiceAccountError('');
+                                                                } else if (result && !result.cancelled) {
+                                                                    // A rejected pick must say WHY. Silently doing nothing
+                                                                    // reads as "Settings is broken" and the user retries
+                                                                    // the same wrong file.
+                                                                    setGoogleServiceAccountError(result.error || t('That file is not a usable Google service-account key.'));
                                                                 }
                                                             }}
                                                             className="px-3 py-2 bg-bg-input hover:bg-bg-elevated border border-border-subtle rounded-lg text-xs font-medium text-text-primary transition-colors flex items-center gap-2"
@@ -2699,6 +2708,9 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({
                                                             <Upload size={14} /> {t('Select File')}
                                                         </button>
                                                     </div>
+                                                    {googleServiceAccountError && (
+                                                        <p className="text-xs text-red-400 mt-2">{googleServiceAccountError}</p>
+                                                    )}
                                                     <p className="text-[10px] text-text-tertiary mt-2">
                                                         {t('Required for Google Cloud Speech-to-Text.')}
                                                     </p>


### PR DESCRIPTION
Rebased, reviewed subset of #428 (which is behind `main` and carries defects found in review). Same intent, 11 files, no unrelated churn.

## What this fixes

**1. Codex CLI vision — "I am not an image model"**
`buildRequestBody` dropped `imagePaths` entirely, so screenshots never reached the model. Now encoded as Responses-API `input_image` items.

> ⚠️ The wire shape is load-bearing: `/v1/responses` takes `{ type: 'input_image', image_url: '<data-URL string>' }`. The Chat Completions shape (`type: 'image_url'` with an object) is **silently ignored** — the model answers as if no image were attached, which *is* the original bug. #428's first commit shipped the wrong one. Pinned by test.

Also: sharp downscale (1920/q85) + 500KB raw cap matching sibling providers, a lower bound so 0-byte/truncated captures aren't sent as malformed data URLs, and a throw when no image encodes instead of silently answering blind.

**2. Google service-account ENOENT crash loop**
`.env.example` shipped a placeholder that got persisted; the Speech SDK then threw ENOENT on every STT start and on quit, surviving removal from `.env`.

New `googleServiceAccount.ts` separates a **definite** rejection ("this is an OAuth client secret") from an **indefinite** one ("the volume isn't mounted") — only definite ones evict persisted state. On macOS an unmounted `/Volumes` path reports ENOENT identically to a deleted file, so evicting there destroys a credential that returns on remount. Boot now tries store → env **in turn** rather than `||`-picking then validating, so a stale stored path can't shadow or delete a working `GOOGLE_APPLICATION_CREDENTIALS`.

**3. Credential store: never overwrite what we couldn't read**
`saveCredentials()` serializes the whole object, so after a keyring decrypt failure the first write of the session replaced the intact file with an empty one — unrecoverable key loss with no fallback present. `decryptString` throws for *transient* reasons (locked keychain, denied prompt, unsynced roaming DPAPI), so writes are refused and the file preserved. Must be a full refusal: the mtime staleness guard deletes the keyring whenever the fallback is newer.

**4. Surfacing** — `setGoogleServiceAccountPath` returns the write result; Settings shows the rejection reason (was indistinguishable from a cancelled dialog); Codex auth errors reach the user verbatim.

## Security note
The verdict deliberately carries no `detail` on a JSON parse failure — `JSON.parse` embeds a snippet of its input in the message, and callers log it, so a malformed key file would print private-key bytes into the app log. Two tests pin this.

## Testing
- **38 new tests**, all mutation-probed (each fix's tests fail when the fix is reverted)
- **Regression:** 184 tests / 12 suites — 19 failures on `origin/main@4915c715`, the same 19 here. **Zero introduced.**
- `Covered by automated macOS branch tests` · `Build validated on macOS` · both typechecks clean

## Not verified — please confirm before release
- `Requires physical macOS verification` — the app was never launched. The ENOENT crash loop and the live Codex vision round-trip are unconfirmed end-to-end.
- `Requires physical Windows verification` — the CredentialsManager change touches the DPAPI path.
- `setLocalOnlyMode()` has no production caller, so the Codex local-only guard is currently unreachable; kept for consistency with the eight sibling providers, and its tests say so explicitly rather than claiming a guarantee.

Supersedes #428 — close that one if this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TspFCUHRDhyJTopG5KxdjS