### PR TITLE
fix(lifecycle): stop rapid meeting start/stop from silently killing the database

### DIFF
--- a/electron/audio/NativelyProSTT.ts
+++ b/electron/audio/NativelyProSTT.ts
@@ -1035,16 +1035,74 @@ export class NativelyProSTT extends EventEmitter {
 
         if (this.ws) {
             const dying = this.ws;
+            const readyState = dying.readyState;
             this.ws = null;
-            // Strip every JS-side listener BEFORE close(). The libuv socket can
-            // still deliver 'message'/'close' events that were already in
-            // flight from the kernel — without removeAllListeners() they would
-            // bubble up to handlers that mutate state on `this` and corrupt
-            // the new connection. The handler-side `guard(ws === this.ws)`
-            // makes this safe even if removeAllListeners() somehow misses
-            // anything, but doing both is the production-grade pattern.
-            try { dying.removeAllListeners(); } catch {}
-            try { dying.close(); } catch {}
+
+            // Strip the state-mutating listeners BEFORE close(). The libuv
+            // socket can still deliver 'open'/'message' events that were
+            // already in flight from the kernel — without removing them they
+            // would bubble up to handlers that mutate state on `this` and
+            // corrupt the new connection. The handler-side
+            // `guard(ws === this.ws)` makes this safe even if the removal
+            // somehow misses anything, but doing both is the production-grade
+            // pattern.
+            //
+            // CRITICAL (2026-08-07): this used to be a blanket
+            // removeAllListeners(), which ALSO stripped 'error'. That is the
+            // one listener we must keep. ws@8's close() on a CONNECTING socket
+            // routes through abortHandshake(), which ends in:
+            //
+            //     process.nextTick(emitErrorAndClose, websocket, err)
+            //
+            // so 'error' is emitted unconditionally ONE TICK LATER with the
+            // message "WebSocket was closed before the connection was
+            // established". With no listener attached, Node's EventEmitter
+            // promotes it to a process-level uncaughtException — and main.ts's
+            // handler responds by closing the SQLite singleton irreversibly,
+            // silently killing meeting persistence for the rest of the session.
+            //
+            // There is no way to suppress that emit: terminate() takes the same
+            // abortHandshake path, and deferring the close() to a later tick
+            // does not help either (both measured against ws@8.21.0). See
+            // websockets/ws#1835 — abortHandshake is deliberately private and
+            // the library's contract is that the caller keeps an 'error'
+            // listener attached across the cancellation.
+            for (const event of ['open', 'message', 'ping', 'pong', 'upgrade', 'unexpected-response']) {
+                try { dying.removeAllListeners(event); } catch {}
+            }
+            try { dying.removeAllListeners('error'); } catch {}
+            try { dying.removeAllListeners('close'); } catch {}
+
+            // Narrow cancellation listeners for the DETACHED socket only. They
+            // are permitted precisely because `dying` is no longer `this.ws`:
+            // an error on the still-owned active socket keeps the normal
+            // provider error path installed by connect(). They release each
+            // other on 'close' so a discarded socket does not retain listeners
+            // — these sockets are cycled on every meeting.
+            const consumeDetachedError = (error: Error): void => {
+                if (process.env.NATIVELY_STT_LIFECYCLE_DEBUG === '1') {
+                    console.log(
+                        `[NativelyProSTT:${this.channel}] detached socket error ` +
+                        `state=${readyState} message=${error?.message}`,
+                    );
+                }
+            };
+            const releaseDetachedListeners = (): void => {
+                try { dying.removeListener('error', consumeDetachedError); } catch {}
+                try { dying.removeListener('close', releaseDetachedListeners); } catch {}
+            };
+            try { dying.on('error', consumeDetachedError); } catch {}
+            try { dying.on('close', releaseDetachedListeners); } catch {}
+
+            // Only CONNECTING/OPEN sockets need a close. A CLOSING socket is
+            // already tearing down (its 'close' will fire and release the
+            // listeners); a CLOSED one will never emit again, so release now
+            // rather than leaving the pair attached forever.
+            if (readyState === WebSocket.CONNECTING || readyState === WebSocket.OPEN) {
+                try { dying.close(); } catch { releaseDetachedListeners(); }
+            } else if (readyState === WebSocket.CLOSED) {
+                releaseDetachedListeners();
+            }
         }
     }
 }

--- a/electron/audio/__tests__/DefaultOutputWatcherEpoch.test.mjs
+++ b/electron/audio/__tests__/DefaultOutputWatcherEpoch.test.mjs
@@ -57,7 +57,7 @@ test('microphone recovery handler aborts when the meeting generation has changed
 });
 
 test('startMeeting resets system + mic recovery counters so a stale meeting cannot consume the new budget', () => {
-  const startMeetingBody = extractMethod(/public\s+async\s+startMeeting\s*\([^)]*\)[^{]*\{/, 'startMeeting');
+  const startMeetingBody = extractMethod(/private\s+async\s+startMeetingTransition\s*\([^)]*\)[^{]*\{/, 'startMeetingTransition');
   for (const counter of ['_systemAudioRecoveryAttempts', '_systemAudioConsecutiveFailures', '_micRecoveryAttempts']) {
     assert.ok(
       new RegExp(`this\\.${counter}\\s*=\\s*0`).test(startMeetingBody),

--- a/electron/audio/__tests__/EndMeetingAbortsInFlightInit.test.mjs
+++ b/electron/audio/__tests__/EndMeetingAbortsInFlightInit.test.mjs
@@ -55,8 +55,8 @@ function extractMethodBody(methodName) {
   return mainSource.slice(start, i - 1);
 }
 
-const startMeetingBody = extractMethodBody('startMeeting');
-const endMeetingBody = extractMethodBody('endMeeting');
+const startMeetingBody = extractMethodBody('startMeetingTransition');
+const endMeetingBody = extractMethodBody('endMeetingTransition');
 
 test('AppState declares _audioInitController and _audioInitPromise fields', () => {
   assert.ok(

--- a/electron/audio/__tests__/EndMeetingClearsHiddenOverlay.test.mjs
+++ b/electron/audio/__tests__/EndMeetingClearsHiddenOverlay.test.mjs
@@ -55,7 +55,7 @@ function extractMethodBody(methodName) {
   return mainSource.slice(start, i - 1);
 }
 
-const endMeetingBody = extractMethodBody('endMeeting');
+const endMeetingBody = extractMethodBody('endMeetingTransition');
 
 test('endMeeting sends session-reset to the overlay so its hidden tree is cleared before the next meeting', () => {
   assert.ok(

--- a/electron/audio/__tests__/MeetingLifecycleDbLiveness2026_08_07.test.mjs
+++ b/electron/audio/__tests__/MeetingLifecycleDbLiveness2026_08_07.test.mjs
@@ -1,0 +1,223 @@
+// Couples the two halves of this bug class: STT lifecycle churn and database
+// liveness.
+//
+// WHY THIS EXISTS: the Windows report was "meetings stop saving". Getting there
+// took three separate defects lining up — a cancelled STT handshake raising an
+// uncaughtException, the fatal handler closing SQLite irreversibly, and the app
+// staying alive afterwards. Each half had tests; NOTHING asserted the
+// end-to-end property the user actually cares about:
+//
+//     after any amount of start/stop churn, can we still save a meeting?
+//
+// So this test cycles the real NativelyProSTT over real sockets through a fixed
+// sequence of handshake outcomes, wires main.ts's REAL fatal policy
+// (uncaughtException -> emergencyCloseDatabase), and after EVERY cycle performs
+// a genuine SELECT 1 + insert + read-back + delete against a real SQLite file.
+//
+// Measured against HEAD (all three fixes reverted) this fails on cycle 0 and
+// every cycle after it:
+//     !! cycle 0 after-stop: DB NOT LIVE -> The database connection is not open
+//     !! cycle 1 after-start: DB NOT LIVE -> The database connection is not open
+//     ... (permanent for the rest of the session — exactly the user's symptom)
+//
+// Hermetic: local servers only, no network. The live-API variant of this run
+// (real Gemini embeddings + real DeepSeek) was executed separately during
+// development; keeping the committed test offline keeps it fast and reliable.
+//
+// ISOLATION: owns its own better-sqlite3 connection and its own process
+// handlers, and removes both. It never touches the DatabaseManager singleton —
+// closing shared state from a test poisons every file that runs after it.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import net from 'node:net';
+import http from 'node:http';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import Module from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+const require = Module.createRequire(path.join(repoRoot, 'package.json'));
+
+// better-sqlite3 is built for Electron's ABI (148) and cannot load under plain
+// `node --test` (141). The binding loads LAZILY, so require() alone does not
+// surface it — the probe has to open a connection.
+let Database = null;
+let skipReason = null;
+try {
+    Database = require('better-sqlite3');
+    new Database(':memory:').close();
+} catch (err) {
+    skipReason = /NODE_MODULE_VERSION/.test(String(err?.message))
+        ? 'better-sqlite3 is built for the Electron ABI — run under ELECTRON_RUN_AS_NODE'
+        : `better-sqlite3 unavailable: ${err?.message}`;
+}
+// node:test treats the PRESENCE of a `skip` key as a skip even when it is null.
+const opts = skipReason ? { skip: skipReason } : {};
+
+const origLoad = Module._load;
+Module._load = function patchedLoad(request) {
+    if (request === 'electron') {
+        return { app: { getAppPath: () => os.tmpdir(), isPackaged: false, isReady: () => false } };
+    }
+    return origLoad.apply(this, arguments);
+};
+
+const { NativelyProSTT } = await import(
+    path.join(repoRoot, 'dist-electron/electron/audio/NativelyProSTT.js'));
+const { MeetingLifecycleQueue } = await import(
+    path.join(repoRoot, 'dist-electron/electron/audio/meetingLifecycleQueue.js'));
+
+const settle = (ms) => new Promise(r => setTimeout(r, ms));
+
+test('25 start/stop cycles leave the database live and writable', opts, async () => {
+    // ── A real SQLite file this test owns outright ─────────────────────────
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'natively-liveness-'));
+    const db = new Database(path.join(dir, 'natively.db'));
+    db.exec(`CREATE TABLE meetings (
+        id TEXT PRIMARY KEY, title TEXT, start_time INTEGER,
+        duration_ms INTEGER, created_at TEXT
+    );`);
+
+    // ── main.ts's REAL fatal policy, scoped to this test ───────────────────
+    // uncaughtException -> emergencyCloseDatabase(). We record instead of
+    // exiting so the run can keep measuring, but the CLOSE is real — that is
+    // the link that turns an STT crash into permanent persistence death.
+    const uncaught = [];
+    const onUncaught = (e) => {
+        uncaught.push(e);
+        try { db.close(); } catch { /* already closed */ }
+    };
+    process.on('uncaughtException', onUncaught);
+
+    // ── Servers covering the handshake outcomes that matter ────────────────
+    const sockets = [];
+    const stalled = net.createServer((s) => sockets.push(s));           // never upgrades
+    await new Promise(r => stalled.listen(0, '127.0.0.1', r));
+    const httpSrv = http.createServer();                                 // upgrades normally
+    const { WebSocketServer } = require('ws');
+    const wss = new WebSocketServer({ server: httpSrv });
+    wss.on('connection', (s) => sockets.push(s));
+    await new Promise(r => httpSrv.listen(0, '127.0.0.1', r));
+    const resetter = net.createServer((s) => {                           // RSTs mid-handshake
+        sockets.push(s);
+        setTimeout(() => { try { s.destroy(); } catch { /* gone */ } }, 15);
+    });
+    await new Promise(r => resetter.listen(0, '127.0.0.1', r));
+    const probe = net.createServer();                                    // connection refused
+    await new Promise(r => probe.listen(0, '127.0.0.1', r));
+    const refusedPort = probe.address().port;
+    await new Promise(r => probe.close(r));
+
+    const URLS = {
+        stalled: `ws://127.0.0.1:${stalled.address().port}/stt`,
+        live: `ws://127.0.0.1:${httpSrv.address().port}/stt`,
+        reset: `ws://127.0.0.1:${resetter.address().port}/stt`,
+        refused: `ws://127.0.0.1:${refusedPort}/stt`,
+    };
+    const BEHAVIOURS = ['stalled', 'live', 'reset', 'refused', 'stalled', 'live'];
+    const FIXTURES = ['dual', 'mic-only', 'system-only'];
+    // Injected, never mutating the global — the lifecycle contract is shared,
+    // so both platforms must exercise the same code.
+    const PLATFORMS = ['darwin', 'win32'];
+
+    function makeStt(url, channel) {
+        const stt = new NativelyProSTT('liveness-key', channel);
+        // SEAM: BACKEND_URL survives start(); `target` is nulled by start(), so
+        // pinning it would silently fall back to the production endpoint.
+        stt.BACKEND_URL = url;
+        stt.on('error', () => {});   // production subscribes at main.ts:3259
+        return stt;
+    }
+
+    const problems = [];
+    function assertDbLive(cycle, phase) {
+        try {
+            assert.equal(db.prepare('SELECT 1 AS ok').get()?.ok, 1);
+            const id = `live-${cycle}-${phase}`;
+            db.prepare('INSERT OR REPLACE INTO meetings (id,title,start_time,duration_ms,created_at) VALUES (?,?,?,?,?)')
+                .run(id, phase, Date.now(), 1234, String(Date.now()));
+            const back = db.prepare('SELECT duration_ms FROM meetings WHERE id = ?').get(id);
+            assert.equal(back?.duration_ms, 1234, 'read-back mismatch');
+            assert.equal(db.prepare('DELETE FROM meetings WHERE id = ?').run(id).changes, 1);
+        } catch (e) {
+            problems.push(`cycle ${cycle} (${phase}): DB NOT LIVE -> ${e.message}`);
+        }
+    }
+
+    const discarded = [];
+    // Everything below runs inside try/finally: if an assertion fails, the
+    // servers and the process handler MUST still be released. Without this a
+    // failing run leaves listening sockets holding the event loop open and the
+    // test runner hangs instead of reporting the failure.
+    try {
+    for (let cycle = 0; cycle < 25; cycle++) {
+        const url = URLS[BEHAVIOURS[cycle % BEHAVIOURS.length]];
+        const fixture = FIXTURES[cycle % FIXTURES.length];
+        const platform = PLATFORMS[cycle % PLATFORMS.length];
+        const states = [];
+        const queue = new MeetingLifecycleQueue((s) => states.push(s));
+
+        let mic = null, sys = null;
+        await queue.start(async () => {
+            if (fixture !== 'system-only') { mic = makeStt(url, 'mic'); mic.start(); }
+            if (fixture !== 'mic-only') { sys = makeStt(url, 'system'); sys.start(); }
+            await settle([0, 12, 45][cycle % 3]);   // cancel at varied handshake depths
+        });
+        assertDbLive(cycle, 'after-start');
+
+        if (mic?.ws) discarded.push(mic.ws);
+        if (sys?.ws) discarded.push(sys.ws);
+
+        await queue.stop(async () => { mic?.stop(); sys?.stop(); await settle(15); });
+        await settle(25);
+        assertDbLive(cycle, 'after-stop');
+
+        assert.equal(queue.getState(), 'idle',
+            `cycle ${cycle} (${platform}/${fixture}) must settle idle`);
+        assert.deepEqual([states[0], states[states.length - 1]], ['starting', 'idle'],
+            `cycle ${cycle}: unexpected state sequence ${JSON.stringify(states)}`);
+
+        for (const [name, s] of [['mic', mic], ['system', sys]]) {
+            if (!s) continue;
+            assert.equal(s.isActive, false, `cycle ${cycle}: ${name} still active`);
+            assert.equal(s.ws, null, `cycle ${cycle}: ${name} still holds a socket`);
+            for (const t of ['reconnectTimer', 'stabilityTimer', 'pendingConnectTimer']) {
+                assert.equal(s[t], null, `cycle ${cycle}: ${name} leaked ${t}`);
+            }
+        }
+    }
+
+    await settle(400);
+
+    // ── The properties that matter ─────────────────────────────────────────
+    assert.deepEqual(problems, [],
+        'The database must remain live and writable across every cycle. A failure here is ' +
+        'the user-visible symptom: meetings silently stop saving for the rest of the session.');
+
+    assert.equal(uncaught.length, 0,
+        `${uncaught.length} uncaught exception(s) escaped: ` +
+        [...new Set(uncaught.map(e => e.message))].join(' | '));
+
+    const retained = discarded.filter(s => s.listenerCount('error') + s.listenerCount('close') > 0);
+    assert.equal(retained.length, 0,
+        `${retained.length}/${discarded.length} discarded sockets retained listeners — ` +
+        'these are cycled every meeting, so a retained listener accumulates for the process lifetime.');
+
+    // Final proof, after everything.
+    assert.equal(db.open, true, 'the database handle must still be open at the end');
+    assertDbLive(999, 'final');
+    assert.deepEqual(problems, [], 'final liveness check must pass');
+
+    } finally {
+        // ── Teardown, guaranteed ───────────────────────────────────────────
+        process.off('uncaughtException', onUncaught);
+        for (const s of sockets) { try { s.destroy?.() ?? s.terminate?.(); } catch { /* gone */ } }
+        for (const srv of [wss, httpSrv, stalled, resetter]) { try { srv.close(); } catch { /* gone */ } }
+        try { db.close(); } catch { /* already closed */ }
+        try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+});

--- a/electron/audio/__tests__/MeetingLifecycleSerialization2026_08_07.test.mjs
+++ b/electron/audio/__tests__/MeetingLifecycleSerialization2026_08_07.test.mjs
@@ -1,0 +1,277 @@
+// Behavioral tests for the meeting start/stop transition queue.
+//
+// THE DEFECT: AppState.startMeeting() and endMeeting() were plain async
+// methods with no serialization. They are reachable concurrently from renderer
+// IPC, calendar auto-start, global shortcuts, and the tray — so two starts, a
+// stop landing mid-start, or a start landing mid-stop could interleave. The
+// existing protections (_meetingGeneration, the _audioInitPromise
+// abort-and-await, _pendingTeardown) each guard ONE hazard inside a
+// transition; none of them prevent two transitions from running at once.
+//
+// The invariant: transitions are serialized. Same-direction duplicates
+// coalesce onto the in-flight request; opposite-direction requests QUEUE and
+// the last requested direction is the one that wins. A start must never be
+// swallowed just because a stop is in flight (that is how "stop then
+// immediately start" silently produced a dead meeting).
+//
+// These are behavioral tests against the extracted queue, not source-shape
+// assertions — the queue is pure and platform-neutral by design, so the same
+// contract is exercised for macOS and Windows callers alike.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distRoot = path.resolve(__dirname, '../../../dist-electron/electron/audio');
+const { MeetingLifecycleQueue } = await import(path.join(distRoot, 'meetingLifecycleQueue.js'));
+
+/** A promise you resolve/reject by hand, so tests control transition timing. */
+function deferred() {
+    let resolve, reject;
+    const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+    return { promise, resolve, reject };
+}
+
+const tick = () => new Promise(r => setImmediate(r));
+
+test('duplicate start requests coalesce into one transition', async () => {
+    const q = new MeetingLifecycleQueue();
+    let runs = 0;
+    const gate = deferred();
+    const run = () => { runs++; return gate.promise; };
+
+    const a = q.start(run);
+    const b = q.start(run);
+    const c = q.start(run);
+    await tick();
+
+    assert.equal(runs, 1, 'only one start transition may execute');
+    assert.equal(q.getState(), 'starting');
+
+    gate.resolve();
+    await Promise.all([a, b, c]);
+    assert.equal(q.getState(), 'active');
+    assert.equal(runs, 1, 'no extra transition ran after settling');
+});
+
+test('starting while already active is a no-op', async () => {
+    const q = new MeetingLifecycleQueue();
+    let runs = 0;
+    await q.start(async () => { runs++; });
+    assert.equal(q.getState(), 'active');
+
+    await q.start(async () => { runs++; });
+    assert.equal(runs, 1, 'an already-active meeting must not start a second time');
+});
+
+test('stopping while already idle is a no-op', async () => {
+    const q = new MeetingLifecycleQueue();
+    let runs = 0;
+    await q.stop(async () => { runs++; });
+    assert.equal(runs, 0, 'stopping an idle lifecycle must not run a teardown');
+    assert.equal(q.getState(), 'idle');
+});
+
+test('a stop requested during a start runs AFTER the start completes', async () => {
+    const q = new MeetingLifecycleQueue();
+    const order = [];
+    const startGate = deferred();
+
+    const started = q.start(async () => { order.push('start:begin'); await startGate.promise; order.push('start:end'); });
+    await tick();
+    const stopped = q.stop(async () => { order.push('stop:begin'); order.push('stop:end'); });
+    await tick();
+
+    assert.deepEqual(order, ['start:begin'], 'the stop must not run while the start is in flight');
+
+    startGate.resolve();
+    await started;
+    await stopped;
+
+    assert.deepEqual(order, ['start:begin', 'start:end', 'stop:begin', 'stop:end']);
+    assert.equal(q.getState(), 'idle');
+});
+
+test('duplicate stops join the in-flight stop', async () => {
+    const q = new MeetingLifecycleQueue();
+    await q.start(async () => {});
+
+    let stops = 0;
+    const gate = deferred();
+    const a = q.stop(async () => { stops++; await gate.promise; });
+    const b = q.stop(async () => { stops++; await gate.promise; });
+    await tick();
+
+    assert.equal(stops, 1, 'concurrent stops must share one teardown');
+
+    gate.resolve();
+    await Promise.all([a, b]);
+    assert.equal(q.getState(), 'idle');
+});
+
+test('a start requested during a stop queues a real restart', async () => {
+    // The regression this pins: coalescing by "is any request pending" rather
+    // than by DIRECTION swallowed the restart, leaving the user staring at a
+    // stopped meeting after pressing Start.
+    const q = new MeetingLifecycleQueue();
+    await q.start(async () => {});
+
+    const order = [];
+    const stopGate = deferred();
+    const stopped = q.stop(async () => { order.push('stop'); await stopGate.promise; });
+    await tick();
+    const restarted = q.start(async () => { order.push('restart'); });
+    await tick();
+
+    assert.deepEqual(order, ['stop'], 'the restart must wait for the stop');
+
+    stopGate.resolve();
+    await stopped;
+    await restarted;
+
+    assert.deepEqual(order, ['stop', 'restart'], 'the restart must actually run');
+    assert.equal(q.getState(), 'active', 'the lifecycle must end ACTIVE — the last request wins');
+});
+
+test('start → stop → start settles active (final requested direction wins)', async () => {
+    const q = new MeetingLifecycleQueue();
+    const order = [];
+    const gate = deferred();
+
+    const p1 = q.start(async () => { order.push('start1'); await gate.promise; });
+    await tick();
+    const p2 = q.stop(async () => { order.push('stop'); });
+    await tick();
+    const p3 = q.start(async () => { order.push('start2'); });
+    await tick();
+
+    gate.resolve();
+    await Promise.all([p1, p2, p3]);
+
+    assert.deepEqual(order, ['start1', 'stop', 'start2']);
+    assert.equal(q.getState(), 'active');
+});
+
+test('stop → start → stop settles idle (final requested direction wins)', async () => {
+    const q = new MeetingLifecycleQueue();
+    await q.start(async () => {});
+
+    const order = [];
+    const gate = deferred();
+    const p1 = q.stop(async () => { order.push('stop1'); await gate.promise; });
+    await tick();
+    const p2 = q.start(async () => { order.push('start'); });
+    await tick();
+    const p3 = q.stop(async () => { order.push('stop2'); });
+    await tick();
+
+    gate.resolve();
+    await Promise.all([p1, p2, p3]);
+
+    assert.deepEqual(order, ['stop1', 'start', 'stop2']);
+    assert.equal(q.getState(), 'idle');
+});
+
+test('a failed transition does not poison the queue', async () => {
+    const q = new MeetingLifecycleQueue();
+
+    await assert.rejects(
+        q.start(async () => { throw new Error('audio pipeline exploded'); }),
+        /audio pipeline exploded/,
+        'the failure must propagate to the caller, not be swallowed'
+    );
+    assert.equal(q.getState(), 'failed');
+
+    // The next transition must still run.
+    let ran = false;
+    await q.start(async () => { ran = true; });
+    assert.equal(ran, true, 'a later start must still execute after a failed one');
+    assert.equal(q.getState(), 'active');
+});
+
+test('a failed stop still lets a subsequent start proceed', async () => {
+    const q = new MeetingLifecycleQueue();
+    await q.start(async () => {});
+    await assert.rejects(q.stop(async () => { throw new Error('teardown failed'); }), /teardown failed/);
+    assert.equal(q.getState(), 'failed');
+
+    let ran = false;
+    await q.start(async () => { ran = true; });
+    assert.equal(ran, true);
+    assert.equal(q.getState(), 'active');
+});
+
+test('state changes are reported to the observer in order', async () => {
+    const seen = [];
+    const q = new MeetingLifecycleQueue((s) => seen.push(s));
+
+    await q.start(async () => {});
+    await q.stop(async () => {});
+
+    assert.deepEqual(seen, ['starting', 'active', 'stopping', 'idle']);
+});
+
+// ── Wiring contract ─────────────────────────────────────────────────────────
+// The queue is only worth anything if AppState actually routes through it. A
+// future edit that makes startMeeting/endMeeting do the work inline again
+// would leave all the behavioral tests above passing while the real app went
+// back to unserialized transitions.
+
+test('AppState routes both public entry points through the queue', async () => {
+    const fs = await import('node:fs');
+    const mainSource = fs.readFileSync(path.resolve(__dirname, '../../main.ts'), 'utf8');
+
+    assert.match(
+        mainSource,
+        /public startMeeting\([^)]*\): Promise<void> \{\s*return this\._meetingLifecycle\.start\(/,
+        'startMeeting must delegate to the lifecycle queue'
+    );
+    assert.match(
+        mainSource,
+        /public endMeeting\(\): Promise<void> \{\s*return this\._meetingLifecycle\.stop\(/,
+        'endMeeting must delegate to the lifecycle queue'
+    );
+    // The ordered bodies must still exist as private transitions.
+    assert.ok(
+        mainSource.includes('private async startMeetingTransition'),
+        'the ordered start body must live in startMeetingTransition'
+    );
+    assert.ok(
+        mainSource.includes('private async endMeetingTransition'),
+        'the ordered stop body must live in endMeetingTransition'
+    );
+    // Regression guard: the public wrappers must stay thin. If the ordered work
+    // migrates back into them it would bypass the queue entirely.
+    const wrapperStart = mainSource.indexOf('public startMeeting(');
+    const wrapperEnd = mainSource.indexOf('private logMeetingLifecycleState', wrapperStart);
+    const wrapper = mainSource.slice(wrapperStart, wrapperEnd);
+    assert.ok(
+        !wrapper.includes('_audioInitPromise') && !wrapper.includes('_pendingTeardown'),
+        'the public startMeeting wrapper must not contain transition work'
+    );
+});
+
+test('a burst of interleaved requests never runs two transitions at once', async () => {
+    // Models the real hazard: renderer IPC, calendar auto-start, a global
+    // shortcut and the tray all firing within the same few ticks.
+    const q = new MeetingLifecycleQueue();
+    let inFlight = 0;
+    let maxConcurrent = 0;
+    const body = async () => {
+        inFlight++;
+        maxConcurrent = Math.max(maxConcurrent, inFlight);
+        await new Promise(r => setTimeout(r, 1));
+        inFlight--;
+    };
+
+    const pending = [];
+    for (let i = 0; i < 40; i++) {
+        pending.push(i % 2 === 0 ? q.start(body) : q.stop(body));
+    }
+    await Promise.allSettled(pending);
+
+    assert.equal(maxConcurrent, 1, `transitions overlapped (max concurrent = ${maxConcurrent})`);
+    assert.ok(['idle', 'active'].includes(q.getState()), `settled in a stable state, got ${q.getState()}`);
+});

--- a/electron/audio/__tests__/MeetingLifecycleSerialization2026_08_07.test.mjs
+++ b/electron/audio/__tests__/MeetingLifecycleSerialization2026_08_07.test.mjs
@@ -56,6 +56,60 @@ test('duplicate start requests coalesce into one transition', async () => {
     assert.equal(runs, 1, 'no extra transition ran after settling');
 });
 
+test('a queued start adopts the NEWEST intent instead of discarding it', async () => {
+    // Greptile PR #439: coalescing returned the first request's promise and
+    // threw away the second closure. startMeeting() closes over `metadata`,
+    // which carries the calendar title/eventId AND the user's chosen audio
+    // devices (metadata.audio.inputDeviceId drives reconfigureAudio). A manual
+    // Start racing a calendar auto-start therefore silently ignored the user's
+    // selected microphone while still reporting success.
+    //
+    // Contract: while the transition is still QUEUED, the latest runner wins.
+    const q = new MeetingLifecycleQueue();
+    const ran = [];
+    const gate = deferred();
+
+    // Occupy the chain so the next start is QUEUED rather than run immediately.
+    // (Do not await these — they are deliberately blocked on `gate`.)
+    const blocker = q.start(async () => { ran.push('blocker'); await gate.promise; });
+    await tick();
+    const stopped = q.stop(async () => { ran.push('stop'); });
+    await tick();
+
+    // Two starts land while the chain is still busy. The SECOND carries the
+    // metadata that must survive.
+    const first = q.start(async () => { ran.push('calendar-metadata'); });
+    const second = q.start(async () => { ran.push('user-selected-mic'); });
+    assert.equal(first, second, 'both callers share one transition — still exactly one meeting');
+
+    gate.resolve();
+    await Promise.allSettled([blocker, stopped, first, second]);
+
+    assert.ok(ran.includes('user-selected-mic'),
+        `the newest start intent must execute, got ${JSON.stringify(ran)}`);
+    assert.ok(!ran.includes('calendar-metadata'),
+        'the superseded runner must NOT also run — that would start twice');
+    assert.equal(q.getState(), 'active');
+});
+
+test('once a start is executing, later starts coalesce and do not swap the runner', async () => {
+    // The mirror of the above: mid-flight the meeting is already starting, so
+    // there is nothing to re-apply and swapping the runner underneath a running
+    // transition would be far worse than coalescing.
+    const q = new MeetingLifecycleQueue();
+    const ran = [];
+    const gate = deferred();
+
+    const first = q.start(async () => { ran.push('executing'); await gate.promise; });
+    await tick();   // let the body begin
+    const second = q.start(async () => { ran.push('too-late'); });
+
+    gate.resolve();
+    await Promise.all([first, second]);
+
+    assert.deepEqual(ran, ['executing'], 'the in-flight runner must not be replaced mid-execution');
+});
+
 test('starting while already active is a no-op', async () => {
     const q = new MeetingLifecycleQueue();
     let runs = 0;

--- a/electron/audio/__tests__/MeetingStartMicBeforeSystemOrder.test.mjs
+++ b/electron/audio/__tests__/MeetingStartMicBeforeSystemOrder.test.mjs
@@ -73,8 +73,8 @@ function assertMicStartsBeforeSystem(body, label) {
   );
 }
 
-test('startMeeting starts microphone before system audio', () => {
-  assertMicStartsBeforeSystem(extractMethodBody('startMeeting'), 'startMeeting');
+test('startMeetingTransition starts microphone before system audio', () => {
+  assertMicStartsBeforeSystem(extractMethodBody('startMeetingTransition'), 'startMeetingTransition');
 });
 
 test('reconfigureAudio restarts microphone before system audio during active meetings', () => {

--- a/electron/audio/__tests__/NativelyProSTTConnectingCancellation2026_08_07.test.mjs
+++ b/electron/audio/__tests__/NativelyProSTTConnectingCancellation2026_08_07.test.mjs
@@ -1,0 +1,285 @@
+// Regression test for the Windows "stop a meeting while STT is still
+// connecting" crash.
+//
+// Symptom: a user stops a meeting a second or two after starting it, while
+// both the mic and system Natively Pro STT sockets are still in CONNECTING.
+// stop() -> closeUpstream() used to call removeAllListeners() and THEN
+// close(). With ws@8, close() on a CONNECTING socket routes through
+// abortHandshake(), which does:
+//
+//     process.nextTick(emitErrorAndClose, websocket, err)
+//
+// i.e. it unconditionally emits 'error' ONE TICK LATER with the message
+// "WebSocket was closed before the connection was established". There is no
+// option to suppress it — see websockets/ws#1835 and #2249; abortHandshake is
+// deliberately private and this is the library's documented contract.
+//
+// Because removeAllListeners() had just stripped the 'error' listener, Node's
+// EventEmitter promoted that orphaned 'error' into a process-level
+// uncaughtException. main.ts's handler then closed the SQLite singleton
+// (irreversibly — closeWithoutCheckpoint nulls the handle with no reopen
+// path) but did NOT exit, so Electron kept serving IPC against a dead
+// database and every later meeting silently failed to persist.
+//
+// Empirically ranked alternatives (all measured against ws@8.21.0):
+//   - terminate() instead of close():        STILL CRASHES (same abortHandshake path)
+//   - deferring close() into setTimeout(0):  STILL CRASHES
+//   - re-attaching a bare no-op 'error':     safe, but leaks one listener per
+//                                            discarded socket, and these sockets
+//                                            are cycled on every meeting
+// Only state-aware selective removal with self-releasing listeners is both
+// crash-safe and leak-free, which is what this test pins down.
+//
+// Strategy: no fakes. A real TCP server accepts the connection but never
+// completes the WebSocket upgrade, so the sockets genuinely sit in CONNECTING.
+// Real ws, real compiled NativelyProSTT, real stop().
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import net from 'node:net';
+import Module from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distRoot = path.resolve(__dirname, '../../../dist-electron/electron/audio');
+
+const origLoad = Module._load;
+Module._load = function patchedLoad(request) {
+    if (request === 'electron') {
+        return {
+            app: {
+                getAppPath: () => '/tmp/fake-natively-app',
+                isPackaged: false,
+                isReady: () => false,
+            },
+        };
+    }
+    return origLoad.apply(this, arguments);
+};
+
+const { NativelyProSTT } = await import(path.join(distRoot, 'NativelyProSTT.js'));
+
+/** A TCP server that accepts but never upgrades — clients stay in CONNECTING. */
+async function stalledServer() {
+    const sockets = [];
+    const server = net.createServer((s) => { sockets.push(s); });
+    await new Promise(r => server.listen(0, '127.0.0.1', r));
+    return {
+        url: `ws://127.0.0.1:${server.address().port}/stt`,
+        close: () => {
+            for (const s of sockets) { try { s.destroy(); } catch { /* already gone */ } }
+            server.close();
+        },
+    };
+}
+
+/**
+ * Builds an STT instance pinned at `url`.
+ *
+ * SEAM: override BACKEND_URL, NOT `target`. start() deliberately nulls
+ * `this.target` so each session re-resolves its relay target, which means a
+ * target assigned before start() is wiped and connect() silently falls back to
+ * BACKEND_URL — i.e. the real production endpoint. Overriding BACKEND_URL is
+ * the only pin that survives start(); with the relay flag off (the default in
+ * tests) connectUrl() returns it verbatim.
+ *
+ * This keeps the test hermetic. It must never open a socket to
+ * api.natively.software: that would make the suite network-dependent and point
+ * dozens of cancelled handshakes per run at production.
+ */
+function makeStt(url, channel) {
+    const stt = new NativelyProSTT('cancellation-key', channel);
+    stt.BACKEND_URL = url;
+    return stt;
+}
+
+/** Runs `body` while capturing anything that escapes to the process level. */
+async function captureProcessFailures(body) {
+    const uncaught = [];
+    const unhandled = [];
+    const onUncaught = (e) => uncaught.push(e);
+    const onUnhandled = (e) => unhandled.push(e);
+
+    // node:test installs its own handlers; ours must run alongside them.
+    process.on('uncaughtException', onUncaught);
+    process.on('unhandledRejection', onUnhandled);
+    try {
+        await body();
+    } finally {
+        process.off('uncaughtException', onUncaught);
+        process.off('unhandledRejection', onUnhandled);
+    }
+    return { uncaught, unhandled };
+}
+
+const settle = (ms = 400) => new Promise(r => setTimeout(r, ms));
+
+test('HERMETICITY GUARD: the socket dials the local server, never production', async () => {
+    // start() nulls this.target, so pinning `target` before start() is silently
+    // discarded and connect() falls back to BACKEND_URL. If this test ever
+    // regresses to that shape it would quietly point every cancelled handshake
+    // below at wss://api.natively.software. Pin it down explicitly.
+    const server = await stalledServer();
+    const stt = makeStt(server.url, 'mic');
+
+    stt.start();
+    await settle(120);
+    const dialed = stt.ws?.url;
+    stt.stop();
+    await settle();
+    server.close();
+
+    assert.ok(dialed, 'a socket must have been created');
+    assert.ok(
+        dialed.startsWith('ws://127.0.0.1:'),
+        `the test must dial the local stalled server, got ${dialed}. ` +
+        'A non-local URL means the seam broke and this suite is now hitting the ' +
+        'real Natively STT endpoint over the network.'
+    );
+    assert.ok(!dialed.includes('natively.software'), 'must never reach production');
+});
+
+test('stopping mic + system STT mid-handshake must not escape as an uncaughtException', async () => {
+    const server = await stalledServer();
+    const mic = makeStt(server.url, 'mic');
+    const system = makeStt(server.url, 'system');
+
+    const { uncaught, unhandled } = await captureProcessFailures(async () => {
+        mic.start();
+        system.start();
+
+        // Let both TCP connects land while the upgrade is still pending.
+        await settle(150);
+        assert.equal(mic.ws?.readyState, 0, 'mic socket must genuinely be CONNECTING');
+        assert.equal(system.ws?.readyState, 0, 'system socket must genuinely be CONNECTING');
+
+        // The user action: stop the meeting while both are still connecting.
+        mic.stop();
+        system.stop();
+
+        // abortHandshake's error lands on the NEXT TICK — wait past it.
+        await settle();
+    });
+
+    server.close();
+
+    assert.deepEqual(
+        uncaught.map(e => e.message),
+        [],
+        'Cancelling a CONNECTING Natively Pro STT socket must not raise a process-level ' +
+        'uncaughtException. ws@8 always emits the abortHandshake error one tick after ' +
+        'close(); closeUpstream() must keep an error listener attached across that tick.'
+    );
+    assert.deepEqual(unhandled.map(String), [], 'no unhandled rejections either');
+});
+
+test('a cancelled STT socket is fully detached and leaves no residual listeners', async () => {
+    const server = await stalledServer();
+    const stt = makeStt(server.url, 'mic');
+
+    const { uncaught } = await captureProcessFailures(async () => {
+        stt.start();
+        await settle(150);
+        const dying = stt.ws;
+        assert.ok(dying, 'socket must exist before teardown');
+
+        stt.stop();
+        await settle();
+
+        // The instance must have released its reference...
+        assert.equal(stt.ws, null, 'closeUpstream must null this.ws');
+        assert.equal(stt.isConnected, false, 'isConnected must be cleared');
+        assert.equal(stt.isConnecting, false, 'isConnecting must be cleared');
+
+        // ...and the discarded socket must not retain listeners. These sockets
+        // are cycled on every meeting, so a listener retained per discarded
+        // socket accumulates for the life of the process.
+        assert.equal(
+            dying.listenerCount('error'), 0,
+            'the cancellation error listener must release itself once the socket closes'
+        );
+        assert.equal(
+            dying.listenerCount('close'), 0,
+            'the cancellation close listener must release itself once the socket closes'
+        );
+    });
+
+    server.close();
+    assert.deepEqual(uncaught.map(e => e.message), [], 'no uncaught exception during detach');
+});
+
+test('no reconnect timer survives a mid-handshake cancellation', async () => {
+    const server = await stalledServer();
+    const stt = makeStt(server.url, 'mic');
+
+    const { uncaught } = await captureProcessFailures(async () => {
+        stt.start();
+        await settle(150);
+        stt.stop();
+        await settle();
+
+        assert.equal(stt.reconnectTimer, null, 'reconnectTimer must be cleared');
+        assert.equal(stt.stabilityTimer, null, 'stabilityTimer must be cleared');
+        assert.equal(stt.pendingConnectTimer, null, 'pendingConnectTimer must be cleared');
+        assert.equal(stt.isActive, false, 'instance must be inactive after stop()');
+    });
+
+    server.close();
+    assert.deepEqual(uncaught.map(e => e.message), [], 'no uncaught exception from an orphan timer');
+});
+
+test('an instance cancelled mid-handshake can start a fresh connection afterwards', async () => {
+    const server = await stalledServer();
+    const stt = makeStt(server.url, 'mic');
+
+    const { uncaught } = await captureProcessFailures(async () => {
+        stt.start();
+        await settle(150);
+        stt.stop();
+        await settle(250);
+
+        // Second meeting on the same instance. BACKEND_URL survives start(),
+        // so no re-pinning is needed.
+        stt.start();
+        await settle(150);
+
+        assert.equal(stt.isActive, true, 'restarted instance must be active');
+        assert.ok(stt.ws, 'restarted instance must own a fresh socket');
+        assert.equal(stt.ws.readyState, 0, 'fresh socket is connecting against the stalled server');
+
+        stt.stop();
+        await settle();
+    });
+
+    server.close();
+    assert.deepEqual(uncaught.map(e => e.message), [], 'restart after cancellation must stay clean');
+});
+
+test('repeated rapid start/stop cycles never escape to the process level', async () => {
+    const server = await stalledServer();
+
+    const { uncaught, unhandled } = await captureProcessFailures(async () => {
+        for (let cycle = 0; cycle < 12; cycle++) {
+            const mic = makeStt(server.url, 'mic');
+            const system = makeStt(server.url, 'system');
+            mic.start();
+            system.start();
+            // Vary the dwell so cancellation lands at different handshake points.
+            await settle(cycle % 3 === 0 ? 0 : 40);
+            mic.stop();
+            system.stop();
+            await settle(60);
+        }
+        await settle(300);
+    });
+
+    server.close();
+
+    assert.equal(
+        uncaught.length, 0,
+        `24 mid-handshake cancellations produced ${uncaught.length} uncaught exception(s): ` +
+        uncaught.map(e => e.message).join(' | ')
+    );
+    assert.equal(unhandled.length, 0, 'no unhandled rejections across the cycles');
+});

--- a/electron/audio/__tests__/SecondMeetingStartDeadlock.test.mjs
+++ b/electron/audio/__tests__/SecondMeetingStartDeadlock.test.mjs
@@ -183,8 +183,8 @@ function extractMethodBody(methodName) {
     return mainSource.slice(start, i - 1);
 }
 
-const endMeetingBody = extractMethodBody('endMeeting');
-const startMeetingBody = extractMethodBody('startMeeting');
+const endMeetingBody = extractMethodBody('endMeetingTransition');
+const startMeetingBody = extractMethodBody('startMeetingTransition');
 
 test('endMeeting NULLS both capture fields synchronously (forces serialized recreate path)', () => {
     assert.ok(

--- a/electron/audio/__tests__/StartStopRaceDeferredInit.test.mjs
+++ b/electron/audio/__tests__/StartStopRaceDeferredInit.test.mjs
@@ -9,7 +9,10 @@ const mainPath = path.resolve(__dirname, '../../../electron/main.ts');
 const mainSource = readFileSync(mainPath, 'utf8');
 
 function extractMethodBody(methodName) {
-  const methodRe = new RegExp(`public\\s+(?:async\\s+)?${methodName}\\s*\\([^)]*\\)[^{]*\\{`);
+  // Accepts any access modifier: the ordered start/stop bodies are `private
+  // async *Transition` methods, wrapped by thin public startMeeting/endMeeting
+  // entry points that delegate to the serialization queue.
+  const methodRe = new RegExp(`(?:public|private|protected)\\s+(?:async\\s+)?${methodName}\\s*\\([^)]*\\)[^{]*\\{`);
   const match = methodRe.exec(mainSource);
   assert.ok(match, `could not locate ${methodName}`);
   let i = match.index + match[0].length;
@@ -25,8 +28,8 @@ function extractMethodBody(methodName) {
   return mainSource.slice(start, i - 1);
 }
 
-const startMeetingBody = extractMethodBody('startMeeting');
-const endMeetingBody = extractMethodBody('endMeeting');
+const startMeetingBody = extractMethodBody('startMeetingTransition');
+const endMeetingBody = extractMethodBody('endMeetingTransition');
 
 test('meeting start captures a generation token and endMeeting invalidates it', () => {
   assert.ok(

--- a/electron/audio/__tests__/StuckWatchdogDisarmOnEndAndAbort.test.mjs
+++ b/electron/audio/__tests__/StuckWatchdogDisarmOnEndAndAbort.test.mjs
@@ -59,8 +59,8 @@ function extractMethodBody(methodName) {
 
 const wireSystemBody = extractMethodBody('wireSystemCapture');
 const wireMicBody    = extractMethodBody('wireMicCapture');
-const endMeetingBody = extractMethodBody('endMeeting');
-const startMeetingBody = extractMethodBody('startMeeting');
+const endMeetingBody = extractMethodBody('endMeetingTransition');
+const startMeetingBody = extractMethodBody('startMeetingTransition');
 
 test('wireSystemCapture attaches __disarmStuckWatchdog on the capture instance', () => {
   assert.ok(

--- a/electron/audio/meetingLifecycleQueue.ts
+++ b/electron/audio/meetingLifecycleQueue.ts
@@ -42,6 +42,23 @@ export class MeetingLifecycleQueue {
     private stopRequest: Promise<void> | null = null;
     /** Direction of the most recently ACCEPTED request — decides coalescing. */
     private lastRequestDirection: TransitionDirection | null = null;
+    /**
+     * The runner a QUEUED-but-not-yet-started transition will execute.
+     *
+     * Coalescing must not discard the newest caller's intent. `startMeeting`
+     * closes over its `metadata`, which carries the calendar title/event id and
+     * the user's chosen audio devices (`metadata.audio.inputDeviceId` drives
+     * reconfigureAudio). Returning the first request's promise while throwing
+     * away the second's closure meant a manual Start racing a calendar
+     * auto-start could silently ignore the user's selected microphone, and the
+     * caller was still told it succeeded.
+     *
+     * So while a transition is still QUEUED, a later same-direction request
+     * replaces its runner — last intent wins. Once the body has begun executing
+     * the slot is cleared and further requests genuinely coalesce, which is
+     * correct: the meeting is already starting and there is nothing to re-apply.
+     */
+    private queuedRunner: { direction: TransitionDirection; run: () => Promise<void> } | null = null;
 
     constructor(private readonly onStateChange?: (state: MeetingLifecycleState) => void) {}
 
@@ -53,7 +70,11 @@ export class MeetingLifecycleQueue {
     start(run: () => Promise<void>): Promise<void> {
         // Join an in-flight start only when nothing has since asked to stop —
         // otherwise this is a genuine restart and must queue behind that stop.
-        if (this.startRequest && this.lastRequestDirection === 'starting') return this.startRequest;
+        if (this.startRequest && this.lastRequestDirection === 'starting') {
+            // Still queued? Adopt the newer intent rather than dropping it.
+            if (this.queuedRunner?.direction === 'starting') this.queuedRunner.run = run;
+            return this.startRequest;
+        }
         // Already running and no teardown pending: nothing to do.
         if (!this.stopRequest && this.state === 'active') return Promise.resolve();
         return this.enqueue('starting', run);
@@ -61,17 +82,29 @@ export class MeetingLifecycleQueue {
 
     /** Request a meeting stop. Returns the transition the caller should await. */
     stop(run: () => Promise<void>): Promise<void> {
-        if (this.stopRequest && this.lastRequestDirection === 'stopping') return this.stopRequest;
+        if (this.stopRequest && this.lastRequestDirection === 'stopping') {
+            if (this.queuedRunner?.direction === 'stopping') this.queuedRunner.run = run;
+            return this.stopRequest;
+        }
         // Already idle and no start pending: nothing to tear down.
         if (!this.startRequest && this.state === 'idle') return Promise.resolve();
         return this.enqueue('stopping', run);
     }
 
     private enqueue(direction: TransitionDirection, runTransition: () => Promise<void>): Promise<void> {
+        // Held in a mutable slot so a later same-direction request can replace
+        // the runner right up until this body starts executing.
+        const slot = { direction, run: runTransition };
+        this.queuedRunner = slot;
+
         const body = async (): Promise<void> => {
+            const run = slot.run;
+            // Past this point the transition owns the meeting; later requests
+            // coalesce onto it instead of swapping the runner underneath it.
+            if (this.queuedRunner === slot) this.queuedRunner = null;
             this.setState(direction);
             try {
-                await runTransition();
+                await run();
                 this.setState(direction === 'starting' ? 'active' : 'idle');
             } catch (error) {
                 // Surface the failure to the caller, but leave the chain usable —

--- a/electron/audio/meetingLifecycleQueue.ts
+++ b/electron/audio/meetingLifecycleQueue.ts
@@ -1,0 +1,115 @@
+/**
+ * Serializes meeting start/stop transitions.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `AppState.startMeeting()` / `endMeeting()` are reachable concurrently from
+ * renderer IPC, calendar auto-start, global shortcuts and the tray. They were
+ * plain async methods with no mutual exclusion, so two starts, a stop landing
+ * mid-start, or a start landing mid-stop could interleave and tear down state
+ * the other half was still using.
+ *
+ * The existing protections each guard ONE hazard *inside* a transition —
+ * `_meetingGeneration` bounds ownership of async audio init, the
+ * `_audioInitPromise` abort-and-await stops a stale pipeline from attaching,
+ * `_pendingTeardown` keeps a background STT drain from clobbering a new
+ * session. None of them stop two transitions from running at the same time.
+ * This queue supplies exactly that missing property and nothing else, so the
+ * carefully-ordered bodies it wraps stay untouched.
+ *
+ * COALESCING RULES
+ * ----------------
+ * Same-direction duplicates join the in-flight request. Opposite-direction
+ * requests QUEUE, and the last requested direction is the one the lifecycle
+ * settles into. That distinction matters: coalescing on "is any request
+ * pending" rather than on DIRECTION silently swallowed the restart in
+ * stop-then-immediately-start, leaving the user looking at a stopped meeting
+ * after pressing Start.
+ *
+ * Deliberately platform-neutral and dependency-free — no Electron, no
+ * `process.platform`. The macOS and Windows lifecycles share this contract.
+ */
+
+export type MeetingLifecycleState = 'idle' | 'starting' | 'active' | 'stopping' | 'failed';
+
+type TransitionDirection = 'starting' | 'stopping';
+
+export class MeetingLifecycleQueue {
+    private state: MeetingLifecycleState = 'idle';
+    /** Tail of the serial chain. Every transition links onto this. */
+    private transition: Promise<void> = Promise.resolve();
+    private startRequest: Promise<void> | null = null;
+    private stopRequest: Promise<void> | null = null;
+    /** Direction of the most recently ACCEPTED request — decides coalescing. */
+    private lastRequestDirection: TransitionDirection | null = null;
+
+    constructor(private readonly onStateChange?: (state: MeetingLifecycleState) => void) {}
+
+    getState(): MeetingLifecycleState {
+        return this.state;
+    }
+
+    /** Request a meeting start. Returns the transition the caller should await. */
+    start(run: () => Promise<void>): Promise<void> {
+        // Join an in-flight start only when nothing has since asked to stop —
+        // otherwise this is a genuine restart and must queue behind that stop.
+        if (this.startRequest && this.lastRequestDirection === 'starting') return this.startRequest;
+        // Already running and no teardown pending: nothing to do.
+        if (!this.stopRequest && this.state === 'active') return Promise.resolve();
+        return this.enqueue('starting', run);
+    }
+
+    /** Request a meeting stop. Returns the transition the caller should await. */
+    stop(run: () => Promise<void>): Promise<void> {
+        if (this.stopRequest && this.lastRequestDirection === 'stopping') return this.stopRequest;
+        // Already idle and no start pending: nothing to tear down.
+        if (!this.startRequest && this.state === 'idle') return Promise.resolve();
+        return this.enqueue('stopping', run);
+    }
+
+    private enqueue(direction: TransitionDirection, runTransition: () => Promise<void>): Promise<void> {
+        const body = async (): Promise<void> => {
+            this.setState(direction);
+            try {
+                await runTransition();
+                this.setState(direction === 'starting' ? 'active' : 'idle');
+            } catch (error) {
+                // Surface the failure to the caller, but leave the chain usable —
+                // a failed start must not block the stop that recovers from it.
+                this.setState('failed');
+                throw error;
+            }
+        };
+
+        // Link onto the tail with the SAME callback for both settle paths so a
+        // rejected predecessor still lets this transition run.
+        const request = this.transition.then(body, body);
+        this.transition = request.catch(() => { /* the chain must never stay rejected */ });
+
+        this.lastRequestDirection = direction;
+        if (direction === 'starting') {
+            this.startRequest = request;
+            void request.then(
+                () => { if (this.startRequest === request) this.startRequest = null; },
+                () => { if (this.startRequest === request) this.startRequest = null; },
+            );
+        } else {
+            this.stopRequest = request;
+            void request.then(
+                () => { if (this.stopRequest === request) this.stopRequest = null; },
+                () => { if (this.stopRequest === request) this.stopRequest = null; },
+            );
+        }
+        return request;
+    }
+
+    private setState(state: MeetingLifecycleState): void {
+        this.state = state;
+        try {
+            this.onStateChange?.(state);
+        } catch {
+            // Lifecycle observation is diagnostics only — it must never be able
+            // to break a start or stop.
+        }
+    }
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -15,6 +15,8 @@ import fs from "fs"
 import os from "os"
 import dns from "dns"
 import { SystemAudioHealthClassifier } from "./audio/systemAudioHealthClassifier.mjs"
+import { FatalMainProcessCoordinator } from "./utils/fatalMainProcess"
+import { MeetingLifecycleQueue, type MeetingLifecycleState } from "./audio/meetingLifecycleQueue"
 import { autoUpdater } from "electron-updater"
 
 import {
@@ -221,6 +223,12 @@ process.on('uncaughtException', (err) => {
     return;
   }
   logToFile('[CRITICAL] Uncaught Exception: ' + redactArgsForLog([err]));
+
+  // The database handle was destroyed above and cannot be reopened. Staying
+  // alive here is the worst outcome: the window keeps working, the user keeps
+  // holding meetings, and every one of them is silently discarded. End the
+  // process so the next launch comes back with a working database.
+  terminateAfterFatalError('uncaughtException', 1);
 });
 
 // Crash-loop guard for unhandledRejection, mirroring the render-process-gone
@@ -274,7 +282,7 @@ process.on('unhandledRejection', (reason, promise) => {
       rejectionsInWindow: unhandledRejectionHistory.length,
       windowMs: UNHANDLED_REJECTION_WINDOW_MS,
     });
-    emergencyCloseDatabase('unhandledRejection-loop-giveup');
+    terminateAfterFatalError('unhandledRejection-loop-giveup', 1);
   }
 });
 
@@ -317,11 +325,16 @@ for (const sig of ['SIGTERM', 'SIGINT'] as const) {
 process.on('SIGHUP', () => {
   try {
     logToFile('[SIGNAL] received SIGHUP');
-    emergencyCloseDatabase('SIGHUP');
   } catch {
     /* never throw from a signal handler */
   }
-  // No exit on SIGHUP — terminal disconnect shouldn't kill a desktop app.
+  // No exit on SIGHUP — a terminal disconnect shouldn't kill a desktop app.
+  //
+  // REGRESSION FIX (2026-08-07): and therefore no emergencyCloseDatabase()
+  // either. Because this handler deliberately keeps the process alive, closing
+  // the database here left the app running against a permanently dead handle
+  // for the rest of the session — silently discarding every meeting saved
+  // afterwards. A process that survives the event must keep its database.
 });
 
 // CQ-04 fix: do NOT call app.getPath() at module load time.
@@ -461,15 +474,25 @@ function logCrashConsole(label: string, payload: Record<string, unknown>): void 
   }
 }
 
-// Module-scope emergency DB close. Called from EVERY crash path
-// (uncaughtException, unhandledRejection, SIGTERM/SIGINT/SIGHUP,
-// render-process-gone, child-process-gone, gpu-process-crashed) so a
-// hard kill still leaves a clean WAL and releases the OS-level file lock.
-// The next launch's `new Database(dbPath)` then never sees a stale WAL
-// holding a kernel lock from the dead writer (the documented launch-hang
-// class of bug). Idempotent: safe to call from multiple paths in the same
-// process. No-ops if the DB manager isn't initialized yet (early-boot
-// handler fires before DatabaseManager.getInstance() exists).
+// Module-scope emergency DB close. Called from every TERMINAL crash path
+// (uncaughtException, unhandledRejection give-up, SIGTERM/SIGINT,
+// render-process-gone terminal/give-up, initializeApp-failed) so a hard kill
+// still leaves a clean WAL and releases the OS-level file lock. The next
+// launch's `new Database(dbPath)` then never sees a stale WAL holding a kernel
+// lock from the dead writer (the documented launch-hang class of bug).
+// Idempotent: safe to call from multiple paths in the same process. No-ops if
+// the DB manager isn't initialized yet (early-boot handler fires before
+// DatabaseManager.getInstance() exists).
+//
+// REGRESSION FIX (2026-08-07): this must ONLY be reached from a path that then
+// ends the process. Closing the handle is irreversible — it nulls the
+// DatabaseManager singleton with no reopen path — so a path that closes and
+// then keeps serving IPC leaves the app looking healthy while every write
+// silently no-ops (saveMeeting() hits `if (!this.db)` and returns undefined
+// without telling the caller). Recoverable events — SIGHUP, gpu-process-crashed,
+// child-process-gone — therefore no longer call this at all. Terminal events go
+// through terminateAfterFatalError(), which makes the close and the exit one
+// atomic decision.
 //
 // The single-shot flag is set INSIDE the success branch — if checkpoint
 // or close throws (transient disk error, half-initialized DB), a later
@@ -515,6 +538,33 @@ function emergencyCloseDatabase(reason: string): void {
     // the flag — a later crash path may run after the manager bootstraps.
     try { logToFile(`[DB-EMERGENCY] failed during ${reason}: ${e?.message || e}`); } catch { /* ignored */ }
   }
+}
+
+// Terminal-failure gate. Closing the database and ending the process are one
+// atomic decision (see FatalMainProcessCoordinator for the full rationale):
+// once the handle is destroyed there is no reopen path, so continuing would
+// leave an interactive app whose every write silently no-ops. Reentrancy-safe
+// — fatal signals routinely arrive in pairs (e.g. the mic and system STT
+// sockets failing in the same tick) and only the first may act.
+let _fatalMainProcess: FatalMainProcessCoordinator | null = null;
+function terminateAfterFatalError(reason: string, exitCode: number): void {
+  if (!_fatalMainProcess) {
+    _fatalMainProcess = new FatalMainProcessCoordinator({
+      closeDatabase: (why) => emergencyCloseDatabase(why),
+      exit: (code) => {
+        // Lazy-require: `app` may not exist pre-whenReady or under
+        // ELECTRON_RUN_AS_NODE in a test harness.
+        try {
+          const { app: electronApp } = require('electron');
+          electronApp.exit(code);
+        } catch {
+          process.exit(code);
+        }
+      },
+      log: (message) => { try { logToFile(message); } catch { /* best-effort */ } },
+    });
+  }
+  _fatalMainProcess.terminate(reason, exitCode);
 }
 
 // Returns true if this exception message looks like the routine native-arch
@@ -1331,6 +1381,13 @@ export class AppState {
   private hasDebugged: boolean = false
   private isMeetingActive: boolean = false; // Guard for session state leaks
   private _meetingGeneration = 0;
+  // Serializes start/stop so two transitions can never interleave. This is the
+  // ONLY mutual-exclusion layer: _meetingGeneration, the _audioInitPromise
+  // abort-and-await and _pendingTeardown each guard a hazard INSIDE a
+  // transition, not between two of them.
+  private readonly _meetingLifecycle = new MeetingLifecycleQueue(
+    (state) => this.logMeetingLifecycleState(state),
+  );
   private _audioInitPromise: Promise<void> | null = null;
   // AbortController handle for the in-flight startMeeting() audio init, so endMeeting()
   // can cancel it (signal.aborted short-circuits the init's isCurrentMeeting() guards)
@@ -5334,7 +5391,39 @@ export class AppState {
     }
   }
 
-  public async startMeeting(metadata?: any): Promise<void> {
+  /**
+   * Public meeting-start entry point. Reachable concurrently from renderer IPC,
+   * calendar auto-start, global shortcuts and the tray, so every request goes
+   * through the transition queue: duplicate starts coalesce, and a start
+   * requested while a stop is in flight queues behind it instead of
+   * interleaving. The ordered body below is unchanged — see
+   * MeetingLifecycleQueue for why this wrapper is the only thing added.
+   */
+  public startMeeting(metadata?: any): Promise<void> {
+    return this._meetingLifecycle.start(() => this.startMeetingTransition(metadata));
+  }
+
+  /**
+   * One structured line per lifecycle boundary. Database availability is
+   * included because a closed singleton is invisible at the call site —
+   * saveMeeting() silently no-ops rather than throwing — so this is the signal
+   * that distinguishes "meeting failed" from "meeting saved into a dead DB".
+   */
+  private logMeetingLifecycleState(state: MeetingLifecycleState): void {
+    let dbAvailable: boolean | 'unknown' = 'unknown';
+    try {
+      const { DatabaseManager } = require('./db/DatabaseManager');
+      dbAvailable = DatabaseManager.getInstance().isAvailable();
+    } catch {
+      // Diagnostics must never be able to block a start or stop.
+    }
+    console.log(
+      `[MeetingLifecycle] state=${state} generation=${this._meetingGeneration} ` +
+      `dbAvailable=${dbAvailable} platform=${process.platform}`,
+    );
+  }
+
+  private async startMeetingTransition(metadata?: any): Promise<void> {
     console.log('[Main] Starting Meeting...', metadata);
 
     // If a previous endMeeting() is still draining STT in the background, wait
@@ -5636,7 +5725,17 @@ export class AppState {
     })(); // Defer to next event loop tick — ensures IPC response reaches renderer before audio init
   }
 
-  public async endMeeting(): Promise<void> {
+  /**
+   * Public meeting-stop entry point. Same rationale as startMeeting(): all
+   * requests are serialized through the transition queue. The existing
+   * `_endMeetingInFlight` guard below is retained — it protects the
+   * synchronous teardown block specifically, which the queue does not replace.
+   */
+  public endMeeting(): Promise<void> {
+    return this._meetingLifecycle.stop(() => this.endMeetingTransition());
+  }
+
+  private async endMeetingTransition(): Promise<void> {
     // Idempotency guard: a double-click on Stop, or a Stop racing with a
     // global-shortcut reset, can deliver two endMeeting() calls within ms of
     // each other. Without this, both invocations would run the synchronous
@@ -8036,10 +8135,20 @@ if (process.env.THINKING_MATRIX === '1') {
     const isCrash = reason === 'crashed' || reason === 'abnormal-exit';
 
     // Never fight an intentional teardown, and don't reload a clean/intentional
-    // exit or an intentional kill — treat those as terminal (preserve the
-    // original crash-path behavior so the WAL lock is released cleanly).
+    // exit or an intentional kill.
     if (!isCrash || appState.isQuitting?.()) {
-      emergencyCloseDatabase('render-process-gone');
+      // Only release the handle when the APP itself is going away — that is the
+      // case the WAL-lock cleanup was written for.
+      //
+      // REGRESSION FIX (2026-08-07): a single renderer exiting cleanly while the
+      // app keeps running (reason 'killed' / 'clean-exit', not quitting) used to
+      // land here and close the database anyway, leaving the surviving app on a
+      // dead handle for the rest of the session.
+      if (appState.isQuitting?.()) {
+        emergencyCloseDatabase('render-process-gone');
+      } else {
+        logToFile(`[main] render-process-gone: non-crash reason=${reason} — not reloading, DB left open`);
+      }
       return;
     }
 
@@ -8084,7 +8193,6 @@ if (process.env.THINKING_MATRIX === '1') {
         reloadsInWindow: history.length,
         windowMs: RENDERER_RELOAD_WINDOW_MS,
       });
-      emergencyCloseDatabase('render-process-gone-loop-giveup');
       try {
         // dialog is not imported at module top — require it lazily (matches
         // the native-arch gate handler's pattern above).
@@ -8095,6 +8203,11 @@ if (process.env.THINKING_MATRIX === '1') {
           'If this continues, update to the latest version.'
         );
       } catch { /* dialog best-effort */ }
+      // showErrorBox is modal and blocks until the user clicks OK, so the
+      // terminal sequence runs AFTER they have seen the message. We told them
+      // to restart, so actually end the process — leaving it alive here meant
+      // the app kept running on a closed database if they ignored the dialog.
+      terminateAfterFatalError('render-process-gone-loop-giveup', 1);
       return;
     }
 
@@ -8116,12 +8229,21 @@ if (process.env.THINKING_MATRIX === '1') {
     logCrashConsole('child-process-gone', { details });
     console.warn('[main] child-process-gone:', details);
     stopAppManagedHindsight('child-process-gone');
-    emergencyCloseDatabase('child-process-gone');
+    // REGRESSION FIX (2026-08-07): do NOT close the database here. This event
+    // fires for ANY dead utility/helper child process, most of which the app
+    // recovers from transparently, and this handler does not exit. Closing the
+    // singleton was therefore killing meeting persistence for the rest of the
+    // session over a recoverable event. Main owns the database synchronously —
+    // a child process dying cannot corrupt it.
   });
 
   app.on('gpu-process-crashed', (_event, killed: boolean) => {
     logCrashConsole('gpu-process-crashed', { killed });
-    emergencyCloseDatabase('gpu-process-crashed');
+    // REGRESSION FIX (2026-08-07): do NOT close the database here either. GPU
+    // process crashes are routine and recoverable — Windows TDR driver resets
+    // raise this event during normal operation — and Electron re-spawns the GPU
+    // process on its own. This handler does not exit, so closing the database
+    // meant a single driver reset silently discarded every meeting afterwards.
   });
 
   app.on('gpu-info-update', () => {
@@ -8329,4 +8451,10 @@ initializeApp().catch((err) => {
     skippedReport: isNativeArchGateCrash(err) ? 'native-arch-gate' : undefined,
   });
   console.error(err);
+  // Startup never completed and the database handle is gone. The native-arch
+  // gate renders its own dialog and exits from its dedicated handler, so skip
+  // it here and let that path own the user-facing message.
+  if (!isNativeArchGateCrash(err)) {
+    terminateAfterFatalError('initializeApp-failed', 1);
+  }
 })

--- a/electron/rag/RAGManager.ts
+++ b/electron/rag/RAGManager.ts
@@ -417,9 +417,39 @@ export class RAGManager {
     }
 
     /**
+     * Whether this instance's connection can still serve statements. Mirrors
+     * VectorStore.isDatabaseUsable() — see that method for the full rationale.
+     */
+    private isDatabaseUsable(): boolean {
+        try {
+            return (this.db as any)?.open === true;
+        } catch {
+            return false;
+        }
+    }
+
+    /**
      * Delete RAG data for a meeting
      */
     deleteMeetingData(meetingId: string): void {
+        // Shutdown guard: RAGManager holds a RAW better-sqlite3 handle
+        // (`this.db = config.db`), so after the fatal path's
+        // closeWithoutCheckpoint() this reference is a closed connection and
+        // every prepare() below would throw out of the driver. This method is
+        // called from the background meeting-teardown block, where a throw is
+        // caught but aborts the remaining teardown steps. Return one controlled,
+        // logged result instead of three separate driver failures.
+        //
+        // Defense in depth for the shutdown window only — nothing here reopens
+        // the database.
+        if (!this.isDatabaseUsable()) {
+            console.warn(
+                `[RAGManager] deleteMeetingData(${meetingId}): database is closed — skipping RAG cleanup. ` +
+                'Expected during fatal shutdown.'
+            );
+            return;
+        }
+
         // 1. Delete from vector store (chunks and summaries)
         this.vectorStore.deleteChunksForMeeting(meetingId);
         

--- a/electron/rag/VectorStore.ts
+++ b/electron/rag/VectorStore.ts
@@ -61,6 +61,33 @@ export class VectorStore {
     }
 
     /**
+     * Whether this instance's connection can still serve statements.
+     *
+     * VectorStore is handed a RAW better-sqlite3 handle and keeps its own
+     * reference to it. When the fatal path runs emergencyCloseDatabase() ->
+     * closeWithoutCheckpoint(), DatabaseManager nulls ITS handle but ours is
+     * left pointing at a closed connection, so every prepare() throws
+     * `TypeError: The database connection is not open` straight out of the
+     * driver.
+     *
+     * We check the handle's own `open` flag rather than asking DatabaseManager,
+     * because this class's correctness depends on the connection it was
+     * actually given — a caller may legitimately construct it over a different
+     * connection (ModeContextRetriever and the real-SQLite tests both do).
+     *
+     * DEFENSE IN DEPTH ONLY — this never reopens anything. It exists so the
+     * shutdown window degrades into one logged no-op instead of a raw driver
+     * exception escaping an internal abstraction.
+     */
+    private isDatabaseUsable(): boolean {
+        try {
+            return this.db?.open === true;
+        } catch {
+            return false;
+        }
+    }
+
+    /**
      * Detect if sqlite-vec is available (per-dimension vec0 tables must exist)
      */
     private detectVecSupport(): boolean {
@@ -305,6 +332,14 @@ export class VectorStore {
      * Delete all chunks for a meeting (removes from all tracked dimension tables)
      */
     deleteChunksForMeeting(meetingId: string): void {
+        if (!this.isDatabaseUsable()) {
+            console.warn(
+                `[VectorStore] deleteChunksForMeeting(${meetingId}): database is closed — skipping. ` +
+                'Expected during fatal shutdown; the rows are removed by ON DELETE CASCADE ' +
+                'or the next launch\'s cleanup.'
+            );
+            return;
+        }
         if (this.useNativeVec) {
             try {
                 const ids = this.db.prepare(
@@ -667,6 +702,13 @@ export class VectorStore {
      * are wiped so the new provider can embed them cleanly.
      */
     clearEmbeddingsForMeeting(meetingId: string): void {
+        if (!this.isDatabaseUsable()) {
+            console.warn(
+                `[VectorStore] clearEmbeddingsForMeeting(${meetingId}): database is closed — skipping. ` +
+                'Expected during fatal shutdown; the embeddings are re-derived on the next launch.'
+            );
+            return;
+        }
         // Wipe embedding blobs from chunks and summaries
         this.db.prepare('UPDATE chunks SET embedding = NULL WHERE meeting_id = ?').run(meetingId);
         this.db.prepare('UPDATE chunk_summaries SET embedding = NULL WHERE meeting_id = ?').run(meetingId);

--- a/electron/rag/__tests__/ClosedDatabaseCleanupGuard2026_08_07.test.mjs
+++ b/electron/rag/__tests__/ClosedDatabaseCleanupGuard2026_08_07.test.mjs
@@ -1,0 +1,183 @@
+// Regression test: RAG cleanup boundaries must not call prepare() on a closed
+// database handle.
+//
+// THE DEFECT (reproduced against a real DB + real Gemini embeddings before the
+// fix): VectorStore and RAGManager are handed a RAW better-sqlite3 handle in
+// their constructors (`this.db = config.db`) and keep their own reference to
+// it. When the fatal path runs emergencyCloseDatabase() ->
+// closeWithoutCheckpoint(), the DatabaseManager singleton nulls ITS handle, but
+// these copies are left pointing at a closed connection. Every
+// `this.db.prepare(...)` then throws straight out of the driver:
+//
+//     TypeError: The database connection is not open
+//
+// Measured post-close, before the fix:
+//     clearEmbeddingsForMeeting: THREW -> The database connection is not open
+//     deleteChunksForMeeting:    THREW -> The database connection is not open
+//
+// Production callers do catch it (the background-teardown try/catch in
+// endMeetingTransition, and processQueue()'s .catch), so this was never a
+// crash. The cost is that a raw driver error escapes an internal abstraction:
+// the caller cannot distinguish "the database is gone, which is EXPECTED during
+// shutdown" from "cleanup is genuinely broken", and the throw skips whatever
+// teardown steps followed it.
+//
+// The contract: at a cleanup boundary an unavailable database is a controlled,
+// logged no-op — not an exception. Defense in depth for the shutdown window
+// ONLY; nothing here reopens the database.
+//
+// ISOLATION: this test owns its own better-sqlite3 connection and never touches
+// the DatabaseManager singleton. An earlier draft closed the shared singleton,
+// which poisoned every RAG test file that ran after it in the same process
+// (8 files failed to load). Closing shared state from a test is never worth it.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import Module from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+const require = Module.createRequire(path.join(repoRoot, 'package.json'));
+
+// better-sqlite3 is built against Electron's ABI (NODE_MODULE_VERSION 148), so
+// it cannot load under plain `node --test` (141). Every real-SQLite test in
+// this directory has the same constraint; the difference is that they hard-fail
+// and add noise to an already-red suite. Skip cleanly instead, and run for real
+// under:
+//     ELECTRON_RUN_AS_NODE=1 ./node_modules/.bin/electron --test <file>
+// (which is what `npm run test:electron` and the RAG suite use).
+// NOTE: require() alone does NOT surface the mismatch — better-sqlite3 loads
+// its native binding lazily, so the ABI error is thrown by `new Database(...)`.
+// The probe therefore has to actually open a connection.
+let Database = null;
+let skipReason = null;
+try {
+    Database = require('better-sqlite3');
+    new Database(':memory:').close();
+} catch (err) {
+    skipReason = /NODE_MODULE_VERSION/.test(String(err?.message))
+        ? 'better-sqlite3 is built for the Electron ABI — run under ELECTRON_RUN_AS_NODE'
+        : `better-sqlite3 unavailable: ${err?.message}`;
+}
+
+// node:test treats the PRESENCE of a `skip` key as a skip, even when its value
+// is null — so only include it when we actually mean to skip.
+const opts = skipReason ? { skip: skipReason } : {};
+
+const { VectorStore } = await import(
+    path.join(repoRoot, 'dist-electron/electron/rag/VectorStore.js'));
+
+const MEETING = 'rag-guard-meeting';
+
+/** A private database with just the tables the cleanup boundaries touch. */
+function makeIsolatedDb() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'natively-ragguard-'));
+    const db = new Database(path.join(dir, 'natively.db'));
+    db.exec(`
+        CREATE TABLE meetings (
+            id TEXT PRIMARY KEY, title TEXT, start_time INTEGER, duration_ms INTEGER,
+            created_at TEXT, embedding_provider TEXT, embedding_dimensions INTEGER,
+            embedding_space TEXT
+        );
+        CREATE TABLE chunks (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, meeting_id TEXT NOT NULL,
+            chunk_index INTEGER NOT NULL, speaker TEXT,
+            start_timestamp_ms INTEGER, end_timestamp_ms INTEGER,
+            cleaned_text TEXT NOT NULL, token_count INTEGER NOT NULL,
+            embedding BLOB, created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE chunk_summaries (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, meeting_id TEXT NOT NULL UNIQUE,
+            summary_text TEXT, embedding BLOB
+        );
+    `);
+    db.prepare('INSERT INTO meetings (id,title,start_time,duration_ms,created_at) VALUES (?,?,?,?,?)')
+        .run(MEETING, 'RAG guard probe', Date.now(), 1000, String(Date.now()));
+    // A 768-dim vector, the shape gemini-embedding-001 returns.
+    const blob = Buffer.from(new Float32Array(768).fill(0.01).buffer);
+    db.prepare(
+        `INSERT INTO chunks (meeting_id, chunk_index, cleaned_text, token_count, embedding,
+                             start_timestamp_ms, end_timestamp_ms)
+         VALUES (?,?,?,?,?,?,?)`
+    ).run(MEETING, 0, 'quarterly revenue target', 4, blob, 0, 1000);
+    return { db, dir };
+}
+
+test('sanity: the cleanup boundaries do their job while the database is OPEN', opts, () => {
+    const { db, dir } = makeIsolatedDb();
+    const store = new VectorStore(db, path.join(dir, 'natively.db'), '');
+
+    const embeddedBefore = db.prepare(
+        'SELECT COUNT(*) c FROM chunks WHERE meeting_id = ? AND embedding IS NOT NULL').get(MEETING).c;
+    store.clearEmbeddingsForMeeting(MEETING);
+    const embeddedAfter = db.prepare(
+        'SELECT COUNT(*) c FROM chunks WHERE meeting_id = ? AND embedding IS NOT NULL').get(MEETING).c;
+
+    assert.equal(embeddedBefore, 1, 'setup must leave one embedded chunk');
+    assert.equal(embeddedAfter, 0, 'the guard must not stop real cleanup on an open database');
+
+    db.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('cleanup boundaries are a controlled no-op once the database is closed', opts, () => {
+    const { db, dir } = makeIsolatedDb();
+    const store = new VectorStore(db, path.join(dir, 'natively.db'), '');
+
+    // Exactly the state emergencyCloseDatabase() leaves behind: the handle the
+    // VectorStore is holding has been closed out from under it.
+    db.close();
+    assert.equal(db.open, false, 'the raw handle VectorStore still holds is closed');
+
+    assert.doesNotThrow(
+        () => store.clearEmbeddingsForMeeting(MEETING),
+        'clearEmbeddingsForMeeting must not throw a raw SqliteError once the ' +
+        'database is closed — it must detect the unavailable handle and return.'
+    );
+    assert.doesNotThrow(
+        () => store.deleteChunksForMeeting(MEETING),
+        'deleteChunksForMeeting must not throw a raw SqliteError once the ' +
+        'database is closed — it must detect the unavailable handle and return.'
+    );
+
+    fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('the guard keys off availability, so real errors on an OPEN database still surface', opts, () => {
+    // If this were a blanket try/catch instead of an availability check, it
+    // would mask genuine cleanup bugs during normal operation.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'natively-ragguard-bare-'));
+    const db = new Database(path.join(dir, 'bare.db'));   // deliberately no schema
+    const store = new VectorStore(db, path.join(dir, 'bare.db'), '');
+
+    assert.equal(db.open, true, 'this handle IS open');
+    assert.throws(
+        () => store.clearEmbeddingsForMeeting('nope'),
+        /no such table/i,
+        'on an OPEN database a genuine schema error must still surface'
+    );
+
+    db.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('RAGManager.deleteMeetingData is guarded at the boundary too', opts, async () => {
+    // RAGManager holds its own raw handle and is the entry point the meeting
+    // teardown block actually calls (main.ts: ragManager.deleteMeetingData).
+    const { RAGManager } = await import(path.join(repoRoot, 'dist-electron/electron/rag/RAGManager.js'));
+    const { db, dir } = makeIsolatedDb();
+
+    const mgr = new RAGManager({ db, dbPath: path.join(dir, 'natively.db'), extPath: '' });
+    db.close();
+
+    assert.doesNotThrow(
+        () => mgr.deleteMeetingData(MEETING),
+        'deleteMeetingData must return a controlled result when the database is closed'
+    );
+
+    fs.rmSync(dir, { recursive: true, force: true });
+});

--- a/electron/services/__tests__/AudioInitPromiseClearedInFinally.test.mjs
+++ b/electron/services/__tests__/AudioInitPromiseClearedInFinally.test.mjs
@@ -9,8 +9,8 @@ const mainPath = path.resolve(__dirname, '../../main.ts');
 const source = fs.readFileSync(mainPath, 'utf8');
 
 // ── Function isolation ──────────────────────────────────────────────────────
-const startMeetingStart = source.indexOf('public async startMeeting');
-const endMeetingStart = source.indexOf('public async endMeeting', startMeetingStart);
+const startMeetingStart = source.indexOf('private async startMeetingTransition');
+const endMeetingStart = source.indexOf('private async endMeetingTransition', startMeetingStart);
 const ragStart = source.indexOf('private async processCompletedMeetingForRAG', endMeetingStart);
 
 const startMeetingSource = source.slice(startMeetingStart, endMeetingStart);

--- a/electron/services/__tests__/MainTeardown.test.mjs
+++ b/electron/services/__tests__/MainTeardown.test.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const mainPath = path.resolve(__dirname, '../../main.ts');
 const source = fs.readFileSync(mainPath, 'utf8');
-const endMeetingStart = source.indexOf('public async endMeeting');
+const endMeetingStart = source.indexOf('private async endMeetingTransition');
 const endMeetingEnd = source.indexOf('private async processCompletedMeetingForRAG', endMeetingStart);
 const endMeetingSource = source.slice(endMeetingStart, endMeetingEnd);
 

--- a/electron/services/__tests__/TelemetryEmissionSites.test.mjs
+++ b/electron/services/__tests__/TelemetryEmissionSites.test.mjs
@@ -35,7 +35,7 @@ describe('Phase 6 — TelemetryService production emission sites', () => {
 
   test('main.ts emits meeting_stop at end-meeting site (before teardown)', () => {
     const src = read('electron/main.ts');
-    const idx = src.search(/public async endMeeting/);
+    const idx = src.search(/private async endMeetingTransition/);
     assert.ok(idx > 0);
     // Widened from 1200 → 2000 chars to accommodate the idempotency-guard
     // comment block (added with the per-meeting-teardown promise) that now

--- a/electron/utils/__tests__/UnhandledRejectionDbSurvival2026_07_11.test.mjs
+++ b/electron/utils/__tests__/UnhandledRejectionDbSurvival2026_07_11.test.mjs
@@ -78,20 +78,28 @@ describe('unhandledRejection no longer unconditionally kills the database', () =
     }
     const body = source.slice(start, i - 1);
 
-    // emergencyCloseDatabase MUST appear only inside a conditional (the
+    // The DB-closing call MUST appear only inside a conditional (the
     // escalation branch), never as a bare top-level statement.
+    //
+    // UPDATED 2026-08-07: the escalation branch now routes through
+    // terminateAfterFatalError(), which closes the database AND exits as one
+    // atomic step (previously it closed the DB and left the process running on
+    // a dead handle). Either spelling satisfies this invariant; what matters is
+    // that the call is gated behind the threshold.
     assert.match(
       body,
-      /if\s*\([^)]*unhandledRejectionHistory[^)]*>=\s*UNHANDLED_REJECTION_MAX[^)]*\)\s*\{[\s\S]*emergencyCloseDatabase/,
-      'emergencyCloseDatabase must only be called inside the escalation-threshold branch',
+      /if\s*\([^)]*unhandledRejectionHistory[^)]*>=\s*UNHANDLED_REJECTION_MAX[^)]*\)\s*\{[\s\S]*(?:emergencyCloseDatabase|terminateAfterFatalError)/,
+      'the DB-closing/terminal call must only happen inside the escalation-threshold branch',
     );
     // Regression guard: the bug shape was an unconditional call right after
     // the logToFile line, with no guarding `if`. Assert that shape is gone —
     // there must be tracking/counting logic between the log line and any
-    // emergencyCloseDatabase call.
+    // DB-closing call.
     const logIdx = body.indexOf('[CRITICAL] Unhandled Rejection');
-    const closeIdx = body.indexOf('emergencyCloseDatabase');
-    assert.ok(logIdx >= 0 && closeIdx > logIdx, 'log line must precede the (now-conditional) close call');
+    const closeMatch = body.match(/emergencyCloseDatabase|terminateAfterFatalError/);
+    assert.ok(closeMatch, 'the escalation branch must still have a terminal DB path');
+    const closeIdx = closeMatch.index;
+    assert.ok(logIdx >= 0 && closeIdx > logIdx, 'log line must precede the (now-conditional) terminal call');
     const between = body.slice(logIdx, closeIdx);
     assert.match(
       between,
@@ -108,11 +116,67 @@ describe('unhandledRejection no longer unconditionally kills the database', () =
     );
   });
 
-  test('sibling terminal crash paths (SIGTERM/SIGINT/render-process-gone-loop-giveup) are unaffected — still call emergencyCloseDatabase directly', () => {
+  test('sibling terminal crash paths (SIGTERM/SIGINT/render-process-gone-loop-giveup) still close the database', () => {
     // This fix must be scoped to unhandledRejection specifically. Sanity-check
-    // the other genuinely-terminal paths still close the DB unconditionally
-    // (they either exit the process or are already gated to a give-up branch).
+    // the other genuinely-terminal paths still close the DB (they either exit
+    // the process directly or route through the terminal coordinator).
     assert.match(source, /for \(const sig of \['SIGTERM', 'SIGINT'\]/);
-    assert.match(source, /emergencyCloseDatabase\('render-process-gone-loop-giveup'\)/);
+    assert.match(source, /terminateAfterFatalError\('render-process-gone-loop-giveup', 1\)/);
+  });
+
+  // ── Added 2026-08-07 ──────────────────────────────────────────────────────
+  // The original bug — "the DB is closed but the process keeps running" — was
+  // never unique to unhandledRejection. Six paths had that shape. These pin the
+  // general invariant so it cannot come back through a different door.
+
+  test('every path that closes the database also ends the process', () => {
+    // terminateAfterFatalError() is the ONLY sanctioned way to close the DB
+    // from a handler that would otherwise keep running. Direct
+    // emergencyCloseDatabase() callers must be paths that exit on their own.
+    const sanctionedDirectCallers = [
+      "emergencyCloseDatabase('uncaughtException')",        // handler ends in terminateAfterFatalError
+      'emergencyCloseDatabase(sig)',                        // SIGTERM/SIGINT — exits immediately after
+      "emergencyCloseDatabase('render-process-gone')",      // guarded by isQuitting() — app is going away
+      "emergencyCloseDatabase('initializeApp-failed')",     // followed by terminateAfterFatalError
+      'emergencyCloseDatabase(why)',                        // the coordinator's own injected close
+    ];
+    // Strip comments first — main.ts discusses emergencyCloseDatabase() at
+    // length in prose, and those mentions are not call sites.
+    const code = source
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .split('\n')
+      .map(line => line.replace(/\/\/.*$/, ''))
+      .join('\n');
+
+    const callSites = [...code.matchAll(/emergencyCloseDatabase\([^)]*\)/g)]
+      .map(m => m[0])
+      // Skip the declaration itself.
+      .filter(s => s !== 'emergencyCloseDatabase(reason: string)');
+
+    assert.ok(callSites.length > 0, 'the scan must actually find call sites (guards against a vacuous pass)');
+
+    for (const site of callSites) {
+      assert.ok(
+        sanctionedDirectCallers.includes(site),
+        `Unreviewed direct emergencyCloseDatabase call: ${site}\n` +
+        'Closing the database is irreversible (it nulls the singleton with no reopen ' +
+        'path). A handler that closes it and then keeps running leaves an interactive ' +
+        'app whose every write silently no-ops. Either route through ' +
+        'terminateAfterFatalError() or do not close the database on this path.',
+      );
+    }
+  });
+
+  test('recoverable process events must not destroy the database', () => {
+    // These three handlers do NOT exit, so they must never close the DB.
+    // gpu-process-crashed in particular fires on routine Windows TDR driver
+    // resets; child-process-gone fires for any dead helper process.
+    for (const reason of ['SIGHUP', 'child-process-gone', 'gpu-process-crashed']) {
+      assert.ok(
+        !source.includes(`emergencyCloseDatabase('${reason}')`),
+        `${reason} is a recoverable event whose handler keeps the process alive — ` +
+        'it must not close the database.',
+      );
+    }
   });
 });

--- a/electron/utils/__tests__/fatalMainProcess2026_08_07.test.mjs
+++ b/electron/utils/__tests__/fatalMainProcess2026_08_07.test.mjs
@@ -1,0 +1,116 @@
+// Behavioral tests for the one-shot fatal-termination coordinator.
+//
+// Background: main.ts had six paths that called emergencyCloseDatabase() —
+// which nulls the better-sqlite3 singleton irreversibly, with no reopen path —
+// and then let the process KEEP RUNNING. Electron stayed fully interactive
+// while every subsequent write silently no-op'd (saveMeeting() hits
+// `if (!this.db)`, logs, and returns undefined — the caller is never told).
+//
+// The invariant this coordinator enforces: closing the database and exiting
+// are a single atomic decision. If we are confident enough to destroy the
+// database handle, we must not leave an interactive app behind; if we are not,
+// we must not close it.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import Module from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distRoot = path.resolve(__dirname, '../../../dist-electron/electron/utils');
+
+const origLoad = Module._load;
+Module._load = function patchedLoad(request) {
+    if (request === 'electron') return { app: { exit: () => {} } };
+    return origLoad.apply(this, arguments);
+};
+
+const { FatalMainProcessCoordinator } = await import(path.join(distRoot, 'fatalMainProcess.js'));
+
+/** Records every close/exit/log the coordinator performs. */
+function spyDeps(overrides = {}) {
+    const calls = { closes: [], exits: [], logs: [] };
+    const deps = {
+        closeDatabase: (reason) => { calls.closes.push(reason); },
+        exit: (code) => { calls.exits.push(code); },
+        log: (message) => { calls.logs.push(message); },
+        ...overrides,
+    };
+    return { calls, deps };
+}
+
+test('a single fatal event closes the database exactly once and exits exactly once', () => {
+    const { calls, deps } = spyDeps();
+    const coordinator = new FatalMainProcessCoordinator(deps);
+
+    coordinator.terminate('uncaughtException', 1);
+
+    assert.deepEqual(calls.closes, ['uncaughtException']);
+    assert.deepEqual(calls.exits, [1]);
+    assert.equal(coordinator.isTerminal(), true);
+    assert.equal(coordinator.getReason(), 'uncaughtException');
+});
+
+test('two nearly-simultaneous fatal events still yield one close and one exit', () => {
+    const { calls, deps } = spyDeps();
+    const coordinator = new FatalMainProcessCoordinator(deps);
+
+    // e.g. the mic and system STT sockets both raising in the same tick.
+    coordinator.terminate('uncaughtException', 1);
+    coordinator.terminate('unhandledRejection-loop-giveup', 1);
+    coordinator.terminate('render-process-gone-loop-giveup', 1);
+
+    assert.deepEqual(calls.closes, ['uncaughtException'], 'database must close only once');
+    assert.deepEqual(calls.exits, [1], 'exit must fire only once');
+    assert.equal(coordinator.getInvocationCount(), 3, 'every attempt is still recorded for triage');
+    assert.equal(coordinator.getReason(), 'uncaughtException', 'the FIRST reason is the one retained');
+});
+
+test('the process still exits when the crash-safe database close throws', () => {
+    // A crashing process is exactly when close() is most likely to fail. If a
+    // throwing close could skip the exit, we would be back to an interactive
+    // app on a half-torn-down database — the very state this class exists to
+    // prevent.
+    const { calls, deps } = spyDeps({
+        closeDatabase: () => { throw new Error('SQLITE_BUSY: database is locked'); },
+    });
+    const coordinator = new FatalMainProcessCoordinator(deps);
+
+    assert.doesNotThrow(
+        () => coordinator.terminate('uncaughtException', 1),
+        'terminate() must never throw back into the fatal handler that called it'
+    );
+
+    assert.deepEqual(calls.exits, [1], 'exit must run even though closeDatabase threw');
+    assert.equal(calls.logs.length, 1, 'the close failure must leave a breadcrumb');
+    assert.match(calls.logs[0], /SQLITE_BUSY/);
+});
+
+test('a throwing exit is contained so the fatal handler cannot re-enter', () => {
+    const { calls, deps } = spyDeps({
+        exit: () => { throw new Error('app not ready'); },
+    });
+    const coordinator = new FatalMainProcessCoordinator(deps);
+
+    assert.doesNotThrow(() => coordinator.terminate('initializeApp-failed', 1));
+    assert.deepEqual(calls.closes, ['initializeApp-failed']);
+    assert.equal(coordinator.isTerminal(), true, 'a failed exit must not un-latch terminal state');
+});
+
+test('exit code is carried through per call site', () => {
+    const { calls, deps } = spyDeps();
+    new FatalMainProcessCoordinator(deps).terminate('nativeArch', 3);
+    assert.deepEqual(calls.exits, [3]);
+});
+
+test('a fresh coordinator starts non-terminal with nothing recorded', () => {
+    const { calls, deps } = spyDeps();
+    const coordinator = new FatalMainProcessCoordinator(deps);
+
+    assert.equal(coordinator.isTerminal(), false);
+    assert.equal(coordinator.getInvocationCount(), 0);
+    assert.equal(coordinator.getReason(), null);
+    assert.deepEqual(calls.closes, []);
+    assert.deepEqual(calls.exits, [], 'constructing the coordinator must have no side effects');
+});

--- a/electron/utils/fatalMainProcess.ts
+++ b/electron/utils/fatalMainProcess.ts
@@ -1,0 +1,98 @@
+/**
+ * One-shot coordinator for genuinely terminal main-process failures.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `emergencyCloseDatabase()` in main.ts is irreversible: it calls
+ * `closeWithoutCheckpoint()`, which nulls the `DatabaseManager` singleton's
+ * handle with no reopen path. Six separate fatal paths used to call it and
+ * then simply `return`, leaving Electron fully interactive on top of a dead
+ * database. The app looked completely normal — windows, IPC, UI all fine — but
+ * `saveMeeting()` hit `if (!this.db)`, logged, and returned `undefined`, so
+ * every meeting for the rest of the session was silently lost with no error
+ * surfaced to the caller and no banner shown to the user.
+ *
+ * The invariant: closing the database and exiting the process are ONE atomic
+ * decision. If a failure is severe enough to justify destroying the database
+ * handle, it is severe enough to end the process. If it is not, the database
+ * must stay open (recoverable events — SIGHUP, gpu-process-crashed,
+ * child-process-gone — no longer close it at all).
+ *
+ * DESIGN
+ * ------
+ * Dependency-injected and free of any direct Electron import, so the policy is
+ * testable without a live app. Reentrancy-safe: fatal signals commonly arrive
+ * in pairs (the mic and system STT sockets failing in the same tick), and a
+ * second close or a second exit must never run. Neither a throwing
+ * `closeDatabase` nor a throwing `exit` may propagate — this class is called
+ * FROM the crash handlers, so an escaping error would re-enter them.
+ */
+
+export interface FatalMainProcessDeps {
+    /** Crash-safe database close. Must be idempotent; may throw. */
+    closeDatabase: (reason: string) => void;
+    /** Terminal process exit. Called exactly once. */
+    exit: (code: number) => void;
+    /** Optional breadcrumb sink for failures inside the terminal sequence. */
+    log?: (message: string) => void;
+}
+
+export class FatalMainProcessCoordinator {
+    private terminal = false;
+    private invocations = 0;
+    private reason: string | null = null;
+
+    constructor(private readonly deps: FatalMainProcessDeps) {}
+
+    /**
+     * Close the database and end the process. Safe to call from any number of
+     * fatal handlers; only the first call has an effect.
+     */
+    terminate(reason: string, exitCode: number): void {
+        this.invocations++;
+        if (this.terminal) return;
+        this.terminal = true;
+        this.reason = reason;
+
+        try {
+            this.deps.closeDatabase(reason);
+        } catch (error: any) {
+            // A crashing process is exactly when the close is most likely to
+            // fail. Swallow it and press on — skipping the exit here would
+            // recreate the interactive-app-on-a-dead-database state this class
+            // exists to prevent.
+            try {
+                this.deps.log?.(
+                    `[FATAL] database close failed during ${reason}: ${error?.message || error}`,
+                );
+            } catch { /* the breadcrumb is best-effort */ }
+        } finally {
+            try {
+                this.deps.exit(exitCode);
+            } catch (error: any) {
+                // Nothing left to do — but never throw back into the crash
+                // handler that called us.
+                try {
+                    this.deps.log?.(
+                        `[FATAL] exit failed during ${reason}: ${error?.message || error}`,
+                    );
+                } catch { /* best-effort */ }
+            }
+        }
+    }
+
+    /** True once a terminal sequence has begun. */
+    isTerminal(): boolean {
+        return this.terminal;
+    }
+
+    /** Total terminate() attempts, including those suppressed by the latch. */
+    getInvocationCount(): number {
+        return this.invocations;
+    }
+
+    /** The reason for the FIRST terminate() call — the one that actually ran. */
+    getReason(): string | null {
+        return this.reason;
+    }
+}


### PR DESCRIPTION
## The bug

A user stopping a meeting within a second or two of starting it — while both Natively Pro STT sockets are still mid-handshake — permanently disabled meeting persistence **for the rest of the session, with no error surfaced anywhere**. The app looked completely healthy: windows, IPC, UI all fine. Every meeting after that point was silently discarded.

Three defects had to line up.

### 1. Cancelling a CONNECTING STT socket raised an uncaughtException

`closeUpstream()` called `removeAllListeners()` then `close()`. With `ws@8`, `close()` on a `CONNECTING` socket routes through `abortHandshake()`, which ends in:

```js
process.nextTick(emitErrorAndClose, websocket, err)
```

`'error'` is emitted **unconditionally one tick later**. With the listener just stripped, Node's EventEmitter promoted it to a process-level `uncaughtException`.

There is no way to suppress that emit. Measured against `ws@8.21.0`:

| approach | result |
|---|---|
| `terminate()` instead of `close()` | **still crashes** (same `abortHandshake` path) |
| deferring `close()` to a later tick | **still crashes** |
| re-attaching a bare no-op `'error'` | safe, but leaks one listener per discarded socket |
| **selective removal + self-releasing pair** | safe **and** leak-free ← this PR |

See [websockets/ws#1835](https://github.com/websockets/ws/issues/1835) — `abortHandshake` is deliberately private and the library's contract is that the caller keeps an `'error'` listener attached. Those sockets cycle on every meeting, so the leak-free variant matters.

### 2. Six paths closed SQLite irreversibly and then kept running

`emergencyCloseDatabase()` nulls the `better-sqlite3` singleton with no reopen path. Six `main.ts` paths called it and then simply returned. `saveMeeting()` hit `if (!this.db)`, logged, and returned `undefined` — **the caller is never told**.

`gpu-process-crashed` was the worst offender: routine Windows TDR driver resets raise it during normal operation, and it killed persistence.

- **Terminal** paths now route through `FatalMainProcessCoordinator`, making the close and the exit one atomic decision (it exits even if the close throws).
- **Recoverable** events — `SIGHUP`, `gpu-process-crashed`, `child-process-gone`, non-quitting `render-process-gone` — no longer close the database at all.

### 3. `startMeeting`/`endMeeting` had no mutual exclusion

They're reachable concurrently from renderer IPC, calendar auto-start, shortcuts and the tray. `MeetingLifecycleQueue` serializes them.

Coalescing is by **direction**, not by "is any request pending" — the latter swallows the restart in stop-then-immediately-start. The ordered bodies move to private `*Transition` methods, unchanged.

### Also: RAG closed-database guards

`VectorStore` and `RAGManager` keep their own raw handle, so after the fatal close every `prepare()` threw a raw driver error out of an internal abstraction. They now check handle availability — **not** a blanket `try/catch`, so genuine schema errors still surface — and return one logged no-op.

## Validation against the real production backend

Not just local servers. Cancelling handshakes to `wss://api.natively.software/v1/transcribe`:

```
before: 6 uncaught exceptions      after: 0
```

All rounds caught sockets in `CONNECTING` even at a 200 ms dwell — TLS to production holds them there far longer than any local test implies, so **production was more exposed than local testing suggested**.

End to end with real Gemini embeddings and a real DeepSeek v4 Flash summary:

```
BEFORE:  cycle 0: dbAvailable=false  ->  save never even attempted
AFTER:   cycles 0-3 clean  ->  row + 3 transcripts + 1 interaction + summary all read back
```

## Tests

New coverage for CONNECTING cancellation (including wss/TLS), the transition queue, the fatal coordinator, the RAG guards, and a lifecycle+DB-liveness stress that asserts a real `SELECT 1` + insert/read/delete after all 25 cycles. That stress **fails at HEAD on cycle 0** — the user's exact symptom.

Ten existing source-contract tests were repointed at the renamed transition methods. **No assertion was weakened.**

- Full `npm test`: **zero regressions** against the baseline
- Typecheck clean on this base, with and without the commit
- Targeted suite on this base: **42/42**

## Not verified

- **Windows hardware** — the mechanism is platform-neutral JS (ws cancelling a pending handshake + EventEmitter promoting an unhandled `'error'`), and `WindowsPlatformParity` is green, but this was not executed on Windows.
- **Packaged build** — dev-mode and test runs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)