### PR TITLE
fix(build/macos): enable hardenedRuntime so extendInfo usage strings reach Info.plist

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
       ],
       "icon": "assets/natively.icns",
       "identity": null,
-      "hardenedRuntime": false,
+      "hardenedRuntime": true,
       "extendInfo": {
         "NSScreenCaptureUsageDescription": "Natively needs Screen Recording permission to capture system audio for meeting transcription.",
         "NSMicrophoneUsageDescription": "Natively needs microphone access to transcribe your voice during meetings.",


### PR DESCRIPTION
macOS release builds ship without any `NS*UsageDescription` keys, even though all three are declared correctly in `build.mac.extendInfo`.

## Symptom

Audio capture never starts. The app shows the "Audio Capture Issue — permissions reset" banner; the user grants Microphone and Screen Recording in System Settings and nothing changes. Neither the mic nor system audio is transcribed.

What makes it confusing to debug is that the app looks healthy from the outside: the process is alive, CoreAudio is loaded, the LLM path works end to end (`meeting_start`, `provider_request_started`, `response_completed` all appear in telemetry), and the ONNX models download fine. Only transcription events are missing.

## Root cause

With `hardenedRuntime: false`, electron-builder takes a simplified signing path and never applies `build.mac.extendInfo` to the packaged `Info.plist`. Without `NSMicrophoneUsageDescription` / `NSScreenCaptureUsageDescription`, macOS does not present the TCC prompts at all — it silently denies. `tccd` logs no requests for the bundle id, because there is nothing to request with.

## Verification

Two builds from a clean clone, macOS 15 / M2 Pro, nothing else changed:

| `hardenedRuntime` | `NS*UsageDescription` in packaged Info.plist |
|---|---|
| `false` (current) | none |
| `true` (this PR) | all three present |

With the fix the TCC prompts appear on first capture and system-audio transcription works.

## Note

`build/entitlements.mac.plist` correctly documents that `com.apple.security.screen-capture` is not a real Apple entitlement and that screen/system-audio access is pure TCC — that is accurate and unchanged here. This PR only makes the existing `extendInfo` block actually take effect.

Enabling hardened runtime is also required for notarization, so this aligns the unsigned build with the signed one.