### PR TITLE
fix(ci): run the Electron unit tests under Electron's ABI

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dist": "npm run app:build",
     "dist:signed": "npm run app:build:signed && node scripts/upload-release.mjs",
     "build:native": "node scripts/build-native.js",
-    "test": "npm run build:electron && node --test \"electron/services/__tests__/**/*.test.mjs\" \"electron/lib/__tests__/**/*.test.mjs\" \"electron/llm/__tests__/**/*.test.mjs\" \"electron/llm/codeVerification/__tests__/**/*.test.mjs\" \"electron/audio/__tests__/**/*.test.mjs\" \"electron/rag/__tests__/**/*.test.mjs\" \"electron/utils/__tests__/**/*.test.mjs\" \"electron/update/**/*.test.mjs\"",
+    "test": "npm run build:electron && node scripts/run-with-env.mjs --default-tmpdir NATIVELY_TEST_USERDATA=natively-test-userdata --set ELECTRON_RUN_AS_NODE=1 -- electron --test \"electron/services/__tests__/**/*.test.mjs\" \"electron/lib/__tests__/**/*.test.mjs\" \"electron/llm/__tests__/**/*.test.mjs\" \"electron/llm/codeVerification/__tests__/**/*.test.mjs\" \"electron/audio/__tests__/**/*.test.mjs\" \"electron/rag/__tests__/**/*.test.mjs\" \"electron/utils/__tests__/**/*.test.mjs\" \"electron/update/**/*.test.mjs\"",
     "test:intelligence": "npm run build:electron && node --test \"electron/intelligence/__tests__/**/*.test.mjs\"",
     "test:lib": "node --experimental-strip-types --test \"src/lib/**/__tests__/**/*.test.mjs\"",
     "test:scripts": "node --test \"scripts/__tests__/**/*.test.mjs\"",


### PR DESCRIPTION
## The bug

`npm test` invoked plain `node --test`, but `postinstall` rebuilds `better-sqlite3` and `keytar` for **Electron's** ABI. Node then can't load them:

```
The module better_sqlite3.node was compiled against a different Node.js version
using NODE_MODULE_VERSION 148. This version of Node.js requires NODE_MODULE_VERSION 127.
```

Every test file that reaches a database died on that. It's why the `macos-latest` **Run Electron unit tests** step has failed on `main` and on **every** branch for weeks.

## The fix

The repo already had the right invocation — `test:electron` runs through `scripts/run-with-env.mjs` with `ELECTRON_RUN_AS_NODE=1` and an isolated `NATIVELY_TEST_USERDATA`. It was just never applied to `test`. This adopts it for the full glob set. **One line.**

## Measured

Clean worktree of `main`, identical globs, same `node_modules`, `resources/` linked so model files are present:

| | tests | pass | fail |
|---|---|---|---|
| before (`node --test`) | 7247 | 6733 | **435** |
| after (Electron runner) | 7247 | 6916 | **269** |

**166 tests recovered.**

## What this does NOT fix

The remaining **269** failures are unrelated to the runner — mostly tests requiring `tests/fixtures/modes/**` (untracked, so absent in CI too) plus genuine assertion failures. Pre-existing, and deliberately out of scope.

**This does not turn the job green.** It makes it run the tests it was always meant to run. I'd rather land a correct runner and see the real failure count than leave 166 tests silently dead.

`test:intelligence` is deliberately left on plain `node --test`: measured 957 tests / 2 failures under **both** runners, so those suites touch no native module and would only pay Electron's startup cost.

## Separate issue, worth its own decision

Both test steps in `.github/workflows/build-smoke.yml` are gated `if: runner.os == 'macOS'`, so **`windows-latest` never runs a single test**. Its green covers install and build only — which makes the platform matrix look considerably stronger than it is. I haven't changed it here because enabling it would turn a currently-green job red, and that's a call for the team.

🤖 Generated with [Claude Code](https://claude.com/claude-code)