### PR TITLE
Toggle redesign + answer-policy/context-intelligence/modes fixes

### DIFF
--- a/electron/IntelligenceEngine.ts
+++ b/electron/IntelligenceEngine.ts
@@ -2850,7 +2850,26 @@ export class IntelligenceEngine extends EventEmitter {
             trace.mark('validation_started', { answerType: answerPlan.answerType });
             wtaTrace.lifecycle('validating', { answerType: answerPlan.answerType });
             const structureValidation = validateAnswerStructure(answerPlan.answerType, fullAnswer);
-            if (!structureValidation.ok && structureValidation.repaired) {
+            // DEADLINE-TRUNCATED ANSWERS ARE NOT MALFORMED (user-reported
+            // 2026-08-09, reproduced): the coding scaffold repair below fabricates
+            // any section the model didn't write — a code block holding
+            // MISSING_CODE_MARKER, "O(?)" complexity, a generic dry-run. That is
+            // the right call for a model that ignored the contract, and the WRONG
+            // call for a stream the first-useful/stall deadline cut short: the
+            // model was still writing.
+            //
+            // It is user-visible because CodingStreamGate opens at 48 chars (or on
+            // the first heading), well below STREAMING_SAFE_PREFIX_CHARS (160), so
+            // a coding answer is ALREADY ON SCREEN while fullAnswer is short.
+            // Measured pre-fix: 68 visible chars of correct approach text replaced
+            // by 676 chars of mostly-fabricated scaffold. Keeping the honest
+            // partial is strictly better — the user keeps what they were reading,
+            // and nothing is invented on their behalf.
+            const structureRepairSuppressedByDeadline = liveDeadlineFired && emittedStreamingToken;
+            if (structureRepairSuppressedByDeadline && !structureValidation.ok) {
+                trace.mark('validation_completed', { reason: 'structure_repair_skipped_deadline_truncated' });
+            }
+            if (!structureRepairSuppressedByDeadline && !structureValidation.ok && structureValidation.repaired) {
                 console.warn('[IntelligenceEngine] Repaired answer structure', {
                     answerType: answerPlan.answerType,
                     missingSections: structureValidation.missingSections,

--- a/electron/llm/__tests__/DeadlineBudgetOrdering2026_08_10.test.mjs
+++ b/electron/llm/__tests__/DeadlineBudgetOrdering2026_08_10.test.mjs
@@ -1,0 +1,83 @@
+// electron/llm/__tests__/DeadlineBudgetOrdering2026_08_10.test.mjs
+//
+// The Electron client and natively-api each enforce their own first-token
+// deadline, and they were INVERTED:
+//
+//   client  LIVE_TOTAL_HARD_TIMEOUT_MS   8_000ms
+//   server  AI_TTFT_BUDGET_MS           10_000ms   (natively-api/server.js)
+//
+// A Natively-key user's chat goes to `${NATIVELY_API_URL}/v1/chat`
+// (LLMHelper.ts:3462), where the server runs a sequential provider cascade —
+// Gemini Flash -> MiniMax-M3 -> Gemini Pro — cutting over at AI_TTFT_BUDGET_MS
+// when a provider is slow to first token. That cutover is the mechanism that is
+// SUPPOSED to rescue a slow turn.
+//
+// With the client ceiling BELOW the server cutover, the client always gave up
+// first: it abandoned the turn at 8s, 2s before the server would have rotated to
+// a healthy provider. The user got the local fallback (or, for coding, the
+// fabricated scaffold — see DeadlineTruncatedCodingNoScaffold2026_08_10) instead
+// of the answer the server was about to produce.
+//
+// Correct ordering: the layer that can actually RECOVER (the server, which has
+// another provider to try) must be allowed to act before the layer that can only
+// GIVE UP (the client). This test pins that invariant so the two budgets cannot
+// silently drift back out of order.
+
+import assert from 'node:assert/strict';
+import { test, describe } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  LIVE_TOTAL_HARD_TIMEOUT_MS,
+  LIVE_PROVIDER_FIRST_USEFUL_HARD_TIMEOUT_MS,
+  LIVE_INTER_TOKEN_STALL_MS,
+} from '../../../dist-electron/electron/llm/index.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SERVER = path.resolve(__dirname, '../../../natively-api/server.js');
+
+/** Read the server's default TTFT budget straight from its source. */
+function serverTtftBudgetMs() {
+  const src = fs.readFileSync(SERVER, 'utf8');
+  const m = /const AI_TTFT_BUDGET_MS = Number\(process\.env\.AI_TTFT_BUDGET_MS\) \|\| ([0-9_]+)/.exec(src);
+  assert.ok(m, 'could not read AI_TTFT_BUDGET_MS from natively-api/server.js');
+  return Number(m[1].replace(/_/g, ''));
+}
+
+describe('client and server first-token deadlines are correctly ordered', () => {
+  test('the client ceiling sits ABOVE the server TTFT cutover', () => {
+    const server = serverTtftBudgetMs();
+    assert.ok(
+      LIVE_TOTAL_HARD_TIMEOUT_MS > server,
+      `client ceiling ${LIVE_TOTAL_HARD_TIMEOUT_MS}ms must exceed server cutover ${server}ms — `
+      + 'otherwise the client abandons the turn before the server can rotate providers',
+    );
+  });
+
+  test('the margin is large enough to cover the cutover plus a rotation', () => {
+    // The server needs headroom AFTER the cutover to actually start the next
+    // provider and get a first token out. A margin under ~2s means the client
+    // still wins the race in practice even though the ordering looks right.
+    const server = serverTtftBudgetMs();
+    assert.ok(
+      LIVE_TOTAL_HARD_TIMEOUT_MS - server >= 2000,
+      `margin is only ${LIVE_TOTAL_HARD_TIMEOUT_MS - server}ms; need >= 2000ms for the server's next leg to deliver`,
+    );
+  });
+
+  test('the per-provider first-useful cap stays below the absolute ceiling', () => {
+    // Pre-existing invariant: the soft per-provider cap must not exceed the hard
+    // ceiling, or the ceiling would fire first and the soft cap become dead code.
+    assert.ok(
+      LIVE_PROVIDER_FIRST_USEFUL_HARD_TIMEOUT_MS < LIVE_TOTAL_HARD_TIMEOUT_MS,
+      `first-useful cap ${LIVE_PROVIDER_FIRST_USEFUL_HARD_TIMEOUT_MS}ms must stay under ceiling ${LIVE_TOTAL_HARD_TIMEOUT_MS}ms`,
+    );
+  });
+
+  test('the inter-token stall guard is unchanged by the ceiling move', () => {
+    // Raising the FIRST-token ceiling must not lengthen how long a mid-stream
+    // hang is tolerated — those are different failure modes.
+    assert.equal(LIVE_INTER_TOKEN_STALL_MS, 8000);
+  });
+});

--- a/electron/llm/liveDeadlines.ts
+++ b/electron/llm/liveDeadlines.ts
@@ -56,10 +56,30 @@ export const LIVE_PROVIDER_FIRST_USEFUL_COMPLEX_TIMEOUT_MS = 7000;
 export const LIVE_LOCAL_FIRST_USEFUL_TIMEOUT_MS = 30000;
 /**
  * Absolute ceiling on a live answer's first-useful token (the no-fallback budget).
- * Sits just above the 7s first-useful cap so a MiniMax stream about to deliver at
+ * Sits above the 7s first-useful cap so a MiniMax stream about to deliver at
  * ~6.5s isn't guillotined by this ceiling.
+ *
+ * MUST ALSO STAY ABOVE natively-api's AI_TTFT_BUDGET_MS (10s), and this is the
+ * binding constraint. A Natively-key user's chat goes to
+ * `${NATIVELY_API_URL}/v1/chat` (LLMHelper.ts), where the server runs a
+ * SEQUENTIAL provider cascade (Gemini Flash -> MiniMax-M3 -> Gemini Pro) and
+ * cuts over to the next provider when one is slow to first token. That cutover
+ * is the thing that actually RESCUES a slow turn — the client, by contrast, can
+ * only give up.
+ *
+ * At the previous 8000 the ordering was inverted: the client abandoned the turn
+ * 2s BEFORE the server would have rotated, so the user got the local fallback
+ * (or, for coding, a fabricated scaffold) instead of the answer the server was
+ * about to deliver. 13000 = the server's 10s cutover + 3s for the next leg to
+ * produce a first token. DeadlineBudgetOrdering2026_08_10.test.mjs reads
+ * AI_TTFT_BUDGET_MS out of server.js and fails if these drift back out of order.
+ *
+ * Cost of the raise is near-zero: this ceiling only fires when a provider is
+ * genuinely slow to first token — a healthy stream delivers in <1s and never
+ * approaches it. The inter-token stall guard (unchanged, 8s) still bounds a
+ * mid-stream hang, which is a different failure mode.
  */
-export const LIVE_TOTAL_HARD_TIMEOUT_MS = 8000;
+export const LIVE_TOTAL_HARD_TIMEOUT_MS = 13000;
 /**
  * Local-provider counterpart to LIVE_TOTAL_HARD_TIMEOUT_MS: the no-fallback ceiling
  * when there is no deterministic fallback to swap in. Matches the local first-useful

--- a/electron/services/__tests__/DeadlineTruncatedCodingNoScaffold2026_08_10.test.mjs
+++ b/electron/services/__tests__/DeadlineTruncatedCodingNoScaffold2026_08_10.test.mjs
@@ -1,0 +1,122 @@
+// electron/services/__tests__/DeadlineTruncatedCodingNoScaffold2026_08_10.test.mjs
+//
+// USER-REPORTED (2026-08-09), reproduced: a CORRECT coding answer becomes
+// visible, then is replaced by a placeholder scaffold containing content the
+// model never produced.
+//
+// Mechanism (not the post-stream repair cascade the PR blamed — that measures
+// 0-6ms):
+//   1. The prose stream path buffers to STREAMING_SAFE_PREFIX_CHARS (160) before
+//      emitting, so short prose is never visible and replacing it is correct.
+//   2. The CODING path emits through CodingStreamGate, which opens on a heading
+//      or at MAX_GATE_CHARS = 48 — far below 160. So a coding answer IS on
+//      screen while `fullAnswer` is still short.
+//   3. If the provider then stalls past the first-useful deadline, the stream is
+//      cut short. `validateAnswerStructure` sees a coding answer missing its
+//      required sections and overwrites it with a six-section scaffold whose
+//      code block is the MISSING_CODE_MARKER and whose complexity is "O(?)".
+//
+// Measured before the fix: user saw 68 chars of correct approach text, 676 chars
+// were committed — including a fake "Dry Run" section and `O(?)` placeholders.
+//
+// The fix: a DEADLINE-TRUNCATED answer is incomplete, not malformed. Scaffolding
+// it fabricates sections the model never wrote and discards text the user is
+// already reading. Keep the honest partial instead.
+
+import assert from 'node:assert/strict';
+import { test, describe, after } from 'node:test';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const enginePath = path.resolve(__dirname, '../../../dist-electron/electron/IntelligenceEngine.js');
+const sessionPath = path.resolve(__dirname, '../../../dist-electron/electron/SessionTracker.js');
+const llmPath = path.resolve(__dirname, '../../../dist-electron/electron/llm/index.js');
+
+const require = createRequire(import.meta.url);
+const { LIVE_TOTAL_HARD_TIMEOUT_MS } = require(llmPath);
+
+// The engine warms a shared classifier worker that is kept alive by design.
+after(() => new Promise((r) => setTimeout(() => { process.exit(0); r(); }, 200)));
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function makeHelper() {
+  return {
+    setNegotiationCoachingHandler() {},
+    isUsingOllama() { return false; },
+    async *streamChat() { /* no repair call expected on this path */ },
+  };
+}
+
+/**
+ * Drive a coding turn whose stream delivers real text and then stalls past the
+ * first-useful deadline, exactly as a slow provider does in production.
+ */
+async function runDeadlineTruncatedCodingTurn(partial) {
+  const { IntelligenceEngine } = await import(pathToFileURL(enginePath).href);
+  const { SessionTracker } = require(sessionPath);
+
+  const question = 'Write a Python function to reverse a linked list.';
+  const session = new SessionTracker();
+  session.addTranscript({ speaker: 'system', text: question, timestamp: Date.now(), final: true });
+
+  const engine = new IntelligenceEngine(makeHelper(), session);
+  engine.whatToAnswerLLM = {
+    async *generateStream() {
+      yield partial;
+      await sleep(LIVE_TOTAL_HARD_TIMEOUT_MS + 3000); // provider stalls
+      yield ' never arrives';
+    },
+  };
+
+  const seen = [];
+  let emitted = null;
+  engine.on('suggested_answer_token', (t) => seen.push(t));
+  engine.on('suggested_answer', (a) => { emitted = a; });
+
+  const returned = await engine.runWhatShouldISay(question, 0.9, undefined, { skipCooldown: true });
+  return { visible: seen.join(''), committed: emitted ?? returned ?? '' };
+}
+
+describe('a deadline-truncated coding answer is not replaced by a placeholder scaffold', () => {
+  // Opens CodingStreamGate on the heading, so this text IS visible to the user
+  // while still being under the 160-char safe-prefix threshold.
+  const PARTIAL = '## Approach\nWalk the list, re-pointing each node to its predecessor.';
+
+  test('the text the user already saw survives into the committed answer', async () => {
+    const { visible, committed } = await runDeadlineTruncatedCodingTurn(PARTIAL);
+    assert.ok(visible.trim().length > 0, 'precondition: the coding gate must have made text visible');
+    assert.ok(
+      committed.includes('re-pointing each node to its predecessor'),
+      `visible text was discarded.\nSAW: ${JSON.stringify(visible)}\nGOT: ${JSON.stringify(committed)}`,
+    );
+  });
+
+  test('no fabricated code block is invented for a truncated stream', async () => {
+    const { committed } = await runDeadlineTruncatedCodingTurn(PARTIAL);
+    assert.ok(
+      !/did not return code\. Regenerate/i.test(committed),
+      `placeholder code marker was injected:\n${committed}`,
+    );
+  });
+
+  test('no fabricated complexity/dry-run sections are invented', async () => {
+    const { committed } = await runDeadlineTruncatedCodingTurn(PARTIAL);
+    assert.ok(!/O\(\?\)/.test(committed), `placeholder complexity injected:\n${committed}`);
+    assert.ok(
+      !/Trace a small sample input through the code/i.test(committed),
+      `fabricated dry-run section injected:\n${committed}`,
+    );
+  });
+
+  test('the answer does not balloon far beyond what the model actually produced', async () => {
+    const { committed } = await runDeadlineTruncatedCodingTurn(PARTIAL);
+    // Pre-fix this was 68 chars in -> 676 chars committed, nearly all fabricated.
+    assert.ok(
+      committed.length < PARTIAL.length * 3,
+      `answer grew from ${PARTIAL.length} to ${committed.length} chars — scaffold was applied`,
+    );
+  });
+});

--- a/electron/services/__tests__/SttReconfigureSerialization.test.mjs
+++ b/electron/services/__tests__/SttReconfigureSerialization.test.mjs
@@ -78,7 +78,12 @@ describe('Fix #1: reconfigureSttProvider is serialized (source contract)', () =>
   it('the real teardown/rebuild lives in _doReconfigureSttProvider', () => {
     const doStart = mainSrc.indexOf('private async _doReconfigureSttProvider(');
     assert.ok(doStart >= 0, 'BUG: _doReconfigureSttProvider (the serialized worker) is missing.');
-    const doBody = mainSrc.slice(doStart, doStart + 2000);
+    // Bounded by the next section's marker, not a fixed char count — a fixed
+    // +2000 previously clipped the function body before reaching the actual
+    // call once the RC-01 fix comment (audio-capture drain ordering) made the
+    // function longer, producing a false positive on an intact rebuild.
+    const doEnd = mainSrc.indexOf('PR #173: Audio Recovery Handler', doStart);
+    const doBody = mainSrc.slice(doStart, doEnd > doStart ? doEnd : doStart + 3000);
     assert.match(
       doBody,
       /setupSystemAudioPipeline/,
@@ -180,12 +185,28 @@ describe('Fix #2: renderer no longer double-fires; server compensates the UI ref
     assert.ok(start >= 0, 'set-natively-api-key handler must exist');
     const end = ipcSrc.indexOf("safeHandle('get-natively-pricing'", start);
     const handlerBody = ipcSrc.slice(start, end > start ? end : start + 4000);
-    assert.match(
-      handlerBody,
-      /send\(\s*['"]credentials-changed['"]\s*\)/,
-      "BUG: set-natively-api-key no longer broadcasts 'credentials-changed'. The Settings STT " +
-        'dropdown will show a stale provider after the Natively key is saved or cleared.',
-    );
+    // Accept either the direct call or the shared broadcastCredentialsChanged()
+    // helper it was later refactored into — assert the helper itself really
+    // sends the event, so this test still catches the helper being hollowed out.
+    const usesHelper = /broadcastCredentialsChanged\s*\(\s*\)/.test(handlerBody);
+    if (usesHelper) {
+      const helperStart = ipcSrc.indexOf('const broadcastCredentialsChanged');
+      assert.ok(helperStart >= 0, 'BUG: broadcastCredentialsChanged helper is called but no longer defined.');
+      const helperBody = ipcSrc.slice(helperStart, helperStart + 400);
+      assert.match(
+        helperBody,
+        /send\(\s*['"]credentials-changed['"]\s*\)/,
+        "BUG: broadcastCredentialsChanged no longer sends 'credentials-changed'. The Settings STT " +
+          'dropdown will show a stale provider after the Natively key is saved or cleared.',
+      );
+    } else {
+      assert.match(
+        handlerBody,
+        /send\(\s*['"]credentials-changed['"]\s*\)/,
+        "BUG: set-natively-api-key no longer broadcasts 'credentials-changed'. The Settings STT " +
+          'dropdown will show a stale provider after the Natively key is saved or cleared.',
+      );
+    }
   });
 });
 

--- a/src/components/ProfileIntelligenceSettings.tsx
+++ b/src/components/ProfileIntelligenceSettings.tsx
@@ -359,12 +359,12 @@ const PI_CSS = `
     }
     .pi-input::placeholder { color: var(--pi-tertiary); }
 
-    /* ── Toggle (shared .t-toggle primitive, theme-tinted here) ── */
-    /* Track surface stays neutral with the card border; checked state paints
-       the accent fill. Disabled state matches the old opacity. */
-    .pi-root .t-toggle { background: rgba(255,255,255,0.12); }
-    .pi-root[data-theme='light'] .t-toggle { background: rgba(0,0,0,0.12); }
-    .pi-root .t-toggle[aria-checked='true'] { background: var(--pi-accent); }
+    /* ── Toggle (shared .t-toggle primitive) ── */
+    /* Colors now come from the shared Apple-style palette in index.css
+       (--toggle-off/--toggle-on) rather than the panel's own accent, so this
+       block only needs to beat the shared rule's specificity, not repaint it. */
+    .pi-root .t-toggle { background: var(--toggle-off); }
+    .pi-root .t-toggle[aria-checked='true'] { background: var(--toggle-on); }
     .pi-root .t-toggle[aria-disabled='true'] { opacity: 0.4; cursor: not-allowed; }
 
     /* ── Toggle card (neutral — no accent tint when on; the toggle itself signals state) ── */

--- a/src/components/SettingsPopup.tsx
+++ b/src/components/SettingsPopup.tsx
@@ -14,21 +14,24 @@ import {
 import { useToggleInit } from './settings/useToggleInit';
 
 /**
- * The quick-settings popup's compact 30x18 switch.
- *
- * Same `.t-toggle` contract as the main settings panels, on the `sm` size
- * variant (12px travel, 15px knob). Two things are deliberately local:
+ * The quick-settings popup's switch (`sm` variant: the shared .t-toggle
+ * rule's literal 88x40/52x32 reference shape at `zoom: 0.45` — a 39.6x18
+ * track, matching the original 18px row height). Same shared `.t-toggle`
+ * contract as the main settings panels — colors, curves, and press
+ * character match every other toggle in the app exactly, by construction
+ * (same design, smaller zoom). Two things are deliberately local:
  *
  *  - The knob is theme-INVERTED here (black on dark, white on light), which is
- *    the opposite of the shared `.t-toggle-thumb` white default. A Tailwind
+ *    the opposite of the shared `.t-toggle-thumb` tinted default. A Tailwind
  *    class alone CANNOT do this: the shared rule sits after `@tailwind
  *    utilities` in index.css, so at equal specificity it beats `bg-black`.
  *    Hence `t-toggle-thumb-custom`, which clears the shared fill so
  *    `knobClassName` takes effect.
- *  - `active:scale-[0.92]` press feedback, which the larger switches don't have.
+ *  - `active:scale-[0.92]` press feedback on the whole button, layered on top
+ *    of (not replacing) the shared thumb's own press-squish.
  *
- * One `useToggleInit()` per instance — a flag shared across switches makes every
- * OFF switch in the panel play the off-bounce the moment any one is touched.
+ * `useToggleInit()` is currently inert — see useToggleInit's docstring; the
+ * CSS bounce it used to arm was replaced by a plain transition.
  */
 const PopupToggle: React.FC<{
     checked: boolean;

--- a/src/components/settings/AIProvidersSettings.tsx
+++ b/src/components/settings/AIProvidersSettings.tsx
@@ -151,7 +151,10 @@ export const AIP_CSS = `
        Progression it has to stay legible against: rest 0.10 -> hover 0.12
        (--aip-border-strong) -> focus 0.36. */
     --aip-input-border-focus: rgba(255,255,255,0.36);
-    --aip-switch-off:         rgba(255,255,255,0.14);
+    /* Repointed to the shared Apple-style toggle palette (index.css) so this
+       switch matches every other one in the app instead of the panel's own
+       neutral-grey range. */
+    --aip-switch-off:         var(--toggle-off);
     --aip-pill-bg:            var(--aip-item-active);
     --aip-pill-border:        var(--aip-border-strong);
     --aip-pill-lift:          inset 0 1px 0 rgba(255,255,255,0.06);
@@ -246,7 +249,7 @@ export const AIP_CSS = `
        #27272A. 0.44 composites to #838486 = 3.16:1. (Was #374151 at 8.7:1.)
        Rest 0.11 -> hover 0.13 -> focus 0.44. */
     --aip-input-border-focus: rgba(0,0,0,0.44);
-    --aip-switch-off:   rgba(0,0,0,0.16);
+    --aip-switch-off:   var(--toggle-off);
     --aip-pill-bg:      #ffffff;
     --aip-pill-border:  rgba(0,0,0,0.06);
     --aip-pill-lift:    none;
@@ -434,26 +437,28 @@ export const AIP_CSS = `
     word-break: break-word;
 }
 
-/* ── Switch. 34x20 track / 14px thumb / 14px travel (border-box: 34 - 2px
-      border - 4px padding - 14px thumb = 14). The thumb is the ONE control
-      with a physical metaphor, so it gets travel + spring. ─────────────── */
-/* Hit target: the visible track is 34x20, under the 24px WCAG 2.5.8 minimum on the
-   vertical axis. A transparent ::after grows the target into the surrounding padding
-   without changing layout or the visual size. */
-.aip-switch::after { content:''; position:absolute; inset:-3px -2px; }
-.aip-switch {
-    /* 34px track − 2*1px border − 2*2px padding − 14px thumb = 14px travel.
-       The shared 14.66px default assumes no border, and left the thumb 0.66px
-       short of the right edge here. */
-    --toggle-travel: 14px;
-    position:relative; box-sizing:border-box; width:34px; height:20px; flex-shrink:0;
-    padding:2px; border-radius:9999px; border:1px solid transparent;
-    background: var(--aip-switch-off);
-    display:inline-flex; align-items:center; cursor:pointer;
-    transition: background var(--aip-dur-state) var(--aip-ease-out),
-                border-color var(--aip-dur-state) var(--aip-ease-out);
+/* ── Switch. Track/thumb geometry, travel, and press are the shared
+      .t-toggle / .t-toggle-thumb rule's literal 88x40/52x32 reference
+      shape (index.css) at zoom:0.5 -> a 44x20 track (matches the original
+      20px row height exactly; width grows from 34px to 44px — same
+      trade-off as every other size variant, see index.css). Only the
+      background color and hit-target stay local here. */
+.aip-switch::after {
+    content:'';
+    position:absolute;
+    /* -3px/-2px at the element's actual (post-zoom) scale; doubled here
+       because this pseudo-element inherits the parent's zoom:0.5 too. */
+    inset:-6px -4px;
 }
-.aip-switch[aria-checked='true'] { background: var(--aip-accent); }
+.aip-switch {
+    zoom: 0.5;
+    flex-shrink:0;
+    background: var(--aip-switch-off);
+    cursor:pointer;
+}
+/* Repointed to --toggle-on (not --aip-accent) so only the switch changes —
+   --aip-accent still drives buttons, links, and chips elsewhere in this panel. */
+.aip-switch[aria-checked='true'] { background: var(--toggle-on); }
 .aip-switch[aria-disabled='true'] { cursor:not-allowed; }
 .aip-switch:disabled { cursor:not-allowed; opacity:0.5; }
 /* Thumb dimensions, position, and bounce are owned by .t-toggle-thumb in
@@ -982,13 +987,15 @@ interface AipSwitchProps {
 
 /**
  * The shared .t-toggle / .t-toggle-thumb classes (defined in src/index.css)
- * own the thumb dimensions, travel, and bounce keyframe. The .aip-switch
- * class continues to drive the per-theme track color via --aip-switch-off
- * / --aip-accent.
+ * own the literal reference geometry (88x40/52x32) AND colors/transitions
+ * now. .aip-switch only supplies `zoom: 0.5` (-> a 44x20 track) and the
+ * hit-target ::after — --aip-switch-off is repointed to the same shared
+ * --toggle-off token, so it no longer diverges from the rest of the app's
+ * switches.
  *
- * `is-init` is added by arm(), called from the click handler, so it lands in
- * the same render as the new data-on — see useToggleInit for why arming a
- * render earlier makes the thumb kick backwards.
+ * `is-init`/`arm()` (via useToggleInit) is now inert: the CSS bounce
+ * keyframe it used to gate was replaced by a plain transition, which
+ * doesn't need arming. Left wired for now rather than ripped out here.
  */
 export const AipSwitch: React.FC<AipSwitchProps> = ({
     checked, onChange, label, title, disabled = false, hardDisabled = false, className = '',

--- a/src/components/settings/PhoneMirrorSettings.tsx
+++ b/src/components/settings/PhoneMirrorSettings.tsx
@@ -79,22 +79,17 @@ const EMPTY_INFO: PhoneMirrorInfo = {
 /**
  * Phone Mirror's own switch: same `.t-toggle` contract as the rest of settings,
  * but it carries a focus ring and a busy/cursor-wait state the shared
- * SettingsToggle does not model. One `useToggleInit()` per instance — a flag
- * shared across switches makes every OFF switch in the panel play the
- * off-bounce the moment any one of them is touched.
+ * SettingsToggle does not model.
  *
- * THESE TWO SWITCHES ARE ASYNC, which the plain arm()-on-click pattern does not
- * cover. `onToggleEnable`/`onToggleLan` go through `apply()`, which sets `busy`
- * synchronously but only updates `info` after the IPC round-trip — so `checked`
- * (and therefore `data-on`) flips one or more renders later. Arming on click
- * would put `is-init` on the element while `data-on` is still stale, matching
- * `.t-toggle.is-init[data-on="false"]` and playing `t-toggle-off` against a
- * thumb already at rest — the backwards nudge.
- *
- * So `is-init` is withheld while `busy`. It reappears in the same commit that
- * carries the new `info` (React batches the `setInfo` + `setBusy(null)` pair),
- * so the class and the new `data-on` land together and the correct keyframe
- * plays from the correct resting position.
+ * `useToggleInit()`/`is-init` below is now inert — the shared CSS moved from a
+ * keyframe bounce (which needed `is-init` to avoid replaying on stale renders)
+ * to a plain `transition`, which doesn't need arming. Left wired rather than
+ * ripped out here; the `busy`-gating logic it's paired with is otherwise
+ * unaffected. THESE TWO SWITCHES ARE ASYNC: `onToggleEnable`/`onToggleLan` go
+ * through `apply()`, which sets `busy` synchronously but only updates `info`
+ * after the IPC round-trip, so `checked` (and therefore `data-on`) flips one
+ * or more renders later — that's still true regardless of what the CSS does
+ * with `is-init`.
  */
 const PhoneMirrorSwitch: React.FC<{
   checked: boolean;
@@ -114,7 +109,9 @@ const PhoneMirrorSwitch: React.FC<{
       aria-label={label}
       disabled={busy}
       onClick={() => { toggleInit.arm(); onChange(); }}
-      /* p-0.5 (2px), not the 3px t-toggle-lg assumes, so travel is 22px here. */
+      /* p-0.5/`t-toggle-tight` are vestigial — geometry is the shared
+         .t-toggle rule's literal 88x40 shape at zoom:0.6 (t-toggle-lg,
+         index.css), not padding-derived. */
       className={`t-toggle t-toggle-lg t-toggle-tight inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full p-0.5 focus:outline-none focus:ring-2 focus:ring-accent-focus ${checked ? onClassName : 'bg-bg-item-active'} ${busy ? 'opacity-60 cursor-wait' : ''} ${busy ? '' : toggleInit.className}`}
     >
       <span className="t-toggle-thumb" aria-hidden="true" />
@@ -823,7 +820,9 @@ const CtxToggle: React.FC<{
       aria-label={label}
       disabled={comingSoon}
       onClick={comingSoon ? undefined : () => { toggleInit.arm(); onChange(); }}
-      /* p-0.5 (2px), not the 3px t-toggle-lg assumes, so travel is 22px here. */
+      /* p-0.5/`t-toggle-tight` are vestigial — geometry is the shared
+         .t-toggle rule's literal 88x40 shape at zoom:0.6 (t-toggle-lg,
+         index.css), not padding-derived. */
       className={`t-toggle t-toggle-lg t-toggle-tight flex-shrink-0 mt-0.5 inline-flex h-6 w-11 items-center rounded-full p-0.5 focus:outline-none focus:ring-2 focus:ring-accent-focus ${
         comingSoon ? 'cursor-not-allowed bg-bg-item-active' : checked ? 'bg-accent-primary' : 'bg-bg-item-active'
       } ${toggleInit.className}`}

--- a/src/components/settings/SettingsToggle.tsx
+++ b/src/components/settings/SettingsToggle.tsx
@@ -2,12 +2,16 @@ import React from 'react';
 import { useToggleInit } from './useToggleInit';
 
 /**
- * The 44x24 settings switch. Wraps the shared `.t-toggle` markup so every
- * instance owns its own `useToggleInit()` — see that hook for why a per-panel
- * flag makes the whole panel flicker on a single click.
+ * The settings switch. Wraps the shared `.t-toggle` markup, which is a
+ * literal copy of the reference 88x40/52x32 toggle shape at `zoom: 0.6`
+ * (`.t-toggle-lg`) — a 52.8x24 track. `w-11 h-6 p-[3px]` below no longer do
+ * anything (kept for layout compatibility rather than stripped from every
+ * caller); the Apple-style palette and press/hover/focus behavior win
+ * unconditionally over whatever track color a caller passes via `className`.
  *
- * Callers keep supplying their own track colors via `className`, since the ON
- * fill is not uniform (accent for most, amber for Phone Mirror's LAN switch).
+ * `useToggleInit()` is currently inert (the CSS bounce it used to arm was
+ * replaced by a plain transition, which needs no arming) but still wired per
+ * instance; see that hook's docstring for the render-ordering bug it guarded.
  */
 export interface SettingsToggleProps {
     checked: boolean;
@@ -45,9 +49,10 @@ export const SettingsToggle: React.FC<SettingsToggleProps> = ({
                 toggleInit.arm();
                 onChange();
             }}
-            /* Every caller paints a 1px border via `className`, which eats 2px
-               of content box: 44 − 2*1 − 2*3 − 18 = 18px, not the 20px
-               t-toggle-lg assumes for a borderless track. */
+            /* `t-toggle-bordered` no longer changes the geometry (it used to
+               subtract a border from --toggle-travel); the shared .t-toggle
+               rule forces border:none, so this class is now just a label —
+               kept on the element rather than stripped from every caller. */
             className={`t-toggle t-toggle-lg t-toggle-bordered w-11 h-6 rounded-full p-[3px] flex items-center shrink-0 ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'} ${className} ${toggleInit.className}`}
         >
             <span className="t-toggle-thumb" aria-hidden="true" />

--- a/src/components/settings/useToggleInit.ts
+++ b/src/components/settings/useToggleInit.ts
@@ -3,6 +3,14 @@ import { useCallback, useState } from 'react';
 /**
  * Arms the shared `.t-toggle` bounce for ONE switch.
  *
+ * CURRENTLY INERT: index.css's `.t-toggle` moved from a keyframe bounce
+ * (gated on `is-init`, exactly as described below) to a plain CSS
+ * `transition`, which fires correctly on every state change with no arming
+ * needed. Every call site still applies `is-init` via `arm()`, but it no
+ * longer matches any selector. Left wired rather than pulled out of every
+ * caller here; harmless to keep, safe to delete if this hook's only purpose
+ * (below) doesn't come back.
+ *
  * WHY ARMING HAPPENS ON ACTIVATION, NOT ON POINTERDOWN. `is-init` and the new
  * `data-on` must land in the SAME render. An earlier version armed on
  * `pointerdown`, which is a separate render from the `click` that flips

--- a/src/index.css
+++ b/src/index.css
@@ -8075,58 +8075,96 @@ html[data-platform="linux"] body {
   }
 }
 
-/* Transitions.dev — Toggle. Settings-area switches only; .t-toggle-lg
-   overrides travel to 20px for the 44x26 controls. */
+/* Apple-style toggle — a LITERAL, pixel-exact copy of the reference
+   component (88x40 track, 4px inset, 52x32 thumb, 28px travel, 56px
+   press-width, 24px press-on travel — every number below matches the
+   reference verbatim, not a re-derived approximation). Per-size variants
+   below apply CSS `zoom` — a uniform scalar, not separate width/height
+   math — so every toggle in the app is the exact same shape at a smaller
+   size: identical aspect ratio, identical relative thumb-to-track
+   proportions, identical relative motion, by construction (it's the same
+   design rendered smaller, not independently recomputed geometry). `zoom`
+   (not `transform: scale`) because it actually shrinks the element's layout
+   box, so surrounding rows reflow around the smaller footprint. */
 :root {
-    --toggle-dur: 350ms;
-    --toggle-travel: 14.66px;
-    --toggle-ov1: 1px;
-    --toggle-ov2: 0px;
-    /* The spec ships 0ms here, but its own header says "the track colour
-       cross-fades on its own clock" — 0ms gives no cross-fade at all, and the
-       migration also stripped the per-panel `transition-colors` that used to
-       fade it, so the track was snapping while the thumb sprang over 350ms.
-       200ms lands the colour comfortably before the bounce settles. */
-    --toggle-track: 200ms;
-    --toggle-ease: cubic-bezier(0.34, 1.35, 0.64, 1);
+    /* Hardcoded on purpose: every caller's own track token (bg-accent-primary,
+       --pi-accent, --aip-accent, Phone Mirror's amber LAN switch, …) is
+       intentionally overridden here so every switch in the app reads
+       identically regardless of theme or panel. --toggle-on/-focus-ring are
+       the exception — they follow the app's real periwinkle accent instead
+       of the reference's arbitrary blue, so the toggle matches the rest of
+       the UI. --toggle-on uses --accent-strong (periwinkle-500 on dark,
+       periwinkle-700 on light) rather than the softer --accent-primary
+       (periwinkle-300/600) — closer to the reference blue's punch while
+       staying periwinkle. */
+    --toggle-off: #474949;
+    --toggle-on: var(--accent-strong);
+    --toggle-thumb: #e1ebfe;
+    --toggle-focus-ring: var(--accent-focus);
 }
-
-/* Travel must equal (track − 2*border − 2*padding − thumb), or the thumb rests
-   off-centre in one of the two states. Each variant below is paired with the
-   exact geometry it assumes; a call site with different padding must override
-   `--toggle-travel` itself (see .aip-switch, which has a 1px border). */
-/* border-color as well as background: the SettingsOverlay and Intelligence
-   tracks swap `border-transparent` <-> `border-border-muted` between states, so
-   fading only the fill would still leave the outline snapping. */
 .t-toggle {
-    transition: background var(--toggle-track) var(--toggle-ease),
-                border-color var(--toggle-track) var(--toggle-ease);
+    width: 88px;
+    height: 40px;
+    position: relative;
+    display: inline-block;
+    padding: 0;
+    margin: 0;
+    border: none;
+    outline: none;
+    border-radius: 999px;
+    background: var(--toggle-off);
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+    transition:
+        background 220ms cubic-bezier(0.4, 0, 0.2, 1),
+        box-shadow 180ms ease,
+        transform 120ms ease;
 }
-/* 44px track, no border, 3px padding, 18px thumb. */
-.t-toggle.t-toggle-lg { --toggle-travel: 20px; }
-/* Same 44px track but with a 1px border (2px less content box) or 2px padding.
-   These are plain classes, NOT Tailwind `[--toggle-travel:18px]` utilities:
-   utilities are emitted where `@tailwind utilities` sits near the top of this
-   file, so `.t-toggle.t-toggle-lg` below would both out-specify (0,2,0 vs
-   0,1,0) and out-order them, and the override would silently do nothing. */
-.t-toggle.t-toggle-lg.t-toggle-bordered { --toggle-travel: 18px; }
-.t-toggle.t-toggle-lg.t-toggle-tight { --toggle-travel: 22px; }
-/* The compact 30x18 switch in the quick-settings popup. */
-.t-toggle.t-toggle-sm { --toggle-travel: 12px; }
-/* The 32x16 switch in the Launcher's detectability row. */
-.t-toggle.t-toggle-xs { --toggle-travel: 16px; }
-/* The thumb is white in both states — it never recolours, so there is no
-   background transition here and nothing colour-related to hint to
-   will-change. Only the travel is animated. */
+.t-toggle:disabled { cursor: not-allowed; opacity: 0.5; }
+.t-toggle[data-on="true"] { background: var(--toggle-on); }
+.t-toggle:focus-visible {
+    box-shadow: 0 0 0 4px var(--toggle-focus-ring);
+}
+/* `hover:` guard so a tap on touch/trackpad doesn't leave a stuck brighten. */
+@media (hover: hover) {
+    .t-toggle:not(:disabled):hover { filter: brightness(1.03); }
+}
+/* Width grows beyond each variant's old fixed-width footprint (track is
+   88×zoom wide, not whatever w-11/w-[30px]/w-8 used to say) — 88×0.6=52.8px,
+   88×0.45=39.6px, 88×0.4=35.2px. Height matches the original row height
+   exactly, since that's what each row was actually built around. */
+.t-toggle.t-toggle-lg { zoom: 0.6; }   /* 24px row height -> 52.8x24 track */
+.t-toggle.t-toggle-sm { zoom: 0.45; }  /* 18px row height -> 39.6x18 track */
+.t-toggle.t-toggle-xs { zoom: 0.4; }   /* 16px row height -> 35.2x16 track */
 .t-toggle-thumb {
-    translate: 0 0;
-    will-change: translate;
-    display: block;
-    width: 14px;
-    height: 14px;
-    border-radius: 9999px;
-    background: #fff;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.28);
+    position: absolute;
+    top: 4px;
+    left: 4px;
+    width: 52px;
+    height: 32px;
+    border-radius: 999px;
+    background: var(--toggle-thumb);
+    transform: translateX(0);
+    box-shadow:
+        0 1px 2px rgba(0, 0, 0, 0.04),
+        inset 0 1px 0 rgba(255, 255, 255, 0.35);
+    transition:
+        transform 280ms cubic-bezier(0.22, 1, 0.36, 1),
+        width 160ms cubic-bezier(0.22, 1, 0.36, 1),
+        background 180ms ease;
+}
+.t-toggle[data-on="true"] .t-toggle-thumb {
+    transform: translateX(28px);
+}
+/* Elastic press, matching the reference exactly: literal width growth (not a
+   scale trick), anchored against whichever wall the thumb is resting on —
+   left edge fixed when OFF; when ON, translateX shrinks by the same 4px so
+   the RIGHT edge stays flush instead of the thumb overshooting the track. */
+.t-toggle:not(:disabled):active .t-toggle-thumb {
+    width: 56px;
+}
+.t-toggle[data-on="true"]:not(:disabled):active .t-toggle-thumb {
+    transform: translateX(24px);
 }
 /* Opt out of the shared fill when a panel paints its own knob. This rule
    exists because `background`/`box-shadow` above sit AFTER `@tailwind
@@ -8138,26 +8176,8 @@ html[data-platform="linux"] body {
     background: none;
     box-shadow: none;
 }
-.t-toggle-lg .t-toggle-thumb { width: 18px; height: 18px; }
-.t-toggle-sm .t-toggle-thumb { width: 15px; height: 15px; }
-.t-toggle-xs .t-toggle-thumb { width: 12px; height: 12px; }
-.t-toggle[data-on="true"] .t-toggle-thumb { translate: var(--toggle-travel) 0; }
-.t-toggle.is-init[data-on="true"] .t-toggle-thumb { animation: t-toggle-on var(--toggle-dur) var(--toggle-ease) both; }
-.t-toggle.is-init[data-on="false"] .t-toggle-thumb { animation: t-toggle-off var(--toggle-dur) var(--toggle-ease) both; }
-@keyframes t-toggle-on {
-    0% { translate: 0 0; }
-    55% { translate: calc(var(--toggle-travel) + var(--toggle-ov1)) 0; }
-    80% { translate: calc(var(--toggle-travel) - var(--toggle-ov2)) 0; }
-    100% { translate: var(--toggle-travel) 0; }
-}
-@keyframes t-toggle-off {
-    0% { translate: var(--toggle-travel) 0; }
-    55% { translate: calc(0px - var(--toggle-ov1)) 0; }
-    80% { translate: var(--toggle-ov2) 0; }
-    100% { translate: 0 0; }
-}
 @media (prefers-reduced-motion: reduce) {
-    .t-toggle-thumb { animation: none !important; }
+    .t-toggle-thumb { transition: none !important; }
 }
 
 /* ── Tabs sliding (transitions.dev 16) ────────────────────────────────


### PR DESCRIPTION
## Summary
- Restyles every toggle in the app (SettingsToggle, ProfileIntelligenceSettings, AIProvidersSettings, PhoneMirrorSettings, SettingsPopup, Launcher) to an Apple-style periwinkle switch — shared shape/motion via CSS `zoom` per size variant, accent color from the app's existing `--accent-strong` periwinkle token.
- Plus the branch's prior commits: answer-pipeline fixes, context-intelligence referent-contamination and answer-policy fixes, built-in modes migration (v26), meeting-notes tabs, audio model catalog additions, and related refactors/tests — see full commit log for `fix/answer-policy-and-conversation-state`.

## Test plan
- [x] `tsc --noEmit` clean on all toggle-touched files
- [x] `ToggleInitPerSwitch2026_08_07.test.mjs` (7/7 passing)
- [x] Toggle geometry/colors verified via live-rendered harness in both light and dark themes
- [ ] Broader suite / CI for the non-toggle commits already on this branch (pre-existing, not from this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DhEYBZ3wQ4Hpv7FqHMzixR