### PR TITLE
fix(conversation-state): stop the self-contained gate eating anaphora

### DIFF
--- a/electron/context-intelligence/__tests__/OwnSubjectOverreach2026_08_10.test.mjs
+++ b/electron/context-intelligence/__tests__/OwnSubjectOverreach2026_08_10.test.mjs
@@ -1,0 +1,139 @@
+// Independent review of the merged 2026-08-09 work found two ways the new
+// self-contained-subject gate is TOO EAGER. Both measured, both regressions
+// against behaviour that worked before that change, and both shipped to main.
+//
+// 1. RELATIONAL / ANAPHORIC PHRASES READ AS SUBJECTS.
+//    `ownSubjectPhrase` accepts anything `extractTopicPhrase` returns, and that
+//    extractor was built for the STATE-ADVANCE path — deciding what to store as
+//    `activeTopic`. A phrase good enough to STORE is not evidence the question
+//    is SELF-CONTAINED. "timeline" is a fine topic; "What about the timeline?"
+//    is purely anaphoric.
+//
+//    Worse, the accepted head noun is often a member of CONTINUATION_NOUN_RE
+//    itself — "difference", "steps", "tradeoffs" — nouns the classifier already
+//    declares cannot denote on their own. The gate sits AHEAD of the
+//    continuation-fragment branch it thereby pre-empts, recreating exactly the
+//    "two gates disagreeing" failure the fragment class was written to close.
+//
+// 2. A SHORT QUOTED TERM IS NOT A QUOTED SUBJECT.
+//    The double-quote branch of QUOTED_SUBJECT_RES has none of the
+//    discrimination the single-quote branch has: no boundary rule, a 2-char
+//    minimum, and it returns unconditionally ahead of every other gate. So
+//    `Did she say "no"?` loses its activePerson binding to a quoted word.
+//
+// The fix keeps the 2026-08-09 intent — a question that genuinely states its
+// own subject must not inherit a stale topic — while restoring anaphora.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const base = path.resolve(process.cwd(), 'dist-electron/electron/context-intelligence');
+const { resolveReference, advance } =
+  await import(pathToFileURL(path.join(base, 'question/conversation-state.js')).href);
+
+const SCOPE = { userId: 'u1', sessionId: 's1' };
+const after = (...turns) => turns.reduce((st, q) => advance(st, { scope: SCOPE, question: q, at: 0 }), null);
+
+describe('anaphoric follow-ups still resolve (regression, 2026-08-10)', () => {
+  const st = () => after('Tell me about the Cassandra migration timeline');
+
+  for (const q of [
+    'What about the timeline?',
+    'What about salary?',
+    'What about the tradeoffs?',
+    'Can you explain the difference?',
+    'Can you explain the steps?',
+    'Explain the difference.',
+    'What about the alternatives?',
+  ]) {
+    test(`resolves: ${q}`, () => {
+      const r = resolveReference(q, st());
+      assert.equal(r.usedState, true,
+        `an anaphoric follow-up must still bind to state; reason=${r.reason}`);
+    });
+  }
+
+  test('PRE-EXISTING gap, not a regression: "Can you give me the pros and cons?"', () => {
+    // Documented rather than asserted as working. `extractTopicPhrase` returns
+    // undefined here, so the 2026-08-09 gate never even runs — the turn fails
+    // the pronoun/bare/rephrase trigger check and passes through untouched,
+    // exactly as it did before that change. It is 8 words, over
+    // FRAGMENT_MAX_WORDS, so isContinuationFragment declines it too.
+    //
+    // Pinned so a future reader does not mistake it for fallout from the
+    // self-contained-subject work. Fixing it means widening the fragment cap or
+    // the trigger set, which is a separate decision.
+    const r = resolveReference('Can you give me the pros and cons?', st());
+    assert.equal(r.usedState, false);
+    assert.equal(r.reason, 'NO_REFERENT_TRIGGER',
+      'if this becomes a real trigger, the gap is closed and this test should assert resolution');
+  });
+});
+
+describe('a short quoted TERM is not a subject (regression, 2026-08-10)', () => {
+  const st = () => after("What is Priya's strongest signal?");
+
+  for (const q of [
+    'Why did she call it "flaky"?',
+    'Did she say "no"?',
+    'What did he mean by "scope"?',
+  ]) {
+    test(`resolves: ${q}`, () => {
+      const r = resolveReference(q, st());
+      assert.equal(r.usedState, true,
+        `a quoted single term must not suppress resolution; reason=${r.reason}`);
+    });
+  }
+
+  test('a quoted single term still binds the personal pronoun to the person', () => {
+    const r = resolveReference('Did she say "no"?', st());
+    assert.match(r.resolved, /Priya/);
+  });
+});
+
+describe('the 2026-08-09 intent is preserved — self-contained turns still do NOT inherit', () => {
+  const st = () => after('What do you think about remote work?');
+
+  for (const q of [
+    // quoted SUBJECT — a full clause, not a term
+    'Give me an example answer for "Why do you want this role?"',
+    "Give me an example answer for 'Why do you want this role?'",
+    'How should I answer "What is your greatest weakness?"',
+    // lowercase subject
+    'How do database indexes work?',
+    'How should I answer a question about salary expectations?',
+    'What should I say about compensation banding?',
+  ]) {
+    test(`unchanged: ${q}`, () => {
+      const r = resolveReference(q, st());
+      assert.equal(r.usedState, false, `must not inherit "remote work"; got ${r.resolved}`);
+    });
+  }
+});
+
+describe('nothing else regresses', () => {
+  test('bare fragment still anchors', () => {
+    assert.equal(resolveReference('examples?', after('What is a REST API?')).usedState, true);
+  });
+  test('"Why not?" still binds the newest subject', () => {
+    const r = resolveReference('Why not?', after('What is a mutex?', 'What is a semaphore?'));
+    assert.equal(r.usedState, true);
+    assert.match(r.resolved, /semaphore/i);
+  });
+  test('pronoun follow-up still resolves', () => {
+    assert.equal(resolveReference('Can you explain it more simply?', after('What is a B-tree?')).usedState, true);
+  });
+  test('personal pronoun still binds the person across a tech turn', () => {
+    const r = resolveReference('Has she used GCP?', after("What is Priya's strongest signal?", 'What is a mutex?'));
+    assert.equal(r.usedState, true);
+    assert.match(r.resolved, /Priya/);
+  });
+  test('a long self-contained turn still binds its own pronoun', () => {
+    const r = resolveReference(
+      'I paid for the subscription yesterday but the app still shows the free plan, please fix this.',
+      after('What is a bloom filter?'));
+    assert.equal(r.usedState, false);
+  });
+});

--- a/electron/context-intelligence/question/conversation-state.ts
+++ b/electron/context-intelligence/question/conversation-state.ts
@@ -313,13 +313,56 @@ const PRONOUN_RESOLUTION_MAX_WORDS = 12;
  *     into a phantom quotation.
  */
 const QUOTED_SUBJECT_RES: readonly RegExp[] = [
-  /"[^"]{2,}"/,
-  /“[^”]{2,}”/,
+  /"([^"]{2,})"/,
+  /“([^”]{2,})”/,
   /(?:^|[\s(\[:;,—–-])['‘]([^'’]{2,})['’](?=$|[\s).,?!\]:;—–-])/,
 ];
+
+/**
+ * A quoted SUBJECT is a clause; a quoted TERM is a word (2026-08-10).
+ *
+ * The double-quote branch originally had no discrimination at all — 2+ chars,
+ * no boundary rule — and returned ahead of every other gate. So
+ * `Did she say "no"?` and `Why did she call it "flaky"?` lost their
+ * activePerson binding to a scare-quoted word, and any pasted error string or
+ * code snippet did the same.
+ *
+ * Requiring 2+ WORDS is the discriminator. Every real case this gate exists for
+ * quotes a whole question — "Why do you want this role?", "What is your
+ * greatest weakness?" — while scare quotes, quoted identifiers and quoted error
+ * tokens are single words. Applied to all three branches so the quote style a
+ * user happens to type cannot change the outcome.
+ */
 function hasQuotedSubject(q: string): boolean {
-  return QUOTED_SUBJECT_RES.some((re) => re.test(q));
+  for (const re of QUOTED_SUBJECT_RES) {
+    const m = q.match(re);
+    if (m && (m[1] ?? '').trim().split(/\s+/).filter(Boolean).length >= 2) return true;
+  }
+  return false;
 }
+
+/**
+ * Nouns that cannot denote on their own — the classifier's own relational set.
+ *
+ * `extractTopicPhrase` happily returns "difference", "steps", "tradeoffs" as a
+ * topic, because for the STATE-ADVANCE path that is fine: it is a reasonable
+ * thing to store as `activeTopic`. It is NOT evidence the current question
+ * states its own subject, and treating it as such made
+ * "Can you explain the difference?" self-contained — pre-empting the
+ * continuation-fragment branch that exists precisely for that shape
+ * (regression found in review, 2026-08-10).
+ *
+ * Kept as a literal mirror of turn-classifier's CONTINUATION_NOUN_RE rather
+ * than an import, because that regex is unanchored and used for a different
+ * question ("does this turn contain a relational noun"); here the test is
+ * "is the extracted phrase HEADED by one".
+ */
+const RELATIONAL_HEAD_RE =
+  /^(?:the\s+|a\s+|an\s+)?(?:examples?|details?|alternatives?|options?|differences?|difference|trade-?offs?|pros|cons|benefits?|drawbacks?|advantages?|disadvantages?|use ?cases?|steps?|reasons?|comparisons?|comparison|syntax|summary|explanation|definitions?|definition|specifics?|clarification|more|thoughts?|opinions?|feedback|suggestions?|recommendations?|takeaways?|ideas?)\b/i;
+
+/** Openers that are anaphoric by construction: "what about X" always means
+ *  "X, in relation to what we were just discussing". */
+const ANAPHORIC_OPENER_RE = /^(?:so\s+|and\s+|but\s+)?(?:what|how)\s+about\b/i;
 
 /**
  * The question's OWN subject, when it states one in lowercase (2026-08-09).
@@ -337,8 +380,13 @@ function hasQuotedSubject(q: string): boolean {
 const PRONOUN_TOKEN_RE =
   /\b(?:i|me|my|mine|we|us|our|ours|you|your|yours|he|him|his|she|her|hers|it|its|they|them|their|theirs|this|that|these|those)\b/i;
 function ownSubjectPhrase(q: string): string | undefined {
+  // "What about X?" is anaphoric however concrete X is.
+  if (ANAPHORIC_OPENER_RE.test(q.trim())) return undefined;
+  // A relational noun is not a subject — see RELATIONAL_HEAD_RE.
+  if (isContinuationFragment(q)) return undefined;
   const phrase = extractTopicPhrase(q);
   if (!phrase || PRONOUN_TOKEN_RE.test(phrase)) return undefined;
+  if (RELATIONAL_HEAD_RE.test(phrase.trim())) return undefined;
   return phrase;
 }
 


### PR DESCRIPTION
Fixes two regressions an independent review found in the merged 2026-08-09 work (#440). Both measured, both already on `main`.

## 1. Relational and anaphoric phrases read as subjects

`ownSubjectPhrase` accepted anything `extractTopicPhrase` returned — but that extractor was built for the **state-advance** path, deciding what to store as `activeTopic`. A phrase good enough to *store* is not evidence the question states its own subject. `"timeline"` is a fine topic; `"What about the timeline?"` is purely anaphoric.

Worse, the accepted head noun was often a member of the classifier's own `CONTINUATION_NOUN_RE` — `difference`, `steps`, `tradeoffs` — nouns that by definition cannot denote alone. The gate sits **ahead** of the continuation-fragment branch, so it pre-empted the very class that branch exists for.

Measured, after `"Tell me about the Cassandra migration timeline"`:

| turn | before | after the regression |
|---|---|---|
| `What about the timeline?` | `RESOLVED_TO_ACTIVE_TOPIC` | **nothing** |
| `What about salary?` | `RESOLVED_TO_ACTIVE_TOPIC` | **nothing** |
| `What about the tradeoffs?` | `ANCHORED_TO_PREVIOUS_QUESTION` | **nothing** |
| `Can you explain the difference?` | `ANCHORED_TO_PREVIOUS_QUESTION` | **nothing** |
| `Can you explain the steps?` | `ANCHORED_TO_PREVIOUS_QUESTION` | **nothing** |
| `Explain the difference.` | `ANCHORED_TO_PREVIOUS_QUESTION` | **nothing** |

Three guards now: an anaphoric-opener check (`what/how about X` is anaphoric however concrete X is), a continuation-fragment check, and a relational-head check on the extracted phrase.

**Why 886 tests passed throughout:** the existing fragment tests use shapes `extractTopicPhrase` cannot match — lowercase `examples?` still resolved. The hole was fragments phrased with *about / explain / describe / define*.

## 2. A short quoted term is not a quoted subject

The double-quote branch had none of the discrimination the single-quote branch got — no boundary rule, a 2-character minimum, returning ahead of every other gate:

```
Why did she call it "flaky"?     → resolution suppressed
Did she say "no"?                → loses its activePerson binding
What did he mean by "scope"?     → resolution suppressed
```

Any pasted error string or code identifier did the same. All three branches now require **2+ words** inside the quotes: every case this gate exists for quotes a whole question (`"Why do you want this role?"`), while scare quotes and identifiers are single words.

## Preserved

The 2026-08-09 intent is pinned by tests: quoted-clause subjects and lowercase subjects still do **not** inherit a stale topic.

## Verification

- **909/909** under `node --test`, **911/911** under the Electron runner
- multi-turn probe still 0 issues across 10 chains
- `tsc` clean

## Also pinned — a pre-existing gap, explicitly not from this work

`"Can you give me the pros and cons?"` never resolved: `extractTopicPhrase` returns `undefined`, so the gate never runs and the turn fails the pronoun/bare/rephrase trigger outright. Recorded so a future reader doesn't mistake it for fallout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)