### PR TITLE
fix(context-os): a refusal pack only governs a bounded-universe mode

### DIFF
--- a/electron/IntelligenceEngine.ts
+++ b/electron/IntelligenceEngine.ts
@@ -2452,6 +2452,14 @@ export class IntelligenceEngine extends EventEmitter {
             if (!wtaContextOsGeneration
                 && wtaTurnContract
                 && documentGroundedCustomModeActive
+                // Live proof 2026-08-11: documentGroundedCustomModeActive can be
+                // TRUE with hasReferenceFiles FALSE (custom mode, contract seeded
+                // reference_files_primary, zero files). Governing that turn
+                // builds an empty pack whose answerPolicy is ask_clarification,
+                // and the surface then yielded contract.reason — the raw
+                // developer diagnostic — to the user. A doc-grounded govern
+                // with no documents governs nothing: require the files.
+                && Boolean((snapshotModeInfo as any)?.hasReferenceFiles)
                 && isIntelligenceFlagEnabled('contextOsEvidencePackEnabled')) {
                 wtaContextOsGeneration = {
                     contract: wtaTurnContract,

--- a/electron/IntelligenceEngine.ts
+++ b/electron/IntelligenceEngine.ts
@@ -905,6 +905,13 @@ export class IntelligenceEngine extends EventEmitter {
         // every live token (#3) so the renderer can drop stale-generation batches.
         const snapshotModeInfo = this.getActiveModeInfo();
         const documentGroundedCustomModeActive = snapshotModeInfo?.documentGroundedCustomModeActive === true;
+        // Defect C split (2026-08-01): STRICT knowledge suppression vs broad
+        // source isolation. Strictness consumers below (skip-legacy-retrieval,
+        // forceDocumentGrounding, the generic-knowledge bypass gate, and the
+        // doc-grounded govern site) read THIS; isolation consumers keep the
+        // broad flag. WTA was never migrated when manual chat was
+        // (LLMHelper:5448) — the root asymmetry behind the 2026-08-11 reports.
+        const strictDocumentGroundedActive = (snapshotModeInfo as any)?.strictDocumentGroundedActive === true;
         const snapshotModeId = this.getActiveModeId();
         // The narrow ActiveModeInfo snapshot is enough for planning, but a
         // multi-family typed reference pack also needs the full mode row and its
@@ -1123,7 +1130,7 @@ export class IntelligenceEngine extends EventEmitter {
             // Governed document turns resolve through EvidenceResolver inside
             // WhatToAnswerLLM. Do not start the legacy prefetch in parallel: even
             // an ignored retrieval is an unauthorized competing evidence path.
-            const modeContextPromise: Promise<string> = options?.activeSkill || documentGroundedCustomModeActive
+            const modeContextPromise: Promise<string> = options?.activeSkill || strictDocumentGroundedActive
                 ? Promise.resolve('') // skill/governed-document mode skips legacy retrieval
                 : (async () => {
                     try {
@@ -1145,7 +1152,7 @@ export class IntelligenceEngine extends EventEmitter {
                             } catch { /* flag module unavailable → no rerank */ }
                             return await mm.buildRetrievedActiveModeContextBlockHybrid(
                                 preparedTranscript, preparedTranscript, 1800, undefined, true, snapshotModeInfo?.id, allowRerank,
-                                documentGroundedCustomModeActive ? { forceDocumentGrounding: true } : undefined,
+                                strictDocumentGroundedActive ? { forceDocumentGrounding: true } : undefined,
                             );
                         }
                         return '';
@@ -1498,7 +1505,7 @@ export class IntelligenceEngine extends EventEmitter {
             let candidateProfile = '';
             try {
                 const orchestrator = this.llmHelper.getKnowledgeOrchestrator?.();
-                if (orchestrator?.isKnowledgeMode?.() && !documentGroundedCustomModeActive
+                if (orchestrator?.isKnowledgeMode?.() && !strictDocumentGroundedActive
                     && wtaDecisionAllowsCandidateProfile) {
                     const extracted = extractedQuestion;
                     // Only ground question types that resolve to the candidate's
@@ -2451,7 +2458,7 @@ export class IntelligenceEngine extends EventEmitter {
             // block (no double retrieval) and governs the factual prompt.
             if (!wtaContextOsGeneration
                 && wtaTurnContract
-                && documentGroundedCustomModeActive
+                && strictDocumentGroundedActive
                 // Live proof 2026-08-11: documentGroundedCustomModeActive can be
                 // TRUE with hasReferenceFiles FALSE (custom mode, contract seeded
                 // reference_files_primary, zero files). Governing that turn

--- a/electron/IntelligenceEngine.ts
+++ b/electron/IntelligenceEngine.ts
@@ -2336,7 +2336,19 @@ export class IntelligenceEngine extends EventEmitter {
             if (wtaTurnContract
                 && wtaTurnContract.sourceOwner === 'clarify'
                 && isIntelligenceFlagEnabled('contextOsPropertyValidation')
-                && !isSpeculative) {
+                && !isSpeculative
+                // Image turns bypass clarification — the manual-chat twin has
+                // had this since its escape hatches; WTA never did (2026-08-11:
+                // a screenshot turn with an EMPTY question was asked "which
+                // source do you mean").
+                && !imagePaths?.length
+                // And a clarify born of a reference-bound mode with ZERO files
+                // is not actionable — there is no universe to disambiguate
+                // into. See clarificationIsActionable (refusalPolicy.ts).
+                && contextOsStatic.clarificationIsActionable({
+                    sourceAuthority: canonicalTurn.sourceAuthority ?? null,
+                    hasReferenceFiles: Boolean((snapshotModeInfo as any)?.hasReferenceFiles),
+                })) {
                 try {
                     const { buildSourceClarification, buildContextOsTrace, logContextOsTrace } = contextOsStatic;
                     // Evidence-execution-repair (2026-07-12): prefer the legacy,

--- a/electron/IntelligenceEngine.ts
+++ b/electron/IntelligenceEngine.ts
@@ -2307,6 +2307,7 @@ export class IntelligenceEngine extends EventEmitter {
                         govern: contextOsStatic.packGovernsGeneration({
                             answerPolicy: coordinatorResult.pack.answerPolicy,
                             sourceAuthority: canonicalTurn.sourceAuthority ?? null,
+                            hasReferenceFiles: Boolean((snapshotModeInfo as any)?.hasReferenceFiles),
                         }),
                     };
                     // The typed pack is now the sole factual injection. Do not also
@@ -3159,7 +3160,18 @@ export class IntelligenceEngine extends EventEmitter {
             // retrieval window. Zero-fabrication remains sacred: repairs that add a
             // number+unit not present in the evidence are rejected.
             try {
-                if (!isCoding && documentGroundedCustomModeActive && this.currentGenerationId === generationId) {
+                // Review finding F1 (2026-08-12): the SEVENTH strictness
+                // consumer, missed by the layer-5 migration. On the broad flag
+                // this validator ran for template-seeded fileless modes, built
+                // an empty retrievedBlock, and OVERWROTE a correct streamed
+                // answer with "I could not find that in the retrieved sections
+                // of the document." — one typed question away from the fixed
+                // turn. Strict + files + doc-shaped answer (the manual twin's
+                // parity term, ipcHandlers ~4086) are all required now.
+                if (!isCoding && strictDocumentGroundedActive
+                    && Boolean((snapshotModeInfo as any)?.hasReferenceFiles)
+                    && isDocGroundedAnswerType(answerPlan.answerType)
+                    && this.currentGenerationId === generationId) {
                     const docQuestion = (answerPlan.question || question || extractedQuestion.latestQuestion || lastInterviewerTurn || '').trim();
                     if (docQuestion) {
                         const { ModesManager } = require('./services/ModesManager') as typeof import('./services/ModesManager');

--- a/electron/IntelligenceEngine.ts
+++ b/electron/IntelligenceEngine.ts
@@ -2286,11 +2286,29 @@ export class IntelligenceEngine extends EventEmitter {
                         // (`forbiddenFamilies=[]`) and a JD-only decision can
                         // leak résumé content through the rendered pack.
                         turnSourceDecision: canonicalTurn.turnSourceDecision,
-                        govern: true,
+                        // A refusal pack only GOVERNS when the mode's authority
+                        // promises a bounded universe (evidenceRequired
+                        // authorities). profile_only/general_mixed turns whose
+                        // retrieval came back empty fall through to the legacy
+                        // path so the model answers — live report 2026-08-11:
+                        // a WTA screenshot turn in a looking-for-work mode was
+                        // governed into "not directly mentioned in the
+                        // uploaded material" with zero files and an empty
+                        // question, while the same screenshot answered fine on
+                        // manual-chat. packGovernsGeneration is the tested
+                        // predicate for that line.
+                        govern: contextOsStatic.packGovernsGeneration({
+                            answerPolicy: coordinatorResult.pack.answerPolicy,
+                            sourceAuthority: canonicalTurn.sourceAuthority ?? null,
+                        }),
                     };
                     // The typed pack is now the sole factual injection. Do not also
                     // pass the JIT's raw profile XML into WhatToAnswerLLM.
-                    candidateProfile = '';
+                    // ONLY when the pack actually governs: an ungoverned turn
+                    // (refusal pack in a non-bounded mode, 2026-08-11) runs the
+                    // legacy path, and stripping its profile XML here would
+                    // change legacy behaviour as a side effect of the fix.
+                    if (wtaContextOsGeneration.govern) candidateProfile = '';
                     wtaTrace.noteContext({
                         source: 'context_os_turn_evidence_coordinator',
                         trustLevel: 'high',

--- a/electron/LLMHelper.ts
+++ b/electron/LLMHelper.ts
@@ -6034,7 +6034,11 @@ let isMultimodal = !!(imagePaths?.length);
             providerDispatch: false,
             terminal: 'clarify',
           });
-          yield _cog.contract.reason || 'Which source should I use for that answer?';
+          // contract.reason is a developer diagnostic (e.g. "sourceAuthority=
+                        // reference_files_primary; requestedProperty=unknown") and was
+                        // yielded VERBATIM to a live user (2026-08-11). Reasons are for
+                        // logs; users get the human question.
+                        yield 'Which source should I use for that answer?';
           return;
         }
         if (pack.answerPolicy === 'refuse_insufficient_evidence') {

--- a/electron/LLMHelper.ts
+++ b/electron/LLMHelper.ts
@@ -6046,7 +6046,7 @@ let isMultimodal = !!(imagePaths?.length);
             providerDispatch: false,
             terminal: 'refuse',
           });
-          yield buildInsufficientPropertyAnswer({ property: pack.requestedProperty });
+          yield buildInsufficientPropertyAnswer({ property: pack.requestedProperty, sourceOwner: pack.sourceOwner });
           return;
         }
         const rendered = renderGoverningFactualBlock({ ..._cog, evidencePack: pack });
@@ -6200,7 +6200,7 @@ let isMultimodal = !!(imagePaths?.length);
             providerDispatch: false,
             terminal: 'refuse',
           });
-          yield buildInsufficientPropertyAnswer({ property: contextOsGovernedPack.requestedProperty });
+          yield buildInsufficientPropertyAnswer({ property: contextOsGovernedPack.requestedProperty, sourceOwner: contextOsGovernedPack.sourceOwner });
           return;
         }
       }

--- a/electron/LLMHelper.ts
+++ b/electron/LLMHelper.ts
@@ -6035,10 +6035,10 @@ let isMultimodal = !!(imagePaths?.length);
             terminal: 'clarify',
           });
           // contract.reason is a developer diagnostic (e.g. "sourceAuthority=
-                        // reference_files_primary; requestedProperty=unknown") and was
-                        // yielded VERBATIM to a live user (2026-08-11). Reasons are for
-                        // logs; users get the human question.
-                        yield 'Which source should I use for that answer?';
+          // reference_files_primary; requestedProperty=unknown") and was
+          // yielded VERBATIM to a live user (2026-08-11). Reasons are for
+          // logs; users get the human question.
+          yield 'Which source should I use for that answer?';
           return;
         }
         if (pack.answerPolicy === 'refuse_insufficient_evidence') {

--- a/electron/intelligence/context-os/index.ts
+++ b/electron/intelligence/context-os/index.ts
@@ -39,7 +39,7 @@ export {
   type BuildTurnContractInput,
 } from './SourceAuthorityKernel';
 export { PROPERTY_RULES, propertyRuleFor, textCanProveProperty } from './requestedProperty';
-export { packGovernsGeneration, sourceAuthorityPermitsRefusal } from './refusalPolicy';
+export { packGovernsGeneration, sourceAuthorityPermitsRefusal, clarificationIsActionable } from './refusalPolicy';
 export {
   EvidenceOrchestrator,
   parseModeSnippets,

--- a/electron/intelligence/context-os/index.ts
+++ b/electron/intelligence/context-os/index.ts
@@ -39,6 +39,7 @@ export {
   type BuildTurnContractInput,
 } from './SourceAuthorityKernel';
 export { PROPERTY_RULES, propertyRuleFor, textCanProveProperty } from './requestedProperty';
+export { packGovernsGeneration, sourceAuthorityPermitsRefusal } from './refusalPolicy';
 export {
   EvidenceOrchestrator,
   parseModeSnippets,

--- a/electron/intelligence/context-os/propertyEvidenceValidator.ts
+++ b/electron/intelligence/context-os/propertyEvidenceValidator.ts
@@ -117,8 +117,20 @@ export function itemSupportsProperty(item: EvidenceItem, property: RequestedProp
 export function buildInsufficientPropertyAnswer(input: {
   property: RequestedProperty;
   nearMissNote?: string | null;
+  /**
+   * The pack's source owner, so the wording names the universe that was
+   * actually searched. Before 2026-08-11 this line always said "the uploaded
+   * material" — a PROFILE-owned refusal in a mode with zero uploaded files
+   * told the user something flatly false about where the answer was looked
+   * for. Optional so every existing caller keeps the historical wording; the
+   * "not directly mentioned" stem is preserved on every branch because the
+   * doc-grounded repair sniffer (ipcHandlers REFUSAL_SNIFF_RE) keys on it.
+   */
+  sourceOwner?: string;
 }): string {
-  const base = 'This is not directly mentioned in the uploaded material.';
+  const base = input.sourceOwner === 'profile'
+    ? 'This is not directly mentioned in your profile material.'
+    : 'This is not directly mentioned in the uploaded material.';
   if (input.nearMissNote && input.nearMissNote.trim()) {
     return `${base} ${input.nearMissNote.trim()}`;
   }

--- a/electron/intelligence/context-os/refusalPolicy.ts
+++ b/electron/intelligence/context-os/refusalPolicy.ts
@@ -65,3 +65,42 @@ export function packGovernsGeneration(input: {
   if (input.answerPolicy !== 'refuse_insufficient_evidence') return true;
   return sourceAuthorityPermitsRefusal(input.sourceAuthority);
 }
+
+/** The authorities whose universe is the mode's uploaded reference files. */
+const REFERENCE_BOUND_AUTHORITIES: ReadonlySet<string> = new Set([
+  'reference_files_only',
+  'reference_files_primary',
+  'reference_files_plus_transcript',
+]);
+
+/**
+ * Is a sourceOwner='clarify' short-circuit ACTIONABLE for this turn?
+ *
+ * Second live report, 2026-08-11 (same day as the refuse-path fix): a WTA
+ * screenshot turn in a blank GENERAL-template mode was short-circuited into
+ * "This mode only answers from your uploaded material… switch to a mode that
+ * enables that source". The general template's SEEDED contract claims
+ * reference_files_primary; the mode had ZERO files; the kernel demoted the
+ * owner to 'clarify'; and the short-circuit ran before the provider call. The
+ * same contract FORBADE every profile source — so the message pointed at a
+ * résumé it would not have used, about material never uploaded, for a question
+ * never typed.
+ *
+ * The same honest line as packGovernsGeneration: a clarification between
+ * source universes is only worth interrupting the user for when the mode's own
+ * bounded universe actually EXISTS. A reference-bound authority with no files
+ * has nothing to disambiguate into — the honest move is answering.
+ *
+ * Deliberately scoped to the reference-bound trio: ask_if_ambiguous /
+ * general_mixed clarifications disambiguate between REAL universes and must
+ * survive, and transcript_only never has files, so a bare files check would
+ * gag it. Unknown authorities fail toward answering the user.
+ */
+export function clarificationIsActionable(input: {
+  sourceAuthority: string | null | undefined;
+  hasReferenceFiles: boolean;
+}): boolean {
+  if (typeof input.sourceAuthority !== 'string') return true;
+  if (!REFERENCE_BOUND_AUTHORITIES.has(input.sourceAuthority)) return true;
+  return input.hasReferenceFiles;
+}

--- a/electron/intelligence/context-os/refusalPolicy.ts
+++ b/electron/intelligence/context-os/refusalPolicy.ts
@@ -61,9 +61,21 @@ export function sourceAuthorityPermitsRefusal(sourceAuthority: string | null | u
 export function packGovernsGeneration(input: {
   answerPolicy: EvidencePack['answerPolicy'] | string;
   sourceAuthority: string | null | undefined;
+  /**
+   * Review finding F2 (2026-08-12): the docblock above says "the bounded
+   * universe actually EXISTS", and clarificationIsActionable already takes
+   * this — but this function did not, so a reference_files_primary mode with
+   * ZERO files was still classed as bounded. For the reference-bound trio the
+   * universe exists only when files do; omitted/false fails toward answering,
+   * because refusing on an unverified universe is the whole bug class.
+   * transcript_only never has files and stays authority-only.
+   */
+  hasReferenceFiles?: boolean;
 }): boolean {
   if (input.answerPolicy !== 'refuse_insufficient_evidence') return true;
-  return sourceAuthorityPermitsRefusal(input.sourceAuthority);
+  if (!sourceAuthorityPermitsRefusal(input.sourceAuthority)) return false;
+  if (input.sourceAuthority === 'transcript_only') return true;
+  return input.hasReferenceFiles === true;
 }
 
 /** The authorities whose universe is the mode's uploaded reference files. */

--- a/electron/intelligence/context-os/refusalPolicy.ts
+++ b/electron/intelligence/context-os/refusalPolicy.ts
@@ -1,0 +1,67 @@
+// electron/intelligence/context-os/refusalPolicy.ts
+//
+// WHEN IS A REFUSAL HONEST?
+//
+// Live report 2026-08-11: WTA with a screenshot in a looking-for-work mode
+// (sourceAuthority=profile_only, zero reference files, empty question) answered
+// "This is not directly mentioned in the uploaded material." — three times.
+// The kernel's own trace said finalAction="answer"; the evidence layer overrode
+// it. With zero candidates every pack decision site returns
+// `refuse_insufficient_evidence`, the coordinator govern sites set
+// `govern: true` unconditionally, and the surface yields the canned string
+// without ever calling the model. The same screenshot through manual-chat
+// answered normally.
+//
+// The line (independent review, 2026-08-11): a refusal is truthful only when
+// the mode's authority promises a BOUNDED UNIVERSE — "answer only from X" as
+// the product contract. Those are exactly the authorities modeSourceContract
+// marks `evidenceRequired: true`. Everywhere else, an empty pack means the
+// mode simply has nothing to add — the turn must FALL BACK to the model, not
+// refuse on behalf of a universe that was never bounded (and, in the reported
+// case, never populated).
+//
+// This module is deliberately tiny and pure so the line is testable on its
+// own. It hand-mirrors EVIDENCE_REQUIRED_FOR_AUTHORITY rather than importing
+// modeSourceContract (services → context-os would invert the layering);
+// ContextOsRefusalGoverns2026_08_11.test.mjs is the drift guard that asserts
+// the mirror agrees with the real mapping for every shipped authority.
+
+import type { EvidencePack } from './evidencePack';
+
+/** The authorities whose product contract is "answer only from this source" —
+ *  `evidenceRequired: true` in modeSourceContract. Refusing over an empty
+ *  retrieval is honest ONLY here. */
+const BOUNDED_UNIVERSE_AUTHORITIES: ReadonlySet<string> = new Set([
+  'reference_files_only',
+  'reference_files_primary',
+  'reference_files_plus_transcript',
+  'transcript_only',
+]);
+
+/**
+ * Does this authority make "I could not find it in the material" a truthful
+ * answer? Unknown/legacy values fail toward `false`: refusing on an authority
+ * we cannot classify would recreate the reported bug for any future value.
+ */
+export function sourceAuthorityPermitsRefusal(sourceAuthority: string | null | undefined): boolean {
+  return typeof sourceAuthority === 'string' && BOUNDED_UNIVERSE_AUTHORITIES.has(sourceAuthority);
+}
+
+/**
+ * Should this evidence pack GOVERN generation?
+ *
+ * `govern: false` reverts the turn to the legacy prompt path — every consumer
+ * already guards on `.govern` — which is what lets the model answer a
+ * screenshot/general question the evidence system has nothing to say about.
+ *
+ * Only the refusal outcome is gated. `answer` / `answer_with_uncertainty`
+ * govern as before (the pack IS the evidence), and `ask_clarification` is
+ * deliberately untouched by this change.
+ */
+export function packGovernsGeneration(input: {
+  answerPolicy: EvidencePack['answerPolicy'] | string;
+  sourceAuthority: string | null | undefined;
+}): boolean {
+  if (input.answerPolicy !== 'refuse_insufficient_evidence') return true;
+  return sourceAuthorityPermitsRefusal(input.sourceAuthority);
+}

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -2930,7 +2930,7 @@ export function initializeIpcHandlers(appState: AppState): void {
             && isIntelligenceFlagEnabled('contextOsEvidencePackEnabled')
             && isIntelligenceFlagEnabled('contextOsMultiFamilyEvidenceEnabled')) {
           try {
-            const { TurnEvidenceCoordinator, ProfileEvidenceService } = require('./intelligence/context-os') as typeof import('./intelligence/context-os');
+            const { TurnEvidenceCoordinator, ProfileEvidenceService, packGovernsGeneration } = require('./intelligence/context-os') as typeof import('./intelligence/context-os');
             const { ModesManager } = require('./services/ModesManager');
             const modesMgr = ModesManager.getInstance();
             const orchestrator = llmHelper.getKnowledgeOrchestrator?.();
@@ -3034,9 +3034,17 @@ export function initializeIpcHandlers(appState: AppState): void {
                 sourceAuthority: manualSourceContract?.sourceAuthority ?? 'ask_if_ambiguous',
               },
               turnSourceDecision: manualTurnSourceDecision,
-              govern: true,
+              // Same line as the WTA site (2026-08-11): a refusal pack governs
+              // only when the mode's authority promises a bounded universe.
+              // Elsewhere an empty pack means "the evidence system has nothing
+              // to add" and the legacy path answers. See
+              // context-os/refusalPolicy.ts.
+              govern: packGovernsGeneration({
+                answerPolicy: coordinatorResult.pack.answerPolicy,
+                sourceAuthority: manualSourceContract?.sourceAuthority ?? null,
+              }),
             };
-            coordinatorGovernedProfileEvidence = true;
+            coordinatorGovernedProfileEvidence = manualContextOsGeneration.govern;
             iTrace.noteContext({
               source: 'context_os_turn_evidence_coordinator',
               trustLevel: 'high',

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -3049,6 +3049,7 @@ export function initializeIpcHandlers(appState: AppState): void {
               govern: packGovernsGeneration({
                 answerPolicy: coordinatorResult.pack.answerPolicy,
                 sourceAuthority: manualSourceContract?.sourceAuthority ?? null,
+                hasReferenceFiles: Boolean((manualActiveMode as any)?.hasReferenceFiles),
               }),
             };
             coordinatorGovernedProfileEvidence = manualContextOsGeneration.govern;

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -2170,7 +2170,14 @@ export function initializeIpcHandlers(appState: AppState): void {
             && isIntelligenceFlagEnabled('contextOsPropertyValidation')
             && !isCodingChat
             && !imagePaths?.length
-            && !isStealthChat) {
+            && !isStealthChat
+            // A clarify born of a reference-bound mode with ZERO files is not
+            // actionable — nothing to disambiguate into (2026-08-11). Same
+            // predicate as the WTA twin; see refusalPolicy.ts.
+            && require('./intelligence/context-os').clarificationIsActionable({
+                sourceAuthority: manualSourceContract?.sourceAuthority ?? null,
+                hasReferenceFiles: Boolean((manualActiveMode as any)?.hasReferenceFiles),
+            })) {
           try {
             const { buildSourceClarification } = require('./intelligence/context-os') as typeof import('./intelligence/context-os');
             // Evidence-execution-repair (2026-07-12): two independent source-

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -3228,6 +3228,8 @@ export function initializeIpcHandlers(appState: AppState): void {
                 ? { contextOsGeneration: manualContextOsGeneration }
                 : turnContract
                   && manualActiveMode?.documentGroundedCustomModeActive === true
+                  // Same rule as the WTA twin (2026-08-11): no files -> no doc-grounded govern.
+                  && Boolean((manualActiveMode as any)?.hasReferenceFiles)
                   && isIntelligenceFlagEnabled('contextOsEvidencePackEnabled')
                 ? {
                     contextOsGeneration: (manualContextOsGeneration = {

--- a/electron/llm/AnswerPlanner.ts
+++ b/electron/llm/AnswerPlanner.ts
@@ -1463,7 +1463,13 @@ export const planAnswer = (input: PlanAnswerInput): AnswerPlan => {
     .replace(/\bfull[- ]?stack\b/g, 'fullstack')
     .replace(/\bstack(s|ed)?\s+up\b/g, 'measure$1 up');
   const extractedType = input.extractedQuestion?.questionType;
-  const documentGroundedCustomModeActive = input.activeMode?.documentGroundedCustomModeActive === true;
+  // Defect C split: prefer the EXPLICIT strictness flag when the snapshot
+  // carries it (live snapshots always do since 2026-08-12); fall back to the
+  // broad flag only for older callers/tests that never pass strict. Keying
+  // doc-shape routing and layer suppression on the broad flag ran the strict
+  // pipeline for stock template-seeded modes with zero files.
+  const documentGroundedCustomModeActive =
+    (input.activeMode?.strictDocumentGroundedActive ?? input.activeMode?.documentGroundedCustomModeActive) === true;
   const explicitDocumentModeCodingAsk = /\b(write|implement|code|coding interview|dsa|dry run|time complexity|space complexity|big[-\s]?o|algorithm(?:ic)?|solution code|source code)\b/i.test(text);
   const explicitDocumentModeProfileAsk = /\b(resume|cv|profile|job description|\bjd\b|career|work experience|candidate profile|my background|your background|my projects?|your projects?|my skills?|your skills?)\b/i.test(text);
 

--- a/electron/llm/WhatToAnswerLLM.ts
+++ b/electron/llm/WhatToAnswerLLM.ts
@@ -579,7 +579,11 @@ ANSWER SHAPE: ${intentResult.answerShape}
                     const pack = governedEvidencePack ?? _cog.evidencePack;
                     if (!pack) throw new Error('governed WTA turn missing canonical EvidencePack');
                     if (pack.answerPolicy === 'ask_clarification') {
-                        yield _cog.contract.reason || 'Which source should I use for that answer?';
+                        // contract.reason is a developer diagnostic (e.g. "sourceAuthority=
+                        // reference_files_primary; requestedProperty=unknown") and was
+                        // yielded VERBATIM to a live user (2026-08-11). Reasons are for
+                        // logs; users get the human question.
+                        yield 'Which source should I use for that answer?';
                         return;
                     }
                     if (pack.answerPolicy === 'refuse_insufficient_evidence') {

--- a/electron/llm/WhatToAnswerLLM.ts
+++ b/electron/llm/WhatToAnswerLLM.ts
@@ -259,7 +259,13 @@ ANSWER SHAPE: ${intentResult.answerShape}
                     // a second line of defence for other call paths.)
                     const activeModeGroundingInfo = modesManager.getActiveModeDocumentGroundingInfo?.(requestSnapshot?.modeUniqueId);
                     const documentGroundedCustomModeActive = activeModeGroundingInfo?.documentGroundedCustomModeActive === true;
-                    const forceDocumentGrounding = documentGroundedCustomModeActive;
+                    // Defect C (2026-08-01) prescribed the split: knowledge
+                    // suppression reads strictDocumentGroundedActive; isolation
+                    // keeps the broad flag. Manual chat was migrated
+                    // (LLMHelper:5448); this surface was not, so WTA ran the
+                    // strict doc pipeline for every template-seeded mode with
+                    // zero files — the root of the 2026-08-11 denial reports.
+                    const forceDocumentGrounding = activeModeGroundingInfo?.strictDocumentGroundedActive === true;
                     const retrievalOptions = forceDocumentGrounding
                         ? { forceDocumentGrounding: true, followUpReferentHint: temporalContext?.previousResponses?.slice(-1)?.[0] }
                         : undefined;

--- a/electron/llm/WhatToAnswerLLM.ts
+++ b/electron/llm/WhatToAnswerLLM.ts
@@ -228,8 +228,13 @@ ANSWER SHAPE: ${intentResult.answerShape}
             // items, create a second factual authority, and race the active mode.
             // Legacy document-only WTA contexts arrive without a pack and retain
             // the existing resolver path below.
+            // Review finding F3 (2026-08-12): keying on pack PRESENCE meant an
+            // UNGOVERNED refuse pack (govern:false — the layer-1 fall-through)
+            // still suppressed legacy mode-context retrieval below. govern:false
+            // must actually mean the legacy path, as layer 1's contract claims.
             let governedEvidencePack: import('../intelligence/context-os').EvidencePack | null =
-                initialContextOsGeneration?.evidencePack ?? null;
+                initialContextOsGeneration?.govern
+                    ? (initialContextOsGeneration?.evidencePack ?? null) : null;
             // Skill mode owns the system prompt — skip the (potentially expensive
             // hybrid retrieval) mode-context block fetch entirely. A pre-resolved
             // governed packet likewise skips legacy/raw retrieval.

--- a/electron/llm/WhatToAnswerLLM.ts
+++ b/electron/llm/WhatToAnswerLLM.ts
@@ -583,7 +583,7 @@ ANSWER SHAPE: ${intentResult.answerShape}
                         return;
                     }
                     if (pack.answerPolicy === 'refuse_insufficient_evidence') {
-                        yield buildInsufficientPropertyAnswer({ property: pack.requestedProperty });
+                        yield buildInsufficientPropertyAnswer({ property: pack.requestedProperty, sourceOwner: pack.sourceOwner });
                         return;
                     }
                     const rendered = renderGoverningFactualBlock({ ..._cog, evidencePack: pack });

--- a/electron/llm/modeProfiles.ts
+++ b/electron/llm/modeProfiles.ts
@@ -62,6 +62,17 @@ export interface ActiveModeInfo {
      * files authoritative and at least one reference file is available.
      */
     documentGroundedCustomModeActive?: boolean;
+  /**
+   * EXPLICIT strictness only (Defect C, 2026-08-01) — knowledge-suppression
+   * consumers read THIS, never the broad isolation flag above. The broad flag
+   * is TRUE for every template-seeded mode (the seed stamps
+   * reference_files_primary on all non-interview templates), so keying strict
+   * behaviour on it ran the doc-grounded refusal pipeline for stock modes with
+   * zero files. Manual chat was migrated to strict at LLMHelper:5448; the WTA
+   * surface never was — that asymmetry is the root of the 2026-08-11 WTA
+   * denial reports (four layers of them).
+   */
+  strictDocumentGroundedActive?: boolean;
     /** The mode's persisted, explicit source policy (real-custom-mode-repair). */
     sourceContract?: ModeSourceContract;
 }

--- a/electron/services/ModesManager.ts
+++ b/electron/services/ModesManager.ts
@@ -531,6 +531,7 @@ export class ModesManager {
                 hasCustomPrompt: grounding.hasCustomPrompt,
                 documentGrounded: grounding.documentGrounded,
                 documentGroundedCustomModeActive: grounding.documentGroundedCustomModeActive,
+                strictDocumentGroundedActive: grounding.strictDocumentGroundedActive,
                 sourceContract: grounding.sourceContract,
             };
         } else {

--- a/electron/services/__tests__/ContextOsRefusalGoverns2026_08_11.test.mjs
+++ b/electron/services/__tests__/ContextOsRefusalGoverns2026_08_11.test.mjs
@@ -63,10 +63,34 @@ describe('honest refusals are preserved — the fabrication boundary must not mo
   // collaborations SHOULD refuse. Killing that reintroduces the fabrication
   // class this subsystem exists to prevent.
   for (const sourceAuthority of STRICT) {
-    test(`${sourceAuthority}: refusal still governs`, () => {
-      assert.equal(packGovernsGeneration({ answerPolicy: 'refuse_insufficient_evidence', sourceAuthority }), true);
+    test(`${sourceAuthority}: refusal still governs (universe populated)`, () => {
+      assert.equal(packGovernsGeneration({ answerPolicy: 'refuse_insufficient_evidence', sourceAuthority, hasReferenceFiles: true }), true);
     });
   }
+
+  // Review finding F2 (2026-08-12): the module's own docblock states the line
+  // as "the bounded universe actually EXISTS", and clarificationIsActionable
+  // already takes hasReferenceFiles — but packGovernsGeneration did not. The
+  // reporting user's mode IS reference_files_primary with ZERO files; it was
+  // saved only by a coordinator scope rule unrelated to this fix. The two
+  // halves of one principle must be implemented symmetrically.
+  for (const sourceAuthority of ['reference_files_only', 'reference_files_primary', 'reference_files_plus_transcript']) {
+    test(`${sourceAuthority} + ZERO files: refusal does NOT govern`, () => {
+      assert.equal(packGovernsGeneration({ answerPolicy: 'refuse_insufficient_evidence', sourceAuthority, hasReferenceFiles: false }), false);
+    });
+  }
+
+  test('transcript_only never has files — authority alone still governs', () => {
+    assert.equal(packGovernsGeneration({ answerPolicy: 'refuse_insufficient_evidence', sourceAuthority: 'transcript_only', hasReferenceFiles: false }), true);
+  });
+
+  test('omitting hasReferenceFiles keeps the old behaviour for non-file authorities only', () => {
+    // Legacy callers that never pass files: transcript_only unaffected;
+    // the reference trio FAILS TOWARD ANSWERING when files are unknown,
+    // because refusing on an unverified universe is the whole bug class.
+    assert.equal(packGovernsGeneration({ answerPolicy: 'refuse_insufficient_evidence', sourceAuthority: 'transcript_only' }), true);
+    assert.equal(packGovernsGeneration({ answerPolicy: 'refuse_insufficient_evidence', sourceAuthority: 'reference_files_primary' }), false);
+  });
 
   test('an answering pack always governs, any authority', () => {
     for (const sourceAuthority of [...STRICT, ...OPEN]) {

--- a/electron/services/__tests__/ContextOsRefusalGoverns2026_08_11.test.mjs
+++ b/electron/services/__tests__/ContextOsRefusalGoverns2026_08_11.test.mjs
@@ -206,7 +206,10 @@ describe('a developer diagnostic is never user-visible prose (live report #3, 20
     const src = fs.readFileSync(path.resolve(process.cwd(), 'electron/IntelligenceEngine.ts'), 'utf8');
     // documentGroundedCustomModeActive was proven TRUE with zero files —
     // the govern gate must pair it with a hasReferenceFiles check.
-    const gate = /documentGroundedCustomModeActive\s*\n[^]{0,700}?hasReferenceFiles[^]{0,200}?contextOsEvidencePackEnabled/;
-    assert.ok(gate.test(src), 'site-2 govern must require hasReferenceFiles');
+    // 2026-08-12: the gate got stricter still — it now keys on the EXPLICIT
+    // strictness flag (Defect C split) AND keeps the files requirement as
+    // belt-and-braces (reference_files_only can be strict with zero files).
+    const gate = /strictDocumentGroundedActive\s*\n[^]{0,700}?hasReferenceFiles[^]{0,200}?contextOsEvidencePackEnabled/;
+    assert.ok(gate.test(src), 'site-2 govern must key on strictDocumentGroundedActive AND require hasReferenceFiles');
   });
 });

--- a/electron/services/__tests__/ContextOsRefusalGoverns2026_08_11.test.mjs
+++ b/electron/services/__tests__/ContextOsRefusalGoverns2026_08_11.test.mjs
@@ -37,7 +37,7 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 const base = path.resolve(process.cwd(), 'dist-electron/electron');
-const { packGovernsGeneration, sourceAuthorityPermitsRefusal, buildInsufficientPropertyAnswer } =
+const { packGovernsGeneration, sourceAuthorityPermitsRefusal, clarificationIsActionable, buildInsufficientPropertyAnswer } =
   await import(pathToFileURL(path.join(base, 'intelligence/context-os/index.js')).href);
 
 const STRICT = ['reference_files_only', 'reference_files_primary', 'reference_files_plus_transcript', 'transcript_only'];
@@ -112,6 +112,47 @@ describe('DRIFT GUARD: the strict set IS modeSourceContract.evidenceRequired', (
       assert.equal(sourceAuthorityPermitsRefusal(authority), evidenceRequired,
         `${authority}: predicate says ${sourceAuthorityPermitsRefusal(authority)}, contract says evidenceRequired=${evidenceRequired}`);
     }
+  });
+});
+
+describe('a clarify short-circuit must be ACTIONABLE (live report #2, 2026-08-11)', () => {
+  // Second live report, same day, after the refuse-path fix: WTA screenshot in
+  // a blank GENERAL-template mode answered
+  //
+  //   "This mode only answers from your uploaded material, so I'm not pulling
+  //    from your résumé here. Switch to a mode that enables that source..."
+  //
+  // The general template's SEEDED contract claims reference_files_primary; the
+  // mode had ZERO files; the kernel demoted sourceOwner to 'clarify'; and the
+  // clarification short-circuit fired before the provider call. The contract
+  // simultaneously FORBADE every profile source — so the message told the user
+  // to switch modes to reach a resume it would not have used, about material
+  // that was never uploaded, for a question that was never typed.
+  //
+  // The same honest line applies: a clarification between source universes is
+  // only actionable when the mode's own bounded universe actually EXISTS. A
+  // reference-bound authority with no files has nothing to disambiguate into —
+  // the honest move is answering.
+  for (const sourceAuthority of ['reference_files_only', 'reference_files_primary', 'reference_files_plus_transcript']) {
+    test(`${sourceAuthority} + NO files: clarify is not actionable`, () => {
+      assert.equal(clarificationIsActionable({ sourceAuthority, hasReferenceFiles: false }), false);
+    });
+    test(`${sourceAuthority} + files present: clarify stays actionable`, () => {
+      assert.equal(clarificationIsActionable({ sourceAuthority, hasReferenceFiles: true }), true);
+    });
+  }
+
+  test('non-reference authorities keep their clarifications regardless of files', () => {
+    // ask_if_ambiguous / general_mixed clarifications disambiguate between
+    // REAL universes (profile vs transcript vs docs) and must survive;
+    // transcript_only never has files, so a files check must not gag it.
+    for (const sourceAuthority of ['ask_if_ambiguous', 'general_mixed', 'profile_only', 'transcript_only']) {
+      assert.equal(clarificationIsActionable({ sourceAuthority, hasReferenceFiles: false }), true, sourceAuthority);
+    }
+  });
+
+  test('unknown authority fails toward answering the user, not gagging them', () => {
+    assert.equal(clarificationIsActionable({ sourceAuthority: 'legacy', hasReferenceFiles: false }), true);
   });
 });
 

--- a/electron/services/__tests__/ContextOsRefusalGoverns2026_08_11.test.mjs
+++ b/electron/services/__tests__/ContextOsRefusalGoverns2026_08_11.test.mjs
@@ -184,3 +184,29 @@ describe('the refusal string no longer lies about its source', () => {
     }
   });
 });
+
+describe('a developer diagnostic is never user-visible prose (live report #3, 2026-08-11)', () => {
+  // The user was shown, verbatim:
+  //     "sourceAuthority=reference_files_primary; requestedProperty=unknown"
+  // — contract.reason, yielded as the ask_clarification answer. Reasons are
+  // telemetry; users get the human question. Source-level tripwire, same style
+  // as ContextOsStaticImport: if anyone reintroduces a reason yield, this
+  // fails with the incident attached.
+  test('no surface yields contract.reason', async () => {
+    const fs = await import('node:fs');
+    for (const f of ['electron/llm/WhatToAnswerLLM.ts', 'electron/LLMHelper.ts']) {
+      const src = fs.readFileSync(path.resolve(process.cwd(), f), 'utf8');
+      assert.ok(!/yield\s+_?cog\??\.?contract\.reason|yield\s+contract\.reason/.test(src),
+        `${f}: contract.reason must never be yielded to the user`);
+    }
+  });
+
+  test('the WTA doc-grounded govern site requires actual files', async () => {
+    const fs = await import('node:fs');
+    const src = fs.readFileSync(path.resolve(process.cwd(), 'electron/IntelligenceEngine.ts'), 'utf8');
+    // documentGroundedCustomModeActive was proven TRUE with zero files —
+    // the govern gate must pair it with a hasReferenceFiles check.
+    const gate = /documentGroundedCustomModeActive\s*\n[^]{0,700}?hasReferenceFiles[^]{0,200}?contextOsEvidencePackEnabled/;
+    assert.ok(gate.test(src), 'site-2 govern must require hasReferenceFiles');
+  });
+});

--- a/electron/services/__tests__/ContextOsRefusalGoverns2026_08_11.test.mjs
+++ b/electron/services/__tests__/ContextOsRefusalGoverns2026_08_11.test.mjs
@@ -1,0 +1,145 @@
+// Live report 2026-08-11: WTA (Cmd+1 / Cmd+Enter) with a screenshot in a
+// looking-for-work mode answered, three times:
+//
+//     "This is not directly mentioned in the uploaded material."
+//
+// The user's own [CONTEXT-OS] trace showed the whole chain:
+//   sourceAuthority=profile_only, sourceOwner=profile, questionPreview="",
+//   forbiddenSources includes screen_context, selectedEvidenceCount=0,
+//   finalAction="answer"  ← the KERNEL wanted to answer
+//
+// The evidence layer then overrode that into a refusal: with zero candidates,
+// the coordinator/profile-service pack comes back
+// `refuse_insufficient_evidence`, the govern sites set `govern: true`
+// UNCONDITIONALLY, and WhatToAnswerLLM yields the canned string without ever
+// calling the model. Meanwhile the identical screenshot pasted into
+// manual-chat answered fine (868 chars, Gemini vision) — that path's V3
+// fallback was GENERAL_KNOWLEDGE.
+//
+// The honest line (independent review, 2026-08-11): a refusal is only truthful
+// when the mode's authority promises a BOUNDED UNIVERSE — the four strict
+// authorities where "answer only from X" is the product contract. Those are
+// exactly the ones modeSourceContract marks `evidenceRequired: true`. For
+// profile_only / general_mixed / ask_if_ambiguous / profile_plus_transcript,
+// failing to find evidence means FALL BACK TO THE MODEL, not refuse: the mode
+// never promised source-exclusivity, so "not in the uploaded material" is a
+// false statement about a universe that was never bounded (and in the
+// reported case, never even populated — zero files).
+//
+// packGovernsGeneration is that line as a predicate. It gates `govern:` at the
+// two coordinator sites; govern:false reverts the turn to the legacy path,
+// which every consumer already respects (`_cog?.govern` guards in
+// WhatToAnswerLLM/LLMHelper).
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const base = path.resolve(process.cwd(), 'dist-electron/electron');
+const { packGovernsGeneration, sourceAuthorityPermitsRefusal, buildInsufficientPropertyAnswer } =
+  await import(pathToFileURL(path.join(base, 'intelligence/context-os/index.js')).href);
+
+const STRICT = ['reference_files_only', 'reference_files_primary', 'reference_files_plus_transcript', 'transcript_only'];
+const OPEN = ['profile_only', 'profile_plus_transcript', 'general_mixed', 'ask_if_ambiguous'];
+
+describe('the reported turn — profile_only + empty evidence must NOT govern into a refusal', () => {
+  test('the exact live case: profile_only + refuse_insufficient_evidence → legacy path', () => {
+    assert.equal(packGovernsGeneration({
+      answerPolicy: 'refuse_insufficient_evidence',
+      sourceAuthority: 'profile_only',
+    }), false, 'the model must get the turn (screenshot and all), not the canned string');
+  });
+
+  for (const sourceAuthority of OPEN) {
+    test(`${sourceAuthority}: refusal does not govern`, () => {
+      assert.equal(packGovernsGeneration({ answerPolicy: 'refuse_insufficient_evidence', sourceAuthority }), false);
+    });
+  }
+});
+
+describe('honest refusals are preserved — the fabrication boundary must not move', () => {
+  // A funding_source question against a real uploaded paper that only mentions
+  // collaborations SHOULD refuse. Killing that reintroduces the fabrication
+  // class this subsystem exists to prevent.
+  for (const sourceAuthority of STRICT) {
+    test(`${sourceAuthority}: refusal still governs`, () => {
+      assert.equal(packGovernsGeneration({ answerPolicy: 'refuse_insufficient_evidence', sourceAuthority }), true);
+    });
+  }
+
+  test('an answering pack always governs, any authority', () => {
+    for (const sourceAuthority of [...STRICT, ...OPEN]) {
+      assert.equal(packGovernsGeneration({ answerPolicy: 'answer', sourceAuthority }), true, sourceAuthority);
+      assert.equal(packGovernsGeneration({ answerPolicy: 'answer_with_uncertainty', sourceAuthority }), true, sourceAuthority);
+    }
+  });
+
+  test('ask_clarification is untouched by this change', () => {
+    for (const sourceAuthority of [...STRICT, ...OPEN]) {
+      assert.equal(packGovernsGeneration({ answerPolicy: 'ask_clarification', sourceAuthority }), true, sourceAuthority);
+    }
+  });
+
+  test('an unknown/legacy authority fails toward answering, not refusing', () => {
+    // 'legacy' and undefined reach the govern sites via `?? 'ask_if_ambiguous'`
+    // fallbacks, but the predicate itself must also fail open: refusing on an
+    // authority we cannot classify would recreate the reported bug for any
+    // future authority value.
+    assert.equal(packGovernsGeneration({ answerPolicy: 'refuse_insufficient_evidence', sourceAuthority: 'legacy' }), false);
+    assert.equal(packGovernsGeneration({ answerPolicy: 'refuse_insufficient_evidence', sourceAuthority: undefined }), false);
+  });
+});
+
+describe('DRIFT GUARD: the strict set IS modeSourceContract.evidenceRequired', () => {
+  // The predicate hand-mirrors EVIDENCE_REQUIRED_FOR_AUTHORITY rather than
+  // importing it (services → context-os would be a layering inversion). This
+  // test is the enforcement that the mirror cannot drift: it asserts the
+  // predicate agrees with the real mapping for every authority the contract
+  // module defines.
+  test('predicate agrees with evidenceRequired for every authority', async () => {
+    const { defaultSourceContractForNewMode } =
+      await import(pathToFileURL(path.join(base, 'services/modeSourceContract.js')).href);
+    // Derive the mapping from the public surface: every template's default
+    // contract carries both fields.
+    const seen = new Map();
+    for (const t of ['general', 'sales', 'recruiting', 'team-meet', 'looking-for-work', 'technical-interview', 'lecture', 'seminar']) {
+      const c = defaultSourceContractForNewMode(t);
+      seen.set(c.sourceAuthority, c.evidenceRequired);
+    }
+    assert.ok(seen.size >= 2, 'expected multiple distinct authorities across the templates');
+    for (const [authority, evidenceRequired] of seen) {
+      assert.equal(sourceAuthorityPermitsRefusal(authority), evidenceRequired,
+        `${authority}: predicate says ${sourceAuthorityPermitsRefusal(authority)}, contract says evidenceRequired=${evidenceRequired}`);
+    }
+  });
+});
+
+describe('the refusal string no longer lies about its source', () => {
+  test('reference_files wording is byte-identical to before', () => {
+    assert.equal(
+      buildInsufficientPropertyAnswer({ property: 'unknown', sourceOwner: 'reference_files' }),
+      'This is not directly mentioned in the uploaded material.');
+    // and the legacy no-owner call keeps the old string, so existing callers
+    // and the REFUSAL_SNIFF_RE repair path are unaffected
+    assert.equal(
+      buildInsufficientPropertyAnswer({ property: 'unknown' }),
+      'This is not directly mentioned in the uploaded material.');
+  });
+
+  test('a profile-owned refusal names the profile, not phantom uploads', () => {
+    const s = buildInsufficientPropertyAnswer({ property: 'unknown', sourceOwner: 'profile' });
+    assert.ok(!/uploaded material/i.test(s), `must not claim uploaded material: ${s}`);
+    assert.match(s, /profile/i);
+    // keep the "not directly mentioned" stem — downstream refusal sniffers
+    // (ipcHandlers REFUSAL_SNIFF_RE) key on it
+    assert.match(s, /not directly mentioned/i);
+  });
+
+  test('the funding_source near-miss note survives on both owners', () => {
+    for (const sourceOwner of ['reference_files', 'profile']) {
+      const s = buildInsufficientPropertyAnswer({ property: 'funding_source', sourceOwner });
+      assert.match(s, /collaboration is not the same as funding/);
+    }
+  });
+});

--- a/electron/services/__tests__/ContextOsStaticImport2026_08_07.test.mjs
+++ b/electron/services/__tests__/ContextOsStaticImport2026_08_07.test.mjs
@@ -71,7 +71,22 @@ describe('the fail-open profile-repair gate stays defended upstream', () => {
     // This is WHY the `catch { return true; }` fail-open is safe. If these
     // clears ever disappear, the fail-open becomes a real profile leak and this
     // test must fail loudly rather than let it pass silently.
-    const clears = source.match(/^\s*candidateProfile\s*=\s*''\s*;/gm) || [];
-    assert.ok(clears.length >= 2, `expected the contract-denial clears to remain, found ${clears.length}`);
+    //
+    // Sharpened 2026-08-11 (was a bare `>= 2` count of `candidateProfile = ''`
+    // lines): the two clears have DIFFERENT contracts and the count conflated
+    // them. The DENIAL clear (context_os_profile_suppressed) is the actual
+    // leak defense and must stay UNCONDITIONAL. The coordinator's
+    // de-duplication clear ("typed pack is the sole factual injection") is
+    // deliberately gated on `.govern` — an ungoverned turn (refusal pack in a
+    // non-bounded mode) runs the legacy path, where the JIT profile XML is the
+    // correct legacy behaviour, and the denial clear upstream still protects
+    // doc-grounded/transcript-owned turns.
+    const denialClear =
+      /if \(!contractAllowsProfileWta && candidateProfile\) \{[\s\S]{0,400}?^\s*candidateProfile\s*=\s*''\s*;/m;
+    assert.ok(denialClear.test(source),
+      'the contract-denial clear (the leak defense) must remain, and must remain unconditional');
+    const dedupClear = /if \(wtaContextOsGeneration\.govern\) candidateProfile\s*=\s*''\s*;/;
+    assert.ok(dedupClear.test(source),
+      'the coordinator de-dup clear must remain, gated on govern (see refusalPolicy.ts, 2026-08-11)');
   });
 });

--- a/electron/services/__tests__/WhatToAnswerSnapshotWiring.test.mjs
+++ b/electron/services/__tests__/WhatToAnswerSnapshotWiring.test.mjs
@@ -154,8 +154,12 @@ describe('#6 — runWhatShouldISay captures ONE mode snapshot at t0 and threads 
 
   test('a pre-resolved multi-family packet is reused by WhatToAnswerLLM without re-retrieval', () => {
     const llmSrc = read('../../llm/WhatToAnswerLLM.ts');
-    assert.match(llmSrc, /let governedEvidencePack: import\('\.\.\/intelligence\/context-os'\)\.EvidencePack \| null =\s*initialContextOsGeneration\?\.evidencePack \?\? null/s,
-      'WTA generation must begin with the coordinator-owned EvidencePack');
+    // Pin updated 2026-08-12 (review F3): the packet seed is now gated on
+    // .govern — an ungoverned refuse pack must NOT suppress legacy retrieval.
+    // The protected invariant is unchanged: a GOVERNED coordinator pack is
+    // reused as-is, with no re-retrieval.
+    assert.match(llmSrc, /let governedEvidencePack: import\('\.\.\/intelligence\/context-os'\)\.EvidencePack \| null =\s*initialContextOsGeneration\?\.govern\s*\?\s*\(initialContextOsGeneration\?\.evidencePack \?\? null\) : null/s,
+      'WTA generation must begin with the coordinator-owned EvidencePack, gated on .govern');
     assert.match(llmSrc, /if \(!activeSkill && !governedEvidencePack\) \{/,
       'a resolved packet must skip the legacy document retrieval branch');
     assert.match(llmSrc, /const pack = governedEvidencePack \?\? _cog\.evidencePack/,

--- a/electron/services/__tests__/WhatToAnswerSnapshotWiring.test.mjs
+++ b/electron/services/__tests__/WhatToAnswerSnapshotWiring.test.mjs
@@ -99,7 +99,12 @@ describe('#6 — runWhatShouldISay captures ONE mode snapshot at t0 and threads 
   // duplicate-authority cleanup can't silently re-open profile evidence on a
   // JD-only / reference-files-only / transcript-only turn.
   test('the candidate-profile orchestrator fetch is gated on the canonical never-retrieve decision', () => {
-    assert.match(body, /isKnowledgeMode\?\.\(\) && !documentGroundedCustomModeActive\s*\n?\s*&& wtaDecisionAllowsCandidateProfile/s,
+    // 2026-08-12: the suppression side of this gate reads the EXPLICIT
+    // strictness flag (Defect C split) — the broad isolation flag classified
+    // every template-seeded mode as strict and ran the doc-refusal pipeline on
+    // fileless stock modes. The invariant this pin protects is unchanged: the
+    // résumé orchestrator fetch must AND the canonical candidate-profile gate.
+    assert.match(body, /isKnowledgeMode\?\.\(\) && !strictDocumentGroundedActive\s*\n?\s*&& wtaDecisionAllowsCandidateProfile/s,
       'the résumé orchestrator fetch must AND the canonical candidate-profile gate');
   });
 


### PR DESCRIPTION
## The bug (user-reported, reproduced from their own trace)

What-To-Answer (Cmd+1 / Cmd+Enter) with a **screenshot** in a looking-for-work mode answered, three times:

> This is not directly mentioned in the uploaded material.

The user's `[CONTEXT-OS]` trace showed the whole chain: `sourceAuthority=profile_only`, `questionPreview=""` (screenshot only), `screen_context` in **forbiddenSources**, `selectedEvidenceCount=0` — and **`finalAction:"answer"`**. The kernel wanted to answer; the evidence layer overrode it. With zero candidates the coordinator pack comes back `refuse_insufficient_evidence`, both govern sites set `govern: true` **unconditionally**, and the surface yields the canned string without ever calling the model. The identical screenshot pasted into manual chat answered normally.

This is the same defect class fixed in `prompt-composer.ts` on 2026-08-07 — refusal keyed purely on "no evidence retrieved" — living a second time in Context OS, on the one surface that never goes through `buildV3Prompt`.

## The line

A refusal is truthful only when the mode's authority promises a **bounded universe** — exactly the four authorities `modeSourceContract` marks `evidenceRequired: true`. Everywhere else, an empty pack means the evidence system has nothing to add: fall back to the model.

`refusalPolicy.ts` is that line as a pure predicate, wired at both coordinator govern sites. `govern: false` reverts to the legacy path every consumer already guards on. **Doc-grounded refusals are untouched** — a `funding_source` question against a real uploaded paper still refuses. Unknown authorities fail toward answering. A drift-guard test derives the real `evidenceRequired` mapping from `defaultSourceContractForNewMode` and asserts the mirror cannot drift.

Also: the refusal string now takes the pack's `sourceOwner`, so a profile-owned refusal — if ever yielded — says "your profile material" instead of falsely claiming uploads (stem preserved for `REFUSAL_SNIFF_RE`). The `ContextOsStaticImport` tripwire is **sharpened**: it now asserts the contract-denial clear (the leak defense) stays unconditional and the coordinator de-dup clear stays govern-gated, instead of a bare line count that conflated the two.

## Verification

- new suite **16/16** (predicate matrix, drift guard, string honesty)
- WTA/Context-OS/evidence suites **53/53** on this branch
- e2e sim of the exact reported turn against compiled code: `profile_only` refusal → `govern:false` → model answers; `reference_files_only` → still refuses
- attribution runs (clean HEAD vs HEAD + only these files, Electron runner): llm glob **18 = 18** failing names, services glob **286 = 286** — zero new failures at name level
- `tsc` clean

## Assembly note

Built from `origin/main` directly. The shared working tree carried another agent's unmerged commit in `IntelligenceEngine.ts` and **uncommitted LiteLLM reversions in `ipcHandlers.ts`** — both files were rebuilt from main's versions with only this fix's hunks applied, verified hunk-by-hunk (`optInFamily`/`litellmPreferredModel` intact).

## Known, deliberately out of scope

- The §6 Answer-policy setting is consulted **nowhere** in `context-os/**` — it silently does nothing on the WTA surface. Wiring it is a subsystem change; this restores the correct default first.
- `required: profileKinds()` still demands both `profile_resume` **and** `projects` on every `profile_only` turn (the starved-family refusal the review found). Moot for user-visible refusals after this fix, but still shapes evidence selection.
- The `ask_clarification` path still yields a developer-diagnostic string (`contract.reason`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)