### PR TITLE
fix(context-os): close the 10 final-review findings — strict/broad straggler consumers

### DIFF
--- a/electron/IntelligenceEngine.ts
+++ b/electron/IntelligenceEngine.ts
@@ -912,6 +912,18 @@ export class IntelligenceEngine extends EventEmitter {
         // broad flag. WTA was never migrated when manual chat was
         // (LLMHelper:5448) — the root asymmetry behind the 2026-08-11 reports.
         const strictDocumentGroundedActive = (snapshotModeInfo as any)?.strictDocumentGroundedActive === true;
+        // Review follow-up R1 (2026-08-12): the strict-only migration
+        // over-corrected for modes that HAVE files. A template-seeded mode
+        // (origin default_new_mode => strict=false even with files) that a
+        // user uploaded a document into was losing forced doc retrieval AND
+        // the post-stream zero-fabrication validator, while manual chat kept
+        // both via its broad-flag gate (ipcHandlers ~4056). Enforcement is
+        // honest exactly when the bounded universe EXISTS: an explicit strict
+        // contract, or any doc-grounded mode with at least one real file —
+        // the same line packGovernsGeneration draws.
+        const docGroundedEnforcementActive = strictDocumentGroundedActive
+            || (snapshotModeInfo?.documentGroundedCustomModeActive === true
+                && Boolean((snapshotModeInfo as any)?.hasReferenceFiles));
         const snapshotModeId = this.getActiveModeId();
         // The narrow ActiveModeInfo snapshot is enough for planning, but a
         // multi-family typed reference pack also needs the full mode row and its
@@ -1130,7 +1142,7 @@ export class IntelligenceEngine extends EventEmitter {
             // Governed document turns resolve through EvidenceResolver inside
             // WhatToAnswerLLM. Do not start the legacy prefetch in parallel: even
             // an ignored retrieval is an unauthorized competing evidence path.
-            const modeContextPromise: Promise<string> = options?.activeSkill || strictDocumentGroundedActive
+            const modeContextPromise: Promise<string> = options?.activeSkill || docGroundedEnforcementActive
                 ? Promise.resolve('') // skill/governed-document mode skips legacy retrieval
                 : (async () => {
                     try {
@@ -1152,7 +1164,7 @@ export class IntelligenceEngine extends EventEmitter {
                             } catch { /* flag module unavailable → no rerank */ }
                             return await mm.buildRetrievedActiveModeContextBlockHybrid(
                                 preparedTranscript, preparedTranscript, 1800, undefined, true, snapshotModeInfo?.id, allowRerank,
-                                strictDocumentGroundedActive ? { forceDocumentGrounding: true } : undefined,
+                                docGroundedEnforcementActive ? { forceDocumentGrounding: true } : undefined,
                             );
                         }
                         return '';
@@ -2345,11 +2357,14 @@ export class IntelligenceEngine extends EventEmitter {
                 && wtaTurnContract.sourceOwner === 'clarify'
                 && isIntelligenceFlagEnabled('contextOsPropertyValidation')
                 && !isSpeculative
-                // Image turns bypass clarification — the manual-chat twin has
+                // Visual turns bypass clarification — the manual-chat twin has
                 // had this since its escape hatches; WTA never did (2026-08-11:
                 // a screenshot turn with an EMPTY question was asked "which
-                // source do you mean").
-                && !imagePaths?.length
+                // source do you mean"). R4 (2026-08-12): images were only one of
+                // WTA's THREE visual channels — screen-OCR and DOM context took
+                // the same dead-end — so the bypass now uses the engine's own
+                // visual-context predicate rather than re-deriving a subset.
+                && !_wtaHasVisualContext
                 // And a clarify born of a reference-bound mode with ZERO files
                 // is not actionable — there is no universe to disambiguate
                 // into. See clarificationIsActionable (refusalPolicy.ts).
@@ -2385,7 +2400,11 @@ export class IntelligenceEngine extends EventEmitter {
                     if (isIntelligenceFlagEnabled('trace')) {
                         logContextOsTrace(buildContextOsTrace({
                             contract: wtaTurnContract,
-                            sourceAuthority: wtaTurnContract.reason,
+                            // R7 (2026-08-12, review finding): this stored
+                            // contract.reason — a diagnostic SENTENCE — as the
+                            // sourceAuthority, corrupting the trace field. Same
+                            // reason-vs-surface class as the 2026-08-11 fix.
+                            sourceAuthority: canonicalTurn.sourceAuthority ?? null,
                             question: String(extractedQuestion.latestQuestion || question || ''),
                             usedSources: [],
                             finalAction: 'clarify',
@@ -2459,7 +2478,7 @@ export class IntelligenceEngine extends EventEmitter {
             // block (no double retrieval) and governs the factual prompt.
             if (!wtaContextOsGeneration
                 && wtaTurnContract
-                && strictDocumentGroundedActive
+                && docGroundedEnforcementActive
                 // Live proof 2026-08-11: documentGroundedCustomModeActive can be
                 // TRUE with hasReferenceFiles FALSE (custom mode, contract seeded
                 // reference_files_primary, zero files). Governing that turn
@@ -2476,7 +2495,10 @@ export class IntelligenceEngine extends EventEmitter {
                     modeSnapshot: {
                         modeId: snapshotModeId ?? null,
                         modeName: snapshotModeInfo?.name ?? null,
-                        sourceAuthority: wtaTurnContract.reason,
+                        // R7 (2026-08-12): was contract.reason — a diagnostic
+                        // sentence — which then flowed into every benchmark
+                        // audit row for site-2-governed turns.
+                        sourceAuthority: canonicalTurn.sourceAuthority ?? null,
                     },
                     turnSourceDecision: canonicalTurn.turnSourceDecision,
                     govern: true,
@@ -3166,9 +3188,11 @@ export class IntelligenceEngine extends EventEmitter {
                 // an empty retrievedBlock, and OVERWROTE a correct streamed
                 // answer with "I could not find that in the retrieved sections
                 // of the document." — one typed question away from the fixed
-                // turn. Strict + files + doc-shaped answer (the manual twin's
-                // parity term, ipcHandlers ~4086) are all required now.
-                if (!isCoding && strictDocumentGroundedActive
+                // turn. Enforcement (strict OR broad-with-files, = the manual
+                // twin's gate) + files + doc-shaped answer are all required —
+                // R1 (2026-08-12): strict-only here dropped the
+                // zero-fabrication validator for seeded modes WITH files.
+                if (!isCoding && docGroundedEnforcementActive
                     && Boolean((snapshotModeInfo as any)?.hasReferenceFiles)
                     && isDocGroundedAnswerType(answerPlan.answerType)
                     && this.currentGenerationId === generationId) {
@@ -4927,7 +4951,16 @@ export class IntelligenceEngine extends EventEmitter {
                 // and the raw context blob are both bypassed.
                 answer = await this.answerLLM.generate(_v3.user, undefined, answerPlan, _v3.system);
             } else {
-                const context = activeModeInfo?.documentGroundedCustomModeActive === true || isCodingAnswerType(answerPlan.answerType)
+                // R5 (2026-08-12, review finding): the broad flag stripped the
+                // live transcript from this fallback for template-seeded modes
+                // that get NO doc-grounding benefit in exchange (the plan is not
+                // doc-shaped, no doc retrieval or validation runs) — a visibly
+                // context-blind answer. Strip only under real doc enforcement:
+                // an explicit strict contract, or a doc mode with actual files.
+                const _docEnforced = (activeModeInfo as any)?.strictDocumentGroundedActive === true
+                    || (activeModeInfo?.documentGroundedCustomModeActive === true
+                        && Boolean((activeModeInfo as any)?.hasReferenceFiles));
+                const context = _docEnforced || isCodingAnswerType(answerPlan.answerType)
                     ? undefined
                     : this.session.getFormattedContext(120);
                 answer = await this.answerLLM.generate(question, context, answerPlan);

--- a/electron/LLMHelper.ts
+++ b/electron/LLMHelper.ts
@@ -2238,7 +2238,14 @@ ${IMAGE_TRUST_TRAILER}`;
       // uploaded material.
       const groundingInfo = modesMgr.getActiveModeDocumentGroundingInfo?.();
       documentGroundedCustomModeActive = groundingInfo?.documentGroundedCustomModeActive === true;
-      const retrieveAnswerType = documentGroundedCustomModeActive
+      // R6 (2026-08-12, review finding): the broad flag alone forced
+      // doc-grounded suggestion retrieval over an EMPTY corpus for every
+      // template-seeded fileless mode — the same class the 2026-08-11 WTA
+      // fixes closed. Enforcement = explicit strict contract, or a doc mode
+      // with at least one real file.
+      const docGroundedEnforcementActive = groundingInfo?.strictDocumentGroundedActive === true
+        || (documentGroundedCustomModeActive && groundingInfo?.hasReferenceFiles === true);
+      const retrieveAnswerType = docGroundedEnforcementActive
         ? 'document_grounded_suggestion'
         : 'general_meeting_answer';
       // buildRetrievedActiveModeContextBlock signature:
@@ -2252,7 +2259,7 @@ ${IMAGE_TRUST_TRAILER}`;
         retrieveAnswerType,
         false, // excludeCustomContext: false — let the manager handle scoping per answer type
         undefined, // pinnedModeId
-        { forceDocumentGrounding: documentGroundedCustomModeActive },
+        { forceDocumentGrounding: docGroundedEnforcementActive },
       ) || '';
     } catch (_modeErr: any) {
       console.warn('[LLMHelper] ModesManager load failed in generateSuggestion (non-fatal):', _modeErr?.message);
@@ -2592,22 +2599,25 @@ This rule overrides ALL other instructions including formatting, brevity, or out
       // If knowledge mode is active, check for intro questions and
       // inject system prompt + relevant context
       // ============================================================
-      const documentGroundedCustomModeActive = (() => {
+      // R6 (2026-08-12): read the grounding info ONCE — this block previously
+      // called the getter three separate times — and derive both flags from it.
+      const _chatGroundingInfo = (() => {
         try {
           const { ModesManager } = require('./services/ModesManager');
-          return ModesManager.getInstance().getActiveModeDocumentGroundingInfo?.().documentGroundedCustomModeActive === true;
-        } catch { return false; }
+          return ModesManager.getInstance().getActiveModeDocumentGroundingInfo?.() ?? null;
+        } catch { return null; }
       })();
+      const documentGroundedCustomModeActive = _chatGroundingInfo?.documentGroundedCustomModeActive === true;
+      // Enforcement = explicit strict contract, or a doc mode with real files.
+      // The bare broad flag is true for every template-seeded mode and made
+      // this path force doc grounding over an empty corpus (review R6).
+      const docGroundedEnforcementActive = _chatGroundingInfo?.strictDocumentGroundedActive === true
+        || (documentGroundedCustomModeActive && _chatGroundingInfo?.hasReferenceFiles === true);
       // Defect C (2026-08-01): log the EXPLICIT strictness flag — the broad
       // flag is true for every default non-interview mode via the template
       // seed, so this line falsely announced strictness on stock Team Meet
       // and Lecture sessions.
-      if ((() => {
-        try {
-          const { ModesManager } = require('./services/ModesManager');
-          return ModesManager.getInstance().getActiveModeDocumentGroundingInfo?.().strictDocumentGroundedActive === true;
-        } catch { return false; }
-      })()) {
+      if (_chatGroundingInfo?.strictDocumentGroundedActive === true) {
         console.log('[LLMHelper] Generic bypass disabled: strict document-grounded mode active', {
           genericBypassDisabledReason: 'strict_document_grounded_mode',
           retrievalRequired: true,
@@ -2619,10 +2629,10 @@ This rule overrides ALL other instructions including formatting, brevity, or out
       // "please upload your document" because it literally has no context. Pull the
       // grounded context block directly from the ModesManager's hybrid retriever
       // (same call the WTA live path uses) and fold it into the user-facing context.
-      if (documentGroundedCustomModeActive) {
+      if (docGroundedEnforcementActive) {
         try {
           const { ModesManager } = require('./services/ModesManager');
-          const groundingInfo = ModesManager.getInstance().getActiveModeDocumentGroundingInfo?.();
+          const groundingInfo = _chatGroundingInfo;
           const groundedContext = await ModesManager.getInstance()
             .buildRetrievedActiveModeContextBlockHybrid(message, undefined, undefined, undefined, true);
           if (groundedContext && groundedContext.trim()) {
@@ -2635,7 +2645,11 @@ This rule overrides ALL other instructions including formatting, brevity, or out
           console.warn('[LLMHelper] Document-grounded manual retrieval failed, proceeding without:', groundedErr.message);
         }
       }
-      if (this.knowledgeOrchestrator?.isKnowledgeMode() && !documentGroundedCustomModeActive) {
+      // R6: knowledge suppression reads the STRICT flag (Defect C doctrine —
+      // same as the manual streaming path at ~5448 and the WTA engine). The
+      // broad flag silently dropped resume/knowledge injection for every
+      // template-seeded mode on this non-streaming path (follow-up-email flow).
+      if (this.knowledgeOrchestrator?.isKnowledgeMode() && _chatGroundingInfo?.strictDocumentGroundedActive !== true) {
         try {
           // Feed only to the depth scorer — NOT feedInterviewerUtterance, which also routes to the
           // negotiation tracker and would misclassify the user's typed question as a recruiter utterance.
@@ -2733,7 +2747,11 @@ try {
   activeModeGroundingInfo = modesMgrForInjection.getActiveModeDocumentGroundingInfo?.();
 } catch { /* non-fatal */ }
 const isActiveCustomMode = activeModeGroundingInfo?.isCustom === true;
-const forceDocumentGrounding = activeModeGroundingInfo?.documentGroundedCustomModeActive === true;
+// R6 (2026-08-12): files-aware — the bare broad flag forced doc grounding
+// for fileless template-seeded modes (review finding; same class as WTA).
+const forceDocumentGrounding = activeModeGroundingInfo?.strictDocumentGroundedActive === true
+  || (activeModeGroundingInfo?.documentGroundedCustomModeActive === true
+    && activeModeGroundingInfo?.hasReferenceFiles === true);
 // Prompt System v2 (flag promptSystemV2): default the base prompt to the
 // composed v2 'answer' prompt when the caller passed no override, and record
 // whether the base is v2-composed so the legacy MODE_* template suffix is not
@@ -5737,7 +5755,7 @@ let isMultimodal = !!(imagePaths?.length);
             hasCustomPrompt: activeModeGroundingInfo?.hasCustomPrompt === true,
             hasReferenceFiles: activeModeGroundingInfo?.hasReferenceFiles === true,
             documentGrounded: activeModeGroundingInfo?.documentGrounded === true,
-            documentGroundedCustomModeActive: forceDocumentGrounding,
+            documentGroundedCustomModeActive: activeModeGroundingInfo?.documentGroundedCustomModeActive === true,
             answerType: routeOptions?.answerType,
             modeLock: true,
             modeLockReason: 'user_created_custom_mode',
@@ -5960,7 +5978,7 @@ let isMultimodal = !!(imagePaths?.length);
         telemetryService.track({
           name: 'pi_doc_grounded_retrieval_summary',
           properties: {
-            documentGroundedCustomModeActive: forceDocumentGrounding,
+            documentGroundedCustomModeActive: activeModeGroundingInfo?.documentGroundedCustomModeActive === true,
             forceDocumentGrounding,
             retrievalSourceUsed: usedRerankPath ? 'hybrid' : 'lexical',
             hybridAttempted: forceDocumentGrounding,

--- a/electron/intelligence/context-os/refusalPolicy.ts
+++ b/electron/intelligence/context-os/refusalPolicy.ts
@@ -113,6 +113,29 @@ export function clarificationIsActionable(input: {
   hasReferenceFiles: boolean;
 }): boolean {
   if (typeof input.sourceAuthority !== 'string') return true;
-  if (!REFERENCE_BOUND_AUTHORITIES.has(input.sourceAuthority)) return true;
-  return input.hasReferenceFiles;
+  // R8 (2026-08-12, review finding): the docblock promised "unknown
+  // authorities fail toward answering the user", but the fall-through
+  // returned TRUE — letting the clarify short-circuit gag a turn on an
+  // authority we cannot even classify (a 'legacy' or future value). The
+  // known non-reference-bound authorities keep clarify available (they
+  // disambiguate between REAL universes); the reference-bound trio needs
+  // files; anything else is unclassifiable and must answer instead.
+  if (REFERENCE_BOUND_AUTHORITIES.has(input.sourceAuthority)) {
+    return input.hasReferenceFiles;
+  }
+  return KNOWN_SOURCE_AUTHORITIES.has(input.sourceAuthority);
 }
+
+/** Every authority modeSourceContract can produce (hand-mirror of
+ *  ModeSourceAuthority — same layering constraint as
+ *  BOUNDED_UNIVERSE_AUTHORITIES; the drift-guard test asserts agreement). */
+const KNOWN_SOURCE_AUTHORITIES: ReadonlySet<string> = new Set([
+  'reference_files_only',
+  'reference_files_primary',
+  'reference_files_plus_transcript',
+  'profile_only',
+  'profile_plus_transcript',
+  'transcript_only',
+  'general_mixed',
+  'ask_if_ambiguous',
+]);

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -4374,7 +4374,13 @@ export function initializeIpcHandlers(appState: AppState): void {
                   // pack exists. A governed `answer`-policy pack that merely
                   // produced a weak answer is still repaired below — only an
                   // explicit governed REFUSAL is trusted here.
-                  const governedRefusal = manualContextOsGeneration?.evidencePack?.answerPolicy === 'refuse_insufficient_evidence';
+                  // R10 (2026-08-12, review finding): keying on pack PRESENCE
+                  // contradicted the docblock ("only an explicit GOVERNED refusal
+                  // is trusted here") — an ungoverned refuse pack from a fileless
+                  // doc-flavored mode could block the false-refusal repair while
+                  // strong document evidence existed. Same class as #446's F3.
+                  const governedRefusal = manualContextOsGeneration?.govern === true
+                    && manualContextOsGeneration?.evidencePack?.answerPolicy === 'refuse_insufficient_evidence';
                   // Both the system's own refusal phrase and a model-phrased
                   // refusal clear the same bar (the question is about a real
                   // document topic). Off-topic questions match neither a whole
@@ -4958,7 +4964,14 @@ export function initializeIpcHandlers(appState: AppState): void {
                   // Phase 9 (exact-pack identity): when the typed pack GOVERNED
                   // this generation (H1), reuse that EXACT pack — same packId end
                   // to end. Otherwise build a verify-pack from the captured block.
-                  const verifyPack: import('./intelligence/context-os').EvidencePack = manualContextOsGeneration?.evidencePack ?? ((): import('./intelligence/context-os').EvidencePack => {
+                  // R3 (2026-08-12, review finding): PR #446 created the
+                  // pack-exists-with-govern:false state, and this consumer kept
+                  // keying on PRESENCE — so a legacy-path answer (the very turn
+                  // the fix un-gagged) was verified against the DISCARDED empty
+                  // refuse pack instead of the capturedEvidenceBlock it was
+                  // actually grounded in, persisting claims under the wrong
+                  // packId/answerPolicy/sourceOwner identity.
+                  const verifyPack: import('./intelligence/context-os').EvidencePack = (manualContextOsGeneration?.govern ? manualContextOsGeneration?.evidencePack : null) ?? ((): import('./intelligence/context-os').EvidencePack => {
                     const evItems = (() => {
                       if (!capturedEvidenceBlock.trim()) return [];
                       const snippets = parseModeSnippets(capturedEvidenceBlock);

--- a/electron/llm/AnswerPlanner.ts
+++ b/electron/llm/AnswerPlanner.ts
@@ -184,8 +184,18 @@ export interface AnswerPlan {
   answerStyle: AnswerStyle;
   /** Soft spoken-length target in seconds (0 = no explicit constraint). */
   answerStyleTargetSeconds: number;
-  /** True when a user-created custom mode requires uploaded/reference files as source of truth. */
+  /** BROAD doc-grounded flag — true for every template-seeded doc mode, files
+   *  or not. Isolation consumers (contextRoute layer suppression,
+   *  conversationHistoryPolicy, candidate-profile drop) key on THIS, per the
+   *  ModesManager Defect C doctrine: isolation is cheap and stays wide.
+   *  R9 (2026-08-12): #446 briefly repurposed this field to strict-preferred,
+   *  silently turning plan-level isolation OFF for broad-not-strict modes. */
   documentGroundedCustomModeActive?: boolean;
+  /** STRICT-preferred doc grounding (explicit strictness when the snapshot
+   *  carries it; broad fallback for legacy callers). Prompt-refusal semantics
+   *  (the grounding policyLine) key on THIS — a refusal instruction is only
+   *  honest for a genuinely bounded universe. */
+  strictDocumentGroundedActive?: boolean;
 }
 
 export interface PlanAnswerInput {
@@ -1470,6 +1480,8 @@ export const planAnswer = (input: PlanAnswerInput): AnswerPlan => {
   // pipeline for stock template-seeded modes with zero files.
   const documentGroundedCustomModeActive =
     (input.activeMode?.strictDocumentGroundedActive ?? input.activeMode?.documentGroundedCustomModeActive) === true;
+  // R9: the raw broad flag, for the PLAN FIELD isolation consumers read.
+  const broadDocumentGroundedActive = input.activeMode?.documentGroundedCustomModeActive === true;
   const explicitDocumentModeCodingAsk = /\b(write|implement|code|coding interview|dsa|dry run|time complexity|space complexity|big[-\s]?o|algorithm(?:ic)?|solution code|source code)\b/i.test(text);
   const explicitDocumentModeProfileAsk = /\b(resume|cv|profile|job description|\bjd\b|career|work experience|candidate profile|my background|your background|my projects?|your projects?|my skills?|your skills?)\b/i.test(text);
 
@@ -2057,7 +2069,8 @@ export const planAnswer = (input: PlanAnswerInput): AnswerPlan => {
     confidence: Math.max(input.intentResult?.confidence || input.extractedQuestion?.confidence || 0.7, 0),
     answerStyle: detectAnswerStyle(question).style,
     answerStyleTargetSeconds: detectAnswerStyle(question).targetSeconds,
-    documentGroundedCustomModeActive,
+    documentGroundedCustomModeActive: broadDocumentGroundedActive,
+    strictDocumentGroundedActive: documentGroundedCustomModeActive,
   };
 };
 
@@ -2149,7 +2162,11 @@ export const formatAnswerPlanForPrompt = (plan: AnswerPlan, includeVerificationS
         // sales sessions (manual regression 2026-06-12).
         ? 'Speak in the FIRST PERSON as the product\'s seller/representative ("our product", "we"). Never identify as an AI assistant.'
         : 'Answer in a neutral, explanatory voice. Do not roleplay as the candidate.';
-  const policyLine = plan.documentGroundedCustomModeActive
+  // R9: the grounding/refusal instruction keys on STRICT-preferred — telling
+  // the model to refuse outside "the uploaded material" is only honest when a
+  // bounded universe exists; the broad flag put that line into every
+  // template-seeded fileless mode's prompt.
+  const policyLine = (plan.strictDocumentGroundedActive ?? plan.documentGroundedCustomModeActive)
     ? 'Ground every concrete claim in the uploaded/reference files for this custom mode. If the answer is not supported by the uploaded material, say plainly that the requested information is not in the uploaded material. Do not reconstruct it from general knowledge, prior assistant answers, profile, resume, JD, or persona context.'
     : plan.profileContextPolicy === 'required'
       ? 'Ground every concrete claim in the provided profile facts. Never invent names, numbers, metrics, companies, or technologies that are not in those facts.'

--- a/electron/llm/WhatToAnswerLLM.ts
+++ b/electron/llm/WhatToAnswerLLM.ts
@@ -270,7 +270,13 @@ ANSWER SHAPE: ${intentResult.answerShape}
                     // (LLMHelper:5448); this surface was not, so WTA ran the
                     // strict doc pipeline for every template-seeded mode with
                     // zero files — the root of the 2026-08-11 denial reports.
-                    const forceDocumentGrounding = activeModeGroundingInfo?.strictDocumentGroundedActive === true;
+                    const strictDocGroundedActive = activeModeGroundingInfo?.strictDocumentGroundedActive === true;
+                    // R1 (2026-08-12): enforcement = explicit strict contract OR a
+                    // doc-grounded mode with at least one real file. Strict-only
+                    // here dropped forced doc retrieval for template-seeded modes
+                    // the user actually uploaded documents into.
+                    const forceDocumentGrounding = strictDocGroundedActive
+                        || (documentGroundedCustomModeActive && activeModeGroundingInfo?.hasReferenceFiles === true);
                     const retrievalOptions = forceDocumentGrounding
                         ? { forceDocumentGrounding: true, followUpReferentHint: temporalContext?.previousResponses?.slice(-1)?.[0] }
                         : undefined;
@@ -301,10 +307,17 @@ ANSWER SHAPE: ${intentResult.answerShape}
                     if (answerPlan && !isLayerAllowed(answerPlan, 'reference_files')) {
                         referenceFilesAllowed = false;
                     }
-                    if (documentGroundedCustomModeActive) {
+                    // R2 (2026-08-12, review finding): this override used the BROAD
+                    // flag, so a template-seeded mode silently overrode the user's
+                    // EXPLICIT providerDataScopes reference_files=false denial and
+                    // shipped file chunks to the cloud provider. The retrievalRequired
+                    // rationale only holds when the mode's contract is genuinely
+                    // strict ("answer only from the files") — everywhere else the
+                    // user's denial wins and the reference layer is simply omitted.
+                    if (strictDocGroundedActive) {
                         if (!referenceFilesAllowed) {
-                            console.warn('[WhatToAnswerLLM] Generic/reference layer exclusion overridden: document-grounded custom mode active', {
-                                genericBypassDisabledReason: 'document_grounded_custom_mode',
+                            console.warn('[WhatToAnswerLLM] Generic/reference layer exclusion overridden: strict document-grounded mode active', {
+                                genericBypassDisabledReason: 'strict_document_grounded_mode',
                                 retrievalRequired: true,
                             });
                         }

--- a/electron/services/__tests__/ContextOsRefusalGoverns2026_08_11.test.mjs
+++ b/electron/services/__tests__/ContextOsRefusalGoverns2026_08_11.test.mjs
@@ -176,7 +176,29 @@ describe('a clarify short-circuit must be ACTIONABLE (live report #2, 2026-08-11
   });
 
   test('unknown authority fails toward answering the user, not gagging them', () => {
-    assert.equal(clarificationIsActionable({ sourceAuthority: 'legacy', hasReferenceFiles: false }), true);
+    // R8 (2026-08-12): this test's TITLE always stated the right invariant but
+    // its assertion baked the inversion in — `true` here means the clarify
+    // short-circuit MAY fire, i.e. the user IS gagged on an authority nobody
+    // can classify. Unknown/legacy/future values must answer instead.
+    assert.equal(clarificationIsActionable({ sourceAuthority: 'legacy', hasReferenceFiles: false }), false);
+    assert.equal(clarificationIsActionable({ sourceAuthority: 'some_future_authority', hasReferenceFiles: true }), false);
+    // null/undefined stay permissive: a missing field is "no contract at all",
+    // which predates the authority system and keeps legacy flows untouched.
+    assert.equal(clarificationIsActionable({ sourceAuthority: null, hasReferenceFiles: false }), true);
+  });
+
+  test('R8 drift guard: every ModeSourceAuthority the contract module can produce is classified', () => {
+    // Mirrors the ModeSourceAuthority union (modeSourceContract.ts). If a new
+    // authority is added there, clarificationIsActionable must learn it —
+    // otherwise every mode carrying it is silently barred from clarifying.
+    const allAuthorities = [
+      'reference_files_only', 'reference_files_primary', 'reference_files_plus_transcript',
+      'profile_only', 'profile_plus_transcript', 'transcript_only', 'general_mixed', 'ask_if_ambiguous',
+    ];
+    for (const sourceAuthority of allAuthorities) {
+      const verdictWithFiles = clarificationIsActionable({ sourceAuthority, hasReferenceFiles: true });
+      assert.equal(verdictWithFiles, true, `${sourceAuthority} with files must remain clarifiable`);
+    }
   });
 });
 
@@ -230,10 +252,12 @@ describe('a developer diagnostic is never user-visible prose (live report #3, 20
     const src = fs.readFileSync(path.resolve(process.cwd(), 'electron/IntelligenceEngine.ts'), 'utf8');
     // documentGroundedCustomModeActive was proven TRUE with zero files —
     // the govern gate must pair it with a hasReferenceFiles check.
-    // 2026-08-12: the gate got stricter still — it now keys on the EXPLICIT
-    // strictness flag (Defect C split) AND keeps the files requirement as
-    // belt-and-braces (reference_files_only can be strict with zero files).
-    const gate = /strictDocumentGroundedActive\s*\n[^]{0,700}?hasReferenceFiles[^]{0,200}?contextOsEvidencePackEnabled/;
+    // 2026-08-12: the gate keys on docGroundedEnforcementActive (R1: explicit
+    // strict contract OR broad-with-files — restores parity with manual chat
+    // for seeded modes the user actually uploaded documents into) AND keeps
+    // the explicit files requirement as belt-and-braces (reference_files_only
+    // can be strict with zero files).
+    const gate = /docGroundedEnforcementActive\s*\n[^]{0,700}?hasReferenceFiles[^]{0,200}?contextOsEvidencePackEnabled/;
     assert.ok(gate.test(src), 'site-2 govern must key on strictDocumentGroundedActive AND require hasReferenceFiles');
   });
 });


### PR DESCRIPTION
## What

Fixes all ten findings from the post-merge multi-angle review of #446 (8 CONFIRMED, 2 PLAUSIBLE). Every finding was the same shape: the strict/broad flag split and the new pack-exists-but-ungoverned state had **more consumers than the seven #446 migrated**. Each claim was re-verified in source before fixing.

| # | Fix |
|---|---|
| R1 | `docGroundedEnforcementActive = strict OR (broad && files)` at IE retrieval/validator/site-2 — seeded modes users actually uploaded files into get their zero-fabrication validator and forced doc retrieval back (manual-chat parity) |
| R2 | The `providerDataScopes.reference_files` denial override narrows to strict-only — a seeded mode no longer overrides an explicit privacy denial |
| R3 | Claims verification keys verifyPack on `.govern`, not pack presence |
| R4 | Clarify bypass uses the full visual predicate (images + screen-OCR + DOM) |
| R5 | Fallback transcript strip requires real doc enforcement |
| R6 | `generateSuggestion` + `chatWithGemini` files-aware; knowledge suppression reads strict (doctrine); getter read once; telemetry labels truthful |
| R7 | `contract.reason` no longer stored as `sourceAuthority` in traces/audit rows |
| R8 | Unknown authorities fail toward answering (mirror set + fixed the test that baked the inversion in) |
| R9 | `AnswerPlan` field split: `documentGroundedCustomModeActive` reverts to broad (plan-level isolation restored), new `strictDocumentGroundedActive` carries the refusal policyLine |
| R10 | `governedRefusal` requires `.govern` before suppressing the false-refusal repair |

## Verification

- Targeted suites (WTA/ContextOs/Evidence/AnswerPlanner/ContextRoute/CustomModes/ModeBleedingMatrix): **183/183**
- Wider slice (all `llm` suites + mode suites, 3,584 tests): **zero new failing names** vs the clean-main baseline (27 fails, all pre-existing long-tail)
- `tsc` + esbuild clean
- All changed code is platform-independent shared TypeScript — `Reviewed but not executed` on both platforms; no platform-sensitive surface touched

## Notes

- The R4 manual-chat twin needs no change: that surface has no screen/DOM channels (verified — those belong to generate-what-to-say).
- R6's knowledge-suppression uses strict (not enforcement) deliberately, matching the manual streaming path and the Defect C doctrine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)