### PR TITLE
fix(review): stop the modal opening pre-rated, and let it actually animate out

### DIFF
--- a/src/components/ReviewModal.tsx
+++ b/src/components/ReviewModal.tsx
@@ -181,10 +181,23 @@ const ReviewModal: React.FC<ReviewModalProps> = ({
 
     // Move focus to the first star button when the modal opens (after the
     // entrance settles) so keyboard users land in the right place.
+    //
+    // Code-review 2026-08-12: each star's `onFocus` paints a hover preview, so
+    // this programmatic focus opened the modal already showing a 1-star "Poor"
+    // verdict the user never chose — with Send disabled (it keys on `rating`,
+    // not `hoverRating`) and no way to clear it without a mouse. Landing focus
+    // is a placement, not an opinion: the flag below suppresses exactly the one
+    // synthetic focus this effect causes. `.focus()` dispatches its event
+    // synchronously, so the flag is set and cleared around that single call and
+    // can never swallow a later, genuine focus.
+    const suppressStarFocusPreview = useRef(false)
     useEffect(() => {
         if (!isOpen) return
         const t = window.setTimeout(() => {
-            document.querySelector<HTMLButtonElement>('[data-review-star="1"]')?.focus()
+            const first = document.querySelector<HTMLButtonElement>('[data-review-star="1"]')
+            if (!first) return
+            suppressStarFocusPreview.current = true
+            try { first.focus() } finally { suppressStarFocusPreview.current = false }
         }, 260)
         return () => window.clearTimeout(t)
     }, [isOpen])
@@ -326,13 +339,19 @@ const ReviewModal: React.FC<ReviewModalProps> = ({
         [shownRating],
     )
 
-    if (!isOpen) return null
-
     const titleId = `review-modal-title-${step}`
     const busy = submitting || testimonialBusy
 
+    // Code-review 2026-08-12: this was `if (!isOpen) return null` ABOVE the
+    // AnimatePresence. Closing the modal unmounted the AnimatePresence together
+    // with its children on the very next render, and AnimatePresence can only
+    // animate children it outlives — it cannot animate its own unmount. Both
+    // `exit` variants below were therefore dead code and the modal hard-cut.
+    // The presence boundary now stays mounted (the parent renders this
+    // component unconditionally) and the CHILDREN are what come and go.
     return (
         <AnimatePresence>
+            {isOpen && (
             <motion.div
                 key="backdrop"
                 initial={{ opacity: 0 }}
@@ -342,6 +361,8 @@ const ReviewModal: React.FC<ReviewModalProps> = ({
                 onClick={() => !busy && dismissLaterAndClose()}
                 className="review-modal-backdrop"
             />
+            )}
+            {isOpen && (
             <motion.div
                 key="container"
                 initial={{ opacity: 0, transform: reduced ? "none" : "translateY(10px) scale(0.985)" }}
@@ -389,6 +410,7 @@ const ReviewModal: React.FC<ReviewModalProps> = ({
                                     onDismissLater={dismissLaterAndClose}
                                     onDismissForever={dismissForeverAndClose}
                                     textareaRef={textareaRef}
+                                    suppressStarFocusPreview={suppressStarFocusPreview}
                                     reduced={reduced}
                                 />
                             )}
@@ -427,6 +449,7 @@ const ReviewModal: React.FC<ReviewModalProps> = ({
                     </div>
                 </motion.div>
             </motion.div>
+            )}
         </AnimatePresence>
     )
 }
@@ -503,13 +526,17 @@ interface StepReviewProps {
     onDismissLater: () => void
     onDismissForever: () => void
     textareaRef: React.RefObject<HTMLTextAreaElement | null>
+    /** True while the open-effect's synthetic `.focus()` is in flight, so
+     *  landing focus on star 1 does not paint a rating the user never chose. */
+    suppressStarFocusPreview: React.RefObject<boolean>
     reduced: boolean
 }
 
 const StepReview: React.FC<StepReviewProps> = ({
     rating, shownRating, ratingWord, setRating, setHoverRating,
     text, setText, maxChars, submitting, error,
-    onSubmit, onDismissLater, onDismissForever, textareaRef, reduced,
+    onSubmit, onDismissLater, onDismissForever, textareaRef,
+    suppressStarFocusPreview, reduced,
 }) => {
     const remaining = maxChars - text.length
     const showCounter = remaining <= 60
@@ -573,7 +600,10 @@ const StepReview: React.FC<StepReviewProps> = ({
                             transition={{ ...(reduced ? { duration: 0 } : SPRING_BOUNCY), delay: reduced ? 0 : i * 0.03 }}
                             whileTap={reduced || submitting ? undefined : { scale: 0.9 }}
                             onMouseEnter={() => !submitting && setHoverRating(n)}
-                            onFocus={() => !submitting && setHoverRating(n)}
+                            onFocus={() => {
+                                if (suppressStarFocusPreview.current) return
+                                if (!submitting) setHoverRating(n)
+                            }}
                             onClick={() => setRating(n)}
                             onKeyDown={(e) => handleStarKey(e, n)}
                             disabled={submitting}

--- a/src/components/__tests__/ReviewModalOpenStateContract2026_08_12.test.mjs
+++ b/src/components/__tests__/ReviewModalOpenStateContract2026_08_12.test.mjs
@@ -1,0 +1,73 @@
+// Two review-modal defects found by code review on 2026-08-12, pinned as
+// source contracts (this component has no render harness in the repo; its
+// sibling suite pins the composition the same way).
+//
+//  1. EXIT ANIMATIONS COULD NEVER RUN. `if (!isOpen) return null` sat ABOVE the
+//     <AnimatePresence>, so closing unmounted the presence boundary together
+//     with its children on the next render. AnimatePresence can only animate
+//     children it outlives — it cannot animate its own unmount — so both `exit`
+//     variants were dead code and the modal hard-cut. The parent
+//     (ReviewPromptHost) renders <ReviewModal> unconditionally, so the boundary
+//     can simply stay mounted and the CHILDREN come and go.
+//
+//  2. THE MODAL OPENED PRE-RATED. The open effect focuses star 1 so keyboard
+//     users land in the rail, but each star's onFocus paints a hover preview —
+//     so the modal opened showing a 1-star "Poor" verdict the user never chose,
+//     with Send disabled (it keys on `rating`, not `hoverRating`) and no way to
+//     clear it without a mouse. Landing focus is a placement, not an opinion.
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const MODAL = readFileSync(join(HERE, '../ReviewModal.tsx'), 'utf8');
+/** Strip comments so prose describing the OLD behaviour can't satisfy a check. */
+const LIVE = MODAL.replace(/\/\/[^\n]*/g, '').replace(/\/\*[\s\S]*?\*\//g, '');
+
+describe('Review modal — open/close state', () => {
+    test('the presence boundary outlives the modal, so exit variants can run', () => {
+        assert.doesNotMatch(LIVE, /if\s*\(\s*!isOpen\s*\)\s*return\s+null/,
+            'an early return above <AnimatePresence> unmounts the boundary with its children; exit animations become dead code');
+    });
+
+    test('the animated children are what mount and unmount', () => {
+        const presenceStart = LIVE.indexOf('<AnimatePresence>');
+        assert.ok(presenceStart >= 0, 'the modal must still use AnimatePresence');
+        const body = LIVE.slice(presenceStart);
+        assert.match(body, /\{isOpen\s*&&\s*\(/,
+            'backdrop and container must be conditional CHILDREN of AnimatePresence');
+    });
+
+    test('both animated children still declare an exit variant', () => {
+        for (const key of ['backdrop', 'container']) {
+            const at = LIVE.indexOf(`key="${key}"`);
+            assert.ok(at > 0, `the ${key} motion element is missing`);
+            assert.match(LIVE.slice(at, at + 600), /exit=\{/, `${key} lost its exit variant`);
+        }
+    });
+
+    test('landing focus on the first star does not paint a rating', () => {
+        // The guard must wrap the FOCUS handler specifically: mouse hover still
+        // previews, and a genuine keyboard focus still previews.
+        const at = LIVE.indexOf('onFocus=');
+        assert.ok(at > 0, 'the star focus handler is missing');
+        assert.match(LIVE.slice(at, at + 220), /suppressStarFocusPreview\.current/,
+            'a programmatic focus must not set hoverRating');
+        assert.match(LIVE, /onMouseEnter=\{\(\)\s*=>\s*!submitting\s*&&\s*setHoverRating\(n\)\}/,
+            'mouse hover preview must be unchanged');
+    });
+
+    test('the suppression flag is set and cleared around the synthetic focus only', () => {
+        const effect = LIVE.slice(LIVE.indexOf('data-review-star="1"') - 400, LIVE.indexOf('data-review-star="1"') + 400);
+        assert.match(effect, /suppressStarFocusPreview\.current\s*=\s*true/);
+        assert.match(effect, /suppressStarFocusPreview\.current\s*=\s*false/,
+            'the flag must be cleared in the same turn, or the first genuine focus is swallowed');
+    });
+
+    test('Send still keys on the CHOSEN rating, never the preview', () => {
+        assert.match(LIVE, /const\s+canSubmit\s*=[^\n]*\brating\b/);
+        assert.doesNotMatch(LIVE, /const\s+canSubmit\s*=[^\n]*hoverRating/);
+    });
+});


### PR DESCRIPTION
Two code-review findings against the modal redesign merged in #450, based on that PR's head so this is a clean one-commit delta.

### The modal opened showing a rating nobody chose
The open effect focuses star 1 so keyboard users land in the rail, but each star's `onFocus` paints a hover preview. So the modal opened on a 1-star **"Poor"** verdict, with Send greyed out (`canSubmit` keys on `rating`, not `hoverRating`) and no way to clear it — only `onMouseLeave` resets the preview, which a keyboard user never fires.

Landing focus is a placement, not an opinion. A ref flag suppresses exactly the one synthetic focus this effect causes; `.focus()` dispatches synchronously, so the flag is set and cleared around that single call and cannot swallow a later, genuine focus. Mouse hover and real keyboard focus still preview.

### The exit animations were dead code
`if (!isOpen) return null` sat **above** the `AnimatePresence`, so closing unmounted the presence boundary together with its children on the next render — and AnimatePresence can only animate children it outlives; it cannot animate its own unmount. Both `exit` variants never played and the modal hard-cut, backdrop and all.

`ReviewPromptHost` renders this component unconditionally, so the boundary now stays mounted and the backdrop/container are conditional *children*, which is what lets their exit run.

### Tests
Adds a contract suite pinning both, since neither is expressible in the composition suite. It fails if the early return comes back, if either exit variant is dropped, if the focus guard is removed, or if `canSubmit` starts keying on the preview rating.

- new suite 6/6, the existing `ReviewModalCinematicContract` 13/13, `tsc --noEmit` exit 0
- verified in a clean worktree off #450's head, not in a shared working tree

Two component tests remain red on this branch and are **not** touched here — `PlansMotionCompositing` (`will-change: transform, width`; width isn't compositable) and `SettingsPeriwinklePortalScopeGuard` (stale guard file list). They were already failing before this change. Worth noting `src/components/__tests__/` is run by no npm script, which is why they went unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSXKVJvchN6bPJK2fKT4Rw