### PR TITLE
fix(answers): [[GIST]] marker leaking on screen, dishonest refusals, ungoverned packs

### DIFF
--- a/electron/IntelligenceEngine.ts
+++ b/electron/IntelligenceEngine.ts
@@ -3242,7 +3242,17 @@ export class IntelligenceEngine extends EventEmitter {
                         // runs on validation failure regardless of governance —
                         // that is a deliberate second attempt at repair, not a
                         // duplicate of the first-pass retrieval.
-                        const _governedPack = wtaContextOsGeneration?.evidencePack;
+                        // Code-review 2026-08-12: keyed on pack PRESENCE, but a
+                        // pack rides along even when it does NOT govern
+                        // (packGovernsGeneration false — the layer-1
+                        // fall-through). Such a pack has no items, so this
+                        // validator checked the answer against an EMPTY
+                        // evidence block for a turn the legacy retrieval path
+                        // actually answered, and refused it. Match
+                        // WhatToAnswerLLM's gate: govern, not presence.
+                        const _governedPack = wtaContextOsGeneration?.govern
+                            ? wtaContextOsGeneration.evidencePack
+                            : undefined;
                         let docContextBlock = (_governedPack && _governedPack.items.length > 0)
                             ? _governedPack.items.map((it) => `[Section: ${it.pointer?.section || it.sourceId}]\n${it.text}`).join('\n\n')
                             : await buildDocContext(false);

--- a/electron/intelligence/__tests__/RefusalWordingBySourceOwner2026_08_12.test.mjs
+++ b/electron/intelligence/__tests__/RefusalWordingBySourceOwner2026_08_12.test.mjs
@@ -1,0 +1,76 @@
+// electron/intelligence/__tests__/RefusalWordingBySourceOwner2026_08_12.test.mjs
+//
+// A refusal must not lie about WHERE it looked. The 2026-08-11 fix added the
+// `sourceOwner` parameter for exactly that reason, but special-cased only
+// 'profile' — so a transcript-owned or mixed-owned refusal still told the user
+// "not directly mentioned in the uploaded material" in modes with zero uploaded
+// files (code review 2026-08-12). SourceAuthorityKernel issues 'transcript' and
+// 'mixed' owners as readily as 'profile', and packGovernsGeneration lets a
+// bounded transcript authority reach the user, so both wordings ship.
+//
+// Every stem must keep the "not directly mentioned" opening: the doc-grounded
+// repair sniffer (ipcHandlers REFUSAL_SNIFF_RE) keys on that phrase to tell a
+// refusal from an answer, and a stem it cannot recognize would be re-repaired.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+const cjsRequire = createRequire(import.meta.url);
+const co = cjsRequire(path.resolve(repoRoot, 'dist-electron/electron/intelligence/context-os/index.js'));
+const { buildInsufficientPropertyAnswer } = co;
+
+// Mirrors ipcHandlers.ts REFUSAL_SNIFF_RE.
+const REFUSAL_SNIFF_RE = /not (?:directly )?(?:mentioned|in (?:the|my) (?:uploaded|seminar|thesis|retrieved) (?:material|sections?|document)|found in|present in)|^I could not find\b|^this is not directly mentioned/i;
+
+const UPLOADED_CLAIM_RE = /uploaded material/i;
+
+describe('refusal wording names the universe that was actually searched', () => {
+  test('a profile-owned refusal says profile material', () => {
+    const line = buildInsufficientPropertyAnswer({ property: 'phase_or_stage', sourceOwner: 'profile' });
+    assert.match(line, /profile material/i);
+    assert.doesNotMatch(line, UPLOADED_CLAIM_RE);
+  });
+
+  test('a transcript-owned refusal does NOT claim uploaded material', () => {
+    const line = buildInsufficientPropertyAnswer({ property: 'phase_or_stage', sourceOwner: 'transcript' });
+    assert.doesNotMatch(line, UPLOADED_CLAIM_RE,
+      `a transcript_only mode has no uploaded files, got: ${line}`);
+    assert.match(line, /conversation/i);
+  });
+
+  test('a mixed-owned refusal does NOT claim uploaded material', () => {
+    const line = buildInsufficientPropertyAnswer({ property: 'phase_or_stage', sourceOwner: 'mixed' });
+    assert.doesNotMatch(line, UPLOADED_CLAIM_RE,
+      `a profile_plus_transcript mode may have zero uploaded files, got: ${line}`);
+  });
+
+  test('an absent or unknown owner keeps the historical wording', () => {
+    assert.match(buildInsufficientPropertyAnswer({ property: 'phase_or_stage' }), UPLOADED_CLAIM_RE);
+    assert.match(
+      buildInsufficientPropertyAnswer({ property: 'phase_or_stage', sourceOwner: 'reference_files' }),
+      UPLOADED_CLAIM_RE,
+    );
+  });
+
+  test('every owner stays recognizable to the refusal sniffer', () => {
+    for (const sourceOwner of ['profile', 'transcript', 'mixed', 'reference_files', undefined]) {
+      const line = buildInsufficientPropertyAnswer({ property: 'phase_or_stage', sourceOwner });
+      assert.match(line, REFUSAL_SNIFF_RE, `sniffer would miss the ${sourceOwner} refusal: ${line}`);
+    }
+  });
+
+  test('the near-miss note and funding rider still attach to every stem', () => {
+    const withNote = buildInsufficientPropertyAnswer({
+      property: 'phase_or_stage', sourceOwner: 'transcript', nearMissNote: 'It does cover the timeline.',
+    });
+    assert.match(withNote, /It does cover the timeline\./);
+
+    const funding = buildInsufficientPropertyAnswer({ property: 'funding_source', sourceOwner: 'mixed' });
+    assert.match(funding, /collaboration is not the same as funding/i);
+  });
+});

--- a/electron/intelligence/context-os/propertyEvidenceValidator.ts
+++ b/electron/intelligence/context-os/propertyEvidenceValidator.ts
@@ -109,6 +109,19 @@ export function itemSupportsProperty(item: EvidenceItem, property: RequestedProp
 }
 
 /**
+ * One stem per source owner the kernel can issue (SourceAuthorityKernel.ts
+ * resolves 'profile' | 'transcript' | 'mixed' | 'reference_files'). Every stem
+ * keeps the "not directly mentioned" opening the doc-grounded repair sniffer
+ * (ipcHandlers REFUSAL_SNIFF_RE) matches on. Unknown/absent owners fall back to
+ * the historical uploaded-material wording.
+ */
+const SOURCE_OWNER_REFUSAL_STEMS: Record<string, string> = {
+  profile: 'This is not directly mentioned in your profile material.',
+  transcript: 'This is not directly mentioned in the conversation so far.',
+  mixed: 'This is not directly mentioned in the material available for this mode.',
+};
+
+/**
  * The honest refusal line for a doc-grounded turn whose evidence has topic
  * overlap but not the requested property (Scenario D). Includes what the
  * material DOES mention when a near-miss category is identifiable — general
@@ -125,12 +138,17 @@ export function buildInsufficientPropertyAnswer(input: {
    * for. Optional so every existing caller keeps the historical wording; the
    * "not directly mentioned" stem is preserved on every branch because the
    * doc-grounded repair sniffer (ipcHandlers REFUSAL_SNIFF_RE) keys on it.
+   *
+   * Code-review 2026-08-12: only 'profile' was special-cased, but
+   * SourceAuthorityKernel also issues 'transcript' and 'mixed' owners — a
+   * transcript_only or profile_plus_transcript refusal still claimed to have
+   * searched uploaded files the user never provided, which is the same
+   * falsehood this parameter was added to remove.
    */
   sourceOwner?: string;
 }): string {
-  const base = input.sourceOwner === 'profile'
-    ? 'This is not directly mentioned in your profile material.'
-    : 'This is not directly mentioned in the uploaded material.';
+  const base = SOURCE_OWNER_REFUSAL_STEMS[input.sourceOwner ?? '']
+    ?? 'This is not directly mentioned in the uploaded material.';
   if (input.nearMissNote && input.nearMissNote.trim()) {
     return `${base} ${input.nearMissNote.trim()}`;
   }

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -4111,7 +4111,17 @@ export function initializeIpcHandlers(appState: AppState): void {
               // resolver failure), the legacy re-retrieval below remains the only
               // source, unchanged.
               let docContextBlock = '';
-              const _governedPack = manualContextOsGeneration?.evidencePack;
+              // Code-review 2026-08-12: keyed on pack PRESENCE, but a pack is
+              // now attached even when it does NOT govern (packGovernsGeneration
+              // false — the layer-1 fall-through for unbounded authorities). An
+              // ungoverned refusal pack has zero items, so `_governedPack` was
+              // truthy, the `!_governedPack` branches below were skipped, and
+              // the validator ran against an empty block for a turn the legacy
+              // path actually answered. `govern` is what the comment above
+              // means by "governed this turn".
+              const _governedPack = manualContextOsGeneration?.govern
+                ? manualContextOsGeneration.evidencePack
+                : undefined;
               // Root-cause fix (2026-07-23): prefer the RAW block the actual
               // generation call retrieved (surfaced via
               // ContextOsGenerationContext.retrievedBlockRaw, written

--- a/electron/llm/__tests__/GistNewlineRecovery2026_08_12.test.mjs
+++ b/electron/llm/__tests__/GistNewlineRecovery2026_08_12.test.mjs
@@ -1,0 +1,108 @@
+// electron/llm/__tests__/GistNewlineRecovery2026_08_12.test.mjs
+//
+// The main-process half of the [[GIST]] split contract. The renderer keeps a
+// hand-duplicated twin (src/lib/displayMarkup.ts, pinned by
+// src/lib/__tests__/displayMarkup.test.mjs) because it cannot import
+// main-process modules — the CASES table below is deliberately identical in
+// both suites, so a change to one copy that skips the other turns red here.
+//
+// Bug (2026-08-12): a model that put the essence on the line BELOW the marker
+// made the old split reject the whole shape, and a literal "[[GIST]]" painted
+// on screen above the essence. The split now recovers that shape for display
+// while spokenFormatViolations still reports it, so the drift stays visible.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const v2 = await import(
+    pathToFileURL(path.resolve(__dirname, '../../../dist-electron/electron/llm/promptSystemV2.js')).href
+);
+
+const { GIST_MARKER, splitGistLine, stripDisplayMarkup, spokenFormatViolations } = v2;
+
+// Keep in lockstep with src/lib/__tests__/displayMarkup.test.mjs.
+const CASES = [
+    ['clean trailing gist', 'Body one.\nBody two.\n[[GIST]] five word essence here',
+        { body: 'Body one.\nBody two.', gist: 'five word essence here' }],
+    ['no marker', 'No gist here.', { body: 'No gist here.', gist: null }],
+    ['marker mid-line is prose', 'text [[GIST]] inline', { body: 'text [[GIST]] inline', gist: null }],
+    ['marker at the top with a body under it', '[[GIST]] top\nreal body',
+        { body: '[[GIST]] top\nreal body', gist: null }],
+    ['marker as the entire single line', '[[GIST]] only line', { body: '', gist: 'only line' }],
+    // A marker that starts its line is chrome even with no essence: it must
+    // never survive into the body, which is what TTS speaks.
+    ['empty essence still strips the marker', 'Body.\n[[GIST]]   ', { body: 'Body.', gist: null }],
+    ['newline before the essence is recovered', 'You sort them first, then subtract.\n[[GIST]]\nSort the numbers and calculate c minus a',
+        { body: 'You sort them first, then subtract.', gist: 'Sort the numbers and calculate c minus a', recovered: true }],
+    ['newline before the essence, no body', '[[GIST]]\nSort the numbers and calculate c minus a',
+        { body: '', gist: 'Sort the numbers and calculate c minus a', recovered: true }],
+    ['blank lines between marker and essence', 'Body.\n[[GIST]]\n\n  five word essence here  \n',
+        { body: 'Body.', gist: 'five word essence here', recovered: true }],
+    ['TWO lines after the marker stay malformed', 'Body.\n[[GIST]]\nline one\nline two',
+        { body: 'Body.\n[[GIST]]\nline one\nline two', gist: null }],
+    // Length breaks the tie between a line-broken gist and a real closing
+    // sentence written under a misplaced marker: a gist is five to eight
+    // words by contract, so a longer line stays in the SPOKEN body.
+    ['a following line too long to be a gist stays malformed',
+        'Sort the array first, then walk it once.\n[[GIST]]\nThe answer is the difference between the last and the first elements.',
+        { body: 'Sort the array first, then walk it once.\n[[GIST]]\nThe answer is the difference between the last and the first elements.', gist: null }],
+    ['ten words is still recovered', 'Body.\n[[GIST]]\none two three four five six seven eight nine ten',
+        { body: 'Body.', gist: 'one two three four five six seven eight nine ten', recovered: true }],
+    ['eleven words is not', 'Body.\n[[GIST]]\none two three four five six seven eight nine ten eleven',
+        { body: 'Body.\n[[GIST]]\none two three four five six seven eight nine ten eleven', gist: null }],
+];
+
+describe('splitGistLine — main-process copy', () => {
+    assert.equal(GIST_MARKER, '[[GIST]]');
+
+    for (const [name, input, expected] of CASES) {
+        test(name, () => {
+            assert.deepEqual(splitGistLine(input), expected);
+        });
+    }
+
+    test('a recovered gist is never spoken', () => {
+        assert.equal(
+            stripDisplayMarkup('The **key term** here.\n[[GIST]]\nessence'),
+            'The key term here.',
+        );
+    });
+});
+
+describe('spokenFormatViolations — recovery is containment, not absolution', () => {
+    test('a clean gist line is not a violation', () => {
+        const rules = spokenFormatViolations('You sort them first, then subtract.\n[[GIST]] sort then subtract')
+            .map((v) => v.rule);
+        assert.ok(!rules.includes('gist_misplaced'), rules.join(','));
+    });
+
+    test('a recovered newline split is STILL reported as gist_misplaced', () => {
+        const rules = spokenFormatViolations('You sort them first, then subtract.\n[[GIST]]\nsort then subtract')
+            .map((v) => v.rule);
+        assert.ok(rules.includes('gist_misplaced'), rules.join(','));
+    });
+
+    test('a mid-line marker is still reported', () => {
+        const rules = spokenFormatViolations('You sort them [[GIST]] first, then subtract.')
+            .map((v) => v.rule);
+        assert.ok(rules.includes('gist_misplaced'), rules.join(','));
+    });
+
+    test('the recovered essence is not linted as prose', () => {
+        // An essence carrying banned prose punctuation must not add em_dash /
+        // semicolon violations: it is display chrome, split off before linting.
+        const rules = spokenFormatViolations('You sort them first, then subtract.\n[[GIST]]\nsort; then subtract — fast')
+            .map((v) => v.rule);
+        assert.deepEqual(rules, ['gist_misplaced']);
+    });
+});
+
+describe('prompt contract states the same-line rule', () => {
+    test('the glance-layer instruction forbids a break after the marker', () => {
+        const prompt = v2.buildSystemPromptV2({ mode: 'general', action: 'answer', tier: 'cloud' });
+        assert.match(prompt, /\[\[GIST\]\] followed on that SAME line/);
+    });
+});

--- a/electron/llm/promptSystemV2.ts
+++ b/electron/llm/promptSystemV2.ts
@@ -238,7 +238,8 @@ For spoken output, use short plain paragraphs, broken at natural breath points e
 Glance layer — for the reader's eye only, never changing the words to say:
 1. After writing the answer, wrap the two or three words that carry it in **double asterisks**: the name, the number, the term the user must not fumble. At most three marks, each at most four words, and never reshape a sentence to showcase a mark — mark the sentence you already wrote. Marked words render as highlights on screen and are spoken like any other word.
 2. When the question itself is enumerable — steps, "three ways", pros and cons, a comparison — answer as a short numbered list, each item one speakable sentence, five items at most. Never use a list for a question that is not enumerable, and never hyphen bullets.
-3. When the spoken answer runs past about forty words, add one final line: [[GIST]] followed by the five-to-eight-word essence. It sits at the very bottom, renders as a summary chip, is never spoken, and does not count toward the answer's length.
+3. When the spoken answer runs past about forty words, add one final line: [[GIST]] followed on that SAME line by the five-to-eight-word essence — never a line break between the marker and the essence. It sits at the very bottom, renders as a summary chip, is never spoken, and does not count toward the answer's length.
+   WRONG: the marker alone on its line with the essence underneath. RIGHT: [[GIST]] sort then subtract
 
 The em dash is the strongest AI tell. Never use — or – in spoken prose; use a comma, or split into two sentences.
 WRONG: "I led the migration — it took about six months."
@@ -794,18 +795,41 @@ export function recommendedGenerationProfile(action: PromptSystemV2Action): Gene
 /** Marker for the bottom gist line — rendered as a summary chip, never spoken. */
 export const GIST_MARKER = '[[GIST]]';
 
-/** Split a response into its speakable body and the optional bottom gist. */
-export function splitGistLine(text: string): { body: string; gist: string | null } {
+/**
+ * Split a response into its speakable body and the optional bottom gist.
+ *
+ * The marker is honored only when it STARTS a line — mid-line it is prose and
+ * stays visible so the lint can flag it. A marker that starts its line is
+ * display chrome either way: even with no essence after it, the marker never
+ * reaches the body (stripDisplayMarkup feeds TTS, which would say it aloud).
+ *
+ * Canonically the essence follows on that same line; a model that breaks the
+ * line after the marker used to leak a literal `[[GIST]]` to screen
+ * (2026-08-12), so a marker alone on its line is RECOVERED when exactly one
+ * short non-empty line follows. Two rejections keep the recovery from eating
+ * real prose: more than one following line, and a following line longer than
+ * a gist can contractually be (the prompt asks for five to eight words; past
+ * RECOVERY_MAX_WORDS it is likelier a real closing sentence written under a
+ * misplaced marker, and demoting it to the chip would silently drop a spoken
+ * sentence). Rejected shapes keep the marker visible and lint-flagged.
+ *
+ * Renderer twin: src/lib/displayMarkup.ts. Keep the two in lockstep.
+ */
+const GIST_RECOVERY_MAX_WORDS = 10;
+
+export function splitGistLine(text: string): { body: string; gist: string | null; recovered?: boolean } {
     const t = (text || '').replace(/\s+$/, '');
     const idx = t.lastIndexOf(GIST_MARKER);
     if (idx < 0) return { body: t, gist: null };
-    // Only honor the marker when it starts the LAST non-empty line — anywhere
-    // else it is malformed output and stays visible so the lint can flag it.
-    const tail = t.slice(idx);
-    if (tail.includes('\n')) return { body: t, gist: null };
     const lineStart = t.lastIndexOf('\n', idx);
     if (t.slice(lineStart + 1, idx).trim() !== '') return { body: t, gist: null };
-    return { body: t.slice(0, lineStart < 0 ? 0 : lineStart).replace(/\s+$/, ''), gist: tail.slice(GIST_MARKER.length).trim() || null };
+    const body = t.slice(0, lineStart < 0 ? 0 : lineStart).replace(/\s+$/, '');
+    const tail = t.slice(idx + GIST_MARKER.length);
+    if (!tail.includes('\n')) return { body, gist: tail.trim() || null };
+    const rest = tail.split('\n').map((l) => l.trim()).filter(Boolean);
+    if (rest.length !== 1) return { body: t, gist: null };
+    if (rest[0].split(/\s+/).length > GIST_RECOVERY_MAX_WORDS) return { body: t, gist: null };
+    return { body, gist: rest[0], recovered: true };
 }
 
 /** Reduce a response to the pure spoken word-stream: hot-word marks removed,
@@ -860,10 +884,13 @@ export function spokenFormatViolations(text: string): SpokenFormatViolation[] {
     if (looksLikeStructuredOutput(text)) return violations;
 
     // The gist line is display chrome, not prose: split it off before linting.
-    // A marker anywhere other than the last line is malformed output.
+    // A marker anywhere other than the last line is malformed output — and so
+    // is a marker whose essence the model pushed onto the next line, even
+    // though the split now recovers that shape for display. The recovery is
+    // containment; this violation is how the drift stays measurable.
     const gistIdx = text.indexOf(GIST_MARKER);
-    const { body: gistBody, gist } = splitGistLine(text);
-    if (gistIdx >= 0 && gist === null) {
+    const { body: gistBody, gist, recovered } = splitGistLine(text);
+    if (gistIdx >= 0 && (gist === null || recovered)) {
         violations.push({ rule: 'gist_misplaced', excerpt: text.slice(gistIdx, gistIdx + 60) });
     }
 

--- a/electron/services/__tests__/GovernedPackGatesValidator2026_08_12.test.mjs
+++ b/electron/services/__tests__/GovernedPackGatesValidator2026_08_12.test.mjs
@@ -1,0 +1,66 @@
+// electron/services/__tests__/GovernedPackGatesValidator2026_08_12.test.mjs
+//
+// A ContextOsGenerationContext carries an evidencePack even when it does NOT
+// govern the turn: packGovernsGeneration returns false for unbounded
+// authorities (profile_only / general_mixed), and the turn then runs the LEGACY
+// retrieval path — that fall-through is the 2026-08-11 fix for WTA screenshot
+// turns being refused with "not directly mentioned in the uploaded material".
+//
+// Three consumers read that pack. WhatToAnswerLLM was gated on `govern` when
+// the fall-through landed; the two post-stream doc-grounded validators were
+// not (code review 2026-08-12). They keyed on pack PRESENCE, so an ungoverned
+// (item-less) pack became the evidence block, the legacy re-retrieval branches
+// were skipped, and the validator refused an answer the legacy path had just
+// produced correctly.
+//
+// Source-level pin: these are deep inside streaming IPC handlers with no unit
+// seam. What must never drift is that all three read `govern`, not presence.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+const read = (rel) => readFileSync(path.join(repoRoot, rel), 'utf8')
+  // Strip comments: prose describing the OLD keying must not satisfy a check.
+  .replace(/\/\/[^\n]*/g, '')
+  .replace(/\/\*[\s\S]*?\*\//g, '');
+
+const SITES = [
+  {
+    file: 'electron/IntelligenceEngine.ts',
+    what: 'the WTA post-stream doc-grounded validator',
+    context: 'wtaContextOsGeneration',
+  },
+  {
+    file: 'electron/ipcHandlers.ts',
+    what: 'the manual-chat post-stream doc-grounded validator',
+    context: 'manualContextOsGeneration',
+  },
+];
+
+describe('an ungoverned evidence pack never becomes a validator evidence block', () => {
+  for (const site of SITES) {
+    test(`${site.what} gates _governedPack on govern, not presence`, () => {
+      const src = read(site.file);
+      const decl = new RegExp(`const\\s+_governedPack\\s*=([\\s\\S]{0,240}?);`, 'm');
+      const match = src.match(decl);
+      assert.ok(match, `${site.file}: _governedPack declaration not found`);
+      assert.match(match[1], /\bgovern\b/,
+        `${site.file}: _governedPack must be read only when the pack GOVERNS the turn, got:${match[1]}`);
+      assert.match(match[1], new RegExp(site.context),
+        `${site.file}: expected the ${site.context} snapshot to be the source`);
+    });
+  }
+
+  test('WhatToAnswerLLM keeps its own govern gate on the generation-side pack', () => {
+    const src = read('electron/llm/WhatToAnswerLLM.ts');
+    const match = src.match(/let\s+governedEvidencePack[\s\S]{0,300}?;/);
+    assert.ok(match, 'governedEvidencePack declaration not found');
+    assert.match(match[0], /govern/,
+      'an ungoverned pack must not suppress the legacy mode-context retrieval');
+  });
+});

--- a/src/lib/__tests__/displayMarkup.test.mjs
+++ b/src/lib/__tests__/displayMarkup.test.mjs
@@ -40,8 +40,13 @@ describe('splitGistLine', () => {
     assert.deepEqual(splitGistLine('[[GIST]] only line'), { body: '', gist: 'only line' });
   });
 
-  test('empty gist text after the marker → gist null', () => {
-    assert.equal(splitGistLine('Body.\n[[GIST]]   ').gist, null);
+  // The body assertion is the load-bearing half: a marker that starts its line
+  // is chrome even with no essence, so it must never survive into the body —
+  // stripDisplayMarkup feeds TTS, which would otherwise SAY "[[GIST]]".
+  test('empty gist text after the marker → gist null, marker still stripped', () => {
+    assert.deepEqual(splitGistLine('Body.\n[[GIST]]   '), { body: 'Body.', gist: null });
+    assert.deepEqual(splitGistLine('Body.\n[[GIST]]'), { body: 'Body.', gist: null });
+    assert.equal(stripDisplayMarkup('Body.\n[[GIST]]'), 'Body.');
   });
 
   test('trailing whitespace after the gist line is tolerated', () => {
@@ -49,6 +54,74 @@ describe('splitGistLine', () => {
       body: 'Body.',
       gist: 'short essence',
     });
+  });
+});
+
+// 2026-08-12: the model sometimes breaks the line after the marker, and the
+// old split rejected the whole shape — so a literal "[[GIST]]" painted on
+// screen above the essence. Recovered for display; still lint-visible.
+describe('splitGistLine — newline between the marker and its essence', () => {
+  test('marker alone on its line, essence underneath → recovered', () => {
+    assert.deepEqual(
+      splitGistLine('You sort them first, then subtract.\n[[GIST]]\nSort the numbers and calculate c minus a'),
+      {
+        body: 'You sort them first, then subtract.',
+        gist: 'Sort the numbers and calculate c minus a',
+        recovered: true,
+      },
+    );
+  });
+
+  test('no body at all → recovered with an empty body', () => {
+    assert.deepEqual(splitGistLine('[[GIST]]\nSort the numbers and calculate c minus a'), {
+      body: '',
+      gist: 'Sort the numbers and calculate c minus a',
+      recovered: true,
+    });
+  });
+
+  test('blank lines between the marker and the essence are tolerated', () => {
+    assert.deepEqual(splitGistLine('Body.\n[[GIST]]\n\n  five word essence here  \n'), {
+      body: 'Body.',
+      gist: 'five word essence here',
+      recovered: true,
+    });
+  });
+
+  test('TWO lines after the marker stay malformed — recovery must not eat body text', () => {
+    assert.deepEqual(splitGistLine('Body.\n[[GIST]]\nline one\nline two'), {
+      body: 'Body.\n[[GIST]]\nline one\nline two',
+      gist: null,
+    });
+  });
+
+  // A misplaced marker with a real closing SENTENCE under it looks identical
+  // to a line-broken gist. Length breaks the tie: a gist is five to eight
+  // words by contract, so a longer line stays in the spoken body rather than
+  // being silently demoted to a chip nobody hears.
+  test('a following line too long to be a gist stays malformed', () => {
+    const text = 'Sort the array first, then walk it once.\n[[GIST]]\nThe answer is the difference between the last and the first elements.';
+    assert.deepEqual(splitGistLine(text), { body: text, gist: null });
+  });
+
+  test('a contract-length essence is still recovered at the boundary', () => {
+    assert.deepEqual(splitGistLine('Body.\n[[GIST]]\none two three four five six seven eight nine ten'), {
+      body: 'Body.',
+      gist: 'one two three four five six seven eight nine ten',
+      recovered: true,
+    });
+    assert.equal(
+      splitGistLine('Body.\n[[GIST]]\none two three four five six seven eight nine ten eleven').gist,
+      null,
+    );
+  });
+
+  test('a clean split carries no recovered flag', () => {
+    assert.equal(splitGistLine('Body.\n[[GIST]] essence').recovered, undefined);
+  });
+
+  test('the recovered gist is not spoken', () => {
+    assert.equal(stripDisplayMarkup('The **key term** here.\n[[GIST]]\nessence'), 'The key term here.');
   });
 });
 
@@ -70,6 +143,23 @@ describe('splitGistLineStreaming', () => {
   test('finished text behaves exactly like splitGistLine', () => {
     const text = 'Body one.\n[[GIST]] essence';
     assert.deepEqual(splitGistLineStreaming(text), splitGistLine(text));
+  });
+
+  // The frame between a COMPLETE marker and its first essence token: the raw
+  // last line is EMPTY, so the old prefix test missed it and the marker
+  // flashed as literal text before the chip mounted.
+  test('a completed marker awaiting its essence on the next line is hidden', () => {
+    for (const partial of ['Body.\n[[GIST]]\n', 'Body.\n[[GIST]]\n  ']) {
+      assert.deepEqual(splitGistLineStreaming(partial), { body: 'Body.', gist: null }, partial);
+    }
+  });
+
+  test('the essence then streams into the chip from the next line', () => {
+    assert.deepEqual(splitGistLineStreaming('Body.\n[[GIST]]\nSort the'), {
+      body: 'Body.',
+      gist: 'Sort the',
+      recovered: true,
+    });
   });
 });
 

--- a/src/lib/displayMarkup.ts
+++ b/src/lib/displayMarkup.ts
@@ -10,21 +10,48 @@ export const GIST_MARKER = '[[GIST]]';
 export interface GistSplit {
   body: string;
   gist: string | null;
+  /** True when the marker was recovered from a malformed shape (the model broke
+   *  the line after the marker). The chip renders normally; the lint still
+   *  reports it so prompt drift stays visible. Absent on clean output.
+   *  No renderer consumer reads this — it exists so the main-process twin's
+   *  spokenFormatViolations() has a field to key off and the two copies stay
+   *  literally identical. Do not delete it as unused. */
+  recovered?: boolean;
 }
 
-/** Split a response into its speakable body and the optional bottom gist. */
+/**
+ * Split a response into its speakable body and the optional bottom gist.
+ *
+ * The marker is honored only when it STARTS a line — mid-line it is prose.
+ * A marker that starts its line is display chrome either way: even with no
+ * essence after it, the marker itself never reaches the body (it would be
+ * rendered AND spoken by every stripDisplayMarkup consumer).
+ *
+ * Canonically the essence follows on that same line. Models break that line
+ * often enough that the marker used to leak to screen as literal `[[GIST]]`
+ * text (2026-08-12), so a marker alone on its line is recovered when exactly
+ * one short non-empty line follows. Two rejections keep the recovery from
+ * eating real prose: more than one following line, and a following line
+ * longer than a gist can contractually be (the prompt asks for five to eight
+ * words; past RECOVERY_MAX_WORDS it is likelier a real closing sentence the
+ * model wrote under a misplaced marker, and losing it would silently drop a
+ * spoken sentence). Rejected shapes keep the marker visible and lint-flagged.
+ */
+const RECOVERY_MAX_WORDS = 10;
+
 export function splitGistLine(text: string): GistSplit {
   const t = (text || '').replace(/\s+$/, '');
   const idx = t.lastIndexOf(GIST_MARKER);
   if (idx < 0) return { body: t, gist: null };
-  const tail = t.slice(idx);
-  if (tail.includes('\n')) return { body: t, gist: null };
   const lineStart = t.lastIndexOf('\n', idx);
   if (t.slice(lineStart + 1, idx).trim() !== '') return { body: t, gist: null };
-  return {
-    body: t.slice(0, lineStart < 0 ? 0 : lineStart).replace(/\s+$/, ''),
-    gist: tail.slice(GIST_MARKER.length).trim() || null,
-  };
+  const body = t.slice(0, lineStart < 0 ? 0 : lineStart).replace(/\s+$/, '');
+  const tail = t.slice(idx + GIST_MARKER.length);
+  if (!tail.includes('\n')) return { body, gist: tail.trim() || null };
+  const rest = tail.split('\n').map((l) => l.trim()).filter(Boolean);
+  if (rest.length !== 1) return { body: t, gist: null };
+  if (rest[0].split(/\s+/).length > RECOVERY_MAX_WORDS) return { body: t, gist: null };
+  return { body, gist: rest[0], recovered: true };
 }
 
 /**
@@ -33,11 +60,16 @@ export function splitGistLine(text: string): GistSplit {
  * partial prefix of the marker is hidden so the marker never flashes as
  * literal text; once complete, the normal split applies (the gist text
  * itself streams into the chip).
+ *
+ * The prefix test runs on the END-TRIMMED text on purpose: after a COMPLETE
+ * marker followed by a newline the raw last line is empty, and testing that
+ * raw line let the frame between "[[GIST]]\n" and the first essence token
+ * paint the marker as literal text.
  */
 export function splitGistLineStreaming(text: string): GistSplit {
   const full = splitGistLine(text);
   if (full.gist !== null) return full;
-  const t = text || '';
+  const t = (text || '').replace(/\s+$/, '');
   const lineStart = t.lastIndexOf('\n');
   const lastLine = t.slice(lineStart + 1).trimStart();
   if (lastLine && GIST_MARKER.startsWith(lastLine)) {


### PR DESCRIPTION
Three independent fixes, branched off current `main` (`cb171a7e`) so this is conflict-free.

### The `[[GIST]]` marker rendered as literal text
Reported symptom: answers showing `[[GIST]]` with the summary underneath.

`splitGistLine` honored the marker only when the essence followed on the **same** line. When the model broke that line the split rejected the whole shape, so the raw marker reached the teleprompter — and, through `stripDisplayMarkup`, the **TTS word stream**.

- A marker alone on its line is now recovered when exactly one short line follows. The bound matters: at most ten words (the prompt contracts for five to eight). A longer line is likelier a real closing sentence written under a misplaced marker, and demoting that to a chip would silently drop it from the spoken answer — a worse failure than showing the marker.
- A line-leading marker never survives into the body **even with no essence after it**. That shape previously returned the text unchanged, so TTS would say "[[GIST]]" out loud.
- The streaming split hides a completed marker awaiting its essence, so it no longer flashes.
- `spokenFormatViolations` still reports a recovered marker as `gist_misplaced` — the recovery is containment, and the lint is how we keep measuring the model's format drift.

Both copies move together. The renderer can't import main-process modules, so `src/lib/displayMarkup.ts` is a hand-maintained twin of the `promptSystemV2.ts` helpers; a shared case table now pins them from both sides.

### Refusals claimed to have searched files that were never uploaded
`buildInsufficientPropertyAnswer` special-cased only `sourceOwner === 'profile'`, but SourceAuthorityKernel also issues `transcript` and `mixed`. A `transcript_only` or `profile_plus_transcript` refusal still read *"not directly mentioned in the uploaded material"* in a mode with zero uploaded files — the same falsehood the `sourceOwner` parameter was added to remove.

Per-owner stems now, each keeping the "not directly mentioned" opening that `REFUSAL_SNIFF_RE` needs to tell a refusal from an answer.

### Ungoverned evidence packs became empty validator evidence
A pack rides along on `ContextOsGenerationContext` even when it does **not** govern the turn — `packGovernsGeneration` returns false for unbounded authorities and the turn runs the legacy path. Both post-stream doc-grounded validators keyed on pack *presence*, so an ungoverned (item-less) pack became the evidence block: the validator checked the answer against nothing and refused a turn the legacy path had just answered correctly.

`WhatToAnswerLLM` already gates its generation-side read on `govern`; the two validators now match it. Their own comments already described this intent.

## Verification

Clean worktree off `cb171a7e`, never a shared working tree:

| | |
|---|---|
| `build:electron` | clean |
| `tsc --noEmit` | exit 0 |
| 19 new tests, 3 files | all pass |
| `test:lib` | 300/300 |
| `electron/llm` suite | **20 fail on plain main, 20 with this change, failing-name diff empty** |

Those 20 are pre-existing on main. Build Smoke has also been failing on main since at least 2026-08-10, so a red check here is not from this PR.

## Not included

Two further fixes from the same review can't land on main yet: the coding-validator guards patch the `substantivelyComplete` exemption, which exists only on `fix/answer-policy-and-conversation-state`, and the AnswerPlanner flag split overlaps a competing fix already merged from that area. Both stay on #454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSXKVJvchN6bPJK2fKT4Rw