### PR TITLE
fix(planner): make the doc-grounding prompt agree with the retrieval it gets

### DIFF
--- a/electron/llm/AnswerPlanner.ts
+++ b/electron/llm/AnswerPlanner.ts
@@ -196,6 +196,12 @@ export interface AnswerPlan {
    *  (the grounding policyLine) key on THIS — a refusal instruction is only
    *  honest for a genuinely bounded universe. */
   strictDocumentGroundedActive?: boolean;
+  /** The engine's `docGroundedEnforcementActive` (R1): explicit strict contract
+   *  OR a doc-grounded mode with at least one real file. Everything that tells
+   *  the model (or the validator) to answer FROM documents keys on THIS, so the
+   *  prompt, the routing, the forced retrieval and the post-stream validator
+   *  cannot disagree about whether a turn is document-grounded. */
+  docGroundedEnforcementActive?: boolean;
 }
 
 export interface PlanAnswerInput {
@@ -1482,6 +1488,32 @@ export const planAnswer = (input: PlanAnswerInput): AnswerPlan => {
     (input.activeMode?.strictDocumentGroundedActive ?? input.activeMode?.documentGroundedCustomModeActive) === true;
   // R9: the raw broad flag, for the PLAN FIELD isolation consumers read.
   const broadDocumentGroundedActive = input.activeMode?.documentGroundedCustomModeActive === true;
+  // 2026-08-13: the SAME predicate IntelligenceEngine calls
+  // `docGroundedEnforcementActive` (R1) — an explicit strict contract, or any
+  // doc-grounded mode with at least one real file.
+  //
+  // It exists here because the four gates that decide "this turn answers from
+  // documents" had drifted apart, and a template-seeded mode the user uploaded
+  // a file into fell through the crack: origin stays 'default_new_mode' so
+  // strict is false, but files exist so enforcement is true. Measured on main:
+  //
+  //   forced retrieval  routed doc-shape  grounding line  validator
+  //   lecture   true        true (fallback)     FALSE        true
+  //   team_meet true        FALSE               FALSE        false
+  //
+  // The lecture row is the dangerous one: the model is handed a document
+  // context block and then graded by the post-stream zero-fabrication
+  // validator, while its prompt never told it to ground anything — judged on a
+  // rule it was never given. The team_meet row is R1's own stated goal
+  // (restore the validator for seeded modes WITH files) going unmet, because
+  // the validator also requires a doc-shaped answerType that routing never
+  // produced.
+  //
+  // Fileless modes are unaffected (enforcement is false without files), so
+  // this cannot reopen the 2026-08-05 Bug 001 refusals. Isolation is untouched
+  // and stays authority-only on `broadDocumentGroundedActive`.
+  const docGroundedEnforcementActive = input.activeMode?.strictDocumentGroundedActive === true
+    || (broadDocumentGroundedActive && input.activeMode?.hasReferenceFiles === true);
   const explicitDocumentModeCodingAsk = /\b(write|implement|code|coding interview|dsa|dry run|time complexity|space complexity|big[-\s]?o|algorithm(?:ic)?|solution code|source code)\b/i.test(text);
   const explicitDocumentModeProfileAsk = /\b(resume|cv|profile|job description|\bjd\b|career|work experience|candidate profile|my background|your background|my projects?|your projects?|my skills?|your skills?)\b/i.test(text);
 
@@ -1968,7 +2000,7 @@ export const planAnswer = (input: PlanAnswerInput): AnswerPlan => {
     answerType = applyModeFallback(answerType, true, input.source, input.activeMode);
   }
 
-  if (documentGroundedCustomModeActive && !explicitDocumentModeCodingAsk && !explicitDocumentModeProfileAsk) {
+  if (docGroundedEnforcementActive && !explicitDocumentModeCodingAsk && !explicitDocumentModeProfileAsk) {
     // A user-created document-grounded custom mode makes uploaded/reference files
     // the primary source. Do not let generic coding/profile heuristics steal normal
     // seminar/thesis questions into contracts that forbid reference_files. Within
@@ -2071,6 +2103,7 @@ export const planAnswer = (input: PlanAnswerInput): AnswerPlan => {
     answerStyleTargetSeconds: detectAnswerStyle(question).targetSeconds,
     documentGroundedCustomModeActive: broadDocumentGroundedActive,
     strictDocumentGroundedActive: documentGroundedCustomModeActive,
+    docGroundedEnforcementActive,
   };
 };
 
@@ -2166,7 +2199,11 @@ export const formatAnswerPlanForPrompt = (plan: AnswerPlan, includeVerificationS
   // the model to refuse outside "the uploaded material" is only honest when a
   // bounded universe exists; the broad flag put that line into every
   // template-seeded fileless mode's prompt.
-  const policyLine = (plan.strictDocumentGroundedActive ?? plan.documentGroundedCustomModeActive)
+  // 2026-08-13: keyed on ENFORCEMENT, so the instruction the model receives
+  // matches the retrieval and validation it is actually subject to. Older
+  // plans that predate the field fall back to the previous behaviour.
+  const policyLine = (plan.docGroundedEnforcementActive
+    ?? plan.strictDocumentGroundedActive ?? plan.documentGroundedCustomModeActive)
     ? 'Ground every concrete claim in the uploaded/reference files for this custom mode. If the answer is not supported by the uploaded material, say plainly that the requested information is not in the uploaded material. Do not reconstruct it from general knowledge, prior assistant answers, profile, resume, JD, or persona context.'
     : plan.profileContextPolicy === 'required'
       ? 'Ground every concrete claim in the provided profile facts. Never invent names, numbers, metrics, companies, or technologies that are not in those facts.'

--- a/electron/llm/__tests__/DocGroundedGateAgreement2026_08_13.test.mjs
+++ b/electron/llm/__tests__/DocGroundedGateAgreement2026_08_13.test.mjs
@@ -1,0 +1,141 @@
+// electron/llm/__tests__/DocGroundedGateAgreement2026_08_13.test.mjs
+//
+// Four separate gates decide "this turn answers from documents", and they had
+// drifted apart:
+//
+//   1. forced retrieval  — IntelligenceEngine `docGroundedEnforcementActive`
+//                          (R1): strict contract OR doc mode WITH files
+//   2. answer-shape routing — AnswerPlanner
+//   3. the grounding instruction in the prompt — AnswerPlanner policyLine
+//   4. the post-stream zero-fabrication validator — needs (1) AND files AND a
+//      doc-shaped answerType from (2)
+//
+// Measured on main before this suite existed, for a template-seeded mode the
+// user had uploaded a file into (origin stays 'default_new_mode' so strict is
+// false, but files exist so enforcement is true):
+//
+//   lecture:    retrieval ON, doc shape ON (via the mode fallback), validator
+//               ON — and the grounding instruction OFF. The model was handed a
+//               document context block and graded by the zero-fabrication
+//               validator while its prompt never told it to ground anything.
+//   team_meet:  retrieval ON, doc shape OFF, validator OFF. R1's own stated
+//               goal — restoring the validator for seeded modes WITH files —
+//               was unmet, because the validator also needs a doc-shaped
+//               answerType that routing never produced.
+//
+// The invariant below is the one that matters and the one that was false:
+// a turn is told to answer from documents exactly when it is made to retrieve
+// them. Isolation is deliberately NOT part of this: it stays authority-only
+// (true before the first upload) and is asserted separately.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { planAnswer, formatAnswerPlanForPrompt } from '../../../dist-electron/electron/llm/index.js';
+import { isDocGroundedAnswerType } from '../../../dist-electron/electron/llm/documentGroundedPrompt.js';
+
+const mode = (o) => ({ id: 'm', name: 'M', isCustom: false, hasCustomPrompt: false, ...o });
+
+/** The engine's predicate, mirrored so drift in either copy fails here. */
+const enforcementOf = (m) => m.strictDocumentGroundedActive === true
+  || (m.documentGroundedCustomModeActive === true && m.hasReferenceFiles === true);
+
+const CASES = [
+  ['template-seeded lecture WITH an uploaded file', mode({
+    templateType: 'lecture', hasReferenceFiles: true, documentGrounded: true,
+    documentGroundedCustomModeActive: true, strictDocumentGroundedActive: false,
+  })],
+  ['template-seeded lecture with NO files', mode({
+    templateType: 'lecture', hasReferenceFiles: false, documentGrounded: false,
+    documentGroundedCustomModeActive: true, strictDocumentGroundedActive: false,
+  })],
+  ['template-seeded team_meet WITH an uploaded file', mode({
+    templateType: 'team_meet', hasReferenceFiles: true, documentGrounded: true,
+    documentGroundedCustomModeActive: true, strictDocumentGroundedActive: false,
+  })],
+  ['template-seeded team_meet with NO files', mode({
+    templateType: 'team_meet', hasReferenceFiles: false, documentGrounded: false,
+    documentGroundedCustomModeActive: true, strictDocumentGroundedActive: false,
+  })],
+  ['user-selected strict contract WITH files', mode({
+    templateType: 'lecture', hasReferenceFiles: true, documentGrounded: true,
+    documentGroundedCustomModeActive: true, strictDocumentGroundedActive: true,
+  })],
+  ['a non-document mode', mode({
+    templateType: 'general', hasReferenceFiles: false, documentGrounded: false,
+    documentGroundedCustomModeActive: false, strictDocumentGroundedActive: false,
+  })],
+];
+
+const QUESTION = {
+  question: 'What does the paper say about batch size?',
+  source: 'manual_input',
+  speakerPerspective: 'user',
+};
+
+const GROUNDING_LINE = /uploaded\/reference files/;
+
+describe('the doc-grounding gates agree with each other', () => {
+  for (const [name, m] of CASES) {
+    test(`${name}: the prompt instructs grounding exactly when retrieval is forced`, () => {
+      const plan = planAnswer({ ...QUESTION, activeMode: m });
+      const prompt = formatAnswerPlanForPrompt(plan);
+      assert.equal(
+        GROUNDING_LINE.test(prompt), enforcementOf(m),
+        enforcementOf(m)
+          ? 'retrieval is forced for this mode, so the model must be told to ground its answer'
+          : 'nothing is retrieved for this mode, so the prompt must not claim uploaded material exists',
+      );
+    });
+  }
+
+  test('the plan publishes the enforcement predicate for downstream consumers', () => {
+    for (const [name, m] of CASES) {
+      const plan = planAnswer({ ...QUESTION, activeMode: m });
+      assert.equal(plan.docGroundedEnforcementActive, enforcementOf(m), name);
+    }
+  });
+
+  test('a doc mode WITH files reaches a doc-shaped answer, so the validator can run', () => {
+    // The post-stream zero-fabrication validator needs enforcement AND files
+    // AND a doc-shaped answerType. team_meet is the case that failed: routing
+    // keyed on strict, which a template seed never sets.
+    for (const templateType of ['lecture', 'team_meet', 'seminar']) {
+      const plan = planAnswer({ ...QUESTION, activeMode: mode({
+        templateType, hasReferenceFiles: true, documentGrounded: true,
+        documentGroundedCustomModeActive: true, strictDocumentGroundedActive: false,
+      }) });
+      assert.ok(isDocGroundedAnswerType(plan.answerType),
+        `${templateType} with files must reach a doc-grounded shape, got ${plan.answerType}`);
+    }
+  });
+
+  test('ISOLATION stays authority-only — it must NOT wait for an upload', () => {
+    // The 2026-07-15 invariant, and the thing two separate fixes have broken.
+    // A doc mode suppresses résumé/JD from the moment it exists.
+    const plan = planAnswer({ ...QUESTION, activeMode: mode({
+      templateType: 'team_meet', hasReferenceFiles: false, documentGrounded: false,
+      documentGroundedCustomModeActive: true, strictDocumentGroundedActive: false,
+    }) });
+    assert.equal(plan.documentGroundedCustomModeActive, true,
+      'plan-level isolation must stay broad — narrowing it re-opens résumé injection');
+  });
+
+  test('a fileless doc mode is never told to refuse against uploaded material', () => {
+    // Bug 001 (2026-08-05). This is the failure the strict gate was introduced
+    // to prevent, and it must survive the reconciliation above.
+    for (const templateType of ['lecture', 'team_meet', 'seminar']) {
+      const plan = planAnswer({ ...QUESTION, activeMode: mode({
+        templateType, hasReferenceFiles: false, documentGrounded: false,
+        documentGroundedCustomModeActive: true, strictDocumentGroundedActive: false,
+      }) });
+      assert.doesNotMatch(formatAnswerPlanForPrompt(plan), /not in the uploaded material/i,
+        `${templateType} with zero files must not carry the uploaded-material refusal instruction`);
+    }
+  });
+
+  test('a mode-blind turn is unaffected', () => {
+    const plan = planAnswer({ ...QUESTION, activeMode: null });
+    assert.equal(plan.docGroundedEnforcementActive, false);
+    assert.doesNotMatch(formatAnswerPlanForPrompt(plan), GROUNDING_LINE);
+  });
+});


### PR DESCRIPTION
Four gates decide *"this turn answers from documents"*, and they had drifted apart:

1. **forced retrieval** — IntelligenceEngine `docGroundedEnforcementActive` (R1): explicit strict contract **OR** a doc mode with at least one real file
2. **answer-shape routing** — AnswerPlanner, keyed on strict-preferred (R9)
3. **the grounding instruction in the prompt** — AnswerPlanner `policyLine`, also strict-preferred
4. **the post-stream zero-fabrication validator** — needs (1) **and** files **and** a doc-shaped `answerType` from (2)

A template seed stamps `origin: 'default_new_mode'`, and that never changes when the user uploads a file — so strict stays `false` while enforcement becomes `true`. That mode falls straight into the gap. Measured on main:

| seeded + files | forced retrieval | doc shape | grounding line | validator |
|---|---|---|---|---|
| `lecture` | ON | ON *(via mode fallback)* | **OFF** | ON |
| `team_meet` | ON | **OFF** | **OFF** | **OFF** |

The `lecture` row is the dangerous one: the model is handed a document context block and then **graded by the zero-fabrication validator, while its prompt never told it to ground anything** — judged against a rule it was never given.

The `team_meet` row is R1's own stated goal going unmet. R1 restored the validator for seeded modes *with* files, but the validator also needs a doc-shaped `answerType`, and routing never produced one because it keyed on strict.

## The change

Routing and the policy line now key on the same predicate the engine already uses for enforcement, published on the plan as `docGroundedEnforcementActive`. Nothing else moves:

- **Isolation is untouched.** It stays authority-only on the broad flag — true from mode creation, before any upload. That 2026-07-15 invariant has now been broken by two separate fixes, so it gets its own assertion here.
- **Fileless modes are unaffected.** Enforcement is false without files, so the 2026-08-05 Bug 001 refusals cannot reopen. Pinned explicitly for three template types.

It also reconciles two concurrent fixes to the same defect — R9 on main, and the flag split that came in with #454 — under R1's existing definition rather than either author's preferred one.

## Verification

Clean worktree off main:

| | |
|---|---|
| new tests | 11, and **5 fail against unpatched main** — not vacuous |
| `electron/llm` suite | 14 failures, **failing names identical to main** |
| intelligence suite | 963 tests, 3 pre-existing failures, unchanged |
| WhatToAnswerSnapshotWiring + ContextOsRefusalGoverns + GovernedPackGates | 65/65 |
| `tsc --noEmit` | exit 0 |

Main is already red (14 llm failures, Build Smoke failing since 2026-08-10), so a red check here is not from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSXKVJvchN6bPJK2fKT4Rw