### PR TITLE
fix(ci): repair the typecheck that has blocked every Build Smoke run

### DIFF
--- a/electron/llm/WhatToAnswerLLM.ts
+++ b/electron/llm/WhatToAnswerLLM.ts
@@ -861,7 +861,18 @@ ANSWER SHAPE: ${intentResult.answerShape}
             // throwing. Production always takes the first branch — pinned by a
             // test asserting the real LLMHelper exposes the method, so this
             // fallback can never quietly become the live path.
-            const _wtaArgs = [_wtaUserMessage, imagePaths, undefined, _wtaSystemPrompt, true, true, packetScopes, abortSignal, wtaThinkingBudget, _wtaRoute] as const;
+            //
+            // The annotation is load-bearing, not decoration. electron/tsconfig.json
+            // runs with `noImplicitAny` but WITHOUT `strictNullChecks`, so a bare
+            // `undefined` in an unannotated array literal widens to an IMPLICIT any
+            // and tsc rejects the whole declaration:
+            //   TS7005: Variable '_wtaArgs' implicitly has an 'readonly [any, ...]' type
+            // At the previous direct call site the same `undefined` was contextually
+            // typed by the parameter, so extracting the arguments into a variable is
+            // what exposed it. Typing the tuple as the callee's own parameter list
+            // fixes that and additionally checks arity and order against the real
+            // signature — which an `as const` tuple silently did not.
+            const _wtaArgs: Parameters<LLMHelper['streamChat']> = [_wtaUserMessage, imagePaths, undefined, _wtaSystemPrompt, true, true, packetScopes, abortSignal, wtaThinkingBudget, _wtaRoute];
             const _wtaStream = typeof (this.llmHelper as any).streamChatWithOutcome === 'function'
                 ? (this.llmHelper as any).streamChatWithOutcome(..._wtaArgs)
                 : { stream: (this.llmHelper as any).streamChat(..._wtaArgs), outcome: { truncated: false } };


### PR DESCRIPTION
## What

`npm run typecheck:electron` has failed on `main` since c2ad3133 merged (PR #454, 2026-08-13):

```
electron/llm/WhatToAnswerLLM.ts(864,19): error TS7005: Variable '_wtaArgs'
implicitly has an 'readonly [any, string[], any, any, ...]' type
```

It is the **first** build step in `Build Smoke`, so nothing after it has run on any PR or scheduled run since — no renderer build, no esbuild bundle, no unit tests, on either matrix leg.

Reproduced deterministically on a clean checkout of `main`, and confirmed clean (`tsc` exit 0) after this change.

## Root cause

`electron/tsconfig.json` sets `noImplicitAny` but **not** `strictNullChecks`. With `strictNullChecks` off, a bare `undefined` widens to an implicit `any`, and tsc rejects the entire declaration it appears in.

That `undefined` had occupied the same argument position for months without complaint because, as a direct call argument, it was contextually typed by the parameter it fed. c2ad3133 extracted the argument list into a local so the same tuple could feed either `streamChatWithOutcome` or `streamChat` — which removed the contextual type and exposed the widening. The extraction is correct; only its type was missing.

## The fix

Annotate the tuple with the callee's own parameter list instead of inferring it via `as const`. This resolves the slot from the signature rather than widening it, and additionally checks arity and order against the real `streamChat` — which the inferred `as const` tuple did not, since both call sites go through `(this.llmHelper as any)`.

Adding the annotation produced **no other errors**, so the tuple was already correct; it simply wasn't being checked.

`strictNullChecks` is deliberately not enabled — that is a large separate change, not a CI repair.

## Validation

| | |
|---|---|
| `npm run typecheck:electron` | **PASS** (exit 0) — failed before the change on the same tree |
| `npm run build` | PASS |
| `npm run test:lib` | PASS |
| `npm run test:scripts` | PASS |
| Covered by automated macOS branch tests | typecheck is platform-neutral; it is the gate on **both** legs |
| Requires physical Windows verification | no — this is a compile-time-only change with no runtime or platform behavior |

Run in a clean worktree of `main` with the `premium` submodule at the pinned commit.

## Note on the unit-test step

Once this merges, `Run Electron unit tests` will execute for the first time since 2026-08-10. The last real measurement (455 failures) is **stale**: it predates both `4933828b` (restored the `tests/fixtures/modes` corpus — ~154 of those failures were `No fixtures for mode folder: …`) and `9d37ebfc` (moved `npm test` onto the Electron runner so native modules load). Both landed 2026-08-13 in the same merge that broke the typecheck, so neither has ever been exercised by CI. The true baseline is unknown until this lands.