### PR TITLE
ci: give main a per-commit signal, and stop one red suite hiding three

### DIFF
--- a/.github/workflows/build-smoke.yml
+++ b/.github/workflows/build-smoke.yml
@@ -2,6 +2,16 @@ name: Build Smoke
 
 on:
   pull_request:
+  # Main had NO per-commit signal: this workflow ran on pull_request only, so a
+  # PR whose Build Smoke failed could be merged and main itself was never
+  # re-checked. That is exactly how c2ad3133 landed a TS7005 that broke the
+  # FIRST build step — `Typecheck Electron main process` — and went unnoticed
+  # for three days while every subsequent PR inherited a red check it did not
+  # cause. With this trigger, a break is attributable to the commit that
+  # introduced it instead of to whoever opens the next PR.
+  push:
+    branches:
+      - main
   workflow_dispatch:
   # MUST live here, not on the job. `schedule` is not a valid job key, and an
   # unknown key makes GitHub reject the whole workflow at parse time — every run
@@ -182,7 +192,21 @@ jobs:
         continue-on-error: ${{ runner.os == 'Windows' }}
         run: npm test
 
+      # The four test steps here are INDEPENDENT suites over disjoint globs, so
+      # each of the three below carries `!cancelled()`. Without it a failed step
+      # skips every later one, and on the macOS leg — the only enforcing leg —
+      # that meant one red suite suppressed the other three: `test:intelligence`
+      # had never once been measured in CI, because `npm test` failed on every
+      # run that ever reached it. (Windows was unaffected only because
+      # `continue-on-error` keeps its steps' conclusion green.)
+      #
+      # `!cancelled()` rather than `always()`: both keep a later suite running
+      # after an earlier one fails, but `always()` ALSO forces the step to run
+      # while the job is being cancelled, turning a cancel into a multi-minute
+      # wait. The job still fails if any suite fails — this only stops one
+      # failure from hiding the others' results.
       - name: Run intelligence unit tests
+        if: ${{ !cancelled() }}
         continue-on-error: ${{ runner.os == 'Windows' }}
         run: npm run test:intelligence
 
@@ -194,6 +218,7 @@ jobs:
       # mirror), so a real production-catalog regression fails CI, not just the
       # hand-maintained mirror.
       - name: Run src/lib unit tests
+        if: ${{ !cancelled() }}
         run: npm run test:lib
 
       # Runs on BOTH legs by design. scripts/package-app.js and
@@ -203,6 +228,7 @@ jobs:
       # resolver / signal-table as parameters, so each leg exercises both
       # platform shapes rather than only its own.
       - name: Run build-script unit tests
+        if: ${{ !cancelled() }}
         run: npm run test:scripts
 
   api-smoke:


### PR DESCRIPTION
Two gaps that together let a broken build sit on `main` for three days.

## 1. No `push` trigger for main

`Build Smoke` ran on `pull_request` only, so **main itself was never re-checked after a merge**. `c2ad3133` landed a TS7005 that broke the *first* build step (`Typecheck Electron main process`); its PR check was red and it was merged anyway. From then on every subsequent PR inherited a red check it did not cause — precisely the signal-destroying pattern the existing `continue-on-error` comment already warns about.

With `push: branches: [main]`, a break is attributable to the commit that introduced it.

`api-smoke` is unaffected: its own `if:` still restricts it to `workflow_dispatch` and `schedule`, so a push does not fire it.

## 2. One failing suite suppressed the other three

The four test steps are independent suites over disjoint globs, but a failed step skips every later one by default. On macOS — the only **enforcing** leg — `npm test` failing hid `test:intelligence`, `test:lib`, and `test:scripts` entirely.

**`test:intelligence` has never once been measured in CI**, because `npm test` has failed on every run that ever reached it.

Windows was unaffected only because `continue-on-error` keeps its steps' *conclusion* green, so later steps still ran there.

`!cancelled()` rather than `always()`: both keep later suites running after an earlier failure, but `always()` also forces the step to run while the job is being **cancelled**, turning a cancel into a multi-minute wait. The job still fails if any suite fails — this only stops one failure from hiding the others' results.

## Validation

- Workflow parses (`yaml.safe_load`)
- Trigger set is `[pull_request, push, workflow_dispatch, schedule]`
- `push` is scoped to `branches: [main]`
- The three later steps carry the guard; `Run Electron unit tests` deliberately does not
- `api-smoke`'s event gate is unchanged

This PR's own run exercises the `!cancelled()` steps: `npm test` is currently red on main, so the three later suites should now **report** instead of showing `skipped`.

Follow-up (not in this PR): branch protection requiring Build Smoke. Deliberately deferred — with the electron suite red it would block every merge, including the PRs that fix it. It goes on once the suite is green.