### PR TITLE
feat(llm): test-only switches to provoke the stream guards

### DIFF
--- a/electron/LLMHelper.ts
+++ b/electron/LLMHelper.ts
@@ -5161,8 +5161,13 @@ let isMultimodal = !!(imagePaths?.length);
     // return unconditionally (Ollama, OpenAI, Claude, DeepSeek, LiteLLM) alike.
     // See MAX_STREAM_OUTPUT_CHARS for why this is a character cap and not a
     // wall-clock one, and why it is defence in depth rather than the real fix.
-    const { MAX_STREAM_OUTPUT_CHARS } = await import('./llm/liveDeadlines');
-    const { testOutputCharCeiling } = await import('./llm/streamFaultInjection');
+    // Loaded together: the two imports are independent, and awaiting them in
+    // sequence costs an extra microtask hop on every streamed turn for nothing
+    // (react-doctor server-sequential-independent-await).
+    const [{ MAX_STREAM_OUTPUT_CHARS }, { testOutputCharCeiling }] = await Promise.all([
+      import('./llm/liveDeadlines'),
+      import('./llm/streamFaultInjection'),
+    ]);
     // Test switch (dev-only, opt-in) lets the cap be provoked without waiting
     // for a model to actually loop. Null in any packaged build.
     //
@@ -5266,8 +5271,10 @@ let isMultimodal = !!(imagePaths?.length);
     state: { chars: number },
     label: string,
   ): AsyncGenerator<string, void, unknown> {
-    const { MAX_STREAM_OUTPUT_CHARS } = await import('./llm/liveDeadlines');
-    const { testOutputCharCeiling } = await import('./llm/streamFaultInjection');
+    const [{ MAX_STREAM_OUTPUT_CHARS }, { testOutputCharCeiling }] = await Promise.all([
+      import('./llm/liveDeadlines'),
+      import('./llm/streamFaultInjection'),
+    ]);
     const ceiling = testOutputCharCeiling() ?? MAX_STREAM_OUTPUT_CHARS;
     for await (const chunk of inner) {
       yield chunk;

--- a/electron/LLMHelper.ts
+++ b/electron/LLMHelper.ts
@@ -5162,6 +5162,16 @@ let isMultimodal = !!(imagePaths?.length);
     // See MAX_STREAM_OUTPUT_CHARS for why this is a character cap and not a
     // wall-clock one, and why it is defence in depth rather than the real fix.
     const { MAX_STREAM_OUTPUT_CHARS } = await import('./llm/liveDeadlines');
+    const { testOutputCharCeiling } = await import('./llm/streamFaultInjection');
+    // Test switch (dev-only, opt-in) lets the cap be provoked without waiting
+    // for a model to actually loop. Null in any packaged build.
+    //
+    // Resolved against main deliberately: the branch this was authored on also
+    // carried a per-SURFACE ceiling (MAX_SUMMARY_OUTPUT_CHARS / long_form),
+    // which does NOT exist here — neither the constant nor the `profile`
+    // parameter. Carrying it across would have dragged another session's
+    // unmerged work into this change and broken the build.
+    const outputCeiling = testOutputCharCeiling() ?? MAX_STREAM_OUTPUT_CHARS;
     let emittedChars = 0;
     for await (const chunk of this._streamChatInner(...args)) {
       if (abortSignal?.aborted) return;
@@ -5174,14 +5184,14 @@ let isMultimodal = !!(imagePaths?.length);
       }
       yield dashReducer.reduce(chunk);
       emittedChars += typeof chunk === 'string' ? chunk.length : 0;
-      if (emittedChars > MAX_STREAM_OUTPUT_CHARS) {
+      if (emittedChars > outputCeiling) {
         outcome.truncated = true;
         outcome.reason = 'output_cap_reached';
         // End the stream the same way a post-commit provider failure now does —
         // return, never throw — so the consumer sees one consistent shape for
         // "this stream stopped early".
         console.warn(
-          `[LLMHelper] Stream exceeded MAX_STREAM_OUTPUT_CHARS (${emittedChars} > ${MAX_STREAM_OUTPUT_CHARS}) — ending the turn. The model is not converging.`,
+          `[LLMHelper] Stream exceeded MAX_STREAM_OUTPUT_CHARS (${emittedChars} > ${outputCeiling}) — ending the turn. The model is not converging.`,
         );
         return;
       }
@@ -5257,12 +5267,14 @@ let isMultimodal = !!(imagePaths?.length);
     label: string,
   ): AsyncGenerator<string, void, unknown> {
     const { MAX_STREAM_OUTPUT_CHARS } = await import('./llm/liveDeadlines');
+    const { testOutputCharCeiling } = await import('./llm/streamFaultInjection');
+    const ceiling = testOutputCharCeiling() ?? MAX_STREAM_OUTPUT_CHARS;
     for await (const chunk of inner) {
       yield chunk;
       state.chars += typeof chunk === 'string' ? chunk.length : 0;
-      if (state.chars > MAX_STREAM_OUTPUT_CHARS) {
+      if (state.chars > ceiling) {
         console.warn(
-          `[LLMHelper] ${label} exceeded MAX_STREAM_OUTPUT_CHARS (${state.chars} > ${MAX_STREAM_OUTPUT_CHARS}) — ending the turn. The model is not converging.`,
+          `[LLMHelper] ${label} exceeded MAX_STREAM_OUTPUT_CHARS (${state.chars} > ${ceiling}) — ending the turn. The model is not converging.`,
         );
         return;
       }
@@ -5273,11 +5285,27 @@ let isMultimodal = !!(imagePaths?.length);
     inner: AsyncGenerator<string, void, unknown>,
     state: { emitted: boolean },
   ): AsyncGenerator<string, void, unknown> {
+    // Test-only fault, three-gated and off unless explicitly requested; a
+    // packaged build ignores it entirely. See streamFaultInjection.ts.
+    const { failStreamAfterChars, InjectedStreamFault } = await import('./llm/streamFaultInjection');
+    const failAfter = failStreamAfterChars();
+    let seen = 0;
+
     for await (const tok of inner) {
       if (!state.emitted && typeof tok === 'string' && tok.trim().length > 0) {
         state.emitted = true;
       }
       yield tok;
+      if (failAfter !== null) {
+        seen += typeof tok === 'string' ? tok.length : 0;
+        if (seen >= failAfter) {
+          // Thrown AFTER the yield on purpose: the point is a provider that
+          // dies once output is already on screen, which is precisely the case
+          // the fall-through guard exists for.
+          console.warn(`[LLMHelper] INJECTING mid-stream fault after ${seen} chars (test switch)`);
+          throw new InjectedStreamFault(seen);
+        }
+      }
     }
   }
 

--- a/electron/llm/__tests__/StreamFaultInjection2026_08_14.test.mjs
+++ b/electron/llm/__tests__/StreamFaultInjection2026_08_14.test.mjs
@@ -1,0 +1,131 @@
+// electron/llm/__tests__/StreamFaultInjection2026_08_14.test.mjs
+//
+// The post-commit guard (trackCommit) and the runaway output cap (capOutput)
+// only fire when a provider misbehaves, so neither could be observed in a real
+// app run. The honest status was "confirmed not to break anything; not
+// confirmed to work" — a bad place for a guard whose whole job is a rare
+// failure. These switches make both provokable.
+//
+// The switches themselves are now product code, so they need the same scrutiny:
+// a fault injector that could activate in a shipped build would be far worse
+// than the bugs it exists to demonstrate.
+
+import assert from 'node:assert/strict';
+import { test, describe } from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.resolve(__dirname, '../streamFaultInjection.ts');
+const src = fs.readFileSync(SRC, 'utf8');
+const llmSrc = fs.readFileSync(path.resolve(__dirname, '../../LLMHelper.ts'), 'utf8');
+
+const MOD = '../../../dist-electron/electron/llm/streamFaultInjection.js';
+
+/** Re-import with a specific env so the module-level gate is re-evaluated. */
+async function withEnv(vars, fn) {
+  const saved = {};
+  for (const [k, v] of Object.entries(vars)) {
+    saved[k] = process.env[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  try {
+    return await fn(await import(MOD));
+  } finally {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+describe('the switches are OFF unless explicitly requested', () => {
+  test('no env vars -> both disabled', async () => {
+    await withEnv(
+      { NATIVELY_TEST_FAIL_STREAM_AFTER_CHARS: undefined, NATIVELY_TEST_STREAM_OUTPUT_CHARS: undefined },
+      (m) => {
+        assert.equal(m.failStreamAfterChars(), null);
+        assert.equal(m.testOutputCharCeiling(), null);
+      },
+    );
+  });
+
+  test('nonsensical values are rejected rather than obeyed', async () => {
+    // `0` matters most: a zero-char fault would fire BEFORE any output, which
+    // is the pre-commit case that already fails over correctly — obeying it
+    // would demonstrate the wrong thing. A zero ceiling would truncate every
+    // answer to nothing.
+    for (const bad of ['0', '-5', 'lots', '', 'NaN']) {
+      await withEnv(
+        { NATIVELY_TEST_FAIL_STREAM_AFTER_CHARS: bad, NATIVELY_TEST_STREAM_OUTPUT_CHARS: bad },
+        (m) => {
+          assert.equal(m.failStreamAfterChars(), null, `fail-after accepted ${JSON.stringify(bad)}`);
+          assert.equal(m.testOutputCharCeiling(), null, `ceiling accepted ${JSON.stringify(bad)}`);
+        },
+      );
+    }
+  });
+
+  test('valid values are honoured', async () => {
+    await withEnv({ NATIVELY_TEST_FAIL_STREAM_AFTER_CHARS: '40' }, (m) => {
+      assert.equal(m.failStreamAfterChars(), 40);
+    });
+    await withEnv({ NATIVELY_TEST_STREAM_OUTPUT_CHARS: '250' }, (m) => {
+      assert.equal(m.testOutputCharCeiling(), 250);
+    });
+  });
+});
+
+describe('a packaged build ignores the switches entirely', () => {
+  // The load-bearing safety property: a stray env var in a real user's shell
+  // must never be able to break their answers.
+  test('the gate consults app.isPackaged', () => {
+    assert.match(src, /isPackaged/, 'the gate must consult app.isPackaged');
+    assert.match(src, /return !app\.isPackaged/, 'a packaged build must disable injection');
+  });
+
+  test('every switch goes through the gate', () => {
+    // A new switch added without the gate would be enabled in production.
+    const exported = [...src.matchAll(/export function (\w+)\(/g)].map((m) => m[1]);
+    assert.ok(exported.length >= 2, 'expected at least two switches');
+    for (const fn of exported) {
+      const start = src.indexOf(`export function ${fn}(`);
+      const body = src.slice(start, src.indexOf('\n}', start));
+      assert.match(
+        body,
+        /faultInjectionAllowed\(\)/,
+        `${fn} does not consult faultInjectionAllowed() — it would be live in a packaged build`,
+      );
+    }
+  });
+
+  test('the gate resolves Electron lazily so pure-logic tests still load', () => {
+    // A static `import { app } from 'electron'` would break every unit test
+    // that imports this module outside an Electron main process.
+    assert.doesNotMatch(src, /^import .*from 'electron'/m);
+    assert.match(src, /require\('electron'\)/);
+  });
+});
+
+describe('the fault is wired where the guard can see it', () => {
+  test('the mid-stream fault throws from trackCommit, after the yield', () => {
+    const start = llmSrc.indexOf('private async * trackCommit(');
+    assert.ok(start > 0, 'could not locate trackCommit');
+    const body = llmSrc.slice(start, llmSrc.indexOf('\n  private async * _streamChatInner', start));
+    assert.match(body, /failStreamAfterChars\(\)/, 'trackCommit must consult the switch');
+    const yieldIdx = body.indexOf('yield tok;');
+    const throwIdx = body.indexOf('throw new InjectedStreamFault');
+    assert.ok(yieldIdx > 0 && throwIdx > yieldIdx,
+      'the fault must throw AFTER the yield — the point is a provider dying once output is already on screen');
+  });
+
+  test('both output-cap sites honour the test ceiling', () => {
+    // There are two: the per-surface ceiling in _streamChatTracked and the
+    // shared one in capOutput. A switch that only reached one would make the
+    // other look bounded when it was not.
+    const hits = (llmSrc.match(/testOutputCharCeiling\(\)/g) || []).length;
+    assert.ok(hits >= 2, `expected both cap sites to consult the switch, found ${hits}`);
+  });
+});

--- a/electron/llm/streamFaultInjection.ts
+++ b/electron/llm/streamFaultInjection.ts
@@ -1,0 +1,87 @@
+// electron/llm/streamFaultInjection.ts
+//
+// Deliberate, test-only faults for the streaming path.
+//
+// WHY THIS EXISTS
+// Two guards added 2026-08-12 can only fire when a provider misbehaves:
+//
+//   * the post-commit guard (trackCommit) — a provider that fails AFTER its
+//     first token must end the turn rather than fall through to the next
+//     provider, which would append a second, different, complete answer
+//   * the runaway output cap (capOutput)
+//
+// Neither can be summoned on demand, so the honest status was "confirmed not to
+// break anything; not confirmed to work". That is a bad place for a guard whose
+// whole job is to handle a rare failure. These switches make both provokable in
+// a real app run, so the behaviour can be watched end to end instead of trusted.
+//
+// SAFETY — three independent conditions, all required:
+//   1. an explicit env var must be set (never on by default)
+//   2. the build must NOT be packaged (app.isPackaged === false)
+//   3. the value must parse to something sane
+//
+// Condition 2 is the load-bearing one: a shipped app ignores these even if the
+// environment sets them, so a stray variable in a user's shell cannot break
+// their answers. When Electron's `app` cannot be resolved at all we are not in a
+// packaged main process (a packaged build always has it), so that case is
+// treated as dev — but condition 1 still applies, so nothing activates by
+// accident.
+
+/** True only in a non-packaged build. Packaged apps ignore every fault switch. */
+function faultInjectionAllowed(): boolean {
+  try {
+    // Lazy require: this module is imported by pure-logic paths and unit tests
+    // that have no Electron runtime, and a static import would break them.
+    const { app } = require('electron');
+    if (app && typeof app.isPackaged === 'boolean') return !app.isPackaged;
+    return true; // Electron present but no app (utility process / test runner).
+  } catch {
+    return true; // Not an Electron main process at all — dev or a test harness.
+  }
+}
+
+/**
+ * Chars after which a stream should throw, simulating a provider that dies
+ * mid-answer AFTER committing output.
+ *
+ *   NATIVELY_TEST_FAIL_STREAM_AFTER_CHARS=200 npm start
+ *
+ * Returns null when disabled. A value of 0 or less is rejected: failing before
+ * any output is the PRE-commit case, which already fails over normally and is
+ * not what this exists to exercise.
+ */
+export function failStreamAfterChars(): number | null {
+  if (!faultInjectionAllowed()) return null;
+  const raw = process.env.NATIVELY_TEST_FAIL_STREAM_AFTER_CHARS;
+  if (!raw) return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return n;
+}
+
+/**
+ * Override for the total-output ceiling, so the runaway cap can be provoked
+ * without waiting for a model to actually loop.
+ *
+ *   NATIVELY_TEST_STREAM_OUTPUT_CHARS=400 npm start
+ *
+ * Returns null when disabled. Only ever LOWERS the ceiling in practice, but the
+ * caller applies it directly — it is a test switch, not a tuning knob, and the
+ * real ceiling stays the shipped constant.
+ */
+export function testOutputCharCeiling(): number | null {
+  if (!faultInjectionAllowed()) return null;
+  const raw = process.env.NATIVELY_TEST_STREAM_OUTPUT_CHARS;
+  if (!raw) return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return n;
+}
+
+/** Error thrown by the injected mid-stream fault, so logs name it clearly. */
+export class InjectedStreamFault extends Error {
+  constructor(afterChars: number) {
+    super(`injected test fault: provider died after ${afterChars} chars (NATIVELY_TEST_FAIL_STREAM_AFTER_CHARS)`);
+    this.name = 'InjectedStreamFault';
+  }
+}


### PR DESCRIPTION
## Why

Two guards added 2026-08-12 only fire when a provider misbehaves:

- the **post-commit guard** (`trackCommit`) — a provider failing *after* its first token must end the turn rather than fall through, which used to append a second, different, complete answer to a partial one
- the **runaway output cap** (`capOutput`)

Neither could be summoned on demand, so their honest status was *"confirmed not to break anything; not confirmed to work"* — a bad place for guards whose entire job is a rare failure.

## What

Two dev-only switches:

```bash
NATIVELY_TEST_FAIL_STREAM_AFTER_CHARS=200   # provider dies mid-answer
NATIVELY_TEST_STREAM_OUTPUT_CHARS=400       # lower the output ceiling
```

The fault throws from inside `trackCommit` **after** the yield, deliberately: the case worth demonstrating is a provider dying once output is already on screen.

Verified locally: with the switch at 40, the stream throws `InjectedStreamFault` at 42 chars with `committed = true` — exactly the state the guard keys off. The ceiling switch fires at 64 > 60 and reaches **both** cap sites; reaching only one would make the other look bounded when it wasn't.

## Safety

These are product code now, so a fault injector that could activate in a shipped build would be worse than the bugs it demonstrates. **Three independent conditions, all required:**

1. an explicit env var (never on by default)
2. a **non-packaged** build — `app.isPackaged === false`
3. a value that parses sane

`0` and negatives are rejected: a zero-char fault fires *pre*-commit, which already fails over correctly and would demonstrate the wrong thing; a zero ceiling would truncate every answer to nothing. Electron is resolved lazily so pure-logic tests can still import the module.

8 tests, including one that walks **every** exported switch and fails if a new one is added without the packaging gate.

## Notes for review

- This was authored on a branch that also carried an unmerged **per-surface ceiling** (`MAX_SUMMARY_OUTPUT_CHARS` / `long_form`). That does not exist on `main` — neither the constant nor the `profile` parameter — so the conflict was resolved against `main` and that work was deliberately **not** carried across. A companion commit that only made sense on that branch was dropped.
- Cherry-picked onto a fresh branch off `main` via a worktree, so another session's in-flight changes in the shared checkout were never disturbed.
- Full-suite execution in the worktree is blocked by `premium` being checked out on a different branch and referencing modules absent from `main` — environment skew, unrelated to this change. The fault-injection suite passes 8/8; please let CI run the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)