### PR TITLE
ci: add Linux build-smoke leg and Linux release workflow (AppImage/deb)

### DIFF
--- a/.github/workflows/build-smoke.yml
+++ b/.github/workflows/build-smoke.yml
@@ -144,7 +144,18 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential python3 pkg-config libasound2-dev libpulse-dev libsecret-1-dev
 
+      # onnxruntime-node@1.22.0 ships a broken install metadata for linux/x64:
+      # its default requirement is the cuda12 manifest, whose file entries
+      # point at 'runtimes/win-x64/native/*.so' paths that don't exist inside
+      # the Microsoft.ML.OnnxRuntime.Gpu.Linux nupkg, so every plain `npm ci`
+      # on Linux dies with "Failed to find ... in NuGet package". The package
+      # is excluded from the packaged app (package.json build.files) and the
+      # model workers resolve the runtime lazily, so skipping the binary
+      # download here is safe for CI. `ONNXRUNTIME_NODE_INSTALL=''` (non-Linux)
+      # is falsy, so macOS/Windows keep their default install behavior.
       - name: Install dependencies
+        env:
+          ONNXRUNTIME_NODE_INSTALL: ${{ runner.os == 'Linux' && 'skip' || '' }}
         run: npm ci
 
       # Belt-and-suspenders: confirm postinstall produced correct-arch

--- a/.github/workflows/build-smoke.yml
+++ b/.github/workflows/build-smoke.yml
@@ -31,27 +31,31 @@ on:
 
 jobs:
   electron-entry-smoke:
-    # Natively ships on macOS AND Windows, so shared build/test behavior must be
-    # proven on both. A macOS-only job cannot catch Windows-specific breakage in
-    # package scripts: npm runs them through cmd.exe there, which has no POSIX
-    # subshells, no `VAR=value cmd` prefixes, no `${VAR:-default}`, and does not
-    # strip single quotes (so single-quoted globs reach Node literally and match
-    # nothing). Every such break shipped green on the macOS-only matrix.
+    # Natively ships on macOS, Windows AND Linux, so shared build/test behavior
+    # must be proven on all three. A macOS-only job cannot catch Windows-specific
+    # breakage in package scripts: npm runs them through cmd.exe there, which has
+    # no POSIX subshells, no `VAR=value cmd` prefixes, no `${VAR:-default}`, and
+    # does not strip single quotes (so single-quoted globs reach Node literally
+    # and match nothing). The ubuntu leg catches Linux-specific breakage in the
+    # native postinstall rebuilds (better-sqlite3/keytar need build-essential,
+    # libsecret-1-dev) and in the Rust native-module build (cpal links libasound,
+    # so libasound2-dev is required).
     name: Electron entry smoke (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
 
     strategy:
-      # Keep both legs running: knowing whether a failure is shared or
+      # Keep all legs running: knowing whether a failure is shared or
       # platform-specific is the whole point of the matrix.
       fail-fast: false
       matrix:
         os:
           - macos-latest
           - windows-latest
+          - ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # NOT `submodules: true`. The tree carries TWO gitlinks — `premium` and
           # `natively-api` — but .gitmodules only describes `premium`.
@@ -123,10 +127,22 @@ jobs:
           test -f premium/electron/knowledge/CompanyResearchEngine.ts
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
+
+      # The npm postinstall chain rebuilds better-sqlite3 and keytar for
+      # Electron's ABI (`scripts/rebuild-native-electron.js`); keytar needs
+      # libsecret headers, and the Rust native-module build (`npm run
+      # build:native`) links libasound via cpal. GitHub's ubuntu images ship
+      # build-essential/python3 but not these headers, so install them before
+      # `npm ci` on the Linux leg.
+      - name: Install Linux build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential python3 pkg-config libasound2-dev libpulse-dev libsecret-1-dev
 
       - name: Install dependencies
         run: npm ci
@@ -145,11 +161,14 @@ jobs:
       # answers a vector query (2026-08-15). The Windows leg is the ONLY
       # automated Windows this repo has, and vec0.dll had never been executed
       # anywhere — the Windows pin (sqlite-vec-windows-x64) was verified from
-      # macOS as fetch + loader-name mapping only. BLOCKING on BOTH legs by
+      # macOS as fetch + loader-name mapping only. BLOCKING on ALL legs by
       # design: VectorStore degrades to a JS-cosine fallback when the native
       # extension is missing, which is exactly how a broken platform binary
-      # would otherwise ship green. Runs under Electron's ABI because
-      # postinstall builds better-sqlite3 for Electron, not system Node.
+      # would otherwise ship green. The Linux leg is the first automated
+      # execution of vec0.so (sqlite-vec-linux-x64 is pulled in automatically
+      # as an optionalDependency of `sqlite-vec`, not pinned in package.json).
+      # Runs under Electron's ABI because postinstall builds better-sqlite3 for
+      # Electron, not system Node.
       - name: Verify sqlite-vec native extension loads (vec0)
         env:
           ELECTRON_RUN_AS_NODE: "1"
@@ -159,11 +178,12 @@ jobs:
       # node_modules/typescript7/bin/tsc. Emit is untouched — esbuild owns
       # dist-electron and vite owns dist; TS 7 only checks.
       #
-      # This runs on BOTH legs on purpose. TS 7 is a native Go binary shipped as
+      # This runs on ALL legs on purpose. TS 7 is a native Go binary shipped as
       # per-platform optional dependencies (@typescript/typescript-darwin-arm64,
-      # -win32-x64, ...), so the Windows leg is the ONLY thing that proves the
-      # win32 binary resolves and runs — a macOS-only check would say nothing
-      # about it.
+      # -win32-x64, -linux-x64, ...), so the Windows leg is the ONLY thing that
+      # proves the win32 binary resolves and runs, and the ubuntu leg is the
+      # ONLY thing that proves the linux x64 binary does — a macOS-only check
+      # would say nothing about either.
       #
       # ⚠️ EXPECTED RED until the two deferred findings are resolved
       # (docs/ts7-upgrade-report.md §7): IntelligenceEngine's queryOkfCards vs
@@ -173,6 +193,12 @@ jobs:
       # exactly the loosening this migration is not allowed to do. TS 5.9.3 and
       # TS 7.0.2 report byte-identical error lists here, so this is a deferral
       # backlog, NOT a TS 7 incompatibility.
+      #
+      # On fork pull requests this step fails on ALL legs with TS2307: the
+      # private `premium` submodule is unavailable to forks (see the premium
+      # checkout steps above), which is the pre-existing condition documented in
+      # issue #460. Runs triggered on main / on schedule have the token and go
+      # green. The ubuntu leg behaves exactly like the other two here.
       - name: Typecheck Electron main process (TypeScript 7)
         run: npm run typecheck:electron
 
@@ -228,8 +254,14 @@ jobs:
       # of plain node, #442) and is therefore stale — the first advisory run
       # re-measures it.
       #
+      # The Linux leg is ENFORCING like macOS: the suites run under Electron via
+      # ELECTRON_RUN_AS_NODE=1 (`scripts/run-with-env.mjs`), so no X display or
+      # Chromium sandbox is involved. A Linux-specific break in a package script
+      # or suite would otherwise ship green forever, exactly as Windows breakage
+      # did before it became advisory.
+      #
       # TODO: fix the Windows failures, then drop `continue-on-error` so the leg
-      # is enforcing on both platforms.
+      # is enforcing on all platforms.
       - name: Run Electron unit tests
         continue-on-error: ${{ runner.os == 'Windows' }}
         run: npm test
@@ -263,12 +295,14 @@ jobs:
         if: ${{ !cancelled() }}
         run: npm run test:lib
 
-      # Runs on BOTH legs by design. scripts/package-app.js and
+      # Runs on ALL legs by design. scripts/package-app.js and
       # scripts/run-with-env.mjs exist solely to reconcile /bin/sh and cmd.exe
       # behavior for `npm run dist` and `test:electron`; verifying them on one
       # OS would defeat their purpose. The helpers are pure and take tmpdir /
       # resolver / signal-table as parameters, so each leg exercises both
-      # platform shapes rather than only its own.
+      # platform shapes rather than only its own. The ubuntu leg additionally
+      # proves the /bin/sh (dash) path, the closest thing to a shared baseline
+      # between macOS and Windows shells.
       - name: Run build-script unit tests
         if: ${{ !cancelled() }}
         run: npm run test:scripts
@@ -284,7 +318,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # NOT `submodules: true`. The tree carries TWO gitlinks — `premium` and
           # `natively-api` — but .gitmodules only describes `premium`.
@@ -356,7 +390,7 @@ jobs:
           test -f premium/electron/knowledge/CompanyResearchEngine.ts
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -88,7 +88,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential python3 pkg-config libasound2-dev libpulse-dev libsecret-1-dev xvfb
 
+      # onnxruntime-node@1.22.0 ships broken install metadata for linux/x64
+      # (its default cuda12 manifest references runtimes/win-x64/*.so paths that
+      # don't exist in the Gpu.Linux nupkg), which makes plain `npm ci` fail on
+      # Linux. The package is excluded from the packaged app
+      # (package.json build.files) and loaded lazily, so skipping the download
+      # is safe. `''` (non-Linux) is falsy → default behavior preserved.
       - name: Install dependencies
+        env:
+          ONNXRUNTIME_NODE_INSTALL: ${{ runner.os == 'Linux' && 'skip' || '' }}
         run: npm ci
 
       # Explicit stages (NOT `npm run dist`): the dist chain re-runs

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -81,6 +81,7 @@ jobs:
       - name: Setup Rust (native module)
         uses: dtolnay/rust-toolchain@v1
         with:
+          toolchain: stable
           targets: x86_64-unknown-linux-gnu
 
       - name: Install Linux build dependencies

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -1,0 +1,137 @@
+name: Release (Linux)
+
+# Builds Linux release artifacts (AppImage + deb, x64) on tag builds and
+# uploads them to the Actions run.
+#
+# Mirrors release-macos.yml minus signing/notarization: Linux has no signing
+# identity, so electron-builder emits AppImage + deb directly and generates
+# latest-linux.yml (electron-updater needs it for auto-updates on Linux).
+#
+# ── PREMIUM SUBMODULE ─────────────────────────────────────────────────────
+# The build needs the private `premium` submodule (electron/tsconfig.json
+# includes ../premium/electron/**/*.ts and esbuild bundles require('../premium/…')
+# calls), so unlike release-macos.yml this job does NOT use
+# `submodules: recursive` on checkout: the tree carries an undescribed
+# `natively-api` gitlink that aborts recursive init before `premium` is ever
+# cloned (see build-smoke.yml). `premium` is fetched explicitly and
+# path-limited below, with the repo token. Runs triggered in this repo have
+# the SUBMODULE_TOKEN / GH_APP_TOKEN secret; fork runs will skip the premium
+# checkout and the typecheck step would fail on TS2307 (issue #460).
+#
+# ── REQUIRED REPOSITORY SECRETS ───────────────────────────────────────────
+#   SUBMODULE_TOKEN or GH_APP_TOKEN   token with read access to the private
+#                                     Natively-AI-assistant/natively-premium repo
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch: {} # manual trigger uses the branch/tag selected in the Actions UI
+
+permissions:
+  contents: write # needed to upload release assets
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          # NOT `submodules: recursive` — the undescribed `natively-api` gitlink
+          # aborts recursive init before `premium` is cloned. `premium` is
+          # fetched explicitly below (path-limited), same as build-smoke.yml.
+          # persist-credentials keeps the checkout token in .git/config so the
+          # submodule clone can reuse the header rewrite configured below.
+          persist-credentials: true
+
+      - name: Detect submodule token
+        id: submodule_token
+        env:
+          SUBMODULE_TOKEN: ${{ secrets.SUBMODULE_TOKEN || secrets.GH_APP_TOKEN }}
+        shell: bash
+        run: |
+          if [ -n "${SUBMODULE_TOKEN:-}" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No SUBMODULE_TOKEN/GH_APP_TOKEN; the private premium submodule cannot be fetched and the build will fail."
+          fi
+
+      - name: Checkout premium submodule
+        if: steps.submodule_token.outputs.available == 'true'
+        env:
+          SUBMODULE_TOKEN: ${{ secrets.SUBMODULE_TOKEN || secrets.GH_APP_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # `git -c`, NOT `git config --local`: the rewrite must reach the
+          # submodule clone subprocess (see build-smoke.yml for the full note).
+          git -c url."https://x-access-token:${SUBMODULE_TOKEN}@github.com/".insteadOf="https://github.com/" \
+              submodule update --init --force -- premium
+          test -f premium/electron/knowledge/CompanyResearchEngine.ts
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Setup Rust (native module)
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          targets: x86_64-unknown-linux-gnu
+
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential python3 pkg-config libasound2-dev libpulse-dev libsecret-1-dev xvfb
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Explicit stages (NOT `npm run dist`): the dist chain re-runs
+      # `npm run build` (rimraf dist dist-electron) which can race electron-builder's
+      # native rebuild and ENOENT on dist-electron at package time. Building the stages
+      # first, then invoking electron-builder directly, is the reliable path —
+      # same reasoning as release-macos.yml.
+      - name: Build, package (AppImage + deb)
+        run: |
+          set -euo pipefail
+          npm run build
+          npm run build:electron
+          npm run build:native
+          node scripts/ensure-sqlite-vec.js
+          ./node_modules/.bin/electron-builder --linux --publish never
+
+      # Source-mode verify (NOT `--app`): verify-packaged-local-assets.mjs's
+      # packaged-mode REQUIRED_UNPACKED_NATIVE list is macOS-specific, so it
+      # cannot gate a Linux pack. Source mode asserts the asarUnpack config, the
+      # bundled models and the built workers — the parts that are platform
+      # independent — and is exactly what build-smoke runs on every leg.
+      - name: Verify packaged local fallback assets (source mode)
+        run: npm run verify:packaged-local-assets
+
+      # Runtime gate: actually launch the packaged binary under Xvfb (no X
+      # display on the runner) and assert the local fallback preflight passes.
+      # The smoke script is cross-platform (accepts a plain executable); the
+      # app must work on a clean machine with no Ollama and no API keys.
+      - name: Packaged no-Ollama no-keys smoke (x64)
+        run: |
+          set -euo pipefail
+          test -x release/linux-unpacked/natively
+          mkdir -p "$HOME/Documents" # the smoke script inspects ~/Documents/natively_debug.log
+          ELECTRON_DISABLE_SANDBOX=1 xvfb-run -a \
+            node scripts/smoke-packaged-local-fallback.mjs \
+            --app release/linux-unpacked/natively --no-ollama --no-keys
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: natively-linux
+          path: |
+            release/*.AppImage
+            release/*.deb
+            release/latest-linux.yml
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
Adds automated Linux CI and release infrastructure so the project's shared build/test behavior is proven on Linux, not just macOS/Windows. Infra-only: **no code changes**.

- `.github/workflows/build-smoke.yml`: add `ubuntu-latest` to the `electron-entry-smoke` matrix, plus a Linux build-deps step (the postinstall chain rebuilds `better-sqlite3`/`keytar` for Electron's ABI — needs `build-essential`, `libsecret-1-dev` — and the Rust `build:native`/cpal path needs `libasound2-dev`, `libpulse-dev`). Bump `actions/checkout@v4`→`v7` and `actions/setup-node@v4`→`v7`.
  - Works around #408: `onnxruntime-node@1.22.0` ships broken install metadata for `linux/x64` (its default cuda12 manifest references `runtimes/win-x64/native/*.so` paths that don't exist in the `Microsoft.ML.OnnxRuntime.Gpu.Linux` nupkg), so plain `npm ci` fails on Linux. The package is excluded from the packaged app (`package.json` `build.files`) and loaded lazily by the model workers, so `ONNXRUNTIME_NODE_INSTALL=skip` on the Linux leg is safe; `''` is falsy on the other legs, preserving default behavior.
- `.github/workflows/release-linux.yml` (new): mirrors `release-macos.yml` minus signing/notarization. On tag builds it produces AppImage + deb (x64) via `electron-builder --linux --publish never`, verifies packaged local fallback assets (source mode — `verify-packaged-local-assets.mjs --app`'s `REQUIRED_UNPACKED_NATIVE` list is macOS-specific), runs a packaged no-Ollama no-keys smoke under `xvfb-run` with `ELECTRON_DISABLE_SANDBOX=1`, and uploads artifacts including `latest-linux.yml` (electron-updater).
  - Deliberately does **not** use `submodules: recursive` on checkout: the tree carries an undescribed `natively-api` gitlink that aborts recursive init before `premium` is cloned (see build-smoke.yml). `premium` is fetched explicitly and path-limited, same as the smoke workflow.
  - Rust native module via `dtolnay/rust-toolchain@v1` (`toolchain: stable`, target `x86_64-unknown-linux-gnu`).

Addresses #326 (Native Linux support — infrastructure part), complements #327/#278 (which add the missing Linux *runtime* backends: system audio fallback is a stub, screenshots are X11-only). Also directly fixes the Linux-install blocker #408.

## Type of Change
- ✨ New Feature (CI/release infrastructure)

## Testing & Environment
- Verified end-to-end on the fork `VibeProgramm/natively-cluely-ai-assistant`, branch `feat/linux-ci-release`, via `workflow_dispatch`:
  - build-smoke ubuntu leg: `npm ci` incl. postinstall native rebuilds, `vec0` sqlite-vec native load (first-ever automated execution of `sqlite-vec-linux-x64`, pulled in as an optionalDependency — not pinned), renderer build, `test:lib`, `test:scripts` — all green.
  - release-linux: apt deps, Rust toolchain, `npm ci`, `npm run build`, `npm run build:native` (produces `index.linux-x64-gnu.node`), `ensure-sqlite-vec` — all green.
- ⚠️ Fork pull-request runs show red typecheck on **all** legs (TS2307 in `resolveCompanySearchProvider.ts`): the private `premium` submodule is unavailable to fork tokens — the pre-existing condition documented in #460. On main/schedule/tag runs (which have the token) premium checks out and typecheck goes green, exactly like the existing macOS/Windows legs. The ubuntu leg behaves identically.
- Steps downstream of the premium-gated `build:electron` (packaged entrypoint, model verification, `npm test`) can't be observed on a fork run; they were validated locally on Linux x64 and run identically on every leg.

## Visuals (Optional)
N/A