### PR TITLE
Point the Issue322 keychain suite at the real degraded-store API

### DIFF
--- a/electron/services/__tests__/Issue322KeychainPersistence.test.mjs
+++ b/electron/services/__tests__/Issue322KeychainPersistence.test.mjs
@@ -130,32 +130,32 @@ test('REPRO: a save during a keychain-decrypt-FAILED session must not permanentl
     'key must survive a transient keychain failure — an empty-state save must not clobber it');
 });
 
-test('wasExistingStoreUnreadable() reports true ONLY during an undecryptable-store launch', () => {
+test('isCredentialStoreDegraded() reports true ONLY during an undecryptable-store launch', () => {
   const env = makeEnv();
 
   // Healthy first run with a saved key → not unreadable.
   const cm = freshManager(env);
   cm.setDeepgramApiKey(SECRET);
-  assert.equal(cm.wasExistingStoreUnreadable(), false, 'a clean save is not an unreadable store');
+  assert.equal(cm.isCredentialStoreDegraded(), false, 'a clean save is not an unreadable store');
 
   // Reopen while the keychain can't decrypt → flag must be true so startup self-heals
   // (e.g. the GOOGLE_APPLICATION_CREDENTIALS persist in main.ts) know to skip persisting.
   env.state.decryptShouldThrow = true;
   const cm2 = freshManager(env);
-  assert.equal(cm2.wasExistingStoreUnreadable(), true, 'undecryptable existing store must report unreadable');
+  assert.equal(cm2.isCredentialStoreDegraded(), true, 'undecryptable existing store must report unreadable');
 
   // Healthy launch again → real data loads, flag clears.
   env.state.decryptShouldThrow = false;
   const cm3 = freshManager(env);
   assert.equal(cm3.getDeepgramApiKey(), SECRET);
-  assert.equal(cm3.wasExistingStoreUnreadable(), false, 'a successful load clears the flag');
+  assert.equal(cm3.isCredentialStoreDegraded(), false, 'a successful load clears the flag');
 });
 
 test('REPRO (side door): a single-field auto-populate during an unreadable session must not clobber the store', () => {
   // This models the main.ts startup self-heal that persists GOOGLE_APPLICATION_CREDENTIALS.
   // It calls a PUBLIC single-field setter (setGoogleServiceAccountPath) — which makes creds
   // non-empty, so saveCredentials()'s empty-set guard does NOT fire. The protection has to
-  // live at the CALL SITE via wasExistingStoreUnreadable(); this test asserts that contract:
+  // live at the CALL SITE via isCredentialStoreDegraded(); this test asserts that contract:
   // an auto-heal that respects the flag leaves the recoverable store intact.
   const env = makeEnv();
 
@@ -167,7 +167,7 @@ test('REPRO (side door): a single-field auto-populate during an unreadable sessi
   assert.equal(cm2.getDeepgramApiKey(), undefined, 'unreadable this session (expected)');
 
   // The fixed call site checks the flag before persisting. Emulate that guarded self-heal:
-  if (!cm2.wasExistingStoreUnreadable()) {
+  if (!cm2.isCredentialStoreDegraded()) {
     cm2.setGoogleServiceAccountPath('/some/env/service-account.json');
   }
   // (If the guard were missing and we called the setter unconditionally, the next launch
@@ -185,12 +185,12 @@ test('REPRO (side door 2): PhoneMirror ext-token mint during an unreadable sessi
   // launch getPhoneMirrorToken() is undefined (creds are the empty recovery set), so an
   // unguarded mint would write a single-field { phoneMirrorToken } — non-empty, past
   // saveCredentials()'s empty-set guard — clobbering the recoverable keyring file. The fixed
-  // call site mints in memory but only PERSISTS when !wasExistingStoreUnreadable().
+  // call site mints in memory but only PERSISTS when !isCredentialStoreDegraded().
   //
   // NOTE: this mirrors the call-site guard rather than importing the bundled function, because
   // PhoneMirrorService is esbuild-bundled with its OWN inlined CredentialsManager singleton —
   // driving the real function would require a test-only CM accessor in production code, a worse
-  // tradeoff than this contract test. The guard mechanism itself (wasExistingStoreUnreadable →
+  // tradeoff than this contract test. The guard mechanism itself (isCredentialStoreDegraded →
   // skip persist → store survives) is exercised end-to-end here and verified honest: defeating
   // the getter makes this and side-door-1 fail. The matching production call site is covered by
   // PhoneMirrorExtensionV2.test.mjs's persist round-trip on the healthy path.
@@ -205,7 +205,7 @@ test('REPRO (side door 2): PhoneMirror ext-token mint during an unreadable sessi
 
   // Emulate loadOrCreatePersistedExtToken()'s guarded mint-and-persist.
   const fresh = 'ext-tok-FRESH-0123456789abcdef';
-  if (!cm2.wasExistingStoreUnreadable()) {
+  if (!cm2.isCredentialStoreDegraded()) {
     cm2.setPhoneMirrorToken(fresh);
   }
 


### PR DESCRIPTION
One test recovered from the macOS Build Smoke backlog. **This does not make CI green** — see below.

## The fix

`wasExistingStoreUnreadable()` does not exist on `CredentialsManager` and never has: `git log -S` over `CredentialsManager.ts` returns nothing for it. The suite called it 9 times, so those tests died on `TypeError: ... is not a function` rather than on anything to do with keychain behavior.

The real accessor is `isCredentialStoreDegraded()`, which returns the same `keyringUnreadable` flag the tests reason about. Renamed all 9 call sites and the test title. 9 lines, one file, no source changes.

Verified with `electron --test` on that file: passing went 1 → 2.

## What this does NOT fix

The other 8 failures in this same file remain, and they split three ways:

- **3 need an unbuilt feature.** `needsCredentialReentry()` is a 3-strike cold-start escalation. No failure counter exists anywhere in `CredentialsManager` — these document a design that was never implemented. Not regressions.
- **4 are unexplained.** The symptom is precise: the mock's `decryptShouldThrow = true` never reaches the decrypt branch — the run logs `Loaded encrypted credentials` 21 times with zero decrypt failures. I falsified three hypotheses: a stale `electron` mock held by an uncached module (busting the entire `dist-electron` require cache changed nothing), module-scope path capture (ruled out by the same experiment), and a mock-shape mismatch.
- **1 was already passing.**

## Context

macOS `Build Smoke` has **125 failures across 55 files** that reproduce both locally and in CI, and has been red on `main` for 7 consecutive runs since 2026-08-10. After this PR: **124 remain**.

Worth recording, because it contradicts the obvious assumption: only **8 of the 125** are `TypeError: ... is not a function` (tests calling APIs that no longer exist). **113 are `AssertionError`** — behavioral failures needing individual root-causing. This file was one of the atypical ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SiDsWPD5XtBYgXWt7ZPizu