### PR TITLE
fix(stt): give Nemotron its own group in the local model picker

### DIFF
--- a/src/components/LocalWhisperModelPanel.tsx
+++ b/src/components/LocalWhisperModelPanel.tsx
@@ -199,6 +199,7 @@ function formatSize(mb: number): string {
 const FAMILY_RULES: Array<{ id: string; label: string; note: string; test: (name: string) => boolean }> = [
     { id: 'moonshine', label: 'Moonshine', note: 'Smallest and quickest to start', test: (n) => /^moonshine/i.test(n) },
     { id: 'parakeet', label: 'Parakeet', note: 'NVIDIA Conformer CTC, English-only', test: (n) => /^parakeet/i.test(n) },
+    { id: 'nemotron', label: 'Nemotron', note: 'NVIDIA FastConformer-RNNT, real streaming, multilingual', test: (n) => /^nemotron/i.test(n) },
     { id: 'distil', label: 'Distil-Whisper', note: 'Compressed Whisper, near-equal accuracy', test: (n) => /^distil/i.test(n) },
     { id: 'whisper', label: 'Whisper', note: 'Original OpenAI checkpoints', test: () => true },
 ];


### PR DESCRIPTION
Follow-up to #476.

The Nemotron catalog entry landed without a matching family rule in `LocalWhisperModelPanel`. `FAMILY_RULES` matches on **display name** and ends in a catch-all (`test: () => true`) labelled *"Whisper — Original OpenAI checkpoints"*, so `"Nemotron 3.5 ASR Streaming"` fell into it.

The model was present and installable the whole time — it just rendered under the **Whisper** heading, described as an OpenAI checkpoint. Anyone scrolling for a Nemotron section found none.

## Why it was silent

The catch-all is deliberate: an unrecognised model should be grouped rather than dropped, because the plain Whisper checkpoints (`Tiny English`, `Base Multilingual`) don't say "Whisper" in their names either. That design makes a *missing* rule invisible rather than loud — which is exactly how this slipped through #476's review.

## Change

One rule, ordered ahead of the catch-all:

```js
{ id: 'nemotron', label: 'Nemotron', note: 'NVIDIA FastConformer-RNNT, real streaming, multilingual', test: (n) => /^nemotron/i.test(n) },
```

## Verification

Ran every real `MODEL_CATALOG` display name through the rules. Nemotron is the only entry whose group changes:

```
moonshine  | Moonshine Tiny / Moonshine Base
parakeet   | Parakeet CTC 0.6B
nemotron   | Nemotron 3.5 ASR Streaming   ← was 'whisper'
distil     | Distil Small/Medium EN, Distil Large v2/v3
whisper    | Whisper Large v3 Turbo, Tiny/Base/Small/Medium ×2
```

Empty groups were already guarded (`rows.length === 0` returns `null`), so the new section can't render blank against a catalog without the model.

- `typecheck:ts7` — clean
- Renderer-only change; no main-process or platform-specific code touched. Grouping is platform-independent, so macOS and Windows render identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011VSHtwCxXjMVdyheoF73Bd