### PR TITLE
docs(readme): restore the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1004,11 +1004,11 @@ Natively is a free-for-personal-use, source-available alternative to:
 
 ## Star History
 
-<a href="https://star-history.com/#evinjohnn/natively-cluely-ai-assistant&Date">
+<a href="https://star-history.dera.page/#evinjohnn/natively-cluely-ai-assistant&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=evinjohnn/natively-cluely-ai-assistant&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=evinjohnn/natively-cluely-ai-assistant&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=evinjohnn/natively-cluely-ai-assistant&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=evinjohnn/natively-cluely-ai-assistant&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=evinjohnn/natively-cluely-ai-assistant&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=evinjohnn/natively-cluely-ai-assistant&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README currently renders blank, since the
service it relied on can no longer deliver the chart reliably. This change
points the chart at a maintained instance so the project's growth stays
visible again. The fix was validated against the same approach already in
use by other repositories.

The badge is intentionally left untouched.