### PR TITLE
fix(stt): restore the local model list on main + gate language/accent by documented model support

### DIFF
--- a/electron/audio/whisper/__tests__/ModelLanguageSupport.test.mjs
+++ b/electron/audio/whisper/__tests__/ModelLanguageSupport.test.mjs
@@ -1,0 +1,158 @@
+// Contract tests for electron/audio/whisper/modelLanguageSupport.ts — the
+// single source of truth for which recognition languages each local STT model
+// accepts (verified against each model's official docs; see that file's
+// provenance comment).
+//
+// Guards three real regressions:
+//  1. The worker's English-only guard was a hand-typed id list that omitted
+//     Parakeet CTC (English-only per NVIDIA's model card). It is now derived
+//     from MODEL_CATALOG's `multilingual` flag — assert every English-only
+//     checkpoint is covered and no multilingual one is.
+//  2. The worker's old LANG_MAP was keyed by BCP-47 tags while the host sends
+//     the app's internal settings key ('english-us'), so language selection
+//     silently never reached multilingual Whisper. resolveWhisperLanguage()
+//     must resolve EVERY RECOGNITION_LANGUAGES key (and the legacy BCP-47
+//     forms) to a valid Whisper language name.
+//  3. The Settings UI restricts language options per model via
+//     getLocalModelLanguageSupport() — assert the Nemotron set matches the
+//     transcription-ready locale table and English-only models lock the
+//     selects.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distWhisper = path.resolve(__dirname, '../../../../dist-electron/electron/audio/whisper');
+const distConfig = path.resolve(__dirname, '../../../../dist-electron/electron/config');
+
+const {
+  getLocalModelLanguageSupport,
+  isEnglishOnlyLocalModel,
+  resolveWhisperLanguage,
+} = await import(pathToFileURL(path.join(distWhisper, 'modelLanguageSupport.js')).href);
+const { MODEL_CATALOG } = await import(pathToFileURL(path.join(distWhisper, 'modelManager.js')).href);
+const { RECOGNITION_LANGUAGES, ENGLISH_VARIANTS } = await import(
+  pathToFileURL(path.join(distConfig, 'languages.js')).href
+);
+const { NEMOTRON_TRANSCRIPTION_READY_LOCALES } = await import(
+  pathToFileURL(path.join(distWhisper, 'nemotron/languageTable.js')).href
+);
+
+const NEMOTRON_ID = 'onnx-community/nemotron-3.5-asr-streaming-0.6b-onnx-int4';
+
+// Whisper's official language names (openai/whisper tokenizer LANGUAGES) for
+// every language this app offers — the resolver must never emit anything
+// outside this set, or transformers.js throws "Unsupported language".
+const OFFICIAL_WHISPER_NAMES = new Set([
+  'english', 'indonesian', 'russian', 'spanish', 'french', 'german', 'italian',
+  'portuguese', 'japanese', 'korean', 'chinese', 'turkish', 'ukrainian',
+  'romanian', 'polish', 'dutch', 'arabic', 'hindi', 'swedish', 'norwegian',
+  'danish', 'czech', 'hungarian', 'vietnamese', 'thai', 'greek', 'bulgarian',
+  'hebrew', 'malay', 'finnish',
+]);
+
+test('every catalog model has a language-support entry with keys drawn from RECOGNITION_LANGUAGES', () => {
+  for (const m of MODEL_CATALOG) {
+    const s = getLocalModelLanguageSupport(m.id);
+    assert.ok(s, `${m.id}: no support entry`);
+    assert.ok(Array.isArray(s.allowedLanguageKeys) && s.allowedLanguageKeys.length > 0, `${m.id}: empty allowed set`);
+    for (const key of s.allowedLanguageKeys) {
+      assert.ok(key in RECOGNITION_LANGUAGES, `${m.id}: allowed key '${key}' is not a RECOGNITION_LANGUAGES key`);
+    }
+  }
+});
+
+test('English-only guard derives from the catalog and covers Parakeet (the old hand-typed set missed it)', () => {
+  const englishOnly = MODEL_CATALOG.filter((m) => !m.multilingual).map((m) => m.id);
+  const multilingual = MODEL_CATALOG.filter((m) => m.multilingual).map((m) => m.id);
+  assert.ok(englishOnly.includes('onnx-community/parakeet-ctc-0.6b-ONNX'), 'catalog must mark Parakeet English-only');
+  for (const id of englishOnly) {
+    assert.equal(isEnglishOnlyLocalModel(id), true, `${id} must be English-only`);
+  }
+  for (const id of multilingual) {
+    assert.equal(isEnglishOnlyLocalModel(id), false, `${id} must NOT be English-only`);
+  }
+  // Unknown ids fail conservative: strip language/task rather than pass them.
+  assert.equal(isEnglishOnlyLocalModel('some/unknown-model'), true);
+});
+
+test('English-only models lock both selects and allow only the English variants', () => {
+  for (const m of MODEL_CATALOG.filter((x) => !x.multilingual)) {
+    const s = getLocalModelLanguageSupport(m.id);
+    assert.equal(s.languageSelectable, false, `${m.id}: language must be locked`);
+    assert.equal(s.accentSelectable, false, `${m.id}: accent must be locked`);
+    assert.deepEqual(
+      [...s.allowedLanguageKeys].sort(),
+      Object.keys(ENGLISH_VARIANTS).sort(),
+      `${m.id}: allowed set must be exactly the English variants`,
+    );
+  }
+});
+
+test('multilingual Whisper-family models allow every language including auto, but no accent conditioning', () => {
+  const whisperMultilingual = MODEL_CATALOG.filter(
+    (m) => m.multilingual && m.sessionLayout !== 'nemotron-rnnt',
+  );
+  assert.ok(whisperMultilingual.length > 0, 'catalog must contain multilingual Whisper checkpoints');
+  for (const m of whisperMultilingual) {
+    const s = getLocalModelLanguageSupport(m.id);
+    assert.equal(s.languageSelectable, true, `${m.id}: language must be selectable`);
+    assert.equal(s.accentSelectable, false, `${m.id}: Whisper has no accent/region parameter`);
+    assert.deepEqual(
+      [...s.allowedLanguageKeys].sort(),
+      Object.keys(RECOGNITION_LANGUAGES).sort(),
+      `${m.id}: must allow the full RECOGNITION_LANGUAGES set (Whisper's 99 languages are a superset)`,
+    );
+    assert.ok(s.allowedLanguageKeys.includes('auto'), `${m.id}: Whisper supports auto-detect`);
+  }
+});
+
+test('Nemotron allows exactly the keys that resolve through the transcription-ready locale table — no auto', () => {
+  const s = getLocalModelLanguageSupport(NEMOTRON_ID);
+  assert.equal(s.languageSelectable, true);
+  assert.equal(s.accentSelectable, true, 'Nemotron is the only local model with regional-variant conditioning');
+  assert.ok(!s.allowedLanguageKeys.includes('auto'), 'Nemotron has no auto-detect mode');
+
+  const expected = [
+    // English variants: en-US/en-GB are table entries; en-IN/en-AU/en-CA route
+    // to en-US via the documented inference in languageTable.ts.
+    'english-us', 'english-uk', 'english-in', 'english-au', 'english-ca',
+    // Direct table entries (ar-SA reaches ar-AR via the documented alias).
+    'spanish', 'french', 'german', 'italian', 'portuguese', 'dutch',
+    'turkish', 'russian', 'arabic', 'hindi', 'japanese', 'korean',
+    'vietnamese', 'ukrainian',
+  ];
+  assert.deepEqual([...s.allowedLanguageKeys].sort(), expected.sort());
+
+  // Sanity anchor against the verified table itself: every non-English
+  // allowed key's BCP-47 locale (or its alias) must exist in the table.
+  for (const key of s.allowedLanguageKeys) {
+    if (key.startsWith('english-')) continue;
+    const bcp47 = RECOGNITION_LANGUAGES[key].bcp47;
+    const aliased = bcp47 === 'ar-SA' ? 'ar-AR' : bcp47;
+    assert.ok(
+      aliased in NEMOTRON_TRANSCRIPTION_READY_LOCALES,
+      `${key} (${bcp47}) not in NEMOTRON_TRANSCRIPTION_READY_LOCALES`,
+    );
+  }
+});
+
+test('resolveWhisperLanguage covers every internal settings key (the old LANG_MAP resolved none of them)', () => {
+  for (const [key, lang] of Object.entries(RECOGNITION_LANGUAGES)) {
+    const resolved = resolveWhisperLanguage(key);
+    if (key === 'auto') {
+      assert.equal(resolved, null, "'auto' must resolve to null (Whisper auto-detect)");
+      continue;
+    }
+    assert.ok(resolved, `internal key '${key}' must resolve`);
+    assert.ok(OFFICIAL_WHISPER_NAMES.has(resolved), `'${key}' resolved to non-official name '${resolved}'`);
+    // Legacy worker contract: BCP-47 tags and bare iso639 codes still resolve
+    // to the same name.
+    assert.equal(resolveWhisperLanguage(lang.bcp47), resolved, `bcp47 '${lang.bcp47}' must match key resolution`);
+    assert.equal(resolveWhisperLanguage(lang.iso639), resolved, `iso639 '${lang.iso639}' must match key resolution`);
+  }
+  assert.equal(resolveWhisperLanguage(''), null);
+  assert.equal(resolveWhisperLanguage('klingon'), null);
+});

--- a/electron/audio/whisper/modelLanguageSupport.ts
+++ b/electron/audio/whisper/modelLanguageSupport.ts
@@ -1,0 +1,184 @@
+// electron/audio/whisper/modelLanguageSupport.ts
+//
+// Single source of truth for WHICH recognition languages each local STT
+// model actually accepts, verified against each model's official reference
+// documentation (2026-08-19):
+//
+//   Moonshine tiny/base      — English-only. Model card
+//                              (huggingface.co/UsefulSensors/moonshine-base):
+//                              "capable of transcribing English speech audio
+//                              into English text".
+//   Parakeet CTC 0.6B        — English-only. Model card
+//                              (huggingface.co/nvidia/parakeet-ctc-0.6b):
+//                              "transcribes speech in lower case English
+//                              alphabet".
+//   Distil-Whisper (all)     — English-only. Model card
+//                              (huggingface.co/distil-whisper/distil-large-v3):
+//                              "the Distil-Whisper English series"; passing
+//                              `language`/`task` to an English-only Whisper
+//                              checkpoint THROWS in transformers.js (see
+//                              whisperWorker.ts's English-only guard).
+//   Whisper *.en             — English-only, same transformers.js contract.
+//   Whisper multilingual     — OpenAI's official 99-language set, which is a
+//   (tiny/base/small/medium/   strict superset of every entry in
+//    large-v3-turbo)           RECOGNITION_LANGUAGES; also supports 'auto'
+//                              (omit the language token). Whisper's language
+//                              conditioning is a plain language token — there
+//                              is NO regional/accent parameter, so en-US vs
+//                              en-GB is not expressible.
+//   Nemotron 3.5 Streaming   — the 19 transcription-ready locales in
+//                              ./nemotron/languageTable.ts, verified
+//                              byte-for-byte against NVIDIA's reference
+//                              PROMPT_DICTIONARY (see that file's provenance
+//                              comment). The ONLY local model whose language
+//                              conditioning distinguishes regional variants
+//                              (en-US vs en-GB, pt-BR vs pt-PT, ...). No
+//                              auto-detect mode.
+//
+// Consumed by:
+//   - whisperWorker.ts       — English-only guard + language-tag resolution
+//   - ipcHandlers.ts         — `local-whisper-get-models` attaches a
+//                              LocalModelLanguageSupport per model so the
+//                              Settings UI can restrict/grey the Language and
+//                              Accent/Region selects to what the active model
+//                              accepts.
+//
+// Pure module: no electron imports, safe in the worker thread and testable
+// under plain node.
+
+import { MODEL_CATALOG } from './modelManager';
+import { RECOGNITION_LANGUAGES, ENGLISH_VARIANTS } from '../../config/languages';
+import { resolveNemotronLangId } from './nemotron/languageTable';
+
+export interface LocalModelLanguageSupport {
+  /**
+   * False when the model's language is fixed (English-only checkpoints):
+   * the Language select should render greyed-out showing "English".
+   */
+  languageSelectable: boolean;
+  /**
+   * True only when the model's language conditioning distinguishes regional
+   * variants (currently Nemotron alone). False → the Accent/Region select
+   * renders greyed-out: Whisper-family models take a regional-neutral
+   * language token, English-only models take nothing at all.
+   */
+  accentSelectable: boolean;
+  /**
+   * RECOGNITION_LANGUAGES keys this model accepts, including 'auto' when the
+   * model can genuinely auto-detect. The Settings UI must offer ONLY these.
+   */
+  allowedLanguageKeys: string[];
+}
+
+// ── Whisper's language-token names, keyed by this app's iso639 codes. ──────
+// Every RECOGNITION_LANGUAGES entry maps to one of Whisper's official 99
+// languages (openai/whisper tokenizer.py LANGUAGES). Values are the full
+// names because that is what the existing worker contract passes to
+// transformers.js (which accepts either names or codes).
+const WHISPER_LANGUAGE_BY_ISO639: Record<string, string> = {
+  en: 'english',
+  id: 'indonesian',
+  ru: 'russian',
+  es: 'spanish',
+  fr: 'french',
+  de: 'german',
+  it: 'italian',
+  pt: 'portuguese',
+  ja: 'japanese',
+  ko: 'korean',
+  zh: 'chinese',
+  tr: 'turkish',
+  uk: 'ukrainian',
+  ro: 'romanian',
+  pl: 'polish',
+  nl: 'dutch',
+  ar: 'arabic',
+  hi: 'hindi',
+  sv: 'swedish',
+  no: 'norwegian',
+  // The app's Norwegian entry uses the BCP-47 tag 'nb-NO' (Bokmål) with
+  // iso639 'no'; Whisper has no separate Bokmål code, so both route to its
+  // 'norwegian' token.
+  nb: 'norwegian',
+  da: 'danish',
+  cs: 'czech',
+  hu: 'hungarian',
+  vi: 'vietnamese',
+  th: 'thai',
+  el: 'greek',
+  bg: 'bulgarian',
+  he: 'hebrew',
+  ms: 'malay',
+  fi: 'finnish',
+};
+
+/**
+ * Resolves what the host passes on WorkerTranscribeMessage.language — the
+ * app's internal settings key ('english-us', 'french', 'auto'; see
+ * RECOGNITION_LANGUAGES) — to the Whisper language name transformers.js
+ * expects, or null for 'auto'/unknown (Whisper then auto-detects).
+ *
+ * Also accepts raw BCP-47 tags ('en-US') and bare iso639 codes ('en') for
+ * compatibility with the worker's previous LANG_MAP contract.
+ */
+export function resolveWhisperLanguage(languageKeyOrTag: string): string | null {
+  const raw = (languageKeyOrTag ?? '').trim();
+  if (!raw || raw === 'auto') return null;
+
+  // Internal settings key ('english-us', 'french', ...)
+  const entry = RECOGNITION_LANGUAGES[raw];
+  if (entry) return WHISPER_LANGUAGE_BY_ISO639[entry.iso639] ?? null;
+
+  // BCP-47 ('en-US') or bare iso639 ('en')
+  const iso = raw.split('-')[0].toLowerCase();
+  return WHISPER_LANGUAGE_BY_ISO639[iso] ?? null;
+}
+
+/**
+ * English-only local models, derived from the catalog's own `multilingual`
+ * flag rather than a hand-maintained id list (the previous hardcoded set in
+ * whisperWorker.ts silently omitted Parakeet). Unknown ids are treated as
+ * English-only — the conservative direction: for these models the worker
+ * omits `language`/`task`, which is always safe, whereas passing them to an
+ * English-only checkpoint throws in transformers.js.
+ */
+export function isEnglishOnlyLocalModel(modelId: string): boolean {
+  const m = MODEL_CATALOG.find((x) => x.id === modelId);
+  return m ? !m.multilingual : true;
+}
+
+const ENGLISH_VARIANT_KEYS = Object.keys(ENGLISH_VARIANTS);
+
+function isNemotronModel(modelId: string): boolean {
+  return MODEL_CATALOG.find((x) => x.id === modelId)?.sessionLayout === 'nemotron-rnnt';
+}
+
+/**
+ * Language capability of one local model. Derivations:
+ *  - Nemotron: every RECOGNITION_LANGUAGES key whose BCP-47 locale resolves
+ *    through resolveNemotronLangId() (the verified transcription-ready tier,
+ *    including the documented en-IN/en-AU/en-CA → en-US inference and the
+ *    ar-SA → ar-AR alias). 'auto' excluded — Nemotron has no auto-detect.
+ *  - Multilingual Whisper family: everything, including 'auto'.
+ *  - English-only models: the English variants only, language locked.
+ */
+export function getLocalModelLanguageSupport(modelId: string): LocalModelLanguageSupport {
+  if (isNemotronModel(modelId)) {
+    const allowed = Object.entries(RECOGNITION_LANGUAGES)
+      .filter(([key, lang]) => key !== 'auto' && resolveNemotronLangId(lang.bcp47) !== null)
+      .map(([key]) => key);
+    return { languageSelectable: true, accentSelectable: true, allowedLanguageKeys: allowed };
+  }
+  if (!isEnglishOnlyLocalModel(modelId)) {
+    return {
+      languageSelectable: true,
+      accentSelectable: false,
+      allowedLanguageKeys: Object.keys(RECOGNITION_LANGUAGES),
+    };
+  }
+  return {
+    languageSelectable: false,
+    accentSelectable: false,
+    allowedLanguageKeys: [...ENGLISH_VARIANT_KEYS],
+  };
+}

--- a/electron/audio/whisper/whisperWorker.ts
+++ b/electron/audio/whisper/whisperWorker.ts
@@ -17,24 +17,19 @@
 import { parentPort } from 'worker_threads';
 import { WhisperProgressAggregator } from './whisperProgressAggregator';
 import { getBoundedOnnxSessionOptions } from '../../utils/onnxThreadConfig';
-
-const LANG_MAP: Record<string, string | null> = {
-  'auto': null,
-  'en-US': 'english',
-  'en-GB': 'english',
-  'fr-FR': 'french',
-  'de-DE': 'german',
-  'es-ES': 'spanish',
-  'ja-JP': 'japanese',
-  'ko-KR': 'korean',
-  'zh-CN': 'chinese',
-  'zh-TW': 'chinese',
-  'pt-BR': 'portuguese',
-  'it-IT': 'italian',
-  'ru-RU': 'russian',
-  'ar': 'arabic',
-  'hi-IN': 'hindi',
-};
+// Shared language-capability module (also consumed by ipcHandlers for the
+// Settings UI). Replaces two hand-maintained tables that had both drifted:
+//  - LANG_MAP was keyed by BCP-47 tags ('en-US') while the host actually
+//    sends the app's internal settings key ('english-us' — LocalWhisperSTT
+//    forwards CredentialsManager.getSttLanguage() verbatim), so EVERY lookup
+//    missed and multilingual Whisper silently ran in auto-detect regardless
+//    of the user's language setting. resolveWhisperLanguage() accepts the
+//    internal key, plus BCP-47/iso639 tags for compatibility, and covers all
+//    30 RECOGNITION_LANGUAGES (the old map covered 13).
+//  - ENGLISH_ONLY_MODELS was a hand-typed id list that omitted Parakeet CTC
+//    (English-only per NVIDIA's model card). isEnglishOnlyLocalModel() is
+//    derived from MODEL_CATALOG's own `multilingual` flag instead.
+import { isEnglishOnlyLocalModel, resolveWhisperLanguage } from './modelLanguageSupport';
 
 let pipe: any = null;
 let loadedModelId = '';
@@ -175,26 +170,6 @@ async function updatePromptCache(promptText: string): Promise<void> {
     cachedPromptIds = null;
   }
 }
-
-// Distil-Whisper checkpoints have NO multilingual decoder. If the user picks
-// 'auto' or any non-English language, the worker will silently transcribe
-// non-English audio as phonetic English. Force language='english' so the
-// behaviour is at least documented and consistent.
-const ENGLISH_ONLY_MODELS = new Set([
-  // Moonshine — English-only by design
-  'onnx-community/moonshine-tiny-ONNX',
-  'onnx-community/moonshine-base-ONNX',
-  // Distil-Whisper — English-only checkpoints
-  'distil-whisper/distil-small.en',
-  'distil-whisper/distil-medium.en',
-  'distil-whisper/distil-large-v2',
-  'distil-whisper/distil-large-v3',
-  // Whisper .en variants
-  'Xenova/whisper-tiny.en',
-  'Xenova/whisper-base.en',
-  'Xenova/whisper-small.en',
-  'Xenova/whisper-medium.en',
-]);
 
 if (!parentPort) throw new Error('whisperWorker must be run as a Worker thread');
 
@@ -513,7 +488,7 @@ parentPort.on('message', async (msg: any) => {
       return;
     }
     try {
-      let language: string | null = LANG_MAP[msg.language] ?? null;
+      let language: string | null = resolveWhisperLanguage(msg.language);
       const streaming: boolean = !!msg.streaming;
 
       // English-only checkpoints (Distil-Whisper + .en variants) have no
@@ -535,7 +510,12 @@ parentPort.on('message', async (msg: any) => {
       //
       // Omitting them is not a downgrade: an English-only checkpoint can only
       // transcribe, and only in English, so there is nothing left to express.
-      const isEnglishOnly = ENGLISH_ONLY_MODELS.has(loadedModelId);
+      //
+      // Derived from MODEL_CATALOG's `multilingual` flag (modelLanguageSupport)
+      // rather than the previous hand-typed id set, which omitted Parakeet CTC
+      // — English-only per NVIDIA's model card, and a CTC pipeline with no
+      // decoder prompt to condition anyway.
+      const isEnglishOnly = isEnglishOnlyLocalModel(loadedModelId);
       if (isEnglishOnly) {
         language = null;
       }

--- a/electron/llm/__tests__/RetiredModelAndEnglishOnlyWhisper2026_08_15.test.mjs
+++ b/electron/llm/__tests__/RetiredModelAndEnglishOnlyWhisper2026_08_15.test.mjs
@@ -210,7 +210,13 @@ describe('an English-only Whisper checkpoint is sent neither task nor language',
   });
 
   test('language is nulled for English-only models', () => {
-    assert.match(workerSrc, /const isEnglishOnly = ENGLISH_ONLY_MODELS\.has\(loadedModelId\);/);
+    // 2026-08-19: the guard's source moved from the worker's own hand-typed
+    // ENGLISH_ONLY_MODELS set to modelLanguageSupport.ts's catalog-derived
+    // isEnglishOnlyLocalModel() (the hand-typed set omitted Parakeet CTC).
+    // The behavior this suite pins — English-only checkpoints get language
+    // nulled and task stripped — is unchanged; only the anchor expression
+    // moved. ModelLanguageSupport.test.mjs covers the derivation itself.
+    assert.match(workerSrc, /const isEnglishOnly = isEnglishOnlyLocalModel\(loadedModelId\);/);
     assert.match(workerSrc, /if \(isEnglishOnly\) \{\s*\n\s*language = null;/);
   });
 

--- a/src/components/LocalWhisperModelPanel.tsx
+++ b/src/components/LocalWhisperModelPanel.tsx
@@ -38,7 +38,7 @@ interface HardwareInfo {
     recommendedModel: string;
 }
 
-interface ChannelConfig {
+export interface ChannelConfig {
     enabled: boolean;
     micModelId: string;
     systemModelId: string;
@@ -208,7 +208,18 @@ function familyOf(model: ModelInfo): string {
     return (FAMILY_RULES.find((r) => r.test(model.name)) ?? FAMILY_RULES[FAMILY_RULES.length - 1]).id;
 }
 
-export function LocalWhisperModelPanel() {
+interface LocalWhisperModelPanelProps {
+    /**
+     * Fires whenever the model assignment changes — initial load, global model
+     * pick, per-channel pick, or the split toggle. SettingsOverlay uses it to
+     * recompute which recognition languages the ACTIVE local model(s) accept,
+     * so the Language / Accent selects below this panel stay restricted to
+     * what the model supports (see modelLanguageSupport.ts main-side).
+     */
+    onModelConfigChanged?: (cfg: ChannelConfig) => void;
+}
+
+export function LocalWhisperModelPanel({ onModelConfigChanged }: LocalWhisperModelPanelProps = {}) {
     const t = useT();
     const reduceMotion = useReducedMotion();
     const aipTheme = useResolvedTheme();
@@ -337,6 +348,25 @@ export function LocalWhisperModelPanel() {
         loadData();
     }, [loadData]);
 
+    // One place that tells the parent which model(s) are active, keyed on the
+    // COMMITTED config rather than fired from each mutator — so every path
+    // (initial load, auto-select, split toggle, per-channel pick) reports
+    // exactly what this panel settled on.
+    //
+    // The callback is held in a ref so it is NOT an effect dependency: a
+    // parent passing an inline arrow would otherwise change its identity on
+    // every render and re-fire this effect (and, when it was a `loadData`
+    // dependency, re-issue the whole model/hardware/download-state IPC batch)
+    // on each parent re-render.
+    const onModelConfigChangedRef = useRef(onModelConfigChanged);
+    useEffect(() => { onModelConfigChangedRef.current = onModelConfigChanged; });
+    useEffect(() => {
+        // Skip the pre-load placeholder: reporting all-empty ids would clear a
+        // capability the parent had already resolved from its own IPC read.
+        if (!config.globalModelId && !config.micModelId && !config.systemModelId) return;
+        onModelConfigChangedRef.current?.(config);
+    }, [config]);
+
     // Handle downloads
     useEffect(() => {
         const unsubProgress = electronAPI?.onLocalWhisperDownloadProgress?.((data: { modelId: string; progress: number }) => {
@@ -398,9 +428,14 @@ export function LocalWhisperModelPanel() {
         await loadData();
     };
 
+    // Every mutator uses the FUNCTIONAL form: two of these can fire before a
+    // re-render (flip Split, then immediately pick a channel model), and a
+    // `{ ...config }` spread off the render-time closure would silently drop
+    // the first update while the main process kept it — the two would then
+    // disagree about `enabled`. The parent is notified from the effect above,
+    // which sees the committed value rather than a locally-computed guess.
     const toggleDualChannel = async (enabled: boolean) => {
-        const newCfg = { ...config, enabled };
-        setConfig(newCfg);
+        setConfig(prev => ({ ...prev, enabled }));
         await electronAPI?.localWhisperSetChannelConfig?.({ enabled });
     };
 

--- a/src/components/SettingsOverlay.tsx
+++ b/src/components/SettingsOverlay.tsx
@@ -18,7 +18,7 @@ import { PlansSettings } from './settings/PlansSettings';
 import { PhoneMirrorSettings } from './settings/PhoneMirrorSettings';
 import { IntelligenceSettings } from './settings/IntelligenceSettings';
 import { SkillsSettings } from './settings/SkillsSettings';
-import { LocalWhisperModelPanel } from './LocalWhisperModelPanel';
+import { LocalWhisperModelPanel, type ChannelConfig as LocalWhisperChannelConfig } from './LocalWhisperModelPanel';
 import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { useShortcuts } from '../hooks/useShortcuts';
 import { isMac } from '../utils/platformUtils';
@@ -180,9 +180,12 @@ interface CustomSelectProps {
     options: MediaDeviceInfo[];
     onChange: (value: string) => void;
     placeholder?: string;
+    /** Greys the control out and blocks the dropdown — used when the active
+     *  local STT model doesn't accept this setting (see modelLanguageSupport). */
+    disabled?: boolean;
 }
 
-const CustomSelect: React.FC<CustomSelectProps> = ({ label, icon, value, options, onChange, placeholder = "Select device" }) => {
+const CustomSelect: React.FC<CustomSelectProps> = ({ label, icon, value, options, onChange, placeholder = "Select device", disabled = false }) => {
     const t = useT();
     const [isOpen, setIsOpen] = useState(false);
     const containerRef = React.useRef<HTMLDivElement>(null);
@@ -210,14 +213,16 @@ const CustomSelect: React.FC<CustomSelectProps> = ({ label, icon, value, options
 
             <div className="relative">
                 <button
-                    onClick={() => setIsOpen(!isOpen)}
-                    className="w-full bg-bg-input border border-border-subtle rounded-lg px-3 py-2.5 text-sm text-text-primary flex items-center justify-between hover:bg-bg-elevated transition-colors"
+                    onClick={() => !disabled && setIsOpen(!isOpen)}
+                    disabled={disabled}
+                    aria-disabled={disabled}
+                    className={`w-full bg-bg-input border border-border-subtle rounded-lg px-3 py-2.5 text-sm text-text-primary flex items-center justify-between transition-colors ${disabled ? 'opacity-50 cursor-not-allowed' : 'hover:bg-bg-elevated'}`}
                 >
                     <span className="truncate pr-4">{selectedLabel}</span>
                     <ChevronDown size={14} className={`text-text-secondary transition-transform ${isOpen ? 'rotate-180' : ''}`} />
                 </button>
 
-                {isOpen && (
+                {isOpen && !disabled && (
                     <div className="absolute top-full left-0 w-full mt-1 bg-bg-elevated border border-border-subtle rounded-lg shadow-xl z-50 max-h-48 overflow-y-auto animated fadeIn">
                         <div className="p-1 space-y-0.5">
                             {options.map((device) => (
@@ -659,6 +664,24 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({
     const [availableLanguages, setAvailableLanguages] = useState<Record<string, any>>({});
     const [autoDetectedLanguage, setAutoDetectedLanguage] = useState<string | null>(null);
 
+    // Active STT provider — declared here (not with the rest of the STT
+    // settings below) because the local-model language-capability effect and
+    // memo that follow depend on it.
+    const [sttProvider, setSttProvider] = useState<'none' | 'google' | 'groq' | 'openai' | 'deepgram' | 'elevenlabs' | 'azure' | 'ibmwatson' | 'soniox' | 'natively' | 'local-whisper'>('none');
+
+    // Local model language capability (local-whisper provider only).
+    // Per-model: which RECOGNITION_LANGUAGES keys the model accepts, whether
+    // language is changeable at all, and whether accent/region variants mean
+    // anything to it — computed main-side from each model's official docs
+    // (electron/audio/whisper/modelLanguageSupport.ts) and attached to
+    // local-whisper-get-models. Combined with the live channel config to
+    // restrict/grey the Language and Accent/Region selects below.
+    const [localModelSupport, setLocalModelSupport] = useState<Record<string, {
+        name: string;
+        support: { languageSelectable: boolean; accentSelectable: boolean; allowedLanguageKeys: string[] };
+    }> | null>(null);
+    const [localWhisperConfig, setLocalWhisperConfig] = useState<LocalWhisperChannelConfig | null>(null);
+
     // AI Response Language
     const [aiResponseLanguage, setAiResponseLanguage] = useState('English');
     const [availableAiLanguages, setAvailableAiLanguages] = useState<any[]>([]);
@@ -911,6 +934,64 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({
         loadLanguages();
     }, []);
 
+    // Load per-model language capability whenever the local provider is
+    // active. The channel config is ALSO pushed live by LocalWhisperModelPanel
+    // via onModelConfigChanged (the panel and these selects are on the same
+    // Settings page), so a model swap re-restricts the selects immediately.
+    useEffect(() => {
+        if (sttProvider !== 'local-whisper') return;
+        let cancelled = false;
+        (async () => {
+            try {
+                const [modelsRes, cfgRes] = await Promise.all([
+                    window.electronAPI?.localWhisperGetModels?.(),
+                    window.electronAPI?.localWhisperGetChannelConfig?.(),
+                ]);
+                if (cancelled) return;
+                if (modelsRes?.models) {
+                    const map: Record<string, { name: string; support: any }> = {};
+                    for (const m of modelsRes.models) {
+                        if (m?.id && m.languageSupport) map[m.id] = { name: m.name ?? m.id, support: m.languageSupport };
+                    }
+                    setLocalModelSupport(map);
+                }
+                if (cfgRes) setLocalWhisperConfig(cfgRes);
+            } catch (err) {
+                console.error('[Settings] Failed to load local model language capability:', err);
+            }
+        })();
+        return () => { cancelled = true; };
+    }, [sttProvider]);
+
+    // Effective capability across the ACTIVE local model(s): in split mode the
+    // one global language setting feeds BOTH channels, so the offered set is
+    // the intersection of what mic and system models accept; accent stays
+    // enabled if ANY active model consumes regional variants (harmless to the
+    // others — they collapse variants to a plain language token).
+    // null → no restriction (cloud providers, or capability not loaded yet).
+    const localLanguageCapability = useMemo(() => {
+        if (sttProvider !== 'local-whisper' || !localModelSupport || !localWhisperConfig) return null;
+        const { enabled, micModelId, systemModelId, globalModelId } = localWhisperConfig;
+        const ids = Array.from(new Set(
+            (enabled ? [micModelId || globalModelId, systemModelId || globalModelId] : [globalModelId]).filter(Boolean)
+        ));
+        const entries = ids.map(id => localModelSupport[id]).filter(Boolean);
+        if (entries.length === 0) return null;
+        let allowedKeys = new Set<string>(entries[0].support.allowedLanguageKeys);
+        for (const e of entries.slice(1)) {
+            allowedKeys = new Set(e.support.allowedLanguageKeys.filter((k: string) => allowedKeys.has(k)));
+        }
+        const accentSelectable = entries.some(e => e.support.accentSelectable);
+        const englishOnlyNames = entries.filter(e => !e.support.languageSelectable).map(e => e.name);
+        // Locked when every offered key sits in one group (the English-only
+        // case) — a select with a single meaningful choice is greyed, not hidden.
+        const allowedGroups = new Set(
+            Array.from(allowedKeys).map(k => availableLanguages[k]?.group).filter(Boolean)
+        );
+        const languageSelectable = allowedGroups.size > 1;
+        return { allowedKeys, accentSelectable, languageSelectable, englishOnlyNames, modelNames: entries.map(e => e.name) };
+    }, [sttProvider, localModelSupport, localWhisperConfig, availableLanguages]);
+
     const handleLanguageChange = async (key: string) => {
         setRecognitionLanguage(key);
         setAutoDetectedLanguage(null);  // always reset — new session may detect a different language
@@ -924,15 +1005,26 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({
 
     const handleGroupChange = (group: string) => {
         setSelectedSttGroup(group);
-        // Find default variant for this group (first one)
-        const firstVariant = Object.entries(availableLanguages).find(([_, lang]) => lang.group === group);
+        // Find default variant for this group (first one the active model accepts)
+        const firstVariant = Object.entries(availableLanguages).find(
+            ([key, lang]) => lang.group === group && isLanguageEntryAllowed(key)
+        );
         if (firstVariant) {
             handleLanguageChange(firstVariant[0]);
         }
     };
 
-    // Helper to get unique groups
-    const languageGroups = Array.from(new Set(Object.values(availableLanguages).map((l: any) => l.group)))
+    // Language keys the active STT backend accepts. Unrestricted for cloud
+    // providers; for local-whisper this is the active model's documented set.
+    const allowedLanguageKeySet = localLanguageCapability?.allowedKeys ?? null;
+    const isLanguageEntryAllowed = (key: string) => !allowedLanguageKeySet || allowedLanguageKeySet.has(key);
+
+    // Helper to get unique groups (restricted to what the active model accepts)
+    const languageGroups = Array.from(new Set(
+        Object.entries(availableLanguages)
+            .filter(([key]) => isLanguageEntryAllowed(key))
+            .map(([, l]: [string, any]) => l.group)
+    ))
         .sort((a, b) => {
             if (a === 'Auto') return -1;
             if (b === 'Auto') return 1;
@@ -941,10 +1033,31 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({
             return a.localeCompare(b);
         });
 
+    // The stored selection can name a language the newly-selected local model
+    // doesn't support (the setting is global across providers and is NOT
+    // rewritten when a model is picked). Display-only fallbacks: a locked
+    // (English-only) model shows English / United States — which IS what the
+    // pipeline does (the worker omits the language token for English-only
+    // checkpoints) — while an unsupported pick on a selectable model keeps
+    // showing the stored value alongside the warning hint below.
+    const languageLocked = localLanguageCapability ? !localLanguageCapability.languageSelectable : false;
+    // 'auto' is its own case, NOT an unsupported language. No local model has a
+    // real auto-detect mode with locale conditioning, but LocalWhisperSTT
+    // normalizes 'auto' to English rather than failing (see
+    // resolveAndApplyNemotronLanguage), so the honest message is "auto-detect
+    // is unavailable, English is used" — not "your language isn't supported".
+    const autoDetectUnavailable =
+        recognitionLanguage === 'auto' && !!allowedLanguageKeySet && !allowedLanguageKeySet.has('auto');
+    const storedLanguageUnsupported =
+        !!recognitionLanguage && recognitionLanguage !== 'auto'
+        && !!allowedLanguageKeySet && !allowedLanguageKeySet.has(recognitionLanguage);
+    const showsEnglishFallback = languageLocked && (storedLanguageUnsupported || autoDetectUnavailable);
+    const displayedSttGroup = showsEnglishFallback ? 'English' : selectedSttGroup;
+    const displayedRecognitionLanguage = showsEnglishFallback ? 'english-us' : recognitionLanguage;
+
     // Helper to get variants for current group
     const currentGroupVariants = Object.entries(availableLanguages)
-
-        .filter(([_, lang]) => lang.group === selectedSttGroup)
+        .filter(([key, lang]) => lang.group === displayedSttGroup && isLanguageEntryAllowed(key))
         .map(([key, lang]) => ({
             deviceId: key,
             label: lang.label,
@@ -1035,8 +1148,9 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({
         reason?: string;
     } | null>(null);
 
-    // STT Provider settings
-    const [sttProvider, setSttProvider] = useState<'none' | 'google' | 'groq' | 'openai' | 'deepgram' | 'elevenlabs' | 'azure' | 'ibmwatson' | 'soniox' | 'natively' | 'local-whisper'>('none');
+    // STT Provider settings — sttProvider itself is declared up with the
+    // recognition-language state: the local-model language-capability effect
+    // and memo there depend on it.
     const [groqSttModel, setGroqSttModel] = useState('whisper-large-v3-turbo');
     const [sttGroqKey, setSttGroqKey] = useState('');
     const [sttOpenaiKey, setSttOpenaiKey] = useState('');
@@ -2962,14 +3076,16 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({
 
                                             {/* Local Whisper Model Panel */}
                                             {sttProvider === 'local-whisper' && (
-                                                <LocalWhisperModelPanel />
+                                                <LocalWhisperModelPanel onModelConfigChanged={setLocalWhisperConfig} />
                                             )}
 
-                                            {/* Recognition Language Family */}
+                                            {/* Recognition Language Family — options restricted to what the
+                                                active local model accepts (per its official docs); greyed out
+                                                entirely when the model is English-only and language cannot change. */}
                                             <CustomSelect
                                                 label={t("Language")}
                                                 icon={<Globe size={14} />}
-                                                value={selectedSttGroup}
+                                                value={displayedSttGroup}
                                                 options={languageGroups.map(g => ({
                                                     deviceId: g,
                                                     label: g,
@@ -2979,19 +3095,64 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({
                                                 }))}
                                                 onChange={handleGroupChange}
                                                 placeholder={t("Select Language")}
+                                                disabled={languageLocked}
                                             />
 
-                                            {/* Variant/Accent Selector (Conditional) */}
+                                            {/* Variant/Accent Selector (Conditional) — greyed out when the
+                                                active local model's language conditioning is region-neutral
+                                                (Whisper-family) or fixed (English-only checkpoints). Only
+                                                Nemotron consumes regional variants. */}
                                             {currentGroupVariants.length > 1 && (
                                                 <div className="mt-3 animated fadeIn">
                                                     <CustomSelect
                                                         label={t("Accent / Region")}
                                                         icon={<MapPin size={14} />}
-                                                        value={recognitionLanguage}
+                                                        value={displayedRecognitionLanguage}
                                                         options={currentGroupVariants}
                                                         onChange={handleLanguageChange}
                                                         placeholder={t("Select Region")}
+                                                        disabled={!!localLanguageCapability && !localLanguageCapability.accentSelectable}
                                                     />
+                                                </div>
+                                            )}
+
+                                            {/* Local model capability notes */}
+                                            {localLanguageCapability && languageLocked && (
+                                                <div className="flex gap-2 items-center mt-2 px-1">
+                                                    <Info size={14} className="text-text-secondary shrink-0" />
+                                                    <p className="text-xs text-text-secondary">
+                                                        {(localLanguageCapability.englishOnlyNames.length > 0
+                                                            ? localLanguageCapability.englishOnlyNames.join(', ')
+                                                            : t('The selected local model'))}
+                                                        {' '}{localLanguageCapability.accentSelectable
+                                                            ? t('supports English only — language is fixed for this model.')
+                                                            : t('supports English only — language and accent are fixed for this model.')}
+                                                    </p>
+                                                </div>
+                                            )}
+                                            {localLanguageCapability && !languageLocked && storedLanguageUnsupported && (
+                                                <div className="flex gap-2 items-center mt-2 px-1">
+                                                    <AlertCircle size={14} className="text-amber-400 shrink-0" />
+                                                    <p className="text-xs text-amber-200/90">
+                                                        {`"${availableLanguages[recognitionLanguage]?.label ?? recognitionLanguage}" ${t("isn't supported by the selected local model — pick one of the listed languages.")}`}
+                                                    </p>
+                                                </div>
+                                            )}
+                                            {localLanguageCapability && !languageLocked && autoDetectUnavailable && (
+                                                <div className="flex gap-2 items-center mt-2 px-1">
+                                                    <Info size={14} className="text-text-secondary shrink-0" />
+                                                    <p className="text-xs text-text-secondary">
+                                                        {t("This model has no auto-detect mode — English is transcribed unless you pick a language.")}
+                                                    </p>
+                                                </div>
+                                            )}
+                                            {localLanguageCapability && !languageLocked && !storedLanguageUnsupported && !autoDetectUnavailable
+                                                && !localLanguageCapability.accentSelectable && currentGroupVariants.length > 1 && (
+                                                <div className="flex gap-2 items-center mt-2 px-1">
+                                                    <Info size={14} className="text-text-secondary shrink-0" />
+                                                    <p className="text-xs text-text-secondary">
+                                                        {t("This model doesn't distinguish accents or regions — only the language itself applies.")}
+                                                    </p>
                                                 </div>
                                             )}
 


### PR DESCRIPTION
## Why this is urgent

`main` is broken right now. PR #489 merged this into `electron/ipcHandlers.ts`:

```ts
const { getLocalModelLanguageSupport } = require('./audio/whisper/modelLanguageSupport');
```

…but `electron/audio/whisper/modelLanguageSupport.ts` was never committed. On `main` today:

- the require throws `MODULE_NOT_FOUND` at runtime;
- `local-whisper-get-models`' own `catch` swallows it and returns `{ models: [], activeModelId: '' }`;
- **the Local Whisper panel renders zero models** — nothing to install or select, local STT unconfigurable.

esbuild emits the unresolved `require` verbatim with **no error and no warning**, so CI has stayed green the whole time. Verified against a clean `git archive origin/main` tree.

This PR lands the missing module and the feature it was written for.

## What it does

Adds `electron/audio/whisper/modelLanguageSupport.ts` as the single source of truth for which recognition languages each local STT model accepts, verified against each model's official documentation:

| Model | Language | Accent/Region |
|---|---|---|
| Moonshine tiny/base | English only | — |
| Parakeet CTC 0.6B | English only | — |
| Distil-Whisper (all) | English only | — |
| Whisper `*.en` | English only | — |
| Whisper multilingual, Large v3 Turbo | all 30 offered (99 supported) | not expressible |
| Nemotron 3.5 Streaming | 19 transcription-ready locales | **yes** (only model that uses it) |

Settings now restricts the Language options to what the active model(s) accept — the intersection in split mode — greys out Language for English-only models and Accent/Region for anything that ignores it, and explains the auto-detect and unsupported-selection cases truthfully.

## Two latent bugs fixed along the way

1. **`LANG_MAP` never matched.** It was keyed by BCP-47 (`'en-US'`), but the host sends the app's internal settings key (`'english-us'` — `LocalWhisperSTT` forwards `CredentialsManager.getSttLanguage()` verbatim). Of the 35 values the host can send, exactly **one** (`'auto'`) ever matched, so multilingual Whisper silently ran in auto-detect no matter what the user picked. The default is `'english-us'`, which never matched either.
2. **Parakeet was missing from the English-only guard** (English-only per NVIDIA's model card), so it was sent `task`/`language` it has no use for. Both the guard and the resolver now derive from `MODEL_CATALOG` instead of parallel hand-maintained tables.

## Validation

- Cherry-picked onto `origin/main` in an isolated worktree: `build:electron` clean, the previously-missing require resolves, **27 whisper + 24 source-assertion tests pass**.
- New `ModelLanguageSupport.test.mjs` (6 tests) pins the per-model allowed sets, the Nemotron locale set, and full resolver coverage — it caught a `nb-NO` (Norwegian Bokmål) gap during development.
- `typecheck:electron`, `typecheck:ts7`, `build:electron` and the renderer build all clean.
- Not exercised in the running app: the greyed-out controls **require physical macOS/Windows verification**. No platform-specific branches in any changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)