### PR TITLE
audit follow-up: fix the 7 defects a review found in PR #487's own fixes

### DIFF
--- a/electron/db/DatabaseManager.ts
+++ b/electron/db/DatabaseManager.ts
@@ -3150,7 +3150,14 @@ export class DatabaseManager {
                     const ph = slice.map(() => '?').join(',');
                     try {
                         this.db!.prepare(`DELETE FROM ${table} WHERE ${column} IN (${ph})`).run(...slice);
-                    } catch (_) { /* dim table may not exist */ }
+                    } catch (e: any) {
+                        // R-20: getExistingVecDims() returns KNOWN_DIMS ∪ discovered, so on a
+                        // normal install most dims have no table and "no such table" is the
+                        // expected, harmless outcome. Swallowing EVERYTHING else too meant a
+                        // real reap failure was indistinguishable from that — the same silence
+                        // that let R-01 hide for a full campaign. Narrow it.
+                        if (!/no such table/i.test(String(e?.message ?? e))) throw e;
+                    }
                 }
             };
             for (const dim of dims) {
@@ -3158,7 +3165,14 @@ export class DatabaseManager {
                 if (summaryIds.length) deleteIn(`vec_summaries_${dim}`, 'summary_id', summaryIds);
             }
         } catch (e) {
-            console.warn(`[DatabaseManager] deleteVectorsForMeeting(${meetingId}) failed (non-fatal):`, e);
+            // R-20: R-12 wrapped this and the parent DELETE in one transaction so the
+            // meeting could not survive a failed reap. Swallowing here defeated that
+            // in the only direction that matters: the transaction saw no error and
+            // committed the DELETE anyway, leaving the meeting gone and its vectors
+            // orphaned in the vec0 tables — where they keep consuming KNN top-K slots
+            // that searchSimilarNative can no longer resolve back to `chunks`.
+            console.error(`[DatabaseManager] deleteVectorsForMeeting(${meetingId}) failed; aborting the delete:`, e);
+            throw e;
         }
     }
 

--- a/electron/db/DatabaseManager.ts
+++ b/electron/db/DatabaseManager.ts
@@ -1621,6 +1621,15 @@ export class DatabaseManager {
                 this.db.pragma('user_version = 29');
             } catch (e) {
                 console.error('[DatabaseManager] v29 vec0 cosine rebuild failed (leaving version at 28 to retry next launch):', e);
+                // R-22: stop here, exactly as v28 does. v29 is currently the LAST
+                // migration, so falling through is harmless TODAY — which is
+                // precisely why it would not stay harmless: the next migration
+                // added below would run and stamp user_version past a v29 that
+                // never applied, and `version < 29` would be false forever after.
+                // That is R-05 verbatim, and R-05 only became reachable because
+                // v28 was written this same way. Terminate the chain on failure
+                // instead of leaving the trap armed for whoever adds v30.
+                return;
             }
         }
 

--- a/electron/db/__tests__/MigrationChainTerminatesOnFailure2026_08_20.test.mjs
+++ b/electron/db/__tests__/MigrationChainTerminatesOnFailure2026_08_20.test.mjs
@@ -1,0 +1,67 @@
+// R-22 regression test.
+//
+// R-05: v28 fell through after a failed repair, so v29's block ran and stamped
+// user_version past a v28 that never applied — `version < 28` was false ever
+// after and the repair never retried. v28 was fixed to `return`.
+//
+// v29 was then written the same way. It is currently the LAST migration, so its
+// fall-through is inert today — which is exactly why it would not have stayed
+// inert: whoever adds v30 inherits R-05 verbatim, with no failing test to warn
+// them.
+//
+// The invariant, stated precisely: a block that stamps user_version INSIDE its
+// try (so a failure skips the stamp) must also stop the chain — by `return` or,
+// as v22 does, by re-throwing to halt startup. Blocks that stamp outside the
+// try advance deliberately and are a different, pre-existing design; this test
+// does not judge them.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const src = fs.readFileSync(new URL('../DatabaseManager.ts', import.meta.url), 'utf8');
+const CHAIN_END = src.indexOf('Migrations completed.');
+
+function migrationBlocks() {
+  const starts = [];
+  const re = /if \(version < (\d+)\) \{/g;
+  let m;
+  while ((m = re.exec(src)) !== null) starts.push({ version: Number(m[1]), at: m.index });
+  assert.ok(starts.length >= 2, 'expected to find the migration chain');
+  return starts.map((b, i) => {
+    const body = src.slice(b.at, starts[i + 1] ? starts[i + 1].at : CHAIN_END);
+    const tryAt = body.indexOf('try {');
+    const catchAt = body.lastIndexOf('} catch (e) {');
+    const stampAt = body.lastIndexOf('user_version =');
+    return {
+      version: b.version,
+      body,
+      // A failure skips the stamp only when the stamp sits inside the try.
+      stampSkippedOnFailure: tryAt !== -1 && catchAt !== -1 && tryAt < stampAt && stampAt < catchAt,
+      terminatesChain: catchAt !== -1 && /\breturn;|\bthrow /.test(body.slice(catchAt)),
+    };
+  });
+}
+
+test('a migration that skips its stamp on failure also stops the chain', () => {
+  const offenders = migrationBlocks()
+    .filter((b) => b.stampSkippedOnFailure && !b.terminatesChain)
+    .map((b) => b.version);
+
+  assert.deepEqual(offenders, [],
+    `v${offenders.join(', v')} skips its user_version stamp on failure but lets the chain continue: `
+    + 'the next migration will stamp past it and it can never retry (R-05)');
+});
+
+test('v29 specifically terminates rather than relying on being last', () => {
+  const v29 = migrationBlocks().find((b) => b.version === 29);
+  assert.ok(v29, 'the v29 block must still exist');
+  assert.equal(v29.stampSkippedOnFailure, true, 'v29 stamps inside its try, so a failure must not fall through');
+  assert.equal(v29.terminatesChain, true, 'v29 must return (or throw) on failure');
+  assert.ok(/leaving version at 28 to retry next launch/.test(v29.body),
+    'the retry intent must remain explicit for whoever adds v30');
+});
+
+test('v28 — the block R-05 was found in — is still terminating', () => {
+  const v28 = migrationBlocks().find((b) => b.version === 28);
+  assert.ok(v28 && v28.terminatesChain, 'R-05 must not regress');
+});

--- a/electron/db/__tests__/VecReapFailurePropagates2026_08_20.test.mjs
+++ b/electron/db/__tests__/VecReapFailurePropagates2026_08_20.test.mjs
@@ -1,0 +1,67 @@
+// R-20 regression test — behavioural, against a real SQLite database.
+//
+// R-12 wrapped the vector reap and the parent DELETE in one transaction so a
+// meeting could not survive a failed reap. But deleteVectorsForMeeting caught
+// everything into a console.warn and returned normally, so the transaction saw
+// no error and committed the DELETE anyway: meeting gone, vectors orphaned in
+// the vec0 tables, where they keep consuming KNN top-K slots that
+// searchSimilarNative can no longer resolve back to `chunks`.
+//
+// deleteIn's per-batch `catch (_) {}` had the same shape one level down. It
+// must still swallow "no such table" — getExistingVecDims() returns
+// KNOWN_DIMS ∪ discovered, so most dims legitimately have no table — but
+// nothing else.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+const src = fs.readFileSync(new URL('../DatabaseManager.ts', import.meta.url), 'utf8');
+
+function bodyOf(signature, len = 4200) {
+  const i = src.indexOf(signature);
+  assert.notEqual(i, -1, `${signature} not found`);
+  return src.slice(i, i + len);
+}
+
+test('a failed vector reap aborts the meeting delete instead of committing it', () => {
+  const body = bodyOf('public deleteVectorsForMeeting(meetingId: string): void {');
+  const catchIdx = body.indexOf('catch (e)');
+  assert.notEqual(catchIdx, -1, 'the outer catch must still exist');
+  const tail = body.slice(catchIdx, catchIdx + 700);
+  assert.ok(/throw e/.test(tail),
+    'the failure must reach the caller, or R-12\'s transaction cannot roll back the parent DELETE');
+});
+
+test('deleteIn swallows a missing dim table and nothing else', () => {
+  const body = bodyOf('const deleteIn = (table: string, column: string, ids: number[]) => {', 1600);
+  assert.ok(/no such table/i.test(body),
+    'the expected missing-table case must be recognised explicitly');
+  assert.ok(/throw e/.test(body),
+    'any other failure must propagate — swallowing all of them is what hid R-01');
+  assert.ok(!/catch \(_\) \{ \/\* dim table may not exist \*\/ \}/.test(body),
+    'the blanket catch must be gone');
+});
+
+test('the narrowed catch actually admits a real missing table and rejects other errors', () => {
+  // Pin the predicate itself against SQLite's real messages.
+  const D = require('better-sqlite3');
+  const db = new D(':memory:');
+  db.exec('CREATE TABLE present (chunk_id INTEGER)');
+
+  const isMissingTable = (e) => /no such table/i.test(String(e?.message ?? e));
+
+  let missing;
+  try { db.prepare('DELETE FROM absent_table WHERE chunk_id IN (?)').run(1); } catch (e) { missing = e; }
+  assert.ok(missing && isMissingTable(missing),
+    'a genuinely absent dim table must still be swallowed');
+
+  let other;
+  try { db.prepare('DELETE FROM present WHERE no_such_column IN (?)').run(1); } catch (e) { other = e; }
+  assert.ok(other && !isMissingTable(other),
+    'a different failure (here: a bad column) must NOT be mistaken for a missing table');
+
+  db.close();
+});

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -5808,7 +5808,12 @@ export function initializeIpcHandlers(appState: AppState): void {
     if (typeof enabled !== 'boolean') {
       return { success: false, error: 'invalid_type' };
     }
-    SettingsManager.getInstance().set('codeVerificationEnabled', enabled);
+    if (!SettingsManager.getInstance().set('codeVerificationEnabled', enabled)) {
+      // R-24: the write was refused (degraded settings store). Returning
+      // success here — and broadcasting below — put every window on a value
+      // disk never received, which silently reverted on the next launch.
+      return { success: false, error: 'settings_store_degraded' };
+    }
     try {
       BrowserWindow.getAllWindows().forEach((win) => {
         if (!win.isDestroyed()) {
@@ -5827,7 +5832,12 @@ export function initializeIpcHandlers(appState: AppState): void {
     if (!['forever', '7d', '30d', 'never'].includes(retention)) {
       return { success: false, error: 'invalid_retention' };
     }
-    SettingsManager.getInstance().set('meetingRetention', retention);
+    if (!SettingsManager.getInstance().set('meetingRetention', retention)) {
+      // R-24: the write was refused (degraded settings store). Returning
+      // success here — and broadcasting below — put every window on a value
+      // disk never received, which silently reverted on the next launch.
+      return { success: false, error: 'settings_store_degraded' };
+    }
     BrowserWindow.getAllWindows().forEach((win) => {
       if (!win.isDestroyed()) {
         win.webContents.send('meeting-retention-changed', retention);
@@ -5853,7 +5863,12 @@ export function initializeIpcHandlers(appState: AppState): void {
     // model-generated code to the cloud runner.
     const settings = SettingsManager.getInstance();
     const merged = mergeProviderDataScopes(settings.get('providerDataScopes'), scopes);
-    settings.set('providerDataScopes', merged as any);
+    if (!settings.set('providerDataScopes', merged as any)) {
+      // R-24: the write was refused (degraded settings store). Returning
+      // success here — and broadcasting below — put every window on a value
+      // disk never received, which silently reverted on the next launch.
+      return { success: false, error: 'settings_store_degraded' };
+    }
     BrowserWindow.getAllWindows().forEach((win) => {
       if (!win.isDestroyed()) {
         // Broadcast the MERGED object, not the incoming payload: the renderer
@@ -5893,7 +5908,12 @@ export function initializeIpcHandlers(appState: AppState): void {
     if (typeof enabled !== 'boolean') {
       return { success: false, error: 'invalid_value' };
     }
-    SettingsManager.getInstance().set('technicalInterviewVisionFirst', enabled);
+    if (!SettingsManager.getInstance().set('technicalInterviewVisionFirst', enabled)) {
+      // R-24: the write was refused (degraded settings store). Returning
+      // success here — and broadcasting below — put every window on a value
+      // disk never received, which silently reverted on the next launch.
+      return { success: false, error: 'settings_store_degraded' };
+    }
     BrowserWindow.getAllWindows().forEach((win) => {
       if (!win.isDestroyed()) {
         win.webContents.send('technical-interview-vision-first-changed', enabled);
@@ -5975,16 +5995,26 @@ export function initializeIpcHandlers(appState: AppState): void {
   safeHandle('hindsight-config:set', async (_, cfg: { baseUrl?: string; apiKey?: string; autoStart?: boolean; serverCommand?: string; llmProvider?: string }) => {
     try {
       const sm = SettingsManager.getInstance();
-      if (typeof cfg?.baseUrl === 'string') sm.set('hindsightBaseUrl', cfg.baseUrl.trim());
+      // R-24: this handler writes up to six keys. A refused write must not be
+      // reported as success, and must not go on to start() a server against
+      // config that was never persisted. Collect the outcomes and fail as one.
+      let persisted = true;
+      const put = <K extends Parameters<typeof sm.set>[0]>(key: K, value: any): void => {
+        if (!sm.set(key, value)) persisted = false;
+      };
+      if (typeof cfg?.baseUrl === 'string') put('hindsightBaseUrl', cfg.baseUrl.trim());
       // Blank apiKey on resave = KEEP the stored one (don't wipe a saved key with an empty
       // field — the documented blank-key-on-resave gotcha). Only write a non-empty value.
-      if (typeof cfg?.apiKey === 'string' && cfg.apiKey.trim()) sm.set('hindsightApiKey', cfg.apiKey.trim());
-      if (typeof cfg?.autoStart === 'boolean') sm.set('hindsightAutoStart', cfg.autoStart);
-      if (typeof cfg?.serverCommand === 'string') sm.set('hindsightServerCommand', cfg.serverCommand.trim());
-      if (typeof cfg?.llmProvider === 'string') sm.set('hindsightLlmProvider', cfg.llmProvider.trim());
+      if (typeof cfg?.apiKey === 'string' && cfg.apiKey.trim()) put('hindsightApiKey', cfg.apiKey.trim());
+      if (typeof cfg?.autoStart === 'boolean') put('hindsightAutoStart', cfg.autoStart);
+      if (typeof cfg?.serverCommand === 'string') put('hindsightServerCommand', cfg.serverCommand.trim());
+      if (typeof cfg?.llmProvider === 'string') put('hindsightLlmProvider', cfg.llmProvider.trim());
       // Saving ANY config reverses the explicit-opt-out sentinel. The user is engaging
       // with Hindsight again — the override should not silently re-apply.
-      if (sm.get('hindsightExplicitlyDisabled') === true) sm.set('hindsightExplicitlyDisabled', false);
+      if (sm.get('hindsightExplicitlyDisabled') === true) put('hindsightExplicitlyDisabled', false);
+      if (!persisted) {
+        return { success: false, error: 'settings_store_degraded' };
+      }
       // Re-run start() so the auto-spawn fires IN-SESSION — previously the user had to restart
       // the app for the boot-time start() to see the new config. start() is idempotent and a
       // no-op when nothing changed (e.g. user just saved the same baseUrl).
@@ -6066,7 +6096,12 @@ export function initializeIpcHandlers(appState: AppState): void {
   safeHandle('hindsight:disable', async () => {
     try {
       const sm = SettingsManager.getInstance();
-      sm.set('hindsightExplicitlyDisabled', true);
+      if (!sm.set('hindsightExplicitlyDisabled', true)) {
+        // R-24: the write was refused (degraded settings store). Returning
+        // success here — and broadcasting below — put every window on a value
+        // disk never received, which silently reverted on the next launch.
+        return { success: false, error: 'settings_store_degraded' };
+      }
       const { HindsightManager } = require('./services/HindsightManager') as typeof import('./services/HindsightManager');
       // If we spawned an app-managed server, kill it. Cloud / user-managed servers stay up.
       try { HindsightManager.getInstance().stopSync(); } catch { /* nothing to stop */ }
@@ -6094,7 +6129,12 @@ export function initializeIpcHandlers(appState: AppState): void {
     if (typeof enabled !== 'boolean') {
       return { success: false, error: 'invalid_value' };
     }
-    SettingsManager.getInstance().set('technicalInterviewVisionFirst', enabled);
+    if (!SettingsManager.getInstance().set('technicalInterviewVisionFirst', enabled)) {
+      // R-24: the write was refused (degraded settings store). Returning
+      // success here — and broadcasting below — put every window on a value
+      // disk never received, which silently reverted on the next launch.
+      return { success: false, error: 'settings_store_degraded' };
+    }
     BrowserWindow.getAllWindows().forEach((win) => {
       if (!win.isDestroyed()) {
         win.webContents.send('technical-interview-vision-first-changed', enabled);
@@ -8530,7 +8570,12 @@ export function initializeIpcHandlers(appState: AppState): void {
       if (!MODEL_CATALOG_IDS.has(modelId)) {
         return { success: false, error: `Unknown local Whisper model: ${modelId}` };
       }
-      SettingsManager.getInstance().set('localWhisperModel', modelId);
+      if (!SettingsManager.getInstance().set('localWhisperModel', modelId)) {
+        // R-24: the write was refused (degraded settings store). Returning
+        // success here — and broadcasting below — put every window on a value
+        // disk never received, which silently reverted on the next launch.
+        return { success: false, error: 'settings_store_degraded' };
+      }
       return { success: true };
     } catch (e: any) {
       return { success: false, error: e.message };
@@ -8551,7 +8596,12 @@ export function initializeIpcHandlers(appState: AppState): void {
       const badGlobal = sm.get('localWhisperModel');
       const badMic = sm.get('localWhisperModelMic');
       const badSystem = sm.get('localWhisperModelSystem');
-      sm.set('localWhisperModel', DEFAULT_MODEL);
+      if (!sm.set('localWhisperModel', DEFAULT_MODEL)) {
+        // R-24: the write was refused (degraded settings store). Returning
+        // success here — and broadcasting below — put every window on a value
+        // disk never received, which silently reverted on the next launch.
+        return { success: false, error: 'settings_store_degraded' };
+      }
       if (badMic) sm.set('localWhisperModelMic', DEFAULT_MODEL);
       if (badSystem) sm.set('localWhisperModelSystem', DEFAULT_MODEL);
       // Drop the recent-failure cooldown for every id we just replaced.
@@ -8599,7 +8649,12 @@ export function initializeIpcHandlers(appState: AppState): void {
         if (typeof cfg?.enabled === 'boolean') sm.set('localWhisperPerChannelEnabled', cfg.enabled);
         if (typeof cfg?.micModelId === 'string') sm.set('localWhisperModelMic', cfg.micModelId);
         if (typeof cfg?.systemModelId === 'string')
-          sm.set('localWhisperModelSystem', cfg.systemModelId);
+          if (!sm.set('localWhisperModelSystem', cfg.systemModelId)) {
+            // R-24: the write was refused (degraded settings store). Returning
+            // success here — and broadcasting below — put every window on a value
+            // disk never received, which silently reverted on the next launch.
+            return { success: false, error: 'settings_store_degraded' };
+          }
         return { success: true };
       } catch (e: any) {
         return { success: false, error: e.message };
@@ -8848,7 +8903,12 @@ export function initializeIpcHandlers(appState: AppState): void {
       llmHelper.setGroqFastTextMode(enabled);
 
       const { SettingsManager } = require('./services/SettingsManager');
-      SettingsManager.getInstance().set('groqFastTextMode', enabled);
+      if (!SettingsManager.getInstance().set('groqFastTextMode', enabled)) {
+        // R-24: the write was refused (degraded settings store). Returning
+        // success here — and broadcasting below — put every window on a value
+        // disk never received, which silently reverted on the next launch.
+        return { success: false, error: 'settings_store_degraded' };
+      }
 
       // Broadcast to all windows
       BrowserWindow.getAllWindows().forEach((win) => {
@@ -8874,7 +8934,12 @@ export function initializeIpcHandlers(appState: AppState): void {
     try {
       const normalized = CodexCliService.normalizeConfig(config || {});
       const sm = SettingsManager.getInstance();
-      sm.set('codexCliEnabled', normalized.enabled);
+      if (!sm.set('codexCliEnabled', normalized.enabled)) {
+        // R-24: the write was refused (degraded settings store). Returning
+        // success here — and broadcasting below — put every window on a value
+        // disk never received, which silently reverted on the next launch.
+        return { success: false, error: 'settings_store_degraded' };
+      }
       sm.set('codexCliPath', normalized.path);
       sm.set('codexCliModel', normalized.model);
       sm.set('codexCliFastModel', normalized.fastModel);
@@ -10094,7 +10159,12 @@ export function initializeIpcHandlers(appState: AppState): void {
   safeHandle('set-action-button-mode', (_, mode: 'recap' | 'brainstorm') => {
     const { SettingsManager } = require('./services/SettingsManager');
     const sm = SettingsManager.getInstance();
-    sm.set('actionButtonMode', mode);
+    if (!sm.set('actionButtonMode', mode)) {
+      // R-24: the write was refused (degraded settings store). Returning
+      // success here — and broadcasting below — put every window on a value
+      // disk never received, which silently reverted on the next launch.
+      return { success: false, error: 'settings_store_degraded' };
+    }
 
     BrowserWindow.getAllWindows().forEach((win) => {
       if (!win.isDestroyed()) {
@@ -10943,7 +11013,12 @@ export function initializeIpcHandlers(appState: AppState): void {
       orchestrator.setKnowledgeMode(enabled);
 
       const { SettingsManager } = require('./services/SettingsManager');
-      SettingsManager.getInstance().set('knowledgeMode', enabled);
+      if (!SettingsManager.getInstance().set('knowledgeMode', enabled)) {
+        // R-24: the write was refused (degraded settings store). Returning
+        // success here — and broadcasting below — put every window on a value
+        // disk never received, which silently reverted on the next launch.
+        return { success: false, error: 'settings_store_degraded' };
+      }
 
       return { success: true };
     } catch (error: any) {

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -9604,8 +9604,12 @@ export function initializeIpcHandlers(appState: AppState): void {
       // Windows let renderer regressions hand Windows shell an unknown
       // protocol → Microsoft Store popup (issue #252). Gate the allowlist on
       // the actual platform so the IPC layer is the last line of defense.
+      // R-23: ms-settings: is the Windows counterpart, and Windows is the only
+      // place it resolves. Gated the same way and for the same reason — issue
+      // #252 was a renderer handing the OTHER platform's scheme to the shell.
       const allowedSystemSettingsUrl =
-        parsed.protocol === 'x-apple.systempreferences:' && process.platform === 'darwin';
+        (parsed.protocol === 'x-apple.systempreferences:' && process.platform === 'darwin')
+        || (parsed.protocol === 'ms-settings:' && process.platform === 'win32');
 
       if (allowedWebUrl || allowedSystemSettingsUrl) {
         await shell.openExternal(url);
@@ -11783,10 +11787,15 @@ export function initializeIpcHandlers(appState: AppState): void {
     if (process.platform === 'win32') {
       let microphone: string = 'granted';
       try {
-        // Any non-'granted' value (denied / restricted / not-determined) must
-        // surface; fall back to 'granted' only if the API itself is unavailable,
-        // so a query failure can never LOCK a working machine out of capture.
-        microphone = systemPreferences.getMediaAccessStatus('microphone') || 'granted';
+        // R-23: surface any ACTIONABLE non-'granted' value (denied /
+        // restricted / not-determined); treat an UNAVAILABLE one as granted so
+        // a query failure can never LOCK a working machine out of capture.
+        // 'unknown' is unavailable, not actionable — Electron's win32 path can
+        // return it when it cannot determine the state, there is nothing for
+        // the user to fix, and it is absent from the union checkPermissions
+        // declares in src/types/electron.d.ts. Normalise rather than widen.
+        const reported = systemPreferences.getMediaAccessStatus('microphone');
+        microphone = (!reported || reported === 'unknown') ? 'granted' : reported;
       } catch {
         microphone = 'granted';
       }
@@ -11796,8 +11805,14 @@ export function initializeIpcHandlers(appState: AppState): void {
     return { microphone: 'granted', screen: 'granted', platform: process.platform };
   });
 
+  // Returns true when the OS consent prompt was shown AND granted. On Windows
+  // there is no such prompt — systemPreferences.askForMediaAccess is macOS-only
+  // — so this resolves false and the renderer deep-links to the privacy pane
+  // instead. R-23: it used to return TRUE there, which told onboarding the
+  // request had succeeded while doing nothing at all, so the mic step could
+  // never be satisfied and the user was stuck on it.
   safeHandle('permissions:request-mic', async () => {
-    if (process.platform !== 'darwin') return true;
+    if (process.platform !== 'darwin') return false;
     try {
       return await systemPreferences.askForMediaAccess('microphone');
     } catch {

--- a/electron/rag/LiveRAGIndexer.ts
+++ b/electron/rag/LiveRAGIndexer.ts
@@ -38,6 +38,18 @@ export class LiveRAGIndexer {
      */
     private inFlightTick: Promise<void> | null = null;
     private isActive = false;
+    /**
+     * R-16: ownership token for the CURRENT live session.
+     *
+     * The previous guards compared `meetingId`, but the only production caller
+     * (main.ts → RAGManager.startLiveIndexing) passes the CONSTANT
+     * 'live-meeting-current' for every meeting. Two consecutive sessions
+     * therefore carry the same id, so `this.meetingId === meetingId` was always
+     * true and the R-03 guards could never fire — the very race they were added
+     * for was the one case they could not detect. A monotonic token is unique
+     * per start() and restores the intended semantics.
+     */
+    private sessionToken = 0;
 
     constructor(vectorStore: VectorStore, embeddingPipeline: EmbeddingPipeline) {
         this.vectorStore = vectorStore;
@@ -54,6 +66,9 @@ export class LiveRAGIndexer {
         }
 
         this.meetingId = meetingId;
+        // Claim a fresh session identity. Anything still in flight from the
+        // previous session now fails stillOwns() and cannot write into ours.
+        this.sessionToken++;
         this.allSegments = [];
         this.indexedSegmentCount = 0;
         this.chunkCounter = 0;
@@ -109,10 +124,11 @@ export class LiveRAGIndexer {
 
         this.isProcessing = true;
         const meetingId = this.meetingId;
+        const token = this.sessionToken;
 
         // R-03(1a): register ONLY a tick that actually reached the body, so
         // stop() awaits the parked work rather than an already-settled no-op.
-        const running = this.runTick(meetingId).finally(() => {
+        const running = this.runTick(meetingId, token).finally(() => {
             this.isProcessing = false;
             if (this.inFlightTick === running) this.inFlightTick = null;
         });
@@ -130,11 +146,11 @@ export class LiveRAGIndexer {
      * all. Baseline's `= this.allSegments.length` self-clamped to the live array
      * and recovered on the next feed, so an unguarded write is a REGRESSION.
      */
-    private stillOwns(meetingId: string): boolean {
-        return this.isActive && this.meetingId === meetingId;
+    private stillOwns(token: number): boolean {
+        return this.isActive && this.sessionToken === token;
     }
 
-    private async runTick(meetingId: string): Promise<void> {
+    private async runTick(meetingId: string, token: number): Promise<void> {
         try {
             // 1. Get only new segments
             // F-414: capture the slice point and advance the high-water mark
@@ -151,14 +167,14 @@ export class LiveRAGIndexer {
             // 2. Preprocess
             const cleaned = preprocessTranscript(newSegments);
             if (cleaned.length === 0) {
-                if (this.stillOwns(meetingId)) this.indexedSegmentCount = processedUpTo;
+                if (this.stillOwns(token)) this.indexedSegmentCount = processedUpTo;
                 return;
             }
 
             // 3. Chunk with offset index
             const chunks = chunkTranscript(meetingId, cleaned);
             if (chunks.length === 0) {
-                if (this.stillOwns(meetingId)) this.indexedSegmentCount = processedUpTo;
+                if (this.stillOwns(token)) this.indexedSegmentCount = processedUpTo;
                 return;
             }
 
@@ -188,6 +204,20 @@ export class LiveRAGIndexer {
                     const { embeddings, space, provider, dimensions } = await this.embeddingPipeline.getEmbeddingsWithFallback(
                         indexedChunks.map((chunk) => chunk.text)
                     );
+                    // R-16: the two awaits above park up to ~90s. If a new
+                    // session claimed the indexer meanwhile, these chunk rows
+                    // were already purged by startLiveIndexing's F-411 delete,
+                    // so storing them writes vec0 rows that resolve to nothing,
+                    // and the meeting-space stamps below would describe THIS
+                    // session's provider on the NEXT session's meeting row
+                    // (the live meeting id is a constant, so it addresses both).
+                    if (!this.stillOwns(token)) {
+                        console.warn(
+                            `[LiveRAGIndexer] discarding a parked embedding batch for ${meetingId}: `
+                            + 'a newer live session owns the indexer.'
+                        );
+                        return;
+                    }
                     for (let i = 0; i < chunkIds.length && i < embeddings.length; i++) {
                         this.vectorStore.storeEmbedding(chunkIds[i], embeddings[i]);
                         embeddedCount++;
@@ -207,7 +237,7 @@ export class LiveRAGIndexer {
                 } catch (err) {
                     console.warn(`[LiveRAGIndexer] Failed to embed live chunk batch for ${meetingId}:`, err);
                 }
-                if (this.stillOwns(meetingId)) this.indexedChunkCount += embeddedCount;
+                if (this.stillOwns(token)) this.indexedChunkCount += embeddedCount;
                 console.log(`[LiveRAGIndexer] Embedded ${embeddedCount}/${chunkIds.length} chunks (${this.indexedChunkCount} total with embeddings)`);
             } else {
                 console.log('[LiveRAGIndexer] Embedding pipeline not ready, chunks saved without embeddings');
@@ -216,7 +246,7 @@ export class LiveRAGIndexer {
             // 6. Advance high-water mark — to what this tick actually
             //    processed (see the sliceStart note above), not to the live
             //    length, so segments appended mid-tick are picked up next time.
-            if (this.stillOwns(meetingId)) this.indexedSegmentCount = processedUpTo;
+            if (this.stillOwns(token)) this.indexedSegmentCount = processedUpTo;
 
         } catch (err) {
             console.error('[LiveRAGIndexer] Processing error:', err);
@@ -234,6 +264,7 @@ export class LiveRAGIndexer {
         // late resumption cannot flush into, or tear down, a meeting that started
         // in the meantime.
         const stopping = this.meetingId;
+        const stoppingToken = this.sessionToken;
 
         console.log(`[LiveRAGIndexer] Stopping for meeting ${this.meetingId}`);
 
@@ -250,14 +281,14 @@ export class LiveRAGIndexer {
         if (this.inFlightTick) {
             try { await this.inFlightTick; } catch { /* the tick logs its own errors */ }
         }
-        if (this.meetingId === stopping) {
+        if (this.sessionToken === stoppingToken) {
             await this.tick(true);
         }
 
-        if (this.meetingId !== stopping) {
+        if (this.sessionToken !== stoppingToken) {
             console.warn(
-                `[LiveRAGIndexer] stop(${stopping}) resumed after ${this.meetingId} had already started — `
-                + 'skipping the reset so the new session is not torn down.'
+                `[LiveRAGIndexer] stop(${stopping}) resumed after session ${this.sessionToken} had already started — `
+                + 'skipping the flush and reset so the new session is not torn down.'
             );
             return;
         }

--- a/electron/rag/LiveRAGIndexer.ts
+++ b/electron/rag/LiveRAGIndexer.ts
@@ -218,21 +218,21 @@ export class LiveRAGIndexer {
                         );
                         return;
                     }
+                    // R-21: settle the meeting's embedding space BEFORE storing this
+                    // batch. Re-stamping now discards the old space's vectors, so doing
+                    // it afterwards (as F-415 did) would wipe the batch we just wrote.
+                    if (provider && space && dimensions
+                        && this.vectorStore.restampMeetingSpaceOnChange?.(meetingId, provider, dimensions, space)) {
+                        // Every previously embedded chunk just lost its vector.
+                        this.indexedChunkCount = 0;
+                    }
                     for (let i = 0; i < chunkIds.length && i < embeddings.length; i++) {
                         this.vectorStore.storeEmbedding(chunkIds[i], embeddings[i]);
                         embeddedCount++;
                     }
                     if (embeddedCount > 0 && provider && space && dimensions) {
+                        // Applies on a fresh meeting, and again after a re-stamp cleared it.
                         this.vectorStore.stampMeetingSpaceIfUnset(meetingId, provider, dimensions, space);
-                        // F-415: the comment above is true WITHIN a batch, but not
-                        // ACROSS ticks. If a later tick falls back to a different
-                        // provider, the meeting is already stamped and
-                        // stampMeetingSpaceIfUnset is a no-op — so the row keeps
-                        // claiming the old space while these chunks are in the new
-                        // one, and the query-time space filter then excludes the
-                        // meeting entirely (zero live results precisely when the
-                        // cloud provider is down). Re-stamp on an actual change.
-                        this.vectorStore.restampMeetingSpaceOnChange?.(meetingId, provider, dimensions, space);
                     }
                 } catch (err) {
                     console.warn(`[LiveRAGIndexer] Failed to embed live chunk batch for ${meetingId}:`, err);

--- a/electron/rag/VectorStore.ts
+++ b/electron/rag/VectorStore.ts
@@ -488,12 +488,35 @@ export class VectorStore {
         try {
             const row = this.db.prepare('SELECT embedding_space AS s FROM meetings WHERE id = ?').get(meetingId) as any;
             if (!row || row.s == null || row.s === space) return false;
-            this.db.prepare(
-                'UPDATE meetings SET embedding_provider = ?, embedding_dimensions = ?, embedding_space = ? WHERE id = ?'
-            ).run(providerName, dimensions, space, meetingId);
-            console.warn(`[VectorStore] Meeting ${meetingId} embedding space changed ${row.s} -> ${space} (mid-meeting provider fallback); re-stamped.`);
+            // R-21: re-stamping alone left every chunk embedded under the OLD space
+            // in place while the meeting row claimed the new one. The query-time
+            // filter is meeting-level, so a same-dimension provider then scored
+            // stale-space vectors against new-space queries, and a different-
+            // dimension one produced hidden orphans (the re-index sweep's
+            // `embedding_space IS NOT NULL AND != ?` is false once re-stamped).
+            // The queued path has always cleared before switching providers —
+            // EmbeddingPipeline.activateMeetingFallback → clearEmbeddingsForMeeting.
+            // Do the same here, so the two paths agree.
+            //
+            // Both halves are ONE unit. clearEmbeddingsForMeeting() nulls
+            // embedding_space on its way through, so a failure between it and the
+            // UPDATE would leave the meeting with some dims cleared and no stamp
+            // at all — and the caller, seeing `false`, would not reset its
+            // queryable-chunk count either. That is strictly worse than the state
+            // this method was called to repair, so it must roll back instead.
+            this.db.transaction(() => {
+                this.clearEmbeddingsForMeeting(meetingId);
+                this.db.prepare(
+                    'UPDATE meetings SET embedding_provider = ?, embedding_dimensions = ?, embedding_space = ? WHERE id = ?'
+                ).run(providerName, dimensions, space, meetingId);
+            })();
+            console.warn(`[VectorStore] Meeting ${meetingId} embedding space changed ${row.s} -> ${space} (mid-meeting provider fallback); cleared the old-space vectors and re-stamped.`);
             return true;
         } catch (e) {
+            // Rolled back: the meeting still claims the OLD space and still has its
+            // old-space vectors — consistent, and the pre-R-21 behaviour. Returning
+            // false keeps the caller's chunk count in step with that.
+            console.warn(`[VectorStore] restampMeetingSpaceOnChange(${meetingId}) failed and was rolled back:`, e);
             return false;
         }
     }

--- a/electron/rag/__tests__/LiveIndexerSessionOwnership2026_08_20.test.mjs
+++ b/electron/rag/__tests__/LiveIndexerSessionOwnership2026_08_20.test.mjs
@@ -1,0 +1,124 @@
+// R-16 regression test — the guards R-03 added could never fire.
+//
+// R-03 added stillOwns()/stop() guards so a tick parked ~90s could not write
+// into, or tear down, a meeting that started meanwhile. They keyed on
+// `meetingId` — but the only production caller (main.ts:5940 →
+// RAGManager.startLiveIndexing) passes the CONSTANT 'live-meeting-current' for
+// every meeting. Two consecutive sessions therefore carried the same id, so
+// `this.meetingId === meetingId` was always true and the guards were inert in
+// exactly the race they were written for.
+//
+// The race is not hypothetical: main.ts:6206 awaits stopLiveIndexing() inside a
+// BACKGROUND teardown IIFE, stop() parks on inFlightTick, and main.ts:6222
+// already logs "New meeting started during cleanup".
+//
+// Measured on the unfixed build: meeting B inherited A's absolute
+// indexedSegmentCount (40 against B's 5 segments), which drives newSegmentCount
+// negative so every later tick early-returns; then A's late stop() ran the full
+// reset and B was dead — isActive=false, meetingId=null, feed and tick no-ops
+// forever. No test drove two sessions, which is why it shipped.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const dist = path.resolve(__dirname, '../../../dist-electron/electron/rag/LiveRAGIndexer.js');
+const { LiveRAGIndexer } = await import(pathToFileURL(dist).href);
+
+const LIVE_ID = 'live-meeting-current';  // the constant every meeting is given
+
+function harness() {
+  const embedded = [];
+  let release;
+  const gate = new Promise((r) => { release = r; });
+  const vectorStore = {
+    saveChunks: (chunks) => chunks.map((_, i) => i + 1),
+    storeEmbedding: (id) => { embedded.push(id); },
+    stampMeetingSpaceIfUnset: () => {},
+    restampMeetingSpaceOnChange: () => {},
+  };
+  const embeddingPipeline = {
+    isReady: () => true,
+    getEmbeddingsWithFallback: async (texts) => {
+      await gate;
+      return { embeddings: texts.map(() => new Float32Array([1, 0, 0])), provider: 'test', space: 'test:space:3', dimensions: 3 };
+    },
+  };
+  return { embedded, release, indexer: new LiveRAGIndexer(vectorStore, embeddingPipeline) };
+}
+
+const seg = (t) => ({ text: t, speaker: 'them', timestamp: Date.now() });
+
+/** Meeting A parked mid-tick, its teardown stop() parked behind it, then B starts. */
+async function overlapSessions() {
+  const h = harness();
+  const { indexer } = h;
+
+  indexer.start(LIVE_ID);                                   // meeting A
+  indexer.feedSegments(Array.from({ length: 40 }, (_, i) => seg(`meeting A sentence ${i} with enough words to chunk`)));
+  const parked = indexer['tick']().catch(() => {});
+  indexer['inFlightTick'] = parked;
+  await new Promise((r) => setTimeout(r, 30));
+  assert.equal(indexer['isProcessing'], true, 'harness must actually park a tick');
+
+  const teardown = indexer.stop();                          // main.ts:6206, un-awaited here
+  await new Promise((r) => setTimeout(r, 10));
+
+  indexer.start(LIVE_ID);                                   // meeting B, same constant id
+  indexer.feedSegments(Array.from({ length: 5 }, (_, i) => seg(`meeting B sentence ${i} with enough words to chunk`)));
+
+  h.release();                                              // A's parked tick resumes
+  await parked;
+  // Snapshot BEFORE the late stop() resumes. On the unfixed build that stop()
+  // zeroes every counter as it tears meeting B down, which would mask the
+  // cross-session write this snapshot exists to catch.
+  const afterLateTick = {
+    indexedSegmentCount: indexer['indexedSegmentCount'],
+    indexedChunkCount: indexer['indexedChunkCount'],
+  };
+  await teardown;
+  return { ...h, parked, afterLateTick };
+}
+
+/** The 30s indexing interval would otherwise hold the test runner's event loop open. */
+function disposeTimer(indexer) {
+  if (indexer['timer']) { clearInterval(indexer['timer']); indexer['timer'] = null; }
+}
+
+test("a previous session's parked tick cannot write into the new session", async () => {
+  const { indexer, afterLateTick } = await overlapSessions();
+  try {
+    assert.equal(afterLateTick.indexedSegmentCount, 0,
+      "meeting A's absolute high-water mark must not be written into meeting B — a "
+      + 'positive value here drives newSegmentCount negative and B is never indexed again');
+    assert.equal(afterLateTick.indexedChunkCount, 0,
+      "meeting A's chunk count must not be credited to meeting B");
+  } finally { disposeTimer(indexer); }
+});
+
+test("a previous session's late stop() cannot tear down the new session", async () => {
+  const { indexer } = await overlapSessions();
+  try {
+    assert.equal(indexer['isActive'], true, 'meeting B must still be active');
+    assert.equal(indexer['meetingId'], LIVE_ID, 'meeting B must still own the indexer');
+    assert.equal(indexer['allSegments'].length, 5, "meeting B's buffered transcript must survive");
+
+    // And B must still actually index — the teardown must not have left it inert.
+    indexer.feedSegments(Array.from({ length: 4 }, (_, i) => seg(`meeting B later sentence ${i} with enough words`)));
+    assert.equal(indexer['allSegments'].length, 9, 'feedSegments must still be accepted for meeting B');
+  } finally { disposeTimer(indexer); }
+});
+
+test('the ownership guard does not key on the caller-supplied meeting id', async () => {
+  // The whole defect was that two sessions are indistinguishable by id. Pin the
+  // property directly so a future refactor cannot silently reintroduce it.
+  const { indexer } = harness();
+  indexer.start(LIVE_ID);
+  const first = indexer['sessionToken'];
+  indexer.start(LIVE_ID);
+  try {
+    assert.notEqual(indexer['sessionToken'], first,
+      'a new start() with the SAME meeting id must still produce a distinct session identity');
+  } finally { disposeTimer(indexer); }
+});

--- a/electron/rag/__tests__/RestampClearsOldSpace2026_08_20.test.mjs
+++ b/electron/rag/__tests__/RestampClearsOldSpace2026_08_20.test.mjs
@@ -1,0 +1,53 @@
+// R-21 regression test.
+//
+// F-415 made the live indexer re-stamp meetings.embedding_space when a later
+// tick fell back to a different provider — but left every chunk embedded under
+// the OLD space in place. The query-time filter is meeting-level, so after the
+// re-stamp a same-dimension provider scored stale-space vectors against
+// new-space queries, and a different-dimension one produced hidden orphans:
+// the re-index sweep's `embedding_space IS NOT NULL AND != ?` is false once the
+// row claims the new space. The queued path had always cleared first
+// (EmbeddingPipeline.activateMeetingFallback → clearEmbeddingsForMeeting); only
+// the live path lacked an equivalent.
+//
+// Ordering matters as much as the clear: the re-stamp now discards vectors, so
+// it must run BEFORE the batch is stored, not after.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const vs = fs.readFileSync(new URL('../VectorStore.ts', import.meta.url), 'utf8');
+const ix = fs.readFileSync(new URL('../LiveRAGIndexer.ts', import.meta.url), 'utf8');
+
+test('re-stamping discards the vectors embedded under the old space', () => {
+  const i = vs.indexOf('restampMeetingSpaceOnChange(meetingId: string');
+  assert.notEqual(i, -1, 'restampMeetingSpaceOnChange must still exist');
+  const body = vs.slice(i, i + 1800);
+
+  const clear = body.indexOf('clearEmbeddingsForMeeting');
+  const update = body.indexOf('UPDATE meetings SET embedding_provider');
+  assert.notEqual(clear, -1,
+    'the old space\'s vectors must be cleared, or they are scored against new-space queries');
+  assert.ok(clear < update,
+    'clear BEFORE the UPDATE — clearEmbeddingsForMeeting nulls embedding_space, so clearing after would undo the re-stamp');
+});
+
+test('the live indexer re-stamps before storing, not after', () => {
+  const i = ix.indexOf('private async runTick');
+  assert.notEqual(i, -1);
+  const body = ix.slice(i);
+
+  const restamp = body.indexOf('restampMeetingSpaceOnChange');
+  const store = body.indexOf('this.vectorStore.storeEmbedding(');
+  assert.notEqual(restamp, -1, 'the live path must still settle the space on a provider change');
+  assert.notEqual(store, -1);
+  assert.ok(restamp < store,
+    're-stamping now clears embeddings, so doing it after storeEmbedding would wipe the batch just written');
+});
+
+test('a re-stamp resets the queryable-chunk count', () => {
+  const i = ix.indexOf('restampMeetingSpaceOnChange');
+  const window = ix.slice(i, i + 400);
+  assert.ok(/this\.indexedChunkCount = 0/.test(window),
+    'every previously embedded chunk just lost its vector; hasIndexedChunks() must not keep claiming otherwise');
+});

--- a/electron/rag/__tests__/RestampClearsOldSpaceBehaviour2026_08_20.test.mjs
+++ b/electron/rag/__tests__/RestampClearsOldSpaceBehaviour2026_08_20.test.mjs
@@ -1,0 +1,126 @@
+// R-21 behavioural test — the REAL compiled VectorStore against real SQLite.
+//
+// The companion source-assertion test pins the ORDERING (clear before the
+// UPDATE; re-stamp before storeEmbedding). This one pins what actually lands in
+// the database, which ordering assertions cannot show.
+//
+// Same harness as RequeueReindexAtomicity: an in-memory DB with no vec_chunks_*
+// table, so detectVecSupport() is false, the pure-SQL path runs, and there is no
+// DatabaseManager singleton dependency.
+import { test, describe, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import Database from 'better-sqlite3';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const vsPath = path.resolve(__dirname, '../../../dist-electron/electron/rag/VectorStore.js');
+const { VectorStore } = await import(pathToFileURL(vsPath).href);
+
+const CLOUD = 'gemini:gemini-embedding-001:768';
+const LOCAL = 'local:bge-small:384';
+
+describe('restampMeetingSpaceOnChange (real VectorStore + SQLite)', () => {
+  let db, vectorStore;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE meetings (
+        id TEXT PRIMARY KEY,
+        embedding_provider TEXT,
+        embedding_dimensions INTEGER,
+        embedding_space TEXT
+      );
+      CREATE TABLE chunks (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        meeting_id TEXT,
+        cleaned_text TEXT,
+        embedding BLOB
+      );
+      CREATE TABLE chunk_summaries (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        meeting_id TEXT,
+        summary_text TEXT,
+        embedding BLOB
+      );
+    `);
+    vectorStore = new VectorStore(db, ':memory:', '/nonexistent-ext');
+
+    // A live meeting whose first ticks embedded 3 chunks under the CLOUD space.
+    const blob = Buffer.alloc(768 * 4);
+    db.prepare("INSERT INTO meetings (id, embedding_provider, embedding_dimensions, embedding_space) VALUES ('live-meeting-current','gemini',768,?)").run(CLOUD);
+    for (let i = 0; i < 3; i++) {
+      db.prepare("INSERT INTO chunks (meeting_id, cleaned_text, embedding) VALUES ('live-meeting-current', ?, ?)").run(`cloud chunk ${i}`, blob);
+    }
+    db.prepare("INSERT INTO chunk_summaries (meeting_id, summary_text, embedding) VALUES ('live-meeting-current','sum', ?)").run(blob);
+  });
+
+  afterEach(() => db.close());
+
+  const embeddedCount = () =>
+    db.prepare("SELECT COUNT(*) AS n FROM chunks WHERE meeting_id='live-meeting-current' AND embedding IS NOT NULL").get().n;
+  const meeting = () =>
+    db.prepare("SELECT embedding_provider AS p, embedding_dimensions AS d, embedding_space AS s FROM meetings WHERE id='live-meeting-current'").get();
+
+  test('a mid-meeting provider fallback discards the old space\'s vectors', () => {
+    assert.equal(embeddedCount(), 3, 'precondition: three chunks embedded under the cloud space');
+
+    const changed = vectorStore.restampMeetingSpaceOnChange('live-meeting-current', 'local', 384, LOCAL);
+    assert.equal(changed, true, 'a genuine space change must be reported');
+
+    assert.equal(embeddedCount(), 0,
+      'the cloud-space vectors must be gone — left in place they are scored against local-space queries');
+    assert.equal(meeting().s, LOCAL, 'the meeting must now claim the local space');
+    assert.equal(meeting().d, 384);
+    assert.equal(meeting().p, 'local');
+  });
+
+  test('the summary embedded under the old space is discarded too', () => {
+    vectorStore.restampMeetingSpaceOnChange('live-meeting-current', 'local', 384, LOCAL);
+    const n = db.prepare("SELECT COUNT(*) AS n FROM chunk_summaries WHERE meeting_id='live-meeting-current' AND embedding IS NOT NULL").get().n;
+    assert.equal(n, 0, 'chunk_summaries is space-bound the same way chunks are');
+  });
+
+  test('an unchanged space is a no-op — it must not wipe a healthy meeting', () => {
+    const changed = vectorStore.restampMeetingSpaceOnChange('live-meeting-current', 'gemini', 768, CLOUD);
+    assert.equal(changed, false, 'the common case must stay a no-op');
+    assert.equal(embeddedCount(), 3, 'nothing may be cleared when the space did not change');
+    assert.equal(meeting().s, CLOUD);
+  });
+
+  test('an unstamped meeting is left to stampMeetingSpaceIfUnset', () => {
+    db.prepare("UPDATE meetings SET embedding_space = NULL WHERE id='live-meeting-current'").run();
+    const changed = vectorStore.restampMeetingSpaceOnChange('live-meeting-current', 'local', 384, LOCAL);
+    assert.equal(changed, false, 'no prior space means nothing to re-stamp — and nothing to discard');
+    assert.equal(embeddedCount(), 3);
+  });
+
+  test('after a re-stamp, stampMeetingSpaceIfUnset does not overwrite it', () => {
+    vectorStore.restampMeetingSpaceOnChange('live-meeting-current', 'local', 384, LOCAL);
+    // This is the very next call in runTick; its WHERE ... AND embedding_space IS NULL
+    // must make it a no-op so the stamp is written from exactly one place.
+    vectorStore.stampMeetingSpaceIfUnset('live-meeting-current', 'gemini', 768, CLOUD);
+    assert.equal(meeting().s, LOCAL, 'the re-stamped space must survive the follow-up call');
+    assert.equal(meeting().d, 384);
+  });
+
+  test('a failed re-stamp rolls back rather than half-clearing the meeting', () => {
+    // Make the UPDATE fail AFTER the clear has run inside the transaction.
+    const realPrepare = db.prepare.bind(db);
+    db.prepare = (sql) => {
+      if (sql.startsWith('UPDATE meetings SET embedding_provider = ?, embedding_dimensions = ?, embedding_space = ? WHERE id = ?')) {
+        throw new Error('simulated write failure');
+      }
+      return realPrepare(sql);
+    };
+
+    const changed = vectorStore.restampMeetingSpaceOnChange('live-meeting-current', 'local', 384, LOCAL);
+    db.prepare = realPrepare;
+
+    assert.equal(changed, false, 'a failure must be reported, not swallowed as success');
+    assert.equal(embeddedCount(), 3,
+      'the clear must roll back — a half-cleared meeting still claiming the old space is worse than before the call');
+    assert.equal(meeting().s, CLOUD, 'and the meeting must still claim its original space');
+  });
+});

--- a/electron/services/SettingsManager.ts
+++ b/electron/services/SettingsManager.ts
@@ -400,9 +400,16 @@ export class SettingsManager {
             // could not READ must not be overwritten from an empty in-memory
             // object. (A genuinely absent file is handled by the existsSync
             // branch above and stays writable, so first-run is unaffected.)
-            console.error('[SettingsManager] Failed to read settings file; continuing READ-ONLY for this session:', e);
-            this.settings = {};
-            this.settingsUnreadable = true;
+            // R-19: R-15 gave the PARSE failure a quarantine-and-recover path but
+            // left this one latching read-only with no way out. A deterministic
+            // read error — EACCES on a root-owned settings.json, EISDIR — is not
+            // transient, so every launch re-latched and the user could never
+            // change a setting again: the exact permanent brick F-703's own
+            // docstring claims to have eliminated. Quarantine here too; renaming
+            // needs directory write permission, not readability of the file, so
+            // it succeeds in precisely the cases that used to be terminal.
+            console.error('[SettingsManager] Failed to read settings file:', e);
+            this.quarantineUnreadableSettings(e);
         }
     }
 
@@ -464,15 +471,15 @@ export class SettingsManager {
             fs.renameSync(this.settingsPath, quarantinePath);
             this.settingsUnreadable = false;
             console.error(
-                `[SettingsManager] settings.json could not be parsed and was moved to ${quarantinePath}. `
+                `[SettingsManager] settings.json could not be read and was moved to ${quarantinePath}. `
                 + 'Continuing with defaults on a writable store; the original file is preserved for recovery. Cause:',
                 cause,
             );
         } catch (renameErr) {
             this.settingsUnreadable = true;
             console.error(
-                '[SettingsManager] settings.json could not be parsed AND could not be quarantined; '
-                + 'continuing READ-ONLY so the existing file is not overwritten. Parse cause:',
+                '[SettingsManager] settings.json could not be read AND could not be quarantined; '
+                + 'continuing READ-ONLY so the existing file is not overwritten. Cause:',
                 cause, 'Quarantine error:', renameErr,
             );
         }

--- a/electron/services/SettingsManager.ts
+++ b/electron/services/SettingsManager.ts
@@ -229,7 +229,18 @@ export class SettingsManager {
         return this.settings[key];
     }
 
-    public set<K extends keyof AppSettings>(key: K, value: AppSettings[K]): void {
+    /**
+     * Persist one setting.
+     *
+     * @returns true when the value was written, false when the store is degraded
+     *          and the write was refused. R-24: this used to be `void`, so a
+     *          caller could not tell the two apart — every settings IPC handler
+     *          reported success and broadcast its `*-changed` event, leaving
+     *          every window showing a value that disk never received and that
+     *          silently reverted on restart. Ignoring the result is still valid
+     *          for callers that have nothing to report.
+     */
+    public set<K extends keyof AppSettings>(key: K, value: AppSettings[K]): boolean {
         // R-15: when the store is degraded, saveSettings() refuses. Mutating
         // in-memory first left the process believing the write succeeded while
         // disk still held the old value — and roughly fifteen IPC handlers report
@@ -237,10 +248,11 @@ export class SettingsManager {
         // and disk cannot disagree.
         if (this.settingsUnreadable) {
             console.warn(`[SettingsManager] Refusing to set "${String(key)}": the settings store is degraded this session (see the quarantine warning at startup).`);
-            return;
+            return false;
         }
         this.settings[key] = value;
         this.saveSettings();
+        return true;
     }
 
     // Resolved screen-understanding mode with default and runtime validation.

--- a/electron/services/__tests__/RefusedSettingWriteReported2026_08_21.test.mjs
+++ b/electron/services/__tests__/RefusedSettingWriteReported2026_08_21.test.mjs
@@ -1,0 +1,62 @@
+// R-24 regression test.
+//
+// R-15 made set() refuse before mutating when the settings store is degraded,
+// so memory and disk could not disagree. But set() was `void`, so no caller
+// could tell a refusal from a success — and its own docstring conceded that
+// "roughly fifteen IPC handlers report success to the renderer off this call".
+//
+// The return value was the lesser half. Those handlers also BROADCAST a
+// `*-changed` event on the way to `return { success: true }`, so a refused
+// write put every window on a value disk never received — which then silently
+// reverted on the next launch, with the UI having confirmed it applied.
+//
+// (After R-19 this state is narrower than it was: settingsUnreadable now
+// latches only when settings.json can be neither read nor quarantined. Narrower
+// is not gone.)
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const sm = fs.readFileSync(new URL('../SettingsManager.ts', import.meta.url), 'utf8');
+const ipc = fs.readFileSync(new URL('../../ipcHandlers.ts', import.meta.url), 'utf8');
+
+test('set() reports whether the write actually landed', () => {
+  const i = sm.indexOf('public set<K extends keyof AppSettings>');
+  assert.notEqual(i, -1, 'set() must still exist');
+  const sig = sm.slice(i, sm.indexOf('{', i));
+  assert.ok(/\)\s*:\s*boolean\s*$/.test(sig.trim()),
+    'set() must return boolean — as void, a refusal is indistinguishable from a success');
+
+  const body = sm.slice(i, i + 900);
+  const refusal = body.slice(body.indexOf('this.settingsUnreadable'));
+  assert.ok(/return false/.test(refusal.slice(0, 400)), 'the refusal path must return false');
+  assert.ok(/return true/.test(body), 'the success path must return true');
+});
+
+test('no settings IPC handler reports success on a refused write', () => {
+  const offenders = [];
+  const re = /safeHandle\('([^']+)'/g;
+  let m;
+  while ((m = re.exec(ipc)) !== null) {
+    const next = ipc.indexOf("safeHandle('", m.index + 12);
+    const body = ipc.slice(m.index, next === -1 ? ipc.length : next);
+    if (!/\.set\('/.test(body) || !body.includes('success: true')) continue;
+    if (!body.includes('settings_store_degraded')) offenders.push(m[1]);
+  }
+  assert.deepEqual(offenders, [],
+    `handler(s) ${offenders.join(', ')} still return success (and broadcast a *-changed event) `
+    + 'after a write the settings store may have refused');
+});
+
+test('the guard precedes the broadcast, not just the return', () => {
+  // Returning an error while still broadcasting would leave the other windows
+  // desynchronised — the half of this bug that the return value does not cover.
+  const i = ipc.indexOf("safeHandle('set-code-verification'");
+  assert.notEqual(i, -1);
+  const body = ipc.slice(i, i + 1200);
+  const guard = body.indexOf('settings_store_degraded');
+  const broadcast = body.indexOf("send('code-verification-changed'");
+  assert.notEqual(broadcast, -1, 'the broadcast must still exist for the success path');
+  assert.ok(guard !== -1 && guard < broadcast,
+    'the refusal must short-circuit BEFORE the *-changed broadcast');
+});

--- a/electron/services/__tests__/SettingsReadFailureQuarantine2026_08_20.test.mjs
+++ b/electron/services/__tests__/SettingsReadFailureQuarantine2026_08_20.test.mjs
@@ -1,0 +1,59 @@
+// R-19 regression test.
+//
+// R-15 gave the PARSE-failure path a quarantine-and-recover route: rename the
+// bad file aside, clear the degraded flag, carry on writable. The outer
+// READ-failure catch was left latching `settingsUnreadable = true` with no
+// quarantine and no recovery. Read errors that reach it are deterministic —
+// EACCES on a root-owned settings.json, EISDIR if the path is a directory — so
+// every launch re-latched and set() refused forever. That is exactly the
+// permanent brick F-703's own docstring claims to have eliminated.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const src = fs.readFileSync(new URL('../SettingsManager.ts', import.meta.url), 'utf8');
+
+function outerReadCatch() {
+  // The catch that wraps the whole existsSync/readFileSync/parse block.
+  const i = src.indexOf('Failed to read settings file');
+  assert.notEqual(i, -1, 'the outer read-failure catch must still exist');
+  return src.slice(i, i + 400);
+}
+
+test('the read-failure path quarantines rather than latching read-only', () => {
+  const body = outerReadCatch();
+  assert.ok(/this\.quarantineUnreadableSettings\(/.test(body),
+    'a file we could not READ must get the same quarantine-and-recover treatment as one we could not PARSE');
+  assert.ok(!/this\.settingsUnreadable\s*=\s*true/.test(body),
+    'it must not latch the degraded flag directly — that is the unrecoverable path');
+});
+
+test('quarantine renames the unreadable file and leaves the store writable', () => {
+  // Prove the mechanism the fix relies on: renaming needs directory write
+  // permission, NOT readability of the file — which is why it recovers the
+  // EACCES case that used to be terminal.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'settings-quarantine-'));
+  const file = path.join(dir, 'settings.json');
+  fs.writeFileSync(file, '{"a":1}');
+  fs.chmodSync(file, 0o000);                       // unreadable by owner
+
+  let readFailed = false;
+  try { fs.readFileSync(file, 'utf8'); } catch { readFailed = true; }
+
+  const quarantined = `${file}.corrupt-stamp`;
+  fs.renameSync(file, quarantined);                // the quarantine step
+
+  assert.ok(fs.existsSync(quarantined), 'the original must be preserved for recovery');
+  assert.ok(!fs.existsSync(file), 'the path must be free for a fresh, writable settings.json');
+  fs.writeFileSync(file, '{}');
+  assert.equal(fs.readFileSync(file, 'utf8'), '{}', 'the store must be writable again');
+
+  // (readFailed is false when running as root, where nothing is unreadable —
+  //  the rename half is the part under test either way.)
+  assert.equal(typeof readFailed, 'boolean');
+
+  fs.chmodSync(quarantined, 0o600);
+  fs.rmSync(dir, { recursive: true, force: true });
+});

--- a/electron/services/__tests__/WindowsMicPermissionResolvable2026_08_20.test.mjs
+++ b/electron/services/__tests__/WindowsMicPermissionResolvable2026_08_20.test.mjs
@@ -1,0 +1,84 @@
+// R-23 regression test — both platform branches.
+//
+// F-706 made Windows report the real microphone privacy state instead of a
+// hardcoded 'granted'. That was right, but it left the resulting state
+// unresolvable:
+//
+//   - onboarding shows the mic step for any status !== 'granted';
+//   - its action is permissions:request-mic;
+//   - that handler was `if (process.platform !== 'darwin') return true` — a
+//     no-op resolving TRUE, so onboarding believed the request had succeeded;
+//   - refreshStatus() then re-read the same non-granted value.
+//
+// A Windows user with the microphone toggle off was parked on that step with no
+// way forward. There is no fix via the request API: Electron's
+// systemPreferences.askForMediaAccess is macOS-only (per its own docs), so
+// Windows has no consent prompt at all. The remedy is the privacy pane.
+//
+// Also: Electron's win32 getMediaAccessStatus can return 'unknown'
+// (ConvertDeviceAccessStatus over GetDeviceAccessStatus(DeviceClass_AudioCapture)),
+// which is NOT in the union checkPermissions declares — and is not actionable.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const ipc = fs.readFileSync(new URL('../../ipcHandlers.ts', import.meta.url), 'utf8');
+const full = fs.readFileSync(new URL('../../../src/components/onboarding/PermissionsOnboardingFull.tsx', import.meta.url), 'utf8');
+const toast = fs.readFileSync(new URL('../../../src/components/onboarding/PermissionsToaster.tsx', import.meta.url), 'utf8');
+const dts = fs.readFileSync(new URL('../../../src/types/electron.d.ts', import.meta.url), 'utf8');
+
+function slice(src, needle, len) {
+  const i = src.indexOf(needle);
+  assert.notEqual(i, -1, `${needle} not found`);
+  return src.slice(i, i + len);
+}
+
+test('darwin still prompts for microphone access', () => {
+  const body = slice(ipc, "safeHandle('permissions:request-mic'", 500);
+  assert.ok(/askForMediaAccess\('microphone'\)/.test(body),
+    'the macOS consent prompt must be untouched — it is the only platform that has one');
+  assert.ok(/process\.platform !== 'darwin'/.test(body), 'the platform split must remain explicit');
+});
+
+test('win32 no longer claims a request it cannot make succeeded', () => {
+  const body = slice(ipc, "safeHandle('permissions:request-mic'", 500);
+  const guard = body.slice(body.indexOf("process.platform !== 'darwin'"));
+  assert.ok(/return false/.test(guard.slice(0, 60)),
+    'returning true told onboarding a no-op had granted access, which is what made the step unsatisfiable');
+});
+
+test('win32 mic step deep-links to the privacy pane instead', () => {
+  for (const [name, src] of [['PermissionsOnboardingFull', full], ['PermissionsToaster', toast]]) {
+    assert.ok(/ms-settings:privacy-microphone/.test(src),
+      `${name} must send Windows users where the setting actually lives`);
+    assert.ok(/platform === 'win32'/.test(src),
+      `${name} must branch on the platform explicitly`);
+  }
+});
+
+test('the ms-settings scheme is allowlisted for win32 only', () => {
+  const body = slice(ipc, 'const allowedSystemSettingsUrl', 400);
+  assert.ok(/'ms-settings:' && process\.platform === 'win32'/.test(body),
+    'ms-settings must be gated to Windows — issue #252 was a renderer handing the wrong platform a scheme it could not resolve');
+  assert.ok(/'x-apple\.systempreferences:' && process\.platform === 'darwin'/.test(body),
+    'the macOS gate must be preserved');
+});
+
+test("'unknown' is normalised rather than surfaced off-contract", () => {
+  const body = slice(ipc, "if (process.platform === 'win32')", 1400);
+  assert.ok(/=== 'unknown'/.test(body), "Electron's win32 'unknown' must be handled");
+  assert.ok(/\? 'granted'/.test(body),
+    "'unknown' means the status could not be determined — blocking a working machine on it is the failure mode F-706's own comment warns against");
+
+  assert.ok(!/'unknown'/.test(slice(dts, 'checkPermissions:', 260)),
+    'and it must not leak into the declared union — normalising beats widening a type no consumer can act on');
+});
+
+test('actionable non-granted states still surface on win32', () => {
+  const body = slice(ipc, "if (process.platform === 'win32')", 1400);
+  for (const s of ['denied', 'restricted', 'not-determined']) {
+    assert.ok(!new RegExp(`=== '${s}'[^\\n]*\\?\\s*'granted'`).test(body),
+      `${s} must NOT be normalised away — F-706 exists to surface it`);
+  }
+  assert.ok(/getMediaAccessStatus\('microphone'\)/.test(body), 'the real query must remain');
+});

--- a/src/components/NativelyInterface.tsx
+++ b/src/components/NativelyInterface.tsx
@@ -6043,6 +6043,14 @@ Instructions:
 Provide only the answer, nothing else.`;
           }
 
+          // R-17: claim the desktop surface BEFORE the round-trip. The stream's
+          // id does not exist until main allocates it, so without a claim a
+          // phone turn still streaming owns the guard and swallows this whole
+          // answer (see chatStreamGuard.mjs). Claiming also evicts that phone
+          // stream from the bubble, which is correct: the user just chose this
+          // surface. The desktop done/error handlers both clear it again.
+          chatStreamIdRef.current = null;
+          chatStreamSourceRef.current = 'desktop';
           requestStartTimeRef.current = Date.now();
           await window.electronAPI.streamGeminiChat(
             question,
@@ -6051,6 +6059,12 @@ Provide only the answer, nothing else.`;
             { skipSystemPrompt: true },
           );
         } catch (err) {
+          // R-17: a throw from invoke() never reaches the main process, so no
+          // gemini-stream-error follows and nothing else releases the claim we
+          // took above. Left set, it would pin the guard to 'desktop' and block
+          // every phone turn — the bug this fix removes, inverted.
+          chatStreamIdRef.current = null;
+          chatStreamSourceRef.current = null;
           setIsProcessing(false);
           setMessages((prev) => {
             const last = prev[prev.length - 1];
@@ -6209,6 +6223,10 @@ Provide only the answer, nothing else.`;
       }
 
       // Pass imagePath if attached, AND conversation context
+      // R-17: claim the desktop surface before the round-trip (see the note at
+      // the other streamGeminiChat call site).
+      chatStreamIdRef.current = null;
+      chatStreamSourceRef.current = 'desktop';
       requestStartTimeRef.current = Date.now();
       await window.electronAPI.streamGeminiChat(
         userText || 'Analyze this screenshot',
@@ -6216,6 +6234,9 @@ Provide only the answer, nothing else.`;
         conversationContextForSubmit, // Pass freshly-derived context so "answer this" works
       );
     } catch (err) {
+      // R-17: release the claim taken above — see the note at the other call site.
+      chatStreamIdRef.current = null;
+      chatStreamSourceRef.current = null;
       setIsProcessing(false);
       setMessages((prev) => {
         const last = prev[prev.length - 1];

--- a/src/components/onboarding/PermissionsOnboardingFull.tsx
+++ b/src/components/onboarding/PermissionsOnboardingFull.tsx
@@ -238,6 +238,16 @@ export const PermissionsOnboardingFull: React.FC<Props> = ({ isOpen, onDismiss }
 
   const handleMicRequest = async () => {
     if (!canClick) return;
+    // R-23: Windows has no consent prompt — systemPreferences.askForMediaAccess
+    // is macOS-only — so requestMicPermission cannot grant anything there. It
+    // used to resolve TRUE anyway, so this step re-read the same non-granted
+    // status forever and onboarding could not be completed on a machine whose
+    // microphone privacy toggle was off. Send the user where the setting
+    // actually lives; the window-focus listener above re-reads on return.
+    if (platform === 'win32') {
+      window.electronAPI?.openExternal?.('ms-settings:privacy-microphone');
+      return;
+    }
     setRequesting(true);
     await window.electronAPI?.requestMicPermission?.();
     await refreshStatus();
@@ -274,7 +284,9 @@ export const PermissionsOnboardingFull: React.FC<Props> = ({ isOpen, onDismiss }
     }
     if (micStatus !== 'granted') {
       return {
-        label: requesting ? 'Requesting access…' : 'Request microphone access',
+        label: platform === 'win32'
+          ? 'Open microphone settings'
+          : (requesting ? 'Requesting access…' : 'Request microphone access'),
         action: handleMicRequest,
         active: !requesting,
       };

--- a/src/components/onboarding/PermissionsToaster.tsx
+++ b/src/components/onboarding/PermissionsToaster.tsx
@@ -146,6 +146,12 @@ export const PermissionsToaster: React.FC<Props> = ({ isOpen, onDismiss }) => {
     if (micStatus === 'granted') {
       setMicStatus('denied');
     } else {
+      // R-23: no consent prompt exists on Windows; deep-link to the privacy
+      // pane instead of invoking a request that cannot grant anything.
+      if (platform === 'win32') {
+        window.electronAPI?.openExternal?.('ms-settings:privacy-microphone');
+        return;
+      }
       setRequesting(true);
       await window.electronAPI?.requestMicPermission?.();
       setMicStatus('granted');

--- a/src/lib/__tests__/chatStreamGuardDesktopClaim2026_08_20.test.mjs
+++ b/src/lib/__tests__/chatStreamGuardDesktopClaim2026_08_20.test.mjs
@@ -1,0 +1,71 @@
+// R-17 regression test — F-303's surface scoping had no answer for the
+// reverse direction.
+//
+// F-303 stopped a phone stream from taking over a live DESKTOP bubble. But the
+// scoping only protects a stream that has ALREADY adopted the bubble. When the
+// user types on the desktop while a phone turn is still streaming, the desktop
+// stream has adopted nothing — its id does not exist until main allocates it —
+// so the phone stream still owns the guard. Every desktop token was then
+// rejected as cross-surface and the desktop `done` went unhonored, so the
+// bubble never finalized: no text at all and a spinner that only Escape
+// cleared. R-02 fixed the same shape for a phone ERROR; a phone turn that is
+// merely still streaming (or that main abandoned at
+// `if (phoneSuperseded) return;`, which emits neither done nor error) was left.
+//
+// Clearing the refs on desktop send cannot fix it on its own: the phone is
+// mid-stream and re-adopts the empty slot long before the desktop's first token
+// arrives. The renderer therefore CLAIMS the surface (source set, id still
+// null) and the guard honours that claim.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveChatStreamToken, resolveChatStreamDone } from '../chatStreamGuard.mjs';
+
+// The state NativelyInterface.tsx enters at both streamGeminiChat call sites.
+const DESKTOP_CLAIM = { activeId: null, activeSource: 'desktop' };
+
+test('a claimed desktop surface is not stolen by an in-flight phone stream', () => {
+  const t = resolveChatStreamToken(DESKTOP_CLAIM.activeId, 7, DESKTOP_CLAIM.activeSource, 'phone');
+  assert.equal(t.accept, false, 'a phone token must not adopt the bubble the desktop turn just claimed');
+  assert.equal(t.activeId, null, 'the claim must survive — adopting here is what dropped the desktop answer');
+  assert.equal(t.activeSource, 'desktop');
+});
+
+test('a phone done cannot finalize a claimed desktop bubble', () => {
+  const d = resolveChatStreamDone(DESKTOP_CLAIM.activeId, 7, DESKTOP_CLAIM.activeSource, 'phone');
+  assert.equal(d.honor, false, "honoring it would finalize the desktop turn's empty placeholder");
+  assert.equal(d.activeSource, 'desktop', 'the claim must still be held');
+});
+
+test('the desktop stream the claim was made for is accepted and finalizes', () => {
+  const first = resolveChatStreamToken(DESKTOP_CLAIM.activeId, 8, DESKTOP_CLAIM.activeSource, undefined);
+  assert.equal(first.accept, true);
+  assert.equal(first.activeId, 8, 'the desktop stream must adopt the bubble it claimed');
+
+  const more = resolveChatStreamToken(first.activeId, 8, first.activeSource, undefined);
+  assert.equal(more.accept, true, 'the rest of the desktop answer must render');
+
+  const done = resolveChatStreamDone(first.activeId, 8, first.activeSource, undefined);
+  assert.equal(done.honor, true, 'the desktop done must finalize, or the spinner never stops');
+  assert.equal(done.activeId, null);
+  assert.equal(done.activeSource, null, 'and the claim must be released for the next turn');
+});
+
+test('an unclaimed guard still lets a phone-only turn through', () => {
+  const t = resolveChatStreamToken(null, 3, null, 'phone');
+  assert.equal(t.accept, true, 'with nothing claimed the phone surface may adopt as before');
+  assert.equal(t.activeSource, 'phone');
+
+  const d = resolveChatStreamDone(t.activeId, 3, t.activeSource, 'phone');
+  assert.equal(d.honor, true);
+});
+
+test('F-303 still holds: an adopted desktop stream is not superseded by phone', () => {
+  const phone = resolveChatStreamToken(41, 42, 'desktop', 'phone');
+  assert.equal(phone.accept, false, 'the original F-303 protection must be unchanged');
+  assert.equal(phone.activeId, 41);
+});
+
+test('id-less tokens keep their backward-compatible behaviour under a claim', () => {
+  const t = resolveChatStreamToken(DESKTOP_CLAIM.activeId, undefined, DESKTOP_CLAIM.activeSource, 'phone');
+  assert.equal(t.accept, true, 'an older main emits no streamId; that path must behave exactly as before');
+});

--- a/src/lib/chatStreamGuard.mjs
+++ b/src/lib/chatStreamGuard.mjs
@@ -31,6 +31,7 @@ export function resolveChatStreamToken(activeId, incomingId, activeSource, incom
   const cur = typeof activeId === 'number' ? activeId : null;
   const curSrc = normalizeSource(activeSource);
   const inSrc = normalizeSource(incomingSource);
+  const claimedSrc = claimOf(activeId, activeSource);
   if (typeof incomingId !== 'number') {
     // Backward-compatible path: no id on the wire → behave exactly as before.
     // Preserve the raw active source: with nothing adopted it stays null rather
@@ -38,6 +39,19 @@ export function resolveChatStreamToken(activeId, incomingId, activeSource, incom
     return { accept: true, activeId: cur, activeSource: cur === null ? null : curSrc };
   }
   if (cur === null) {
+    // R-17: a CLAIM is "surface known, id not yet" — the state the renderer
+    // enters the moment the user sends from a surface, before main has
+    // allocated that stream's id. Without it, F-303's surface scoping only
+    // protected a stream that had ALREADY adopted the bubble: a desktop turn
+    // typed while a phone turn was still streaming had nothing adopted, so the
+    // phone's next token won the empty slot and every desktop token was then
+    // rejected as cross-surface. The desktop answer was dropped in full and its
+    // `done` went unhonored, leaving a spinner that only Escape cleared.
+    // Clearing the refs alone cannot fix that: the phone is mid-stream and
+    // would simply re-adopt long before the desktop's first token arrives.
+    if (claimedSrc !== null && claimedSrc !== inSrc) {
+      return { accept: false, activeId: null, activeSource: claimedSrc };
+    }
     return { accept: true, activeId: incomingId, activeSource: inSrc };
   }
   // F-303: supersession is SURFACE-SCOPED. The desktop and phone-mirror paths
@@ -60,6 +74,19 @@ export function resolveChatStreamToken(activeId, incomingId, activeSource, incom
   }
   // incomingId < cur → an older, already-superseded stream is still emitting. Drop.
   return { accept: false, activeId: cur, activeSource: curSrc };
+}
+
+/**
+ * The surface holding a CLAIM, or null when none is held.
+ *
+ * A claim is "source set, id still null": the window between the user sending
+ * from a surface and main allocating that stream's id. An adopted stream (id
+ * present) is NOT a claim — it is handled by the surface-scoping rules above.
+ */
+function claimOf(activeId, activeSource) {
+  if (typeof activeId === 'number') return null;
+  if (typeof activeSource !== 'string' || !activeSource) return null;
+  return normalizeSource(activeSource);
 }
 
 /** Absent/unknown source means the legacy desktop path. */
@@ -90,6 +117,11 @@ export function resolveChatStreamDone(activeId, incomingId, activeSource, incomi
   // bubble with its own, finalText-less completion.
   if (cur !== null && curSrc !== inSrc) {
     return { honor: false, activeId: cur, activeSource: curSrc };
+  }
+  // R-17: nor may it finalize a CLAIM. Honoring a phone `done` here would
+  // finalize the empty placeholder the desktop turn just reserved.
+  if (claimOf(activeId, activeSource) !== null && claimOf(activeId, activeSource) !== inSrc) {
+    return { honor: false, activeId: null, activeSource: normalizeSource(activeSource) };
   }
   if (cur === null || incomingId >= cur) {
     return { honor: true, activeId: null, activeSource: null };


### PR DESCRIPTION
A high-effort review of #487 surfaced 8 findings in the campaign's own fixes. Seven were real; this branch fixes all seven. The eighth was refuted.

Each fix has a regression test that **fails on the unfixed source** — verified by reverting each file to its pre-fix state and re-running.

| Finding | Fix |
|---|---|
| R-16 | `LiveRAGIndexer`'s R-03 guards keyed on `meetingId`, but the only caller passes the constant `'live-meeting-current'` — so they could never fire. Now a per-session token. |
| R-17 | A desktop turn typed while a phone turn streamed was dropped in full: tokens rejected cross-surface, `done` unhonored, spinner stuck. The send path now claims the surface. |
| R-19 | `SettingsManager`'s read-failure path latched read-only with no quarantine — a permanent brick R-15's own docstring claims to have removed. |
| R-20 | A failed vector reap was swallowed, so R-12's transaction committed the meeting DELETE anyway, orphaning vectors. |
| R-21 | Re-stamping `embedding_space` left the old space's vectors in place, to be scored against new-space queries. Now clears, atomically. |
| R-22 | v29 lacked v28's `return`, re-arming R-05 for whoever adds v30. |
| R-23 | F-706 surfaced a Windows mic state nothing could resolve — `request-mic` is a no-op there that returned `true`. Now deep-links to the privacy pane. |

**Two corrections to the review**, both established empirically rather than argued:

- R-16's alleged mechanism (rowid reuse contaminating the next meeting's vectors) is **wrong** — `chunks.id` is `INTEGER PRIMARY KEY AUTOINCREMENT`, measured `[1,2,3] → [4,5]`, never reused. The finding survives on a worse mechanism proven by execution: the next meeting is silently killed.
- Finding #8 (an alleged `TypeError` in `AIProvidersSettings`) is **refuted** — optional chaining short-circuits the whole chain, `.then()` included. No bug, no change.

Also included: **R-24**, found while fixing R-19 — `set()` was `void`, so all 14 settings IPC handlers reported success *and broadcast their `*-changed` event* on a refused write, desynchronising every window onto a value disk never received.

## Validation

- typecheck (electron + renderer) clean
- `test:lib` 337/337 · db 24/24 · rag 274 pass / 5 pre-existing environmental · services 3197 tests, 3159 pass / 3 pre-existing environmental (same names as baseline)
- R-16 and R-17 additionally verified by **executing** the race, not just reading it
- R-21 covered behaviourally against the real compiled `VectorStore` and real SQLite, including the rollback path
- R-23's test drives **both** platform branches

## Not verified

- The renderer edits (`NativelyInterface.tsx`, the two onboarding components) are reviewed but **not executed** — the app was never launched.
- **Requires physical Windows verification.** R-23 makes the state resolvable; it does not confirm Windows behaviour on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESRcrBN7iFQ4F9uNgBh6V8