### PR TITLE
fix(stt): selecting Chinese kills Google STT for the whole session — map zh→cmn and drop latest_long for Mandarin

### DIFF
--- a/electron/audio/GoogleSTT.ts
+++ b/electron/audio/GoogleSTT.ts
@@ -38,6 +38,26 @@ export class GoogleSTT extends EventEmitter {
     //   16 = UNAUTHENTICATED (bad/expired credentials)
     private static readonly PERMANENT_GRPC_CODES = new Set([3, 7, 16]);
 
+    // Google STT v1 does not accept the common `zh-*` BCP-47 tags — its
+    // supported-languages table lists Mandarin only as `cmn-Hans-CN` (and
+    // Traditional as `cmn-Hant-TW`). The shared RECOGNITION_LANGUAGES map
+    // keeps `zh-CN` because other providers (Deepgram, Soniox) expect it,
+    // so the translation must stay Google-local.
+    private static readonly V1_LANGUAGE_CODE_OVERRIDES: Record<string, string> = {
+        'zh-CN': 'cmn-Hans-CN',
+        'zh-TW': 'cmn-Hant-TW',
+    };
+
+    // Languages the `latest_long` model does not cover in STT v1 (Mandarin
+    // supports only `default`/`command_and_search`). Requesting latest_long
+    // for these returns INVALID_ARGUMENT (gRPC code 3), which
+    // PERMANENT_GRPC_CODES above then escalates to a session-wide STT
+    // shutdown — the "Chinese never transcribes" bug.
+    private static readonly LANGUAGES_WITHOUT_LATEST_LONG = new Set([
+        'cmn-Hans-CN',
+        'cmn-Hant-TW',
+    ]);
+
     // Config
     private encoding = 'LINEAR16' as const;
     private sampleRateHertz = 16000;
@@ -125,8 +145,8 @@ export class GoogleSTT extends EventEmitter {
                     return;
                 }
 
-                console.log(`[GoogleSTT/${this.label}] Updating recognition language to: ${key} (${config.bcp47})`);
-                this.languageCode = config.bcp47;
+                this.languageCode = GoogleSTT.V1_LANGUAGE_CODE_OVERRIDES[config.bcp47] ?? config.bcp47;
+                console.log(`[GoogleSTT/${this.label}] Updating recognition language to: ${key} (${this.languageCode})`);
 
                 if ('alternates' in config) {
                     this.alternativeLanguageCodes = (config as EnglishVariant).alternates;
@@ -364,7 +384,9 @@ export class GoogleSTT extends EventEmitter {
                     audioChannelCount: this.audioChannelCount,
                     languageCode: this.languageCode,
                     enableAutomaticPunctuation: true,
-                    model: 'latest_long',
+                    model: GoogleSTT.LANGUAGES_WITHOUT_LATEST_LONG.has(this.languageCode)
+                        ? 'default'
+                        : 'latest_long',
                     useEnhanced: true,
                     alternativeLanguageCodes: this.alternativeLanguageCodes,
                 },

--- a/electron/audio/__tests__/GoogleSttMandarinLatestLongFallback.test.mjs
+++ b/electron/audio/__tests__/GoogleSttMandarinLatestLongFallback.test.mjs
@@ -1,0 +1,74 @@
+// Regression test for the "Google STT never transcribes when the language
+// is set to Chinese" bug.
+//
+// Symptom: selecting Chinese in Settings maps to bcp47 'zh-CN'
+// (RECOGNITION_LANGUAGES in electron/config/languages.ts), which GoogleSTT
+// forwarded verbatim as languageCode while hardcoding model: 'latest_long'.
+// Google STT v1 accepts Mandarin only as 'cmn-Hans-CN', and latest_long does
+// not cover Mandarin at all — the very first streamingRecognize request
+// failed with INVALID_ARGUMENT (gRPC code 3), which PERMANENT_GRPC_CODES
+// escalated to a session-wide STT shutdown ("disabling STT for this
+// session"). English worked because en-US + latest_long is a valid pair.
+//
+// Fix: GoogleSTT translates zh-* tags to their cmn-* equivalents at
+// setRecognitionLanguage() time (Google-local — other providers still need
+// 'zh-CN'), and startStream() falls back to the 'default' model for
+// languages latest_long does not support.
+//
+// Strategy: structural assertion against GoogleSTT.ts source, matching
+// GoogleSttPendingLanguageChangeCleared.test.mjs.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const gPath = path.resolve(__dirname, '../../../electron/audio/GoogleSTT.ts');
+const gSource = readFileSync(gPath, 'utf8');
+
+function extractMethodBody(methodName) {
+  const re = new RegExp(`(?:^|\\n)\\s*(?:public|private|protected)\\s+(?:async\\s+)?${methodName}\\s*\\([^)]*\\)\\s*(?::[^{]*)?\\{`);
+  const m = re.exec(gSource);
+  assert.ok(m, `could not locate ${methodName} declaration in GoogleSTT.ts`);
+  let i = m.index + m[0].length;
+  let depth = 1;
+  const start = i;
+  while (i < gSource.length && depth > 0) {
+    const ch = gSource[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') depth--;
+    i++;
+  }
+  assert.equal(depth, 0, `unbalanced braces in ${methodName}`);
+  return gSource.slice(start, i - 1);
+}
+
+test('zh-CN is translated to cmn-Hans-CN for Google v1', () => {
+  assert.ok(
+    /'zh-CN'\s*:\s*'cmn-Hans-CN'/.test(gSource),
+    "BUG: V1_LANGUAGE_CODE_OVERRIDES must map 'zh-CN' -> 'cmn-Hans-CN'. Google STT v1 does not list zh-CN as a language code; sending it fails the stream with INVALID_ARGUMENT.",
+  );
+  const setLangBody = extractMethodBody('setRecognitionLanguage');
+  assert.ok(
+    /V1_LANGUAGE_CODE_OVERRIDES\s*\[\s*config\.bcp47\s*\]\s*\?\?\s*config\.bcp47/.test(setLangBody),
+    'BUG: setRecognitionLanguage() must apply V1_LANGUAGE_CODE_OVERRIDES to config.bcp47 before assigning this.languageCode — otherwise the shared zh-CN tag reaches the Google API verbatim.',
+  );
+});
+
+test('startStream() falls back from latest_long for unsupported languages', () => {
+  const startStreamBody = extractMethodBody('startStream');
+  assert.ok(
+    !/model\s*:\s*'latest_long'\s*,/.test(startStreamBody),
+    "BUG: startStream() must not hardcode model: 'latest_long' — Mandarin (cmn-Hans-CN) only supports the 'default' and 'command_and_search' models in STT v1, and an unsupported model+language pair is a permanent gRPC code-3 error that disables STT for the whole session.",
+  );
+  assert.ok(
+    /LANGUAGES_WITHOUT_LATEST_LONG\.has\s*\(\s*this\.languageCode\s*\)/.test(startStreamBody),
+    'BUG: startStream() must consult LANGUAGES_WITHOUT_LATEST_LONG to pick the model per language.',
+  );
+  assert.ok(
+    /'cmn-Hans-CN'/.test(gSource) && /LANGUAGES_WITHOUT_LATEST_LONG\s*=\s*new Set\(/.test(gSource),
+    'sanity: LANGUAGES_WITHOUT_LATEST_LONG must exist and cover cmn-Hans-CN.',
+  );
+});


### PR DESCRIPTION
## Summary

Setting the STT provider to **Google** and the language to **Chinese** produces no transcription at all — the whole meeting runs with zero captions — while English works fine. The failure is silent and total: the first `streamingRecognize` request is rejected and STT is disabled for the rest of the session.

Two independent mismatches in `electron/audio/GoogleSTT.ts` line up only for Chinese:

1. **Wrong language code.** Chinese resolves to `zh-CN` and is sent verbatim as Google's `languageCode`. Google STT v1 has no `zh-CN` — Mandarin is `cmn-Hans-CN`.
2. **Wrong model.** `startStream()` hardcodes `model: 'latest_long'`, which v1 does not support for Mandarin (only `default` / `command_and_search`). English works because `en-US` + `latest_long` is valid.

Either one returns gRPC `INVALID_ARGUMENT` (code 3), which is in `PERMANENT_GRPC_CODES` → `isFatalError = true` → the session's STT is torn down with no retry.

**Fix** (kept inside the Google adapter; shared `RECOGNITION_LANGUAGES` still exposes `zh-CN` because Deepgram/Soniox expect it):
- Translate `zh-CN → cmn-Hans-CN` and `zh-TW → cmn-Hant-TW` in `setRecognitionLanguage()`.
- Fall back to the `default` model for codes `latest_long` doesn't cover; every other language keeps `latest_long` unchanged.

## Type of Change
- 🐛 Bug Fix

## Testing & Environment
- [x] Manual test on **macOS (Apple Silicon)**: Google STT + Chinese, spoke Mandarin in a live meeting — captions now appear, stream logs `lang=cmn-Hans-CN`, no code-3 error; English path re-confirmed unchanged.
- Added `GoogleSttMandarinLatestLongFallback.test.mjs` (source-structure regression, same style as the sibling `GoogleSttPendingLanguageChangeCleared.test.mjs`) — passes with the existing GoogleSTT suite.
- Not physically tested on Windows: pure-TypeScript adapter logic with no platform branches, so behavior is expected to be identical.
