### PR TITLE
Auto Answer setting + Windows-scoped mic VAD (reworks #495)

### DIFF
--- a/electron/IntelligenceEngine.ts
+++ b/electron/IntelligenceEngine.ts
@@ -690,6 +690,29 @@ export class IntelligenceEngine extends EventEmitter {
     }
 
     /**
+     * Gate for the AUTOMATIC post-question trigger (Settings > General → Auto
+     * Answer). Both halves matter, and neither is enforced downstream:
+     *
+     *  - Mode: `runWhatShouldISay` opens with
+     *    `whatToAnswerCancellationToken.abort('superseded')`, so an auto-trigger
+     *    arriving while a manual What-to-Answer press is still streaming would
+     *    kill the answer the user explicitly asked for. 'idle'/'assist' are the
+     *    same states `maybeSpeculate` treats as free.
+     *  - Cooldown: `planSuggestionTrigger` runs `classifyIntent` — a regex pass
+     *    then a zero-shot ONNX classifier — BEFORE `planNextAssistantAction`
+     *    applies this same cooldown and returns `silent: cooldown`. Checking it
+     *    first means the classifier isn't paid for on a turn that cannot answer.
+     *
+     * Manual presses deliberately do NOT consult this: they pass `skipCooldown`
+     * and are allowed to supersede.
+     */
+    canAutoAnswer(): boolean {
+        if (this.activeMode !== 'idle' && this.activeMode !== 'assist') return false;
+        if (Date.now() - this.lastTriggerTime < this.triggerCooldown) return false;
+        return true;
+    }
+
+    /**
      * Handle suggestion trigger from native audio service
      * This is the primary auto-trigger path
      */

--- a/electron/IntelligenceManager.ts
+++ b/electron/IntelligenceManager.ts
@@ -189,6 +189,11 @@ export class IntelligenceManager extends EventEmitter {
         return this.engine.handleSuggestionTrigger(trigger);
     }
 
+    /** Mode + cooldown gate for the Auto Answer trigger. See IntelligenceEngine.canAutoAnswer. */
+    canAutoAnswer(): boolean {
+        return this.engine.canAutoAnswer();
+    }
+
     // ============================================
     // Mode Executors (delegates to engine)
     // ============================================

--- a/electron/intelligence/autoAnswerGate.ts
+++ b/electron/intelligence/autoAnswerGate.ts
@@ -1,0 +1,68 @@
+/**
+ * The decision half of the Auto Answer trigger (Settings > General, default OFF).
+ *
+ * Split out of AppState so every guard is reachable from a test. AppState owns
+ * the timer and the STT wiring; this owns "given the world at the moment the
+ * debounce fired, do we dispatch?" — which is where the failure modes are.
+ *
+ * See AppState.scheduleAutoAnswer for why the trigger is a FINAL interviewer
+ * transcript and not the native VAD's `speech_ended`.
+ */
+
+export interface AutoAnswerGateInput {
+    /** Settings > General → Auto Answer. Off means the hotkey is the only path. */
+    enabled: boolean;
+    /** False once Stop is pressed. The transcript handler still runs during the
+     *  post-Stop drain window, and a finished meeting must not produce an answer. */
+    meetingActive: boolean;
+    /** `_meetingGeneration` read when the debounce was armed... */
+    generationAtSchedule: number;
+    /** ...and read again now. A stop→start inside the debounce window changes it,
+     *  and the pending timer belongs to the meeting that is over. */
+    generationNow: number;
+    /** `getLastInterviewerTurn()` — always a FINAL turn (SessionTracker.addTranscript
+     *  returns null on !final), so an empty value means no question has landed yet. */
+    lastQuestion: string | null | undefined;
+    /** The turn already dispatched, or null. */
+    lastAnsweredQuestion: string | null;
+    /** IntelligenceEngine.canAutoAnswer() — mode + cooldown. */
+    engineAccepting: boolean;
+}
+
+export type AutoAnswerSkipReason =
+    | 'disabled'
+    | 'meeting_inactive'
+    | 'stale_generation'
+    | 'no_question'
+    | 'already_answered'
+    | 'engine_busy_or_cooling';
+
+export type AutoAnswerGateDecision =
+    | { dispatch: true; question: string }
+    | { dispatch: false; reason: AutoAnswerSkipReason };
+
+/**
+ * Pure. Order matters only for which reason is reported; every guard is
+ * independently sufficient to skip.
+ */
+export function evaluateAutoAnswerGate(input: AutoAnswerGateInput): AutoAnswerGateDecision {
+    if (!input.enabled) return { dispatch: false, reason: 'disabled' };
+    if (!input.meetingActive) return { dispatch: false, reason: 'meeting_inactive' };
+    if (input.generationNow !== input.generationAtSchedule) {
+        return { dispatch: false, reason: 'stale_generation' };
+    }
+
+    const question = (input.lastQuestion ?? '').trim();
+    if (!question) return { dispatch: false, reason: 'no_question' };
+
+    // Without this the planner's 3 s cooldown would let one unchanged final turn
+    // be re-answered every time the cooldown lapsed — an interviewer who asks a
+    // question and then thinks out loud would collect a new answer every 3 s.
+    if (question === input.lastAnsweredQuestion) {
+        return { dispatch: false, reason: 'already_answered' };
+    }
+
+    if (!input.engineAccepting) return { dispatch: false, reason: 'engine_busy_or_cooling' };
+
+    return { dispatch: true, question };
+}

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -5800,6 +5800,15 @@ export function initializeIpcHandlers(appState: AppState): void {
     return { success: true };
   });
 
+  safeHandle('get-auto-answer-enabled', async () => {
+    return appState.getAutoAnswerEnabled();
+  });
+
+  safeHandle('set-auto-answer-enabled', async (_, enabled: boolean) => {
+    appState.setAutoAnswerEnabled(enabled);
+    return { success: true };
+  });
+
   safeHandle('get-code-verification', async () => {
     // Default OFF: code verification is currently disabled. Only true when the
     // user has explicitly opted in via Settings → General or env override.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1218,6 +1218,7 @@ import { GoogleSTT } from "./audio/GoogleSTT"
 import { RestSTT } from "./audio/RestSTT"
 import { DeepgramStreamingSTT } from "./audio/DeepgramStreamingSTT"
 import { isIntelligenceFlagEnabled } from "./intelligence/intelligenceFlags"
+import { evaluateAutoAnswerGate } from "./intelligence/autoAnswerGate"
 import { SonioxStreamingSTT } from "./audio/SonioxStreamingSTT"
 import { ElevenLabsStreamingSTT } from "./audio/ElevenLabsStreamingSTT"
 import { OpenAIStreamingSTT } from "./audio/OpenAIStreamingSTT"
@@ -1434,6 +1435,7 @@ export class AppState {
   private _isQuitting: boolean = false;
   private _verboseLogging: boolean = false;
   private _ambientChatEnabled: boolean = false;
+  private _autoAnswerEnabled: boolean = false;
   // Tracks whether STT sample-rate has been applied for the current capture
   // session. Reset on every reconfigureAudio / new pipeline build so the next
   // first-chunk handler reads the freshly-detected native rate.
@@ -1489,7 +1491,8 @@ export class AppState {
     this._verboseLogging = settingsManager.get('verboseLogging') ?? true;
     setVerboseLoggingFlag(this._verboseLogging);
     this._ambientChatEnabled = settingsManager.get('ambientChatEnabled') ?? false;
-    console.log(`[AppState] Initialized with isUndetectable=${this.isUndetectable}, disguiseMode=${this.disguiseMode}, verboseLogging=${this._verboseLogging}, ambientChatEnabled=${this._ambientChatEnabled}`);
+    this._autoAnswerEnabled = settingsManager.get('autoAnswerEnabled') ?? false;
+    console.log(`[AppState] Initialized with isUndetectable=${this.isUndetectable}, disguiseMode=${this.disguiseMode}, verboseLogging=${this._verboseLogging}, ambientChatEnabled=${this._ambientChatEnabled}, autoAnswerEnabled=${this._autoAnswerEnabled}`);
 
     // Context Intelligence debug logging (Developer settings). Bind the level
     // reader + log directory once; precedence (env > setting) and the
@@ -3152,6 +3155,90 @@ export class AppState {
   private _audioTestStarting = false;               // P2-12: in-flight guard against concurrent calls
   private googleSTT: STTProvider | null = null; // Interviewer
   private googleSTT_User: STTProvider | null = null; // User
+  // ── AUTO ANSWER (Settings > General, default OFF) ────────────────────────
+  // `handleSuggestionTrigger` — the method IntelligenceEngine documents as
+  // "the primary auto-trigger path" — had no production caller: the only call
+  // site was the __e2e__:ask harness. The speculative prefetch that runs on
+  // interviewer PARTIALS never reaches the UI by design (runWhatShouldISay
+  // returns silently when `speculative`), it only warms a cache that
+  // handleSuggestionTrigger was supposed to consume. So automatic answers were
+  // dead in production and every answer came from the hotkey.
+  //
+  // The trigger is a FINAL interviewer transcript, NOT the native VAD's
+  // `speech_ended`. Driving it off the VAD fires `speech_hangover` (600 ms for
+  // system audio) + debounce after the audio stops, and `getLastInterviewerTurn()`
+  // only ever returns a FINAL turn (SessionTracker.addTranscript returns null on
+  // !final). For the REST providers `speech_ended` is what *starts* the upload
+  // (RestSTT.notifySpeechEnded), so the final cannot exist yet by construction,
+  // and streaming providers lose the race intermittently. Firing with a stale
+  // turn is worse than not firing: handleSuggestionTrigger Jaccard-compares it
+  // against the in-flight speculative run, rejects on the mismatch, bumps
+  // currentGenerationId — cancelling the correctly-prefetched answer — and then
+  // generates one for the PREVIOUS question.
+  private autoAnswerTimer: NodeJS.Timeout | null = null;
+  // The turn already dispatched. The planner's 3 s cooldown alone would let a
+  // stable last-turn be re-answered every time the cooldown lapsed.
+  private lastAutoAnsweredQuestion: string | null = null;
+  // Long enough for a multi-segment question ("Tell me about a time..." /
+  // "...where you disagreed with your manager") to coalesce into one trigger;
+  // each new final restarts it.
+  private static readonly AUTO_ANSWER_DEBOUNCE_MS = 900;
+
+  private scheduleAutoAnswer(): void {
+    if (!this._autoAnswerEnabled) return;
+    // The transcript handler also runs during the post-Stop drain window
+    // (`_isDraining`); a meeting that is over must not produce a new answer.
+    if (!this.isMeetingActive) return;
+
+    const generation = this._meetingGeneration;
+    if (this.autoAnswerTimer) clearTimeout(this.autoAnswerTimer);
+
+    this.autoAnswerTimer = setTimeout(() => {
+      this.autoAnswerTimer = null;
+      // Every remaining guard lives in evaluateAutoAnswerGate so it is reachable
+      // from a test. The engine half — mode + cooldown — matters because
+      // `runWhatShouldISay` aborts any live What-to-Answer stream with
+      // 'superseded': without it an auto-trigger would kill the answer the user
+      // just requested by hand. The cooldown is consulted HERE rather than left
+      // to the planner because planSuggestionTrigger runs the zero-shot ONNX
+      // intent classifier BEFORE planNextAssistantAction applies that cooldown,
+      // so the classification would be paid for and thrown away.
+      const decision = evaluateAutoAnswerGate({
+        enabled: this._autoAnswerEnabled,
+        meetingActive: this.isMeetingActive,
+        generationAtSchedule: generation,
+        generationNow: this._meetingGeneration,
+        lastQuestion: this.intelligenceManager.getLastInterviewerTurn(),
+        lastAnsweredQuestion: this.lastAutoAnsweredQuestion,
+        engineAccepting: this.intelligenceManager.canAutoAnswer(),
+      });
+      if (!decision.dispatch) {
+        if (this._verboseLogging) console.log(`[Main] Auto Answer skipped: ${decision.reason}`);
+        return;
+      }
+      const lastQuestion = decision.question;
+      this.lastAutoAnsweredQuestion = lastQuestion;
+
+      // The planner still decides whether the turn is answerable at all; this
+      // confidence reflects a completed STT final, not a claim that every
+      // interviewer sentence is a question.
+      void this.intelligenceManager.handleSuggestionTrigger({
+        context: this.intelligenceManager.getFormattedContext(120),
+        lastQuestion,
+        confidence: 0.9,
+      }).catch((error) => {
+        console.warn('[Main] Automatic interviewer answer failed:', error);
+      });
+    }, AppState.AUTO_ANSWER_DEBOUNCE_MS);
+  }
+
+  private cancelAutoAnswer(): void {
+    if (this.autoAnswerTimer) {
+      clearTimeout(this.autoAnswerTimer);
+      this.autoAnswerTimer = null;
+    }
+    this.lastAutoAnsweredQuestion = null;
+  }
 
   private createSTTProvider(speaker: 'interviewer' | 'user'): STTProvider | null {
     const { CredentialsManager } = require('./services/CredentialsManager');
@@ -3344,6 +3431,13 @@ export class AppState {
         sttProvider: effectiveSttId,
         punctuationSource: punctuationSourceFor(effectiveSttId, segment.isFinal),
       });
+
+      // Auto Answer (Settings > General, default OFF): a FINAL interviewer
+      // turn is the trigger — see scheduleAutoAnswer() for why the native
+      // VAD's speech_ended is the wrong seam for this.
+      if (segment.isFinal && speaker === 'interviewer') {
+        this.scheduleAutoAnswer();
+      }
 
       // Feed final transcript to JIT RAG indexer
       if (segment.isFinal && this.ragManager) {
@@ -5754,6 +5848,7 @@ export class AppState {
 
   private async startMeetingTransition(metadata?: any): Promise<void> {
     console.log('[Main] Starting Meeting...', metadata);
+    this.cancelAutoAnswer();
 
     // If a previous endMeeting() is still draining STT in the background, wait
     // for it to finish before we boot a new session — otherwise the BG teardown
@@ -6069,6 +6164,8 @@ export class AppState {
       await this._pendingTeardown?.catch((): void => {});
       return;
     }
+
+    this.cancelAutoAnswer();
     // Cover the window between here and `_pendingTeardown` assignment, during which
     // the new in-flight-audio-init await below yields the event loop.
     this._endMeetingInFlight = true;
@@ -7461,6 +7558,19 @@ export class AppState {
     this._ambientChatEnabled = enabled;
     SettingsManager.getInstance().set('ambientChatEnabled', enabled);
     console.log(`[AppState] ambientChatEnabled set to ${enabled}`);
+  }
+
+  public getAutoAnswerEnabled(): boolean {
+    return this._autoAnswerEnabled;
+  }
+
+  public setAutoAnswerEnabled(enabled: boolean): void {
+    this._autoAnswerEnabled = enabled;
+    SettingsManager.getInstance().set('autoAnswerEnabled', enabled);
+    // Drop anything already armed: turning the toggle off mid-meeting must not
+    // let one more auto-answer land a second later.
+    if (!enabled) this.cancelAutoAnswer();
+    console.log(`[AppState] autoAnswerEnabled set to ${enabled}`);
   }
 
   public setDisguise(mode: 'terminal' | 'settings' | 'activity' | 'none'): void {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -911,6 +911,8 @@ interface ElectronAPI {
   // Ambient AI Chat — when enabled, meetings run without mic/system audio capture
   getAmbientChatEnabled: () => Promise<boolean>;
   setAmbientChatEnabled: (enabled: boolean) => Promise<{ success: boolean }>;
+  getAutoAnswerEnabled: () => Promise<boolean>;
+  setAutoAnswerEnabled: (enabled: boolean) => Promise<{ success: boolean }>;
   getCodeVerification: () => Promise<boolean>;
   setCodeVerification: (enabled: boolean) => Promise<{ success: boolean }>;
   getMeetingRetention: () => Promise<'forever' | '7d' | '30d' | 'never'>;
@@ -2597,6 +2599,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // Ambient AI Chat — when enabled, meetings run without mic/system audio capture
   getAmbientChatEnabled: () => ipcRenderer.invoke('get-ambient-chat-enabled'),
   setAmbientChatEnabled: (enabled: boolean) => ipcRenderer.invoke('set-ambient-chat-enabled', enabled),
+  getAutoAnswerEnabled: () => ipcRenderer.invoke('get-auto-answer-enabled'),
+  setAutoAnswerEnabled: (enabled: boolean) => ipcRenderer.invoke('set-auto-answer-enabled', enabled),
   getCodeVerification: () => ipcRenderer.invoke('get-code-verification'),
   setCodeVerification: (enabled: boolean) => ipcRenderer.invoke('set-code-verification', enabled),
   getMeetingRetention: () => ipcRenderer.invoke('get-meeting-retention'),

--- a/electron/services/SettingsManager.ts
+++ b/electron/services/SettingsManager.ts
@@ -19,6 +19,11 @@ export interface AppSettings {
     // while idle. Off by default — the hotkey's existing behavior is unchanged
     // until the user opts in from Settings > General.
     ambientChatEnabled?: boolean;
+    // Automatic answers after the interviewer finishes a question. Off by
+    // default: until the user opts in from Settings > General, an answer is
+    // produced only by the What-to-Answer hotkey, exactly as before. The
+    // trigger itself lives in AppState.scheduleAutoAnswer().
+    autoAnswerEnabled?: boolean;
     actionButtonMode?: 'recap' | 'brainstorm';
     groqFastTextMode?: boolean;
     codexCliEnabled?: boolean;

--- a/electron/services/__tests__/AutoAnswer.test.mjs
+++ b/electron/services/__tests__/AutoAnswer.test.mjs
@@ -1,0 +1,157 @@
+/**
+ * Auto Answer (Settings > General, default OFF).
+ *
+ * Two halves are covered here:
+ *   1. evaluateAutoAnswerGate — every guard AppState consults when the debounce
+ *      fires. Pure, so each guard gets an isolated case plus a mutation probe
+ *      proving the case is not vacuous.
+ *   2. IntelligenceEngine.canAutoAnswer — the mode + cooldown gate that stops an
+ *      auto-trigger from superseding an in-flight manual What-to-Answer press.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const gatePath = path.resolve(__dirname, '../../../dist-electron/electron/intelligence/autoAnswerGate.js');
+const enginePath = path.resolve(__dirname, '../../../dist-electron/electron/IntelligenceEngine.js');
+const sessionPath = path.resolve(__dirname, '../../../dist-electron/electron/SessionTracker.js');
+const require = createRequire(import.meta.url);
+
+const { evaluateAutoAnswerGate } = require(gatePath);
+
+/** The world in which a dispatch SHOULD happen. Each case below breaks one field. */
+function healthyInput(overrides = {}) {
+  return {
+    enabled: true,
+    meetingActive: true,
+    generationAtSchedule: 7,
+    generationNow: 7,
+    lastQuestion: 'Tell me about a time you disagreed with your manager.',
+    lastAnsweredQuestion: null,
+    engineAccepting: true,
+    ...overrides,
+  };
+}
+
+test('the healthy baseline dispatches — otherwise every case below is vacuous', () => {
+  const decision = evaluateAutoAnswerGate(healthyInput());
+  assert.equal(decision.dispatch, true);
+  assert.equal(decision.question, 'Tell me about a time you disagreed with your manager.');
+});
+
+test('the toggle is the master switch: off means the hotkey stays the only path', () => {
+  assert.deepEqual(
+    evaluateAutoAnswerGate(healthyInput({ enabled: false })),
+    { dispatch: false, reason: 'disabled' },
+  );
+});
+
+test('a meeting that has stopped produces no answer, even mid-drain', () => {
+  // The transcript handler keeps running during the post-Stop `_isDraining`
+  // window so trailing finals are not lost; those finals must not answer.
+  assert.deepEqual(
+    evaluateAutoAnswerGate(healthyInput({ meetingActive: false })),
+    { dispatch: false, reason: 'meeting_inactive' },
+  );
+});
+
+test('a timer armed by a previous meeting cannot fire into the next one', () => {
+  assert.deepEqual(
+    evaluateAutoAnswerGate(healthyInput({ generationAtSchedule: 7, generationNow: 8 })),
+    { dispatch: false, reason: 'stale_generation' },
+  );
+});
+
+test('no final interviewer turn yet means nothing to answer', () => {
+  for (const lastQuestion of [null, undefined, '', '   ']) {
+    assert.deepEqual(
+      evaluateAutoAnswerGate(healthyInput({ lastQuestion })),
+      { dispatch: false, reason: 'no_question' },
+      `expected no_question for ${JSON.stringify(lastQuestion)}`,
+    );
+  }
+});
+
+test('an unchanged turn is answered once, not once per cooldown lapse', () => {
+  const question = 'What is your greatest weakness?';
+  const first = evaluateAutoAnswerGate(healthyInput({ lastQuestion: question }));
+  assert.equal(first.dispatch, true);
+
+  // AppState records the dispatched turn; the same final arriving again (the
+  // interviewer thinking out loud, no new question) must not re-answer.
+  assert.deepEqual(
+    evaluateAutoAnswerGate(healthyInput({ lastQuestion: question, lastAnsweredQuestion: question })),
+    { dispatch: false, reason: 'already_answered' },
+  );
+
+  // A genuinely new question still gets through.
+  assert.equal(
+    evaluateAutoAnswerGate(healthyInput({
+      lastQuestion: 'And how did you resolve it?',
+      lastAnsweredQuestion: question,
+    })).dispatch,
+    true,
+  );
+});
+
+test('dedup compares the trimmed turn, matching what AppState stores', () => {
+  assert.deepEqual(
+    evaluateAutoAnswerGate(healthyInput({
+      lastQuestion: '  Why this role?  ',
+      lastAnsweredQuestion: 'Why this role?',
+    })),
+    { dispatch: false, reason: 'already_answered' },
+  );
+});
+
+test('a busy or cooling engine defers — this is what protects a manual answer', () => {
+  assert.deepEqual(
+    evaluateAutoAnswerGate(healthyInput({ engineAccepting: false })),
+    { dispatch: false, reason: 'engine_busy_or_cooling' },
+  );
+});
+
+// ── IntelligenceEngine.canAutoAnswer ────────────────────────────────────────
+
+async function makeEngine() {
+  const { IntelligenceEngine } = await import(pathToFileURL(enginePath).href);
+  const { SessionTracker } = require(sessionPath);
+  const session = new SessionTracker();
+  const engine = new IntelligenceEngine({ setNegotiationCoachingHandler() {} }, session);
+  return engine;
+}
+
+test('canAutoAnswer accepts an idle engine', async () => {
+  const engine = await makeEngine();
+  engine.lastTriggerTime = 0;
+  assert.equal(engine.canAutoAnswer(), true);
+});
+
+test('canAutoAnswer refuses while a What-to-Answer stream is live', async () => {
+  const engine = await makeEngine();
+  engine.lastTriggerTime = 0;
+
+  // runWhatShouldISay opens with whatToAnswerCancellationToken.abort('superseded'),
+  // so dispatching here would kill the answer the user asked for by hand.
+  engine.activeMode = 'what_to_say';
+  assert.equal(engine.canAutoAnswer(), false);
+
+  // 'assist' is passive observation — the same state maybeSpeculate treats as free.
+  engine.activeMode = 'assist';
+  assert.equal(engine.canAutoAnswer(), true);
+});
+
+test('canAutoAnswer refuses inside the trigger cooldown and recovers after it', async () => {
+  const engine = await makeEngine();
+  engine.activeMode = 'idle';
+
+  engine.lastTriggerTime = Date.now();
+  assert.equal(engine.canAutoAnswer(), false, 'a trigger just fired');
+
+  // triggerCooldown is 3000ms; step just past it without sleeping.
+  engine.lastTriggerTime = Date.now() - 3001;
+  assert.equal(engine.canAutoAnswer(), true, 'cooldown elapsed');
+});

--- a/native-module/src/silence_suppression.rs
+++ b/native-module/src/silence_suppression.rs
@@ -86,10 +86,37 @@ impl SilenceSuppressionConfig {
         }
     }
 
-    /// Create config for microphone (standard).
-    /// Uses Normal VAD mode instead of Aggressive because built-in microphones with heavy
-    /// hardware DSP (like macOS Apple Silicon) sound "unnatural" to strict models (#128).
+    /// Create config for microphone.
+    ///
+    /// PLATFORM SPLIT on stage 2. On macOS the WebRTC VAD stays ON and uses
+    /// Quality mode rather than Aggressive, because built-in microphones with
+    /// heavy hardware DSP (Apple Silicon) sound "unnatural" to strict models
+    /// (#128) — it is the only stage that rejects typing, fans and other
+    /// non-speech, and it also keeps interviewer audio bleeding from the
+    /// speakers back into the mic out of the user's own transcript.
+    ///
+    /// On Windows it is OFF: device DSP routinely pulls normal laptop/headset
+    /// speech below what the VAD will accept, so the gate never opens, the
+    /// channel emits only zero keepalives, and the user sees the misleading
+    /// "Microphone Is Silent" warning. Cloud STT providers run their own
+    /// speech detection, and the adaptive RMS gate below still suppresses a
+    /// genuinely idle microphone.
+    ///
+    /// Note on `speech_threshold_rms`: it is only the INITIAL
+    /// `adaptive_threshold`. The suppressor starts in `Suppressed`, so the
+    /// first non-speech frame overwrites it with
+    /// `max(noise_floor_ema * adaptive_multiplier, adaptive_min_floor)` — with
+    /// `noise_floor_ema` seeded at `adaptive_min_floor`, that is ~59 within one
+    /// frame. Lowering this value therefore does NOT lower the gate; the live
+    /// knobs are `adaptive_min_floor` and `adaptive_multiplier`.
     pub fn for_microphone() -> Self {
+        Self::for_microphone_on(cfg!(target_os = "windows"))
+    }
+
+    /// `for_microphone` with the platform decision injected, so a test on
+    /// EITHER host can exercise BOTH branches. A suite that only covers the
+    /// branch its own OS compiles is not coverage for a platform split.
+    pub fn for_microphone_on(is_windows: bool) -> Self {
         Self {
             speech_threshold_rms: 100.0,
             speech_hangover: Duration::from_millis(500), // increased from 150ms to prevent clipping trailing consonants (s, t, etc)
@@ -98,7 +125,7 @@ impl SilenceSuppressionConfig {
             adaptive_min_floor: 20.0,
             ema_alpha: 0.02,
             native_sample_rate: 48000,
-            use_vad: true,
+            use_vad: !is_windows,
             vad_mode: VadMode::Quality,
         }
     }
@@ -442,5 +469,70 @@ mod tests {
         // Another silent frame should NOT trigger speech_ended again
         let (_, ended) = suppressor.process(&silent_frame);
         assert!(!ended, "Speech_ended should only fire once per transition");
+    }
+
+    /// The mic VAD split is platform-scoped on purpose: Windows device DSP
+    /// starves the VAD ("Microphone Is Silent"), while macOS needs stage 2 to
+    /// reject typing/fans and speaker bleed. A global flip would silently take
+    /// noise rejection away from macOS, so assert BOTH branches here rather
+    /// than only whichever one this build happens to compile.
+    #[test]
+    fn test_microphone_vad_is_platform_scoped() {
+        // BOTH branches, from whichever host runs the suite.
+        assert!(
+            !SilenceSuppressionConfig::for_microphone_on(true).use_vad,
+            "Windows mic must bypass the WebRTC VAD (device DSP starves it)"
+        );
+        assert!(
+            SilenceSuppressionConfig::for_microphone_on(false).use_vad,
+            "non-Windows mic must keep the WebRTC VAD (typing/fan/bleed rejection)"
+        );
+
+        // The live constructor agrees with the branch this build compiled for.
+        assert_eq!(
+            SilenceSuppressionConfig::for_microphone().use_vad,
+            !cfg!(target_os = "windows")
+        );
+
+        // Everything EXCEPT use_vad is shared — the split must not drift into a
+        // second, silently divergent microphone tuning.
+        let win = SilenceSuppressionConfig::for_microphone_on(true);
+        let mac = SilenceSuppressionConfig::for_microphone_on(false);
+        assert_eq!(win.speech_threshold_rms, mac.speech_threshold_rms);
+        assert_eq!(win.speech_hangover, mac.speech_hangover);
+        assert_eq!(win.adaptive_multiplier, mac.adaptive_multiplier);
+        assert_eq!(win.adaptive_min_floor, mac.adaptive_min_floor);
+        assert_eq!(win.ema_alpha, mac.ema_alpha);
+
+        // System audio is VAD-free on every platform (#127); not part of this split.
+        assert!(!SilenceSuppressionConfig::for_system_audio().use_vad);
+    }
+
+    /// Guards the comment on for_microphone(): the initial speech_threshold_rms
+    /// is NOT the gate. One non-speech frame replaces it with the adaptive
+    /// value, which is HIGHER than a "lowered" initial of 50 — the reason the
+    /// 100 -> 50 edit this replaced could not have had the effect it claimed.
+    #[test]
+    fn test_initial_threshold_is_superseded_by_adaptive() {
+        let mut suppressor = SilenceSuppressor::new(SilenceSuppressionConfig {
+            speech_threshold_rms: 50.0,
+            native_sample_rate: 16000,
+            ..SilenceSuppressionConfig::for_microphone()
+        });
+        assert_eq!(suppressor.adaptive_threshold, 50.0, "seeded from the initial value");
+
+        let silent_frame: Vec<i16> = vec![0; 320];
+        let _ = suppressor.process(&silent_frame);
+
+        let expected = (20.0_f32 * 0.98) * 3.0; // ema decays from adaptive_min_floor toward 0
+        assert!(
+            (suppressor.adaptive_threshold - expected).abs() < 0.5,
+            "adaptive threshold {} should have replaced the initial 50.0",
+            suppressor.adaptive_threshold
+        );
+        assert!(
+            suppressor.adaptive_threshold > 50.0,
+            "the adaptive gate sits ABOVE a 'lowered' initial value"
+        );
     }
 }

--- a/src/components/SettingsOverlay.tsx
+++ b/src/components/SettingsOverlay.tsx
@@ -555,6 +555,7 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({
 
     const [verboseLogging, setVerboseLogging] = useState(false);
     const [ambientChatEnabled, setAmbientChatEnabled] = useState(false);
+    const [autoAnswerEnabled, setAutoAnswerEnabled] = useState(false);
     const [meetingRetention, setMeetingRetention] = useState<'forever' | '7d' | '30d' | 'never'>('forever');
     const [showVerboseToast, setShowVerboseToast] = useState(false);
     const [codeVerification, setCodeVerification] = useState(false);
@@ -573,6 +574,7 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({
             window.electronAPI?.getDisguise?.().then(setDisguiseMode).catch(() => { });
             window.electronAPI?.getVerboseLogging?.().then(setVerboseLogging).catch(() => { });
             window.electronAPI?.getAmbientChatEnabled?.().then(setAmbientChatEnabled).catch(() => { });
+            window.electronAPI?.getAutoAnswerEnabled?.().then(setAutoAnswerEnabled).catch(() => { });
             window.electronAPI?.getCodeVerification?.().then((v) => setCodeVerification(v === true)).catch(() => { });
             window.electronAPI?.getMeetingRetention?.().then(setMeetingRetention).catch(() => { });
         }
@@ -2014,6 +2016,29 @@ const SettingsOverlay: React.FC<SettingsOverlayProps> = ({
                                                             window.electronAPI?.setAmbientChatEnabled?.(newState);
                                                         }}
                                                         className={ambientChatEnabled ? 'bg-accent-primary border border-transparent' : 'bg-bg-toggle-switch border border-border-muted'}
+                                                    />
+                                                </div>
+
+                                                {/* Auto Answer */}
+                                                <div className="flex items-center justify-between px-4 py-3">
+                                                    <div className="flex items-center gap-4">
+                                                        <div className="w-10 h-10 bg-bg-item-surface rounded-lg border border-border-subtle text-text-primary flex items-center justify-center shrink-0">
+                                                            <Zap size={20} />
+                                                        </div>
+                                                        <div>
+                                                            <h3 className="text-sm font-bold text-text-primary">{t('Auto Answer')}</h3>
+                                                            <p className="text-xs text-text-secondary mt-0.5">{t('Answer automatically when the interviewer finishes a question, instead of waiting for the hotkey')}</p>
+                                                        </div>
+                                                    </div>
+                                                    <SettingsToggle
+                                                        checked={autoAnswerEnabled}
+                                                        label={t('Auto Answer')}
+                                                        onChange={() => {
+                                                            const newState = !autoAnswerEnabled;
+                                                            setAutoAnswerEnabled(newState);
+                                                            window.electronAPI?.setAutoAnswerEnabled?.(newState);
+                                                        }}
+                                                        className={autoAnswerEnabled ? 'bg-accent-primary border border-transparent' : 'bg-bg-toggle-switch border border-border-muted'}
                                                     />
                                                 </div>
 

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -641,6 +641,8 @@ export interface ElectronAPI {
   // Ambient AI Chat — when enabled, meetings run without mic/system audio capture
   getAmbientChatEnabled: () => Promise<boolean>;
   setAmbientChatEnabled: (enabled: boolean) => Promise<{ success: boolean }>;
+  getAutoAnswerEnabled: () => Promise<boolean>;
+  setAutoAnswerEnabled: (enabled: boolean) => Promise<{ success: boolean }>;
 
   getCodeVerification: () => Promise<boolean>;
   setCodeVerification: (enabled: boolean) => Promise<{ success: boolean }>;


### PR DESCRIPTION
Reworks PR #495. **Default OFF — with the new toggle off, behaviour is exactly what ships today: the What-to-Answer hotkey stays the only path to an answer.**

Rebuilt on current `main` rather than merged, because `main` moved ~14 commits during review and landed the NVIDIA brand mark independently (from lobehub `nvidia-color.svg`, not the simple-icons asset #495 vendored). This branch is 11 files, all additive, and touches nothing else.

#495 should be closed as superseded. Mohak is credited as co-author — the diagnosis was the valuable part of that PR and it was right.

## The bug #495 found

`handleSuggestionTrigger` — the method `IntelligenceEngine` documents as *"the primary auto-trigger path"* — had **no production caller**. The only call site was the `__e2e__:ask` harness. The speculative prefetch that runs on interviewer *partials* never reaches the UI by design (`runWhatShouldISay` returns silently when `speculative`); it only warms a cache `handleSuggestionTrigger` was supposed to consume. Automatic answers were dead and every answer came from the hotkey.

## The trigger, rebuilt

- **Fires on a FINAL interviewer transcript, not the native VAD's `speech_ended`.** `getLastInterviewerTurn()` only ever returns a final turn (`SessionTracker.addTranscript` returns `null` on `!final`), and for the REST providers `speech_ended` is what *starts* the upload (`RestSTT.notifySpeechEnded`). #495's 250 ms post-VAD debounce therefore read the **previous** question by construction on those providers, and raced intermittently on streaming ones.

  Firing stale is worse than not firing: `handleSuggestionTrigger` Jaccard-compares the stale turn against the in-flight speculative run, rejects on the mismatch, bumps `currentGenerationId` — **cancelling the correctly-prefetched answer** — and then generates one for the previous question.
- **900 ms debounce**, restarted by each new final, so a multi-segment question coalesces into one trigger.
- **`IntelligenceEngine.canAutoAnswer()` — mode + cooldown.** `runWhatShouldISay` opens with `whatToAnswerCancellationToken.abort('superseded')`, so without the mode half an auto-trigger would kill the answer the user just requested by hand. The cooldown is consulted here rather than left to the planner because `planSuggestionTrigger` runs the zero-shot ONNX intent classifier *before* `planNextAssistantAction` applies it.
- **Dedup on the dispatched turn** — the planner's 3 s cooldown alone would let one unchanged final be re-answered every time it lapsed — plus a `_meetingGeneration` guard matching the convention used elsewhere in `AppState`.

The decision half is extracted to `electron/intelligence/autoAnswerGate.ts` so every guard is reachable from a test.

## Microphone VAD — scoped to Windows

#495 turned the WebRTC VAD off for **all** microphones to fix a Windows symptom (device DSP pulls speech below what the VAD accepts, the gate never opens, and the user sees "Microphone Is Silent"). Now scoped via an injected flag, so macOS keeps the only stage that rejects typing, fans, and interviewer audio bleeding from the speakers back into the user's own transcript.

#495's `speech_threshold_rms` 100 → 50 edit is **dropped as inert**: it is only the *initial* `adaptive_threshold`, which the first non-speech frame overwrites with `max(noise_floor_ema * adaptive_multiplier, adaptive_min_floor)` ≈ 59 — higher than the "lowered" value. The live knobs are `adaptive_min_floor` and `adaptive_multiplier`.

## Also dropped from #495

- **`NvidiaNimStreamingSTT.ts` entirely.** Everything #495 changed there had already landed in #492 in a stronger form (byte-bounded buffer vs chunk-count, `generation` guards, capped backoff with an attempt ceiling, `resolveLanguageCode`). Its `closing` latch was a regression: `finalize()` set it, only `start()` cleared it, and `finalizeMicSTT()` runs mid-meeting on every manual-answer press — so with NVIDIA NIM selected the first press would kill mic transcription for the rest of the session.
- **The brand-mark files.** `main` landed its own, better-documented version.

## Validation

- `Covered by automated macOS branch tests` — `npm test`: **8121 pass / 3 fail**. All three are pre-existing and environmental: 2 × `OllamaManager` expect a closed port but Ollama runs on this host; 1 × `KnowledgeIngestSpaceMetadata` calls `setEmbedWithMetadataFn`, which exists in `premium` at `ae7b4ba` — the same pointer `main` records — only when the submodule working copy is checked out, and fails on a fresh clone of the pinned tree.
- `Covered by automated macOS branch tests` **and** `Covered by automated Windows branch tests` — the Rust mic split asserts **both** branches through the injected flag, so either host covers both. 5/5 in `silence_suppression`, including a test pinning the adaptive-threshold behaviour that made #495's RMS edit inert.
- 11 new tests for the gate and `canAutoAnswer`, **mutation-probed**: removing the dedup guard reds exactly 2, removing the mode guard reds exactly 1.
- `Build validated on macOS` — `typecheck:electron`, renderer `typecheck`, `build:electron`, `npm run build` all clean.
- `Reviewed but not executed on macOS` — **the trigger wiring itself.** The gate and `canAutoAnswer` are pure and unit-tested; the `AppState` hook that makes them reachable is not, and no test in this repo can fail if that hook is deleted. Confirmed in the built bundle (exactly one `this.scheduleAutoAnswer()` call site, inside the transcript handler, guarded by `segment.isFinal && speaker === "interviewer"`) but **not run against a live meeting**. The passing suite covers decision logic only.
- `Requires physical Windows verification` — that `use_vad: false` actually clears the "Microphone Is Silent" warning. This PR's CI is the first the change has ever seen; #495 was `CONFLICTING`, so its workflows never queued.

## Known residual

`AUTO_ANSWER_DEBOUNCE_MS` restarts on every interviewer final. A provider emitting finals more often than every 900 ms would starve the timer. Not observed with the current providers; a max-wait cap would close it if it shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUVjKg6MFnaYa6XTg74UJH