### PR TITLE
Real brand marks in the model picker (Nvidia and the rest)

### DIFF
--- a/src/assets/provider-logos/README.md
+++ b/src/assets/provider-logos/README.md
@@ -112,17 +112,18 @@ against the dark theme.
 
 Raster marks have no `currentColor` to resolve, so they are imported as URLs and
 rendered with `<img>`. Both consumers split their registries along that line:
-`AIP_PROVIDER_LOGOS` / `AIP_PROVIDER_LOGO_IMAGES` in `AIProvidersSettings.tsx`
-(for `litellm.png`), and `BRAND_MARKS` / `BRAND_MARK_IMAGES` in `BrandMark.tsx`
-(for the Natively app icon). `BrandMark` resolves the vector registry first, so
-an id must not appear in both — the coverage test enforces that.
+`AI_PROVIDER_MARKS` / `AI_PROVIDER_MARK_IMAGES` in `ui/aiProviderMarks.ts` (for
+`litellm.png` and the Natively app icon), and `BRAND_MARKS` /
+`BRAND_MARK_IMAGES` in `BrandMark.tsx`. Both renderers resolve the vector
+registry first, so an id must not appear in both — the coverage test enforces
+that.
 
 ## Colour vs monochrome
 
 The two consumers make opposite choices, for reasons specific to the surface
 each one renders onto. Neither is an inconsistency to be tidied up.
 
-**AI Providers** (`AIP_PROVIDER_LOGOS`) matches each brand: `gemini`, `claude`
+**AI providers** (`AI_PROVIDER_MARKS`) matches each brand: `gemini`, `claude`
 and `deepseek` carry their own colours; `groq`, `openai` and `ollama` are
 `currentColor` because those marks *are* monochrome, so they adapt to the light
 and dark themes for free. Do not "fix" this by tinting the monochrome three or
@@ -174,9 +175,21 @@ inventing a brand colour.
 ## Adding a mark later
 
 Drop the SVG here, add the key to the registry for the surface you are adding to
-— `AIP_PROVIDER_LOGOS` in `src/components/settings/AIProvidersSettings.tsx` for
-AI providers, `BRAND_MARKS` in `src/components/ui/BrandMark.tsx` for speech
+— `AI_PROVIDER_MARKS` in `src/components/ui/aiProviderMarks.ts` for AI/model
+providers, `BRAND_MARKS` in `src/components/ui/BrandMark.tsx` for speech
 providers — and record its source and licence above.
+
+`AI_PROVIDER_MARKS` is ONE registry with two renderers over it, and adding a
+provider to it covers both surfaces at once: `<AipProviderMark>` draws the tiled
+version for Settings > AI Providers (it needs `AIP_CSS`, which is scoped to that
+panel), and `<ProviderMark>` draws the bare glyph everywhere else — currently the
+overlay's model picker. `AIProvidersSettings.tsx` re-exports the maps under their
+original `AIP_*` names, so existing call sites still resolve.
+
+The model picker is why the split exists: it rendered a generic `<Cloud>` glyph
+for every provider except Gemini, so `Nvidia Nim`, `OpenAI`, `Claude`, `DeepSeek`
+and `Groq` all shipped with no brand. `ModelPickerProviderMarkCoverage.test.mjs`
+now fails if a provider reachable from `STANDARD_CLOUD_MODELS` has no mark.
 
 For a speech provider, also set `neutralTile: true` on its option in
 `SettingsOverlay.tsx`, and normalise the asset to `width="1em" height="1em"`

--- a/src/components/__tests__/ModelPickerProviderMarkCoverage.test.mjs
+++ b/src/components/__tests__/ModelPickerProviderMarkCoverage.test.mjs
@@ -1,0 +1,134 @@
+/**
+ * ModelPickerProviderMarkCoverage.test.mjs
+ *
+ * The overlay's model picker used to render
+ *   `provider === 'gemini' ? <Monitor/> : <Cloud/>`
+ * so every Nvidia Nim, OpenAI, Claude, DeepSeek and Groq row shipped with a
+ * generic cloud glyph — the same "everything shares one placeholder" failure the
+ * speech selector had, on a surface nobody was checking.
+ *
+ * This pins the link: every provider STANDARD_CLOUD_MODELS can emit, plus the
+ * Natively row the picker adds itself, must resolve to a real mark in
+ * ui/aiProviderMarks. A new provider added to modelUtils without a mark fails
+ * here instead of shipping as a cloud glyph.
+ *
+ * Source-read rather than import: these are .tsx/.ts with `?raw` asset imports
+ * that only Vite can resolve, so the test parses the registries out of the files.
+ *
+ * Run: `node --test src/components/__tests__/ModelPickerProviderMarkCoverage.test.mjs`
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '../../..');
+const MARKS = join(REPO_ROOT, 'src/components/ui/aiProviderMarks.ts');
+const PICKER = join(REPO_ROOT, 'src/components/ui/ModelSelector.tsx');
+const MODEL_UTILS = join(REPO_ROOT, 'src/utils/modelUtils.ts');
+
+const marksSrc = readFileSync(MARKS, 'utf8');
+const pickerSrc = readFileSync(PICKER, 'utf8');
+const modelUtilsSrc = readFileSync(MODEL_UTILS, 'utf8');
+
+/**
+ * TOP-LEVEL keys of an `export const NAME ... = { ... }` object literal.
+ * Depth-tracked: STANDARD_CLOUD_MODELS nests a config object under each
+ * provider, and a flat line scan would return `ids`/`names`/`pmKey` instead of
+ * the provider ids — which passes the wrong list to the assertion and reds a
+ * healthy tree.
+ */
+function registryKeys(src, name) {
+    const decl = src.indexOf(`export const ${name}`);
+    assert.notEqual(decl, -1, `${name} not found — was it renamed?`);
+    // Skip the type annotation: `Record<string, { ... }> = {` also contains
+    // braces, so anchor on the LAST `= {` that opens the value literal.
+    const open = src.indexOf('= {', decl);
+    assert.notEqual(open, -1, `${name} literal not parseable`);
+
+    const keys = [];
+    let depth = 0;
+    let buf = '';
+    const take = () => {
+        const m = buf.trim().replace(/^\/\/.*$/, '').match(/([A-Za-z0-9_]+)\s*:\s*$/)
+            || buf.trim().match(/^([A-Za-z0-9_]+)\s*:/);
+        if (m && !buf.trim().startsWith('//')) keys.push(m[1]);
+        buf = '';
+    };
+    for (let i = src.indexOf('{', open); i < src.length; i++) {
+        const ch = src[i];
+        if (ch === '{') {
+            if (depth === 1) take();      // `gemini: {` — key precedes the brace
+            else buf = '';
+            depth++;
+            continue;
+        }
+        if (ch === '}') { depth--; buf = ''; if (depth === 0) break; continue; }
+        if (ch === '\n') { if (depth === 1) take(); else buf = ''; continue; }
+        buf += ch;
+    }
+    assert.equal(depth, 0, `${name} braces did not balance`);
+    return keys;
+}
+
+const markKeys = new Set([
+    ...registryKeys(marksSrc, 'AI_PROVIDER_MARKS'),
+    ...registryKeys(marksSrc, 'AI_PROVIDER_MARK_IMAGES'),
+]);
+
+test('the registry is non-empty — otherwise every assertion below is vacuous', () => {
+    assert.ok(markKeys.size >= 8, `expected a populated registry, got ${markKeys.size}`);
+    assert.ok(markKeys.has('nvidia_nim'), 'nvidia_nim must resolve to a mark');
+});
+
+test('every cloud provider the picker can list resolves to a real brand mark', () => {
+    const providers = registryKeys(modelUtilsSrc, 'STANDARD_CLOUD_MODELS');
+    assert.ok(providers.length >= 5, `expected the provider table, got ${providers.length}`);
+
+    const missing = providers.filter(p => !markKeys.has(p));
+    assert.deepEqual(
+        missing, [],
+        `these providers would render the generic <Cloud> fallback: ${missing.join(', ')}. `
+        + 'Add the mark to src/components/ui/aiProviderMarks.ts — see src/assets/provider-logos/README.md.',
+    );
+});
+
+test('the Natively row the picker adds itself also has a mark', () => {
+    assert.match(pickerSrc, /provider: 'natively'/, 'picker no longer adds a natively row — update this test');
+    assert.ok(markKeys.has('natively'), 'natively must resolve to a mark');
+});
+
+test('every registered mark points at an asset that exists on disk', () => {
+    const imports = [...marksSrc.matchAll(/from '(\.\.[^']*provider-logos\/[^']+?)(\?raw)?'/g)].map(m => m[1]);
+    const appIcon = [...marksSrc.matchAll(/from '(\.\.\/\.\.\/\.\.\/assets\/[^']+)'/g)].map(m => m[1]);
+    const all = [...imports, ...appIcon];
+    assert.ok(all.length >= 8, `expected the asset imports, got ${all.length}`);
+    for (const rel of all) {
+        const abs = join(REPO_ROOT, 'src/components/ui', rel);
+        assert.ok(existsSync(abs), `missing asset: ${rel}`);
+    }
+});
+
+test('the picker renders ProviderMark, not a bare glyph ternary', () => {
+    assert.match(
+        pickerSrc,
+        /<ProviderMark\s+provider=\{m\.provider\}/,
+        'the cloud rows must resolve their icon through ProviderMark',
+    );
+    assert.doesNotMatch(
+        pickerSrc,
+        /const icon = m\.provider === 'gemini' \?/,
+        'the generic-glyph ternary is back',
+    );
+});
+
+test('AIProvidersSettings sources the same registry — no second copy to drift', () => {
+    const aip = readFileSync(join(REPO_ROOT, 'src/components/settings/AIProvidersSettings.tsx'), 'utf8');
+    assert.match(aip, /from '\.\.\/ui\/aiProviderMarks'/, 'AI Providers must import the shared registry');
+    assert.doesNotMatch(
+        aip,
+        /export const AIP_PROVIDER_LOGOS: Record<string, string> = \{/,
+        'AIP_PROVIDER_LOGOS was re-declared as its own literal — that is the drift this split removed',
+    );
+});

--- a/src/components/settings/AIProvidersSettings.tsx
+++ b/src/components/settings/AIProvidersSettings.tsx
@@ -17,18 +17,14 @@ import { useToggleInit } from './useToggleInit';
 // is a separate document context, so those would render black and disappear
 // against the dark theme. Inlining lets them inherit the tile's colour and
 // adapt to both themes for free.
-import geminiMark from '../../assets/provider-logos/gemini.svg?raw';
-import claudeMark from '../../assets/provider-logos/claude.svg?raw';
-import deepseekMark from '../../assets/provider-logos/deepseek.svg?raw';
-import groqMark from '../../assets/provider-logos/groq.svg?raw';
-import openaiMark from '../../assets/provider-logos/openai.svg?raw';
-import ollamaMark from '../../assets/provider-logos/ollama.svg?raw';
-import nvidiaMark from '../../assets/provider-logos/nvidia.svg?raw';
-// LiteLLM ships its mark only as a raster favicon (160x160 PNG), so this one is a
-// URL rather than inlined markup. No currentColor to resolve in a PNG, so <img>
-// loses nothing here. Vendored from BerriAI/litellm — MIT, and outside the
-// `enterprise/` directory that their LICENSE carves out.
-import litellmMark from '../../assets/provider-logos/litellm.png';
+// The marks themselves live in ../ui/aiProviderMarks so the overlay's model
+// picker can render the same registry without pulling this panel in. Re-exported
+// below under their original AIP_* names.
+import {
+    AI_PROVIDER_BRANDS,
+    AI_PROVIDER_MARKS,
+    AI_PROVIDER_MARK_IMAGES,
+} from '../ui/aiProviderMarks';
 import { useResolvedTheme } from '../../hooks/useResolvedTheme';
 
 /* ═══════════════════════════════════════════════════════════════════════════
@@ -1099,19 +1095,7 @@ export const CLOUD_PROVIDERS = [
 ];
 export type CloudProviderId = (typeof CLOUD_PROVIDERS)[number]['id'];
 
-export const AIP_PROVIDER_BRANDS: Record<string, { mono: string; brand: string }> = {
-    gemini:   { mono: 'GE', brand: '#7C9CF5' },
-    groq:     { mono: 'GQ', brand: '#F2755C' },
-    openai:   { mono: 'OA', brand: '#10A37F' },
-    claude:   { mono: 'CL', brand: '#D97757' },
-    deepseek: { mono: 'DS', brand: '#4D6BFE' },
-    // Mark is vendored (nvidia.svg), so `mono` is only a safety net; `brand`
-    // still drives the tile wash. Hex is NVIDIA green as shipped in the mark.
-    nvidia_nim: { mono: 'NV', brand: '#76B900' },
-    codex:    { mono: 'CX', brand: '#10A37F' },
-    litellm:  { mono: 'LL', brand: '#8B5CF6' },
-    ollama:   { mono: 'OL', brand: '#9CA3AF' },
-};
+export const AIP_PROVIDER_BRANDS = AI_PROVIDER_BRANDS;
 
 interface AipMonogramProps {
     /** Two letters. Longer strings are clipped to two. */
@@ -1138,21 +1122,9 @@ export const AipMonogram: React.FC<AipMonogramProps> = ({ mono, brand, className
  * `codex` maps to the OpenAI mark because it is the same brand.
  */
 /** Raster marks, rendered as <img>. See AIP_PROVIDER_LOGOS for the inlined SVGs. */
-export const AIP_PROVIDER_LOGO_IMAGES: Record<string, string> = {
-    litellm: litellmMark,
-};
+export const AIP_PROVIDER_LOGO_IMAGES = AI_PROVIDER_MARK_IMAGES;
 
-export const AIP_PROVIDER_LOGOS: Record<string, string> = {
-    gemini: geminiMark,
-    claude: claudeMark,
-    anthropic: claudeMark,
-    deepseek: deepseekMark,
-    groq: groqMark,
-    openai: openaiMark,
-    codex: openaiMark,
-    ollama: ollamaMark,
-    nvidia_nim: nvidiaMark,
-};
+export const AIP_PROVIDER_LOGOS = AI_PROVIDER_MARKS;
 
 interface AipProviderMarkProps {
     /** Provider id. Falls back to a monogram when no mark is vendored. */

--- a/src/components/ui/ModelSelector.tsx
+++ b/src/components/ui/ModelSelector.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { ChevronDown, Check, Cloud, Terminal, Monitor, Server, Plus } from 'lucide-react';
+import { ChevronDown, Check, Cloud, Terminal, Server, Plus } from 'lucide-react';
 import { getCodexCliModelDisplayName, STANDARD_CLOUD_MODELS, prettifyModelId } from '../../utils/modelUtils';
 import { useT } from '../../i18n';
+import { ProviderMark } from './ProviderMark';
 
 interface ModelSelectorProps {
     currentModel: string;
@@ -159,7 +160,12 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({ currentModel, onSe
                                     cloudModels.map((m, idx) => {
                                         const prevProvider = idx > 0 ? cloudModels[idx - 1].provider : null;
                                         const showDivider = prevProvider && prevProvider !== m.provider;
-                                        const icon = m.provider === 'gemini' ? <Monitor size={14} /> : <Cloud size={14} />;
+                                        // Real brand mark per provider. This used to be
+                                        // `provider === 'gemini' ? <Monitor/> : <Cloud/>`, so every
+                                        // Nvidia Nim, OpenAI, Claude, DeepSeek and Groq row shipped
+                                        // with a generic cloud glyph and no brand at all — and even
+                                        // Gemini got a monitor icon rather than its own mark.
+                                        const icon = <ProviderMark provider={m.provider} size={14} fallback={<Cloud size={14} />} />;
                                         return (
                                             <React.Fragment key={m.id}>
                                                 {showDivider && <div className="h-px bg-border-subtle my-1" />}

--- a/src/components/ui/ProviderMark.tsx
+++ b/src/components/ui/ProviderMark.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { AI_PROVIDER_MARKS, AI_PROVIDER_MARK_IMAGES, AI_PROVIDER_BRANDS } from './aiProviderMarks';
+
+interface ProviderMarkProps {
+    /** Provider id, e.g. 'nvidia_nim'. Case-insensitive. */
+    provider: string;
+    /** Rendered size in px. Vendored marks are 1em, so this is applied as font-size. */
+    size?: number;
+    /**
+     * Rendered when the provider has no vendored mark — custom endpoints, local
+     * engines, anything without a licence-clean logo. Required rather than
+     * optional: returning null here is how the model picker ended up with rows
+     * that had no icon at all.
+     */
+    fallback: React.ReactNode;
+    className?: string;
+}
+
+/**
+ * A bare AI-provider mark — no tile, no surface, no border.
+ *
+ * The tile-less twin of <AipProviderMark>, which wraps its mark in `.aip-tile`.
+ * That class is defined in AIP_CSS, a token block scoped to the AI Providers
+ * panel, so the tiled renderer paints as an unstyled box anywhere else. This one
+ * emits only the glyph and is safe in the overlay.
+ *
+ * `dangerouslySetInnerHTML` is safe here and is the point of the `?raw` import:
+ * these are build-time constants vendored from pinned packages and verified to
+ * contain only vector paths — no <script>, no <foreignObject>, no external
+ * references. Nothing user-supplied ever reaches this.
+ */
+export const ProviderMark: React.FC<ProviderMarkProps> = ({ provider, size = 16, fallback, className = '' }) => {
+    const key = (provider || '').toLowerCase();
+    const markup = AI_PROVIDER_MARKS[key];
+    const imageSrc = AI_PROVIDER_MARK_IMAGES[key];
+
+    if (!markup && imageSrc) {
+        return (
+            <img
+                src={imageSrc}
+                alt=""
+                aria-hidden="true"
+                width={size}
+                height={size}
+                className={`object-contain ${className}`}
+            />
+        );
+    }
+
+    if (!markup) return <>{fallback}</>;
+
+    return (
+        <span
+            aria-hidden="true"
+            className={`inline-flex items-center justify-center ${className}`}
+            style={{
+                // The marks are width/height="1em", so font-size IS the size.
+                fontSize: size,
+                lineHeight: 0,
+                // Resolves fill="currentColor" on the monochrome marks. The
+                // full-colour ones (gemini, claude, deepseek, nvidia) carry their
+                // own fills and ignore this entirely.
+                color: AI_PROVIDER_BRANDS[key]?.brand,
+            }}
+            dangerouslySetInnerHTML={{ __html: markup }}
+        />
+    );
+};

--- a/src/components/ui/aiProviderMarks.ts
+++ b/src/components/ui/aiProviderMarks.ts
@@ -1,0 +1,88 @@
+/**
+ * AI-provider brand marks — the single source for every surface that names a
+ * cloud MODEL provider.
+ *
+ * Extracted from AIProvidersSettings.tsx, which still re-exports all three maps
+ * under their original `AIP_*` names. It moved here because a second surface
+ * needs them: the overlay's model picker rendered a generic <Cloud> glyph for
+ * every provider except Gemini, so "Llama 3.1 8B (Nvidia Nim)" and every OpenAI,
+ * Claude, DeepSeek and Groq entry shipped with no brand at all. Duplicating the
+ * registry there is exactly the drift src/assets/provider-logos/README.md warns
+ * about, so there is one map and two renderers over it:
+ *
+ *   <AipProviderMark>  tiled,      Settings > AI Providers (needs AIP_CSS)
+ *   <ProviderMark>     tile-less,  anywhere else (the model picker)
+ *
+ * Adding a provider means adding it HERE, once. See the README for licence rules
+ * and for why some brands stay monograms.
+ *
+ * Imported with `?raw` and inlined rather than used as <img src>: most of these
+ * paint with `fill="currentColor"`, which does not resolve inside an <img> — a
+ * separate document context — so the monochrome marks would render black and
+ * disappear against the dark theme.
+ */
+import geminiMark from '../../assets/provider-logos/gemini.svg?raw';
+import claudeMark from '../../assets/provider-logos/claude.svg?raw';
+import deepseekMark from '../../assets/provider-logos/deepseek.svg?raw';
+import groqMark from '../../assets/provider-logos/groq.svg?raw';
+import openaiMark from '../../assets/provider-logos/openai.svg?raw';
+import ollamaMark from '../../assets/provider-logos/ollama.svg?raw';
+import nvidiaMark from '../../assets/provider-logos/nvidia.svg?raw';
+// LiteLLM ships its mark only as a raster favicon (160x160 PNG), so this one is a
+// URL rather than inlined markup. No currentColor to resolve in a PNG, so <img>
+// loses nothing here. Vendored from BerriAI/litellm — MIT, and outside the
+// `enterprise/` directory that their LICENSE carves out.
+import litellmMark from '../../assets/provider-logos/litellm.png';
+// Our own app icon, for the Natively API row. Raster and full-colour, so it is a
+// URL rendered with <img> for the same reason as litellm.
+import nativelyIcon from '../../../assets/icon-512.png';
+
+/**
+ * Monogram letters + the tile wash colour, for providers with no vendored mark
+ * (and as the safety net behind every provider that has one).
+ */
+export const AI_PROVIDER_BRANDS: Record<string, { mono: string; brand: string }> = {
+    gemini:   { mono: 'GE', brand: '#7C9CF5' },
+    groq:     { mono: 'GQ', brand: '#F2755C' },
+    openai:   { mono: 'OA', brand: '#10A37F' },
+    claude:   { mono: 'CL', brand: '#D97757' },
+    deepseek: { mono: 'DS', brand: '#4D6BFE' },
+    // Mark is vendored (nvidia.svg), so `mono` is only a safety net; `brand`
+    // still drives the tile wash. Hex is NVIDIA green as shipped in the mark.
+    nvidia_nim: { mono: 'NV', brand: '#76B900' },
+    codex:    { mono: 'CX', brand: '#10A37F' },
+    litellm:  { mono: 'LL', brand: '#8B5CF6' },
+    ollama:   { mono: 'OL', brand: '#9CA3AF' },
+    natively: { mono: 'NA', brand: '#7C9CF5' },
+};
+
+/** Raster marks, rendered as <img>. See AI_PROVIDER_MARKS for the inlined SVGs. */
+export const AI_PROVIDER_MARK_IMAGES: Record<string, string> = {
+    litellm: litellmMark,
+    natively: nativelyIcon,
+};
+
+/**
+ * Provider id → inlined brand mark. Absent keys fall through to
+ * AI_PROVIDER_MARK_IMAGES, then to a monogram (tiled renderer) or the caller's
+ * fallback glyph (tile-less renderer). Custom providers are user-defined
+ * endpoints with no brand, so they always land on the fallback.
+ * `codex` maps to the OpenAI mark and `anthropic` to Claude's — same brands.
+ */
+export const AI_PROVIDER_MARKS: Record<string, string> = {
+    gemini: geminiMark,
+    claude: claudeMark,
+    anthropic: claudeMark,
+    deepseek: deepseekMark,
+    groq: groqMark,
+    openai: openaiMark,
+    codex: openaiMark,
+    ollama: ollamaMark,
+    nvidia_nim: nvidiaMark,
+};
+
+/** True when this provider resolves to a real mark rather than a fallback. */
+export const hasAiProviderMark = (provider: string): boolean => {
+    const key = (provider || '').toLowerCase();
+    return Boolean(AI_PROVIDER_MARKS[key] || AI_PROVIDER_MARK_IMAGES[key]);
+};


### PR DESCRIPTION
The model picker had no NVIDIA logo — and no OpenAI, Claude, DeepSeek or Groq logo either. It resolved its icon as:

```tsx
const icon = m.provider === 'gemini' ? <Monitor size={14} /> : <Cloud size={14} />;
```

so every cloud row except Gemini rendered a generic cloud glyph, and Gemini got a monitor icon rather than its own mark. The marks were already vendored and registered — this surface just never looked them up. Same failure the speech selector had before its coverage test, on a surface nobody was checking.

## Why a small refactor rather than a one-liner

`nvidia.svg` and friends were reachable only from `AIP_PROVIDER_LOGOS`, defined *inside* `AIProvidersSettings.tsx` — a large panel component the overlay has no reason to import. Copying the map into `ModelSelector` is exactly the registry drift `src/assets/provider-logos/README.md` warns about, so the registry moves to `src/components/ui/aiProviderMarks.ts` and gets two renderers over it:

| renderer | shape | surface |
|---|---|---|
| `<AipProviderMark>` | tiled | Settings > AI Providers (needs `AIP_CSS`, scoped to that panel) |
| `<ProviderMark>` | bare glyph | everywhere else — currently the model picker |

`AIProvidersSettings` re-exports all three maps under their original `AIP_*` names, so no existing call site changes. Adding a provider is still one edit, now in one file both surfaces read.

Also picks up the Natively app icon for the Natively API row (a cloud glyph before), and drops the now-unused `Monitor` import.

## Regression cover

`ModelPickerProviderMarkCoverage.test.mjs` pins the link that was missing: every provider reachable from `STANDARD_CLOUD_MODELS`, plus the Natively row the picker adds itself, must resolve to a real mark. A provider added to `modelUtils` without one now fails there instead of shipping as a cloud glyph. It also asserts the generic-glyph ternary has not come back, and that `AIProvidersSettings` has not re-grown its own copy of the registry.

Mutation-probed: dropping `nvidia_nim` from the registry reds both the coverage assertion and the anti-vacuity guard.

## Validation

- `Covered by automated macOS branch tests` — `src/components/__tests__`: 94 tests, 92 pass. The 2 failures (`Plans & Billing — composited motion`, `Periwinkle Settings — portal scope guard`) reproduce **identically on clean `origin/main`** with my changes stashed, so they are pre-existing and unrelated.
- `Build validated on macOS` — renderer `typecheck` and `npm run build` clean.
- Rendered and visually confirmed: all seven providers paint their real marks in both themes, NVIDIA in NVIDIA green.
- `Requires physical Windows verification` — none needed; renderer-only, no platform branches touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VUVjKg6MFnaYa6XTg74UJH