### PR TITLE
Fix overlay resizing and narrow layout

### DIFF
--- a/electron/WindowHelper.ts
+++ b/electron/WindowHelper.ts
@@ -403,8 +403,21 @@ export class WindowHelper {
   // EDGE CASE: if the grown window would overflow the work area's right edge,
   // the X clamp below shifts the window left — that one case can show a
   // one-frame shift, same as any clamped move always could.
-  public setOverlayDimensionsAnchored(width: number, height: number): void {
-    if (!this.overlayWindow || this.overlayWindow.isDestroyed()) return;
+  //
+  // RETURNS the size actually APPLIED after clamping. The renderer needs this:
+  // it mirrors the same floor(workArea * 0.9) clamp locally, but the display it
+  // measures (window.screen.availWidth) and the one this method measures
+  // (the work area of the display the window sits on) can disagree — on a
+  // multi-monitor setup they routinely do. Adopting the echoed value keeps the
+  // renderer's panel width, the toggle anchor and the hover-gate margin locked
+  // to the window that actually exists, instead of the one it asked for.
+  public setOverlayDimensionsAnchored(
+    width: number,
+    height: number,
+  ): { width: number; height: number } {
+    if (!this.overlayWindow || this.overlayWindow.isDestroyed()) {
+      return { width, height };
+    }
 
     const currentBounds = this.overlayWindow.getBounds();
     const currentContentSize = this.overlayWindow.getContentSize();
@@ -443,7 +456,7 @@ export class WindowHelper {
         currentContentSize,
         computed: { x: newX, y: newY, width: newWidth, height: newHeight },
       });
-      return;
+      return { width: currentContentSize[0], height: currentContentSize[1] };
     }
 
     // Atomic frame change: a single setBounds avoids the 1-frame split where
@@ -451,19 +464,25 @@ export class WindowHelper {
     // is what causes the shell to visibly slide and snap during code-expansion.
     this.overlayWindow.setBounds({ x: newX, y: newY, width: newWidth, height: newHeight });
     this.overlayBounds = this.overlayWindow.getBounds();
+    const appliedContentSize = this.overlayWindow.getContentSize();
     traceOverlayResize('setOverlayDimensionsAnchored:applied', {
       requested: { width, height },
       appliedBounds: this.overlayBounds,
-      contentSizeAfter: this.overlayWindow.getContentSize(),
+      contentSizeAfter: appliedContentSize,
     });
+    return { width: appliedContentSize[0], height: appliedContentSize[1] };
   }
 
-  // NOTE: the overlay window is a FIXED WIDTH (OVERLAY_DEFAULT_WIDTH = 732)
-  // for its entire visible lifetime; the renderer always reports that fixed
-  // width, so every report here is height-only (width delta 0) — top-anchored,
-  // X never moves, no width setBounds ever. The expand/contract animation is
-  // CSS-only in the renderer (panel tweens 600↔732 centered inside the fixed
-  // window). See NativelyInterface.startTransition for the renderer side.
+  // NOTE: the overlay window's width is FIXED FOR THE WHOLE LIFETIME OF AN
+  // ANIMATION. It is born at OVERLAY_DEFAULT_WIDTH (732) and only ever changes
+  // when the USER drags a resize handle (or on restore of a previously dragged
+  // size) — never during the expand/contract spring, which stays CSS-only in
+  // the renderer (the panel tweens collapsed↔expanded centered inside the
+  // window). So every report arriving here DURING an animation is still
+  // height-only (width delta 0): top-anchored, X never moves, no width
+  // setBounds. See NativelyInterface.startTransition for the renderer side and
+  // src/lib/overlayCustomSize.mjs for why the invariant is per-animation
+  // rather than per-lifetime.
 
   public createWindow(): void {
     if (this.launcherWindow !== null) return; // Already created
@@ -1374,12 +1393,22 @@ export class WindowHelper {
     this.repositionOverlayPopovers();
   }
 
-  // The panel's live LEFT margin inside the fixed window: (732 - panelW)/2,
-  // derived from the streamed togglePanelRight = (732 + panelW)/2. Popover
+  // The panel's live LEFT margin inside the window: (windowW - panelW)/2,
+  // derived from the streamed togglePanelRight = (windowW + panelW)/2. Popover
   // anchors are stored relative to the panel, not the window, so they follow
   // the symmetric width spring.
+  //
+  // Reads the window's LIVE width rather than OVERLAY_DEFAULT_WIDTH: the user
+  // can now resize the overlay, and the renderer streams togglePanelRight
+  // against whatever width the window actually has. Using the constant here
+  // while the renderer used the live width would offset every popover by
+  // (732 - actualWidth) / 2.
   public getOverlayPanelLeftMargin(): number {
-    return Math.max(0, WindowHelper.OVERLAY_DEFAULT_WIDTH - this.togglePanelRight);
+    const windowWidth =
+      this.overlayWindow && !this.overlayWindow.isDestroyed()
+        ? this.overlayWindow.getContentSize()[0]
+        : WindowHelper.OVERLAY_DEFAULT_WIDTH;
+    return Math.max(0, windowWidth - this.togglePanelRight);
   }
 
   // Re-anchor any open overlay popovers (settings / model-selector) to the

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -582,15 +582,19 @@ export function initializeIpcHandlers(appState: AppState): void {
     },
   );
 
-  // X-anchored variant: the window's X origin never moves. The overlay window
-  // is a FIXED WIDTH (WindowHelper.OVERLAY_DEFAULT_WIDTH = 732) and the
-  // renderer always reports that width, so in practice this is a pure
-  // height-only, top-anchored resize. Channel name is historical (it used to
-  // keep the center fixed across width changes).
+  // X-anchored variant: the window's X origin never moves. The renderer reports
+  // the WINDOW width (which only changes when the user drags a resize handle),
+  // so during an expand/collapse animation this is a pure height-only,
+  // top-anchored resize. Channel name is historical (it used to keep the center
+  // fixed across width changes).
+  //
+  // RESOLVES with the size actually applied after the main-process clamp, so
+  // the renderer can adopt it instead of drifting from the real window. See
+  // WindowHelper.setOverlayDimensionsAnchored.
   safeHandle(
     'update-content-dimensions-centered',
     async (event, { width, height }: { width: number; height: number }) => {
-      if (!width || !height) return;
+      if (!width || !height) return undefined;
       const senderWebContents = event.sender;
       const overlayWin = appState.getWindowHelper().getOverlayWindow();
       if (
@@ -598,8 +602,9 @@ export function initializeIpcHandlers(appState: AppState): void {
         !overlayWin.isDestroyed() &&
         overlayWin.webContents.id === senderWebContents.id
       ) {
-        appState.getWindowHelper().setOverlayDimensionsAnchored(width, height);
+        return appState.getWindowHelper().setOverlayDimensionsAnchored(width, height);
       }
+      return undefined;
     },
   );
 
@@ -703,11 +708,11 @@ export function initializeIpcHandlers(appState: AppState): void {
     appState.getWindowHelper().isOverlayGroupDragManaged(),
   );
 
-  // (Removed) 'animate-overlay-width' — the overlay window is a FIXED WIDTH
-  // (WindowHelper.OVERLAY_DEFAULT_WIDTH = 732) and is NEVER width-resized.
-  // The expand/contract animation is CSS-only in the renderer (the panel
-  // tweens 600↔732 centered inside the fixed window), so every
-  // 'update-content-dimensions-centered' report is height-only — a
+  // (Removed) 'animate-overlay-width' — the overlay window's width changes ONLY
+  // on an explicit user resize, never as part of the expand/contract animation.
+  // That animation is CSS-only in the renderer (the panel tweens
+  // collapsed↔expanded centered inside the window), so every
+  // 'update-content-dimensions-centered' report during it is height-only — a
   // top-anchored resize that does not move X. No sideways jump, no per-frame
   // transparent-window re-raster. See NativelyInterface.startTransition.
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -17,7 +17,10 @@ interface DomCaptureMeta {
 // Types for the exposed Electron API
 interface ElectronAPI {
   updateContentDimensions: (dimensions: { width: number; height: number }) => Promise<void>;
-  updateContentDimensionsCentered: (dimensions: { width: number; height: number }) => Promise<void>;
+  updateContentDimensionsCentered: (dimensions: {
+    width: number;
+    height: number;
+  }) => Promise<{ width: number; height: number } | undefined>;
   sendOverlayUiState: (state: Record<string, unknown>) => Promise<void>;
   onOverlayUiState: (callback: (state: Record<string, unknown>) => void) => () => void;
   sendOverlayToggleAnchor: (payload: { panelRight: number }) => Promise<void>;

--- a/src/components/NativelyInterface.tsx
+++ b/src/components/NativelyInterface.tsx
@@ -2060,6 +2060,19 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
   // on every frame (correct at every in-between width — no clip/scale/transform).
   // Only HEIGHT flows to the OS, via the ResizeObserver / reportShellSize (and
   // a rate-limited channel during the tween).
+  const savedCustomWidth = (() => {
+    try {
+      const value = Number(localStorage.getItem('natively_custom_overlay_width'));
+      return Number.isFinite(value) && value >= 360 && value <= 2500 ? value : null;
+    } catch { return null; }
+  })();
+  const savedCustomHeight = (() => {
+    try {
+      const value = Number(localStorage.getItem('natively_custom_overlay_height'));
+      return Number.isFinite(value) && value >= 180 && value <= 2500 ? value : null;
+    } catch { return null; }
+  })();
+
   const SHELL_WIDTH_COLLAPSED = 600;
   const SHELL_WIDTH_EXPANDED = 732;
   // The OS overlay window's FIXED width. MUST equal
@@ -2068,7 +2081,9 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
   // window edge-to-edge when expanded; the old 780 gutter existed only for
   // the resize toggle, which now has its own aux window).
   const OVERLAY_WINDOW_WIDTH = SHELL_WIDTH_EXPANDED;
-  const shellWidth = useMotionValue(SHELL_WIDTH_COLLAPSED);
+  const shellWidth = useMotionValue(savedCustomWidth || SHELL_WIDTH_COLLAPSED);
+  const customOverlayHeightRef = useRef<number | null>(savedCustomHeight);
+  const [customOverlayHeight, setCustomOverlayHeight] = useState<number | null>(savedCustomHeight);
   // Vertical budget cap for the chat scroll area. Default Infinity = "not yet
   // measured / unbounded", so the width-derived aesthetic max applies until we
   // know the display height. measureVerticalCap (below) sets the real value:
@@ -2084,17 +2099,15 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
   // spring runs (widthDerivedScrollMax: 320px collapsed → 560px expanded), so the
   // visible chat region tracks the panel size frame-for-frame. This is a motion
   // value bound to a style, so it updates without a React re-render.
-  const scrollMaxH = useTransform([shellWidth, verticalCap], ([w, cap]: number[]) =>
-    // Pass the real collapsed/expanded panel widths so the 320→560 scroll-height
-    // ramp reaches its max at the actual expanded width (732), not the default 780.
-    Math.min(
-      widthDerivedScrollMax(w, {
-        collapsedWidth: SHELL_WIDTH_COLLAPSED,
-        expandedWidth: SHELL_WIDTH_EXPANDED,
-      }),
-      cap,
-    ),
-  );
+  const scrollMaxH = useTransform([shellWidth, verticalCap], ([w, cap]: number[]) => {
+    const baseMax = customOverlayHeight
+      ? Math.max(200, customOverlayHeight - 160)
+      : widthDerivedScrollMax(w, {
+          collapsedWidth: SHELL_WIDTH_COLLAPSED,
+          expandedWidth: SHELL_WIDTH_EXPANDED,
+        });
+    return Math.min(baseMax, cap);
+  });
   // NOTE: the resize toggle and the TopPill no longer render in this window at
   // all — each lives in its OWN tiny BrowserWindow (see
   // WindowHelper.createOverlayAuxWindows + OverlayAuxWindows.tsx), positioned
@@ -2380,12 +2393,8 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
     // clock — the startup shake. Layout height is immune to descendant
     // transforms, so genuine content growth still flows through while the
     // entry flourish stays purely compositor-side.
-    // The OS window is a FIXED WIDTH (OVERLAY_WINDOW_WIDTH = 732) and never
-    // width-resizes — ALWAYS report that fixed width, never the live
-    // in-between CSS shell width. setOverlayDimensionsAnchored therefore sees
-    // widthDelta 0 on every call: a pure height-only, top-anchored resize.
-    const width = OVERLAY_WINDOW_WIDTH;
-    const height = contentRef.current.offsetHeight;
+    const width = Math.round(shellWidth.get()) || OVERLAY_WINDOW_WIDTH;
+    const height = customOverlayHeightRef.current || contentRef.current.offsetHeight;
     if (process.env.NODE_ENV === 'development') {
       const scrollEl = scrollContainerRef.current;
       console.log('[overlay-resize] reportShellSize', {
@@ -2404,7 +2413,7 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
       window.electronAPI?.updateContentDimensions({ width, height });
     }
     syncStreamingHeightBaseline(height);
-  }, [attachedContext.length, OVERLAY_WINDOW_WIDTH, syncStreamingHeightBaseline]);
+  }, [attachedContext.length, OVERLAY_WINDOW_WIDTH, shellWidth, syncStreamingHeightBaseline]);
 
   // Compute the vertical budget cap for the chat scroll area and push it into
   // the `verticalCap` motion value (which scrollMaxH mins against the
@@ -2551,16 +2560,16 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
   const resizeOverlayWindow = useCallback(
     (height: number) => {
       if (height <= 0) return;
-      // Width is ALWAYS the fixed window width → widthDelta 0 in the main
-      // process; this collapses to a pure height-only resize.
+      const width = Math.round(shellWidth.get()) || OVERLAY_WINDOW_WIDTH;
+      const targetHeight = customOverlayHeightRef.current || height;
       const api = window.electronAPI as any;
       if (api?.updateContentDimensionsCentered) {
-        api.updateContentDimensionsCentered({ width: OVERLAY_WINDOW_WIDTH, height });
+        api.updateContentDimensionsCentered({ width, height: targetHeight });
       } else {
-        window.electronAPI?.updateContentDimensions({ width: OVERLAY_WINDOW_WIDTH, height });
+        window.electronAPI?.updateContentDimensions({ width, height: targetHeight });
       }
     },
-    [OVERLAY_WINDOW_WIDTH],
+    [OVERLAY_WINDOW_WIDTH, shellWidth],
   );
 
   // Height channel used by the ResizeObserver WHILE a message is actively
@@ -2818,6 +2827,64 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
     manualWidthOverrideRef.current = target;
     startTransition(target);
   }, [shellWidth, startTransition, SHELL_WIDTH_COLLAPSED, SHELL_WIDTH_EXPANDED]);
+
+  // Free-form resize handles. Pointer events are used as the single input
+  // path so Windows does not start duplicate pointer/mouse drag sessions.
+  const isResizingRef = useRef(false);
+  const handleResizePointerDown = useCallback(
+    (direction: 'se' | 'sw' | 'e' | 'w' | 's', e: React.PointerEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      try { e.currentTarget.setPointerCapture(e.pointerId); } catch {}
+
+      const startX = e.clientX;
+      const startY = e.clientY;
+      const startW = Math.round(shellWidth.get()) || SHELL_WIDTH_COLLAPSED;
+      const startH = contentRef.current?.offsetHeight ?? 400;
+      isResizingRef.current = true;
+      heightReportSuppressedUntilRef.current = Date.now() + 100000;
+
+      const move = (event: PointerEvent) => {
+        if (!isResizingRef.current) return;
+        const dx = event.clientX - startX;
+        const dy = event.clientY - startY;
+        const maxW = Math.max(732, (window.screen?.availWidth || 1920) - 40);
+        const maxH = Math.max(360, (window.screen?.availHeight || 1080) - 40);
+        const nextW = Math.max(360, Math.min(maxW, startW + (direction === 'w' || direction === 'sw' ? -dx : dx)));
+        const nextH = direction === 'se' || direction === 'sw' || direction === 's'
+          ? Math.max(180, Math.min(maxH, startH + dy))
+          : startH;
+        shellWidth.set(nextW);
+        manualWidthOverrideRef.current = nextW;
+        customOverlayHeightRef.current = nextH;
+        setCustomOverlayHeight(nextH);
+        const api = window.electronAPI as any;
+        api?.updateContentDimensionsCentered?.({ width: Math.round(nextW), height: Math.round(nextH) });
+      };
+
+      const end = () => {
+        if (!isResizingRef.current) return;
+        isResizingRef.current = false;
+        heightReportSuppressedUntilRef.current = 0;
+        window.removeEventListener('pointermove', move, true);
+        window.removeEventListener('pointerup', end, true);
+        window.removeEventListener('pointercancel', end, true);
+        const finalW = Math.round(shellWidth.get());
+        const finalH = customOverlayHeightRef.current || startH;
+        try {
+          localStorage.setItem('natively_custom_overlay_width', String(finalW));
+          localStorage.setItem('natively_custom_overlay_height', String(finalH));
+        } catch {}
+        const api = window.electronAPI as any;
+        api?.updateContentDimensionsCentered?.({ width: finalW, height: finalH });
+      };
+
+      window.addEventListener('pointermove', move, { passive: false, capture: true });
+      window.addEventListener('pointerup', end, { capture: true });
+      window.addEventListener('pointercancel', end, { capture: true });
+    },
+    [SHELL_WIDTH_COLLAPSED, shellWidth],
+  );
 
   // ── Aux-window bridge ─────────────────────────────────────────────────────
   // The TopPill and resize toggle live in their own BrowserWindows. Broadcast
@@ -8783,7 +8850,7 @@ Provide only the answer, nothing else.`;
                   )}
                 </AnimatePresence>
                 <div
-                  className={`flex flex-nowrap justify-center items-center gap-1.5 px-4 pb-3 overflow-x-hidden ${rollingTranscript && showTranscript ? 'pt-1' : 'pt-3'}`}
+                  className={`flex flex-wrap justify-center items-center gap-1.5 px-4 pb-3 max-w-full overflow-visible ${rollingTranscript && showTranscript ? 'pt-1' : 'pt-3'}`}
                 >
                 <button
                   onClick={handleWhatToSay}
@@ -9068,9 +9135,10 @@ Provide only the answer, nothing else.`;
 
                   {/* Custom Rich Placeholder */}
                   {!inputValue && (
-                    <div className="absolute left-3 top-1/2 -translate-y-1/2 flex items-center gap-1.5 pointer-events-none text-[13px] overlay-text-muted">
-                      <span>{t('Ask anything on screen or conversation, or')}</span>
-                      <div className="flex items-center gap-1 opacity-80">
+                    <div className="absolute inset-x-3 top-1/2 -translate-y-1/2 min-w-0 overflow-hidden whitespace-nowrap pointer-events-none text-[13px] overlay-text-muted">
+                      <span className="overlay-input-placeholder-full inline-flex items-center gap-1.5">
+                        <span>{t('Ask anything on screen or conversation, or')}</span>
+                      <span className="flex items-center gap-1 opacity-80">
                         {(
                           shortcuts.selectiveScreenshot || [getModifierSymbol('cmd'), 'Shift', 'H']
                         ).map((key, i) => (
@@ -9084,8 +9152,10 @@ Provide only the answer, nothing else.`;
                             </kbd>
                           </React.Fragment>
                         ))}
-                      </div>
+                      </span>
                       <span>{t('for selective screenshot')}</span>
+                      </span>
+                      <span className="overlay-input-placeholder-compact">{t('Ask anything…')}</span>
                     </div>
                   )}
 
@@ -9244,6 +9314,39 @@ Provide only the answer, nothing else.`;
                   </button>
                 </div>
               </div>
+
+              {/* Multi-direction resize handles: the renderer changes the
+                  panel width/height; the native overlay remains stable. */}
+              <div
+                data-resize-handle="e"
+                className="resize-handle absolute top-4 bottom-4 right-0 z-50 w-4 no-drag touch-none"
+                onPointerDown={(e) => handleResizePointerDown('e', e)}
+                title={t('Drag to resize width')}
+              />
+              <div
+                data-resize-handle="w"
+                className="resize-handle absolute top-4 bottom-4 left-0 z-50 w-4 no-drag touch-none"
+                onPointerDown={(e) => handleResizePointerDown('w', e)}
+                title={t('Drag to resize width')}
+              />
+              <div
+                data-resize-handle="s"
+                className="resize-handle absolute bottom-0 left-8 right-8 z-50 h-4 no-drag touch-none"
+                onPointerDown={(e) => handleResizePointerDown('s', e)}
+                title={t('Drag to resize height')}
+              />
+              <div
+                data-resize-handle="sw"
+                className="resize-handle absolute bottom-0 left-0 z-50 h-8 w-8 no-drag touch-none"
+                onPointerDown={(e) => handleResizePointerDown('sw', e)}
+                title={t('Drag to resize')}
+              />
+              <div
+                data-resize-handle="se"
+                className="resize-handle absolute bottom-0 right-0 z-50 h-9 w-9 no-drag touch-none"
+                onPointerDown={(e) => handleResizePointerDown('se', e)}
+                title={t('Drag to resize')}
+              />
             </motion.div>
           </motion.div>
       {/* end always-mounted shell */}

--- a/src/components/NativelyInterface.tsx
+++ b/src/components/NativelyInterface.tsx
@@ -273,6 +273,18 @@ import {
   splitStreamingCodeLines,
 } from '../lib/overlayStreamingCodeUi.mjs';
 import { widthDerivedScrollMax, verticalScrollCap } from '../lib/overlayScrollBudget.mjs';
+import {
+  OVERLAY_DEFAULT_WINDOW_WIDTH,
+  readCustomOverlaySize,
+  writeCustomOverlaySize,
+  clearCustomOverlaySize,
+  maxWindowWidthFor,
+  maxWindowHeightFor,
+  collapsedWidthFor,
+  OVERLAY_MIN_WINDOW_HEIGHT,
+  computeResizeFrame,
+  type OverlayResizeDirection,
+} from '../lib/overlayCustomSize.mjs';
 import { resolveChatStreamToken, resolveChatStreamDone, resolveLiveAnswerBatch, resolveChatStreamSurfaceError } from '../lib/chatStreamGuard.mjs';
 import {
   applyFirstStreamingToken,
@@ -1621,6 +1633,9 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
   // freeze height reporting. A deadline lapses on its own. Set to 0 to release
   // immediately (session reset).
   const heightReportSuppressedUntilRef = useRef(0);
+  // True for the duration of a user resize drag. Declared up here because the
+  // ResizeObserver (above the drag handler) gates its height reporting on it.
+  const isResizingRef = useRef(false);
   // ── Streaming-height headroom-buffer state ────────────────────────────
   // See STREAMING_HEIGHT_GROW_BUFFER_PX's comment near the top of this file
   // for the full rationale (an earlier springed/interpolated version of this
@@ -2060,30 +2075,54 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
   // on every frame (correct at every in-between width — no clip/scale/transform).
   // Only HEIGHT flows to the OS, via the ResizeObserver / reportShellSize (and
   // a rate-limited channel during the tween).
-  const savedCustomWidth = (() => {
-    try {
-      const value = Number(localStorage.getItem('natively_custom_overlay_width'));
-      return Number.isFinite(value) && value >= 360 && value <= 2500 ? value : null;
-    } catch { return null; }
-  })();
-  const savedCustomHeight = (() => {
-    try {
-      const value = Number(localStorage.getItem('natively_custom_overlay_height'));
-      return Number.isFinite(value) && value >= 180 && value <= 2500 ? value : null;
-    } catch { return null; }
-  })();
+  // The user's persisted overlay size, read ONCE via a lazy initialiser — this
+  // component re-renders on every streaming token, so a bare localStorage read
+  // in the body would run thousands of times per answer for a value only the
+  // mount uses.
+  const [restoredOverlaySize] = useState(() =>
+    readCustomOverlaySize(typeof window !== 'undefined' ? window.localStorage : null),
+  );
+  // ── Overlay window size ───────────────────────────────────────────────────
+  // The OS window's width used to be a compile-time constant (732). It is now a
+  // value the USER can change by dragging a resize handle — but it is still
+  // FIXED for the entire lifetime of an expand/collapse spring, so there is
+  // still no width setBounds during an animation (the flicker that the old
+  // fixed-width design existed to prevent).
+  //
+  // Critically, this is the SINGLE SOURCE OF TRUTH: the three consumers that
+  // derive geometry from the window width — the toggle aux window's anchor
+  // (sendOverlayToggleAnchor below), the settings/model popover margin
+  // (WindowHelper.getOverlayPanelLeftMargin) and the click-through hover gate —
+  // all read it, so they cannot disagree about how wide the window is.
+  // See src/lib/overlayCustomSize.mjs for the full rationale.
+  const [customWindowWidth, setCustomWindowWidth] = useState<number | null>(
+    restoredOverlaySize.width,
+  );
+  // The pinned window HEIGHT is a ref, not state: nothing RENDERS from it (the
+  // scroll budget flows through the `verticalCap` motion value, and the size
+  // reporters read it imperatively), so holding it in state would only add a
+  // re-render of this whole component on every frame of a height drag.
+  const customOverlayHeightRef = useRef<number | null>(restoredOverlaySize.height);
 
-  const SHELL_WIDTH_COLLAPSED = 600;
-  const SHELL_WIDTH_EXPANDED = 732;
-  // The OS overlay window's FIXED width. MUST equal
-  // WindowHelper.OVERLAY_DEFAULT_WIDTH (the window's birth width — the
-  // startup-slide invariant) and SHELL_WIDTH_EXPANDED (the panel fills the
-  // window edge-to-edge when expanded; the old 780 gutter existed only for
-  // the resize toggle, which now has its own aux window).
+  // The panel fills the window when expanded; the collapsed width scales with
+  // it. collapsedWidthFor(732) === 600 exactly, so with no custom size these
+  // are bit-identical to the constants they replace. Recomputed per render like
+  // the old literals were — every dependency array that listed the literals
+  // already lists these, so no memoisation is needed or wanted.
+  const SHELL_WIDTH_EXPANDED = customWindowWidth ?? OVERLAY_DEFAULT_WINDOW_WIDTH;
+  const SHELL_WIDTH_COLLAPSED = collapsedWidthFor(SHELL_WIDTH_EXPANDED);
+  // The OS overlay window's width. Equals SHELL_WIDTH_EXPANDED always (the
+  // panel fills the window edge-to-edge when expanded), and at its default
+  // equals WindowHelper.OVERLAY_DEFAULT_WIDTH (the window's birth width — the
+  // startup-slide invariant).
   const OVERLAY_WINDOW_WIDTH = SHELL_WIDTH_EXPANDED;
-  const shellWidth = useMotionValue(savedCustomWidth || SHELL_WIDTH_COLLAPSED);
-  const customOverlayHeightRef = useRef<number | null>(savedCustomHeight);
-  const [customOverlayHeight, setCustomOverlayHeight] = useState<number | null>(savedCustomHeight);
+  // The PANEL always starts COLLAPSED. A restored custom size sizes the
+  // WINDOW, not the panel's expand state — seeding the panel with the window
+  // width would boot it visually expanded while codeExpandedRef and
+  // isShellWide both still read "collapsed".
+  const shellWidth = useMotionValue(
+    collapsedWidthFor(restoredOverlaySize.width ?? OVERLAY_DEFAULT_WINDOW_WIDTH),
+  );
   // Vertical budget cap for the chat scroll area. Default Infinity = "not yet
   // measured / unbounded", so the width-derived aesthetic max applies until we
   // know the display height. measureVerticalCap (below) sets the real value:
@@ -2099,15 +2138,21 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
   // spring runs (widthDerivedScrollMax: 320px collapsed → 560px expanded), so the
   // visible chat region tracks the panel size frame-for-frame. This is a motion
   // value bound to a style, so it updates without a React re-render.
-  const scrollMaxH = useTransform([shellWidth, verticalCap], ([w, cap]: number[]) => {
-    const baseMax = customOverlayHeight
-      ? Math.max(200, customOverlayHeight - 160)
-      : widthDerivedScrollMax(w, {
-          collapsedWidth: SHELL_WIDTH_COLLAPSED,
-          expandedWidth: SHELL_WIDTH_EXPANDED,
-        });
-    return Math.min(baseMax, cap);
-  });
+  // A user-pinned window height does NOT get its own branch here: it is folded
+  // into `verticalCap` by measureVerticalCap, which already knows the measured
+  // chrome height. That keeps one code path, reuses the tested
+  // verticalScrollCap helper instead of an ad-hoc `height - 160`, and — because
+  // verticalCap is a motion value — makes a pure-height drag (the `s` handle,
+  // which never changes shellWidth) actually recompute the scroll budget.
+  const scrollMaxH = useTransform([shellWidth, verticalCap], ([w, cap]: number[]) =>
+    Math.min(
+      widthDerivedScrollMax(w, {
+        collapsedWidth: SHELL_WIDTH_COLLAPSED,
+        expandedWidth: SHELL_WIDTH_EXPANDED,
+      }),
+      cap,
+    ),
+  );
   // NOTE: the resize toggle and the TopPill no longer render in this window at
   // all — each lives in its OWN tiny BrowserWindow (see
   // WindowHelper.createOverlayAuxWindows + OverlayAuxWindows.tsx), positioned
@@ -2385,6 +2430,12 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
     // window to re-rasterize in the background. Re-enabled the moment
     // isExpanded flips back to true.
     if (!isExpandedRef.current) return;
+    // A user resize drag owns the size channel for its duration: it reports at
+    // its own ~30fps cadence. Without this guard, every setCustomWindowWidth
+    // during the drag changes this callback's identity, re-runs the sizing
+    // effect, and fires a SECOND rAF-scheduled report per frame against the
+    // same window.
+    if (isResizingRef.current) return;
     // offsetHeight is the LAYOUT (untransformed) border-box height. We must NOT
     // use getBoundingClientRect().height here: that returns the POST-transform
     // box, so the shell's scale 0.95→1 / y 20→0 entry animation would feed a
@@ -2393,7 +2444,15 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
     // clock — the startup shake. Layout height is immune to descendant
     // transforms, so genuine content growth still flows through while the
     // entry flourish stays purely compositor-side.
-    const width = Math.round(shellWidth.get()) || OVERLAY_WINDOW_WIDTH;
+    // The WINDOW width — never the live CSS panel width. The panel tweens
+    // inside the window; reporting its in-between width would push a native
+    // width setBounds on every frame of the spring (re-rastering a transparent
+    // blurred window) and would desynchronise the toggle anchor, the popover
+    // margin and the hover gate, all of which are computed against the window.
+    const width = OVERLAY_WINDOW_WIDTH;
+    // A user-pinned height wins over measured content: the chat scrolls inside
+    // the chosen size rather than growing the window (measureVerticalCap has
+    // already bounded the scroll area to match).
     const height = customOverlayHeightRef.current || contentRef.current.offsetHeight;
     if (process.env.NODE_ENV === 'development') {
       const scrollEl = scrollContainerRef.current;
@@ -2406,14 +2465,13 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
         screenAvailHeight: window.screen?.availHeight,
       });
     }
-    const api = window.electronAPI as any;
-    if (api?.updateContentDimensionsCentered) {
-      api.updateContentDimensionsCentered({ width, height });
+    if (window.electronAPI?.updateContentDimensionsCentered) {
+      void window.electronAPI.updateContentDimensionsCentered({ width, height });
     } else {
-      window.electronAPI?.updateContentDimensions({ width, height });
+      void window.electronAPI?.updateContentDimensions({ width, height });
     }
     syncStreamingHeightBaseline(height);
-  }, [attachedContext.length, OVERLAY_WINDOW_WIDTH, shellWidth, syncStreamingHeightBaseline]);
+  }, [attachedContext.length, OVERLAY_WINDOW_WIDTH, syncStreamingHeightBaseline]);
 
   // Compute the vertical budget cap for the chat scroll area and push it into
   // the `verticalCap` motion value (which scrollMaxH mins against the
@@ -2438,7 +2496,14 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
     }
     const availHeight = typeof window !== 'undefined' ? window.screen?.availHeight ?? 0 : 0;
     const chromeHeight = contentEl.offsetHeight - scrollEl.clientHeight;
-    const nextCap = verticalScrollCap({ availHeight, chromeHeight });
+    // When the user has pinned a window height, THAT is the vertical budget —
+    // not workArea*0.9. Passing budgetRatio 1 makes verticalScrollCap subtract
+    // the measured chrome from the pinned height, so the chat scrolls inside
+    // the size the user chose instead of overflowing it.
+    const pinnedHeight = customOverlayHeightRef.current;
+    const nextCap = pinnedHeight
+      ? verticalScrollCap({ availHeight: pinnedHeight, chromeHeight, budgetRatio: 1 })
+      : verticalScrollCap({ availHeight, chromeHeight });
     if (process.env.NODE_ENV === 'development') {
       console.log('[overlay-resize] measureVerticalCap', {
         availHeight,
@@ -2480,7 +2545,13 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
         // the flicker. measureVerticalCap above keeps the scroll area bounded
         // meanwhile; the single authoritative height settle is deferred to the
         // transition's onComplete (one setBounds, not one per frame).
-        if (Date.now() < heightReportSuppressedUntilRef.current) {
+        // `isResizingRef` covers a user resize drag, which has no deadline —
+        // it ends when the pointer is released. Gating on the ref rather than a
+        // long timestamp means a lost pointerup can never wedge height
+        // reporting off for a fixed number of seconds; the drag's own teardown
+        // (including its pointercancel / lostpointercapture / blur paths) is
+        // the single thing that clears it.
+        if (isResizingRef.current || Date.now() < heightReportSuppressedUntilRef.current) {
           return;
         }
         // While a message is actively streaming, route through the
@@ -2560,16 +2631,18 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
   const resizeOverlayWindow = useCallback(
     (height: number) => {
       if (height <= 0) return;
-      const width = Math.round(shellWidth.get()) || OVERLAY_WINDOW_WIDTH;
+      // Window width, not panel width — see reportShellSize. During the spring
+      // this is constant, so the main process still sees widthDelta 0 and the
+      // resize collapses to a pure height-only, top-anchored setBounds.
+      const width = OVERLAY_WINDOW_WIDTH;
       const targetHeight = customOverlayHeightRef.current || height;
-      const api = window.electronAPI as any;
-      if (api?.updateContentDimensionsCentered) {
-        api.updateContentDimensionsCentered({ width, height: targetHeight });
+      if (window.electronAPI?.updateContentDimensionsCentered) {
+        void window.electronAPI.updateContentDimensionsCentered({ width, height: targetHeight });
       } else {
-        window.electronAPI?.updateContentDimensions({ width, height: targetHeight });
+        void window.electronAPI?.updateContentDimensions({ width, height: targetHeight });
       }
     },
-    [OVERLAY_WINDOW_WIDTH, shellWidth],
+    [OVERLAY_WINDOW_WIDTH],
   );
 
   // Height channel used by the ResizeObserver WHILE a message is actively
@@ -2828,63 +2901,190 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
     startTransition(target);
   }, [shellWidth, startTransition, SHELL_WIDTH_COLLAPSED, SHELL_WIDTH_EXPANDED]);
 
-  // Free-form resize handles. Pointer events are used as the single input
-  // path so Windows does not start duplicate pointer/mouse drag sessions.
-  const isResizingRef = useRef(false);
+  // ── Free-form resize handles ──────────────────────────────────────────────
+  // EAST-side directions only ('e', 's', 'se'). A west-side handle would need
+  // the window's X origin to move, which setOverlayDimensionsAnchored
+  // deliberately never does: an X-origin move flashes for a frame on macOS
+  // because Chromium does not sync setBounds to renderer paint. Growing
+  // rightward from a left-anchored window is the only artifact-free direction,
+  // so it is the only one offered — rather than shipping 'w'/'sw' handles that
+  // compute (startWidth - dx) while the window still grows rightward, which
+  // makes dragging the west edge leftward push the panel to the RIGHT.
+  //
+  // Pointer events are the single input path, so Windows never starts a
+  // duplicate mouse drag session alongside the pointer one.
   const handleResizePointerDown = useCallback(
-    (direction: 'se' | 'sw' | 'e' | 'w' | 's', e: React.PointerEvent) => {
+    (direction: OverlayResizeDirection, e: React.PointerEvent<HTMLDivElement>) => {
+      if (e.button !== 0 || isResizingRef.current) return;
       e.preventDefault();
       e.stopPropagation();
-      try { e.currentTarget.setPointerCapture(e.pointerId); } catch {}
+
+      const handleEl = e.currentTarget;
+      const { pointerId } = e;
+      // Capture keeps the move stream coming even when the pointer leaves the
+      // 16px strip; best-effort because a detached node can reject it.
+      try {
+        handleEl.setPointerCapture(pointerId);
+      } catch {
+        /* capture is an optimisation, not a requirement */
+      }
 
       const startX = e.clientX;
       const startY = e.clientY;
-      const startW = Math.round(shellWidth.get()) || SHELL_WIDTH_COLLAPSED;
-      const startH = contentRef.current?.offsetHeight ?? 400;
+      // Start from the WINDOW width, not the live panel width: the drag resizes
+      // the window, and the panel follows it.
+      const startWidth = OVERLAY_WINDOW_WIDTH;
+      // Whether the HEIGHT was already pinned before this drag. An east-only
+      // drag must not silently freeze the height as a side effect of widening.
+      const heightWasPinned = customOverlayHeightRef.current !== null;
+      const pinsHeight = heightWasPinned || direction === 's' || direction === 'se';
+      const startHeight =
+        customOverlayHeightRef.current ??
+        contentRef.current?.offsetHeight ??
+        OVERLAY_MIN_WINDOW_HEIGHT;
+      // Stop exactly where the MAIN PROCESS clamps (floor(workArea * 0.9)), so
+      // the drag cannot run past the largest window it will ever be granted and
+      // persist a size that can never be applied.
+      const maxWidth = maxWindowWidthFor(window.screen?.availWidth ?? 0);
+      const maxHeight = maxWindowHeightFor(window.screen?.availHeight ?? 0);
+
       isResizingRef.current = true;
-      heightReportSuppressedUntilRef.current = Date.now() + 100000;
+      let latest = { width: startWidth, height: startHeight };
+
+      // Push a size into the renderer's own state. Deduped per dimension so an
+      // 'e' drag (height never changes) costs one setState per frame, not two.
+      const applyLocal = (next: { width: number; height: number }) => {
+        if (next.width !== latest.width) {
+          setCustomWindowWidth(next.width);
+          // The panel fills the window while dragging, so the edge under the
+          // pointer IS the panel's edge. This also keeps the streamed toggle
+          // anchor — (windowWidth + panelWidth) / 2 — on the real corner.
+          shellWidth.set(next.width);
+        }
+        if (next.height !== latest.height) {
+          customOverlayHeightRef.current = next.height;
+        }
+        latest = next;
+        // Re-derive the scroll budget from the new pinned height so the chat
+        // scrolls inside the chosen size instead of overflowing it.
+        measureVerticalCap();
+      };
+
+      // Rate-limited to ~30fps, matching the width spring's height channel:
+      // every setBounds re-rasters the transparent backdrop-blur window, so a
+      // per-frame native resize is exactly the flicker avoided elsewhere.
+      const RESIZE_REPORT_INTERVAL_MS = 33;
+      let lastSentAt = 0;
 
       const move = (event: PointerEvent) => {
         if (!isResizingRef.current) return;
-        const dx = event.clientX - startX;
-        const dy = event.clientY - startY;
-        const maxW = Math.max(732, (window.screen?.availWidth || 1920) - 40);
-        const maxH = Math.max(360, (window.screen?.availHeight || 1080) - 40);
-        const nextW = Math.max(360, Math.min(maxW, startW + (direction === 'w' || direction === 'sw' ? -dx : dx)));
-        const nextH = direction === 'se' || direction === 'sw' || direction === 's'
-          ? Math.max(180, Math.min(maxH, startH + dy))
-          : startH;
-        shellWidth.set(nextW);
-        manualWidthOverrideRef.current = nextW;
-        customOverlayHeightRef.current = nextH;
-        setCustomOverlayHeight(nextH);
-        const api = window.electronAPI as any;
-        api?.updateContentDimensionsCentered?.({ width: Math.round(nextW), height: Math.round(nextH) });
+        // Self-healing net: if the button is already up we missed the pointerup
+        // (capture stolen by an OS gesture, release outside every Natively
+        // window). Ending here on the next move cannot false-positive the way a
+        // window 'blur' listener would — the overlay is a non-activating panel
+        // and blurs for reasons that have nothing to do with the drag.
+        if (event.buttons === 0) {
+          end();
+          return;
+        }
+        const next = computeResizeFrame({
+          direction,
+          dx: event.clientX - startX,
+          dy: event.clientY - startY,
+          startWidth,
+          startHeight,
+          maxWidth,
+          maxHeight,
+        });
+        if (next.width === latest.width && next.height === latest.height) return;
+        applyLocal(next);
+        const now = Date.now();
+        if (now - lastSentAt < RESIZE_REPORT_INTERVAL_MS) return;
+        lastSentAt = now;
+        void window.electronAPI?.updateContentDimensionsCentered?.(next);
       };
 
-      const end = () => {
-        if (!isResizingRef.current) return;
-        isResizingRef.current = false;
-        heightReportSuppressedUntilRef.current = 0;
+      const detach = () => {
         window.removeEventListener('pointermove', move, true);
         window.removeEventListener('pointerup', end, true);
         window.removeEventListener('pointercancel', end, true);
-        const finalW = Math.round(shellWidth.get());
-        const finalH = customOverlayHeightRef.current || startH;
-        try {
-          localStorage.setItem('natively_custom_overlay_width', String(finalW));
-          localStorage.setItem('natively_custom_overlay_height', String(finalH));
-        } catch {}
-        const api = window.electronAPI as any;
-        api?.updateContentDimensionsCentered?.({ width: finalW, height: finalH });
+        window.removeEventListener('lostpointercapture', end, true);
       };
+
+      function end() {
+        if (!isResizingRef.current) return;
+        // Cleared FIRST and unconditionally: the ResizeObserver gates on this
+        // ref, so nothing below can leave height reporting wedged off.
+        isResizingRef.current = false;
+        detach();
+        try {
+          handleEl.releasePointerCapture(pointerId);
+        } catch {
+          /* already released, or the node is gone */
+        }
+        // Adopt the size the window ACTUALLY became. The main process clamps to
+        // its own view of the work area, which can differ from
+        // window.screen.availWidth on a multi-monitor setup; without adopting
+        // the echo, the panel width, the toggle anchor and the hover-gate
+        // margin would all drift from the real window for the rest of the
+        // session AND be persisted in that drifted state.
+        void Promise.resolve(
+          window.electronAPI?.updateContentDimensionsCentered?.(latest),
+        )
+          .then((applied) => {
+            const settledWidth =
+              typeof applied?.width === 'number' ? applied.width : latest.width;
+            const settledHeight =
+              typeof applied?.height === 'number' ? applied.height : latest.height;
+            setCustomWindowWidth(settledWidth);
+            shellWidth.set(settledWidth);
+            if (pinsHeight) {
+              customOverlayHeightRef.current = settledHeight;
+            }
+            measureVerticalCap();
+            if (
+              !writeCustomOverlaySize(
+                typeof window !== 'undefined' ? window.localStorage : null,
+                { width: settledWidth, height: pinsHeight ? settledHeight : null },
+              )
+            ) {
+              console.warn(
+                '[overlay-resize] custom overlay size could not be persisted — this size is session-only',
+              );
+            }
+          })
+          .catch(() => {
+            /* the window went away mid-drag; local state is already correct */
+          });
+      }
 
       window.addEventListener('pointermove', move, { passive: false, capture: true });
       window.addEventListener('pointerup', end, { capture: true });
       window.addEventListener('pointercancel', end, { capture: true });
+      // Safety net: a pointer stream can end without a pointerup when the
+      // capture is stolen (an OS gesture, a window-manager grab). Together with
+      // the buttons===0 check in `move`, this is what guarantees a drag cannot
+      // stay "live" and leave height reporting suppressed.
+      window.addEventListener('lostpointercapture', end, { capture: true });
     },
-    [SHELL_WIDTH_COLLAPSED, shellWidth],
+    [OVERLAY_WINDOW_WIDTH, shellWidth, measureVerticalCap],
   );
+
+  // Double-click any handle to forget the custom size and return to
+  // auto-sizing. Without this the very first drag pins the overlay forever —
+  // the pin survives relaunches via localStorage, and nothing else clears it.
+  const handleResizeReset = useCallback(() => {
+    if (isResizingRef.current) return;
+    clearCustomOverlaySize(typeof window !== 'undefined' ? window.localStorage : null);
+    customOverlayHeightRef.current = null;
+    setCustomWindowWidth(null);
+    manualWidthOverrideRef.current = null;
+    shellWidth.set(collapsedWidthFor(OVERLAY_DEFAULT_WINDOW_WIDTH));
+    // No manual re-report needed: clearing the state changes
+    // OVERLAY_WINDOW_WIDTH, which changes reportShellSize's identity, which
+    // re-runs the sizing effect with the DEFAULT width. Reporting here instead
+    // would send the stale width captured in this render's closure.
+  }, [shellWidth]);
 
   // ── Aux-window bridge ─────────────────────────────────────────────────────
   // The TopPill and resize toggle live in their own BrowserWindows. Broadcast
@@ -8111,7 +8311,7 @@ Provide only the answer, nothing else.`;
             <motion.div
               ref={shellRef}
               data-shell-card=""
-              className={`relative max-w-full backdrop-blur-2xl border rounded-[24px] overflow-hidden flex flex-col draggable-area overlay-shell-surface ${overlayPanelClass}`}
+              className={`relative max-w-full backdrop-blur-2xl border rounded-[24px] overflow-hidden flex flex-col draggable-area overlay-shell-surface overlay-shell-container ${overlayPanelClass}`}
               style={{
                 ...appearance.shellStyle,
                 // The panel width is bound to the LIVE `shellWidth` motion value,
@@ -9315,37 +9515,29 @@ Provide only the answer, nothing else.`;
                 </div>
               </div>
 
-              {/* Multi-direction resize handles: the renderer changes the
-                  panel width/height; the native overlay remains stable. */}
+              {/* Resize handles. EAST-side only — see handleResizePointerDown
+                  for why a west-side handle cannot be made artifact-free.
+                  Double-click any of them to return to automatic sizing. */}
               <div
                 data-resize-handle="e"
-                className="resize-handle absolute top-4 bottom-4 right-0 z-50 w-4 no-drag touch-none"
+                className="resize-handle resize-handle-e absolute top-4 bottom-4 right-0 z-50 w-4 no-drag touch-none"
                 onPointerDown={(e) => handleResizePointerDown('e', e)}
-                title={t('Drag to resize width')}
-              />
-              <div
-                data-resize-handle="w"
-                className="resize-handle absolute top-4 bottom-4 left-0 z-50 w-4 no-drag touch-none"
-                onPointerDown={(e) => handleResizePointerDown('w', e)}
-                title={t('Drag to resize width')}
+                onDoubleClick={handleResizeReset}
+                title={t('Drag to resize width · double-click to reset')}
               />
               <div
                 data-resize-handle="s"
-                className="resize-handle absolute bottom-0 left-8 right-8 z-50 h-4 no-drag touch-none"
+                className="resize-handle resize-handle-s absolute bottom-0 left-8 right-8 z-50 h-4 no-drag touch-none"
                 onPointerDown={(e) => handleResizePointerDown('s', e)}
-                title={t('Drag to resize height')}
-              />
-              <div
-                data-resize-handle="sw"
-                className="resize-handle absolute bottom-0 left-0 z-50 h-8 w-8 no-drag touch-none"
-                onPointerDown={(e) => handleResizePointerDown('sw', e)}
-                title={t('Drag to resize')}
+                onDoubleClick={handleResizeReset}
+                title={t('Drag to resize height · double-click to reset')}
               />
               <div
                 data-resize-handle="se"
-                className="resize-handle absolute bottom-0 right-0 z-50 h-9 w-9 no-drag touch-none"
+                className="resize-handle resize-handle-se absolute bottom-0 right-0 z-50 h-9 w-9 no-drag touch-none"
                 onPointerDown={(e) => handleResizePointerDown('se', e)}
-                title={t('Drag to resize')}
+                onDoubleClick={handleResizeReset}
+                title={t('Drag to resize · double-click to reset')}
               />
             </motion.div>
           </motion.div>

--- a/src/components/NativelyInterface.tsx
+++ b/src/components/NativelyInterface.tsx
@@ -281,6 +281,8 @@ import {
   maxWindowWidthFor,
   maxWindowHeightFor,
   collapsedWidthFor,
+  pinsHeightFor,
+  minWindowHeightFor,
   OVERLAY_MIN_WINDOW_HEIGHT,
   computeResizeFrame,
   type OverlayResizeDirection,
@@ -2116,6 +2118,13 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
   // equals WindowHelper.OVERLAY_DEFAULT_WIDTH (the window's birth width — the
   // startup-slide invariant).
   const OVERLAY_WINDOW_WIDTH = SHELL_WIDTH_EXPANDED;
+  // Latest-value ref for the two long-lived subscriptions below (the toggle
+  // anchor stream and the hover gate). They must read the LIVE window width but
+  // must NOT re-subscribe when it changes: a drag updates it ~30x/second, and
+  // depending on it would tear down and rebuild both subscriptions every frame
+  // — re-sending the hover-gate handshake IPC each time.
+  const overlayWindowWidthRef = useRef(OVERLAY_WINDOW_WIDTH);
+  overlayWindowWidthRef.current = OVERLAY_WINDOW_WIDTH;
   // The PANEL always starts COLLAPSED. A restored custom size sizes the
   // WINDOW, not the panel's expand state — seeding the panel with the window
   // width would boot it visually expanded while codeExpandedRef and
@@ -2404,6 +2413,44 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
     streamingHeightCommittedRef.current = height;
   }, []);
 
+  // measureVerticalCap is declared below (it needs reportShellSize's neighbours);
+  // adoptAppliedSize has to reach it without listing it as a dependency.
+  const measureVerticalCapRef = useRef<(() => void) | null>(null);
+
+  // Adopt the size the main process ACTUALLY applied.
+  //
+  // This runs on EVERY report, not only at the end of a drag. The restore path
+  // is the case that matters: a width persisted on a 1920px external monitor is
+  // re-applied on a 1366px laptop, where the main process clamps it to
+  // floor(1366*0.9). If the renderer kept the requested width, the panel would
+  // render wider than its window and be clipped, the toggle anchor would stream
+  // (requested + panelW)/2 while getOverlayPanelLeftMargin measures the REAL
+  // width, and the two would disagree by exactly the offset that method exists
+  // to prevent. Converges in one extra round-trip: adopting re-reports the
+  // clamped value, which main applies verbatim and echoes back unchanged.
+  const adoptAppliedSize = useCallback((applied?: { width: number; height: number }) => {
+    if (!applied) return;
+    const { width, height } = applied;
+    if (typeof width === 'number' && width > 0 && width !== overlayWindowWidthRef.current) {
+      // Written before the state update so the toggle-anchor stream and the
+      // hover gate — both of which read this ref — are correct immediately,
+      // not one render late.
+      overlayWindowWidthRef.current = width;
+      setCustomWindowWidth(width);
+    }
+    // Only reconcile the height when the user actually pinned one; otherwise
+    // the window is content-sized and there is nothing to hold.
+    if (
+      typeof height === 'number' &&
+      height > 0 &&
+      customOverlayHeightRef.current !== null &&
+      height !== customOverlayHeightRef.current
+    ) {
+      customOverlayHeightRef.current = height;
+      measureVerticalCapRef.current?.();
+    }
+  }, []);
+
   // Single canonical size-reporter. Width is ALWAYS the fixed
   // OVERLAY_WINDOW_WIDTH (the OS window never width-resizes — the CSS panel
   // animates inside it), so this is effectively a height-only reporter;
@@ -2449,7 +2496,7 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
     // width setBounds on every frame of the spring (re-rastering a transparent
     // blurred window) and would desynchronise the toggle anchor, the popover
     // margin and the hover gate, all of which are computed against the window.
-    const width = OVERLAY_WINDOW_WIDTH;
+    const width = overlayWindowWidthRef.current;
     // A user-pinned height wins over measured content: the chat scrolls inside
     // the chosen size rather than growing the window (measureVerticalCap has
     // already bounded the scroll area to match).
@@ -2466,12 +2513,21 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
       });
     }
     if (window.electronAPI?.updateContentDimensionsCentered) {
-      void window.electronAPI.updateContentDimensionsCentered({ width, height });
+      void window.electronAPI
+        .updateContentDimensionsCentered({ width, height })
+        .then(adoptAppliedSize)
+        .catch(() => {
+          /* window gone; nothing to reconcile against */
+        });
     } else {
       void window.electronAPI?.updateContentDimensions({ width, height });
     }
     syncStreamingHeightBaseline(height);
-  }, [attachedContext.length, OVERLAY_WINDOW_WIDTH, syncStreamingHeightBaseline]);
+    // Deliberately NOT dependent on OVERLAY_WINDOW_WIDTH — it reads the ref. A
+    // drag changes that width ~30x/second, and depending on it would give this
+    // callback a new identity every frame, tearing down and rebuilding the
+    // ResizeObserver (and every effect keyed on it) each time.
+  }, [attachedContext.length, syncStreamingHeightBaseline, adoptAppliedSize]);
 
   // Compute the vertical budget cap for the chat scroll area and push it into
   // the `verticalCap` motion value (which scrollMaxH mins against the
@@ -2500,9 +2556,15 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
     // not workArea*0.9. Passing budgetRatio 1 makes verticalScrollCap subtract
     // the measured chrome from the pinned height, so the chat scrolls inside
     // the size the user chose instead of overflowing it.
+    // A pinned height is still subject to the main-process clamp. Taking the
+    // min means a height restored from a taller display cannot size the scroll
+    // area for a window the OS will never grant — which would lay the
+    // overflow-hidden shell out taller than its window and clip the footer.
     const pinnedHeight = customOverlayHeightRef.current;
-    const nextCap = pinnedHeight
-      ? verticalScrollCap({ availHeight: pinnedHeight, chromeHeight, budgetRatio: 1 })
+    const grantableHeight =
+      pinnedHeight !== null ? Math.min(pinnedHeight, maxWindowHeightFor(availHeight)) : null;
+    const nextCap = grantableHeight
+      ? verticalScrollCap({ availHeight: grantableHeight, chromeHeight, budgetRatio: 1 })
       : verticalScrollCap({ availHeight, chromeHeight });
     if (process.env.NODE_ENV === 'development') {
       console.log('[overlay-resize] measureVerticalCap', {
@@ -2516,6 +2578,7 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
     }
     verticalCap.set(nextCap);
   }, [attachedContext.length, verticalCap]);
+  measureVerticalCapRef.current = measureVerticalCap;
 
   // NOTE: the old per-frame "chase" subscriber that pushed the live shell width
   // to setBounds every frame is GONE. The OS window is a fixed width (732) for
@@ -2588,13 +2651,16 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
   // both re-derive the vertical cap (a screenshot strip grows chrome) and
   // re-run the canonical reporter — no more "what width should I use right
   // now?" branching against animation flags.
+  // `customWindowWidth` is in the deps because reportShellSize is now
+  // identity-stable across width changes (it reads a ref). A reset, or a
+  // restored size at mount, therefore has no other path to the OS.
   useEffect(() => {
     const id = requestAnimationFrame(() => {
       measureVerticalCap();
       reportShellSize();
     });
     return () => cancelAnimationFrame(id);
-  }, [attachedContext, reportShellSize, measureVerticalCap]);
+  }, [attachedContext, customWindowWidth, reportShellSize, measureVerticalCap]);
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -2634,15 +2700,18 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
       // Window width, not panel width — see reportShellSize. During the spring
       // this is constant, so the main process still sees widthDelta 0 and the
       // resize collapses to a pure height-only, top-anchored setBounds.
-      const width = OVERLAY_WINDOW_WIDTH;
+      const width = overlayWindowWidthRef.current;
       const targetHeight = customOverlayHeightRef.current || height;
       if (window.electronAPI?.updateContentDimensionsCentered) {
-        void window.electronAPI.updateContentDimensionsCentered({ width, height: targetHeight });
+        void window.electronAPI
+          .updateContentDimensionsCentered({ width, height: targetHeight })
+          .then(adoptAppliedSize)
+          .catch(() => {});
       } else {
         void window.electronAPI?.updateContentDimensions({ width, height: targetHeight });
       }
     },
-    [OVERLAY_WINDOW_WIDTH],
+    [adoptAppliedSize],
   );
 
   // Height channel used by the ResizeObserver WHILE a message is actively
@@ -2746,6 +2815,13 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
 
   const startTransition = useCallback(
     (targetWidth: number) => {
+      // The user's drag owns `shellWidth` for its duration. Without this the
+      // first token of a code answer arriving mid-drag would call
+      // startTransition (queueToken's eager-expand path) and animate the panel
+      // out from under the pointer, fighting the drag's own .set() every frame.
+      // Guarding the single choke point covers all four callers — the manual
+      // toggle, checkCodeVisibility, the aux-window action and queueToken.
+      if (isResizingRef.current) return;
       codeExpandedRef.current = targetWidth === SHELL_WIDTH_EXPANDED;
 
       const fromWidth = Math.round(shellWidth.get());
@@ -2916,7 +2992,11 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
   const handleResizePointerDown = useCallback(
     (direction: OverlayResizeDirection, e: React.PointerEvent<HTMLDivElement>) => {
       if (e.button !== 0 || isResizingRef.current) return;
-      e.preventDefault();
+      // NOT preventDefault(): calling it on pointerdown suppresses the
+      // compatibility mouse events, and with them the `dblclick` that the
+      // reset gesture is built on. Text selection is prevented by
+      // `user-select: none` on .resize-handle instead, and window dragging by
+      // its -webkit-app-region: no-drag.
       e.stopPropagation();
 
       const handleEl = e.currentTarget;
@@ -2936,8 +3016,7 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
       const startWidth = OVERLAY_WINDOW_WIDTH;
       // Whether the HEIGHT was already pinned before this drag. An east-only
       // drag must not silently freeze the height as a side effect of widening.
-      const heightWasPinned = customOverlayHeightRef.current !== null;
-      const pinsHeight = heightWasPinned || direction === 's' || direction === 'se';
+      const pinsHeight = pinsHeightFor(direction, customOverlayHeightRef.current !== null);
       const startHeight =
         customOverlayHeightRef.current ??
         contentRef.current?.offsetHeight ??
@@ -2947,21 +3026,48 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
       // persist a size that can never be applied.
       const maxWidth = maxWindowWidthFor(window.screen?.availWidth ?? 0);
       const maxHeight = maxWindowHeightFor(window.screen?.availHeight ?? 0);
+      // Measured floor, not the bare 216 constant: the shell is
+      // overflow-hidden, so anything shorter than (chrome + a usable scroll
+      // viewport) clips the footer instead of scrolling.
+      const scrollEl = scrollContainerRef.current;
+      const contentEl = contentRef.current;
+      const minHeight =
+        scrollEl && contentEl
+          ? minWindowHeightFor(contentEl.offsetHeight - scrollEl.clientHeight)
+          : OVERLAY_MIN_WINDOW_HEIGHT;
 
       isResizingRef.current = true;
       let latest = { width: startWidth, height: startHeight };
+      // A pointerdown that never moves is a CLICK, not a resize. Without this
+      // every click on a handle would pin the overlay at its current size —
+      // and, because the two clicks of a double-click each run this handler,
+      // the trailing end()'s async persist would race the reset that the
+      // dblclick just performed and write the cleared size straight back.
+      let moved = false;
 
       // Push a size into the renderer's own state. Deduped per dimension so an
       // 'e' drag (height never changes) costs one setState per frame, not two.
       const applyLocal = (next: { width: number; height: number }) => {
         if (next.width !== latest.width) {
           setCustomWindowWidth(next.width);
+          overlayWindowWidthRef.current = next.width;
+          // The panel now fills the window, i.e. it IS at the expanded width.
+          // codeExpandedRef is otherwise only written by startTransition, so
+          // without this the code-visibility watcher (`if
+          // (codeExpandedRef.current)`) would never collapse the panel again
+          // after a drag — it would sit at full width until the next code
+          // answer happened to run a transition.
+          codeExpandedRef.current = true;
           // The panel fills the window while dragging, so the edge under the
           // pointer IS the panel's edge. This also keeps the streamed toggle
           // anchor — (windowWidth + panelWidth) / 2 — on the real corner.
           shellWidth.set(next.width);
         }
-        if (next.height !== latest.height) {
+        // Only a height-driving drag pins the height. computeResizeFrame also
+        // CLAMPS the pass-through height, so an east-only drag that starts
+        // taller than the display budget would otherwise pin it as a side
+        // effect of the clamp alone.
+        if (pinsHeight && next.height !== latest.height) {
           customOverlayHeightRef.current = next.height;
         }
         latest = next;
@@ -2995,8 +3101,10 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
           startHeight,
           maxWidth,
           maxHeight,
+          minHeight,
         });
         if (next.width === latest.width && next.height === latest.height) return;
+        moved = true;
         applyLocal(next);
         const now = Date.now();
         if (now - lastSentAt < RESIZE_REPORT_INTERVAL_MS) return;
@@ -3022,6 +3130,9 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
         } catch {
           /* already released, or the node is gone */
         }
+        // Nothing moved: this was a click (or one half of a double-click).
+        // Report nothing, persist nothing, leave the pin exactly as it was.
+        if (!moved) return;
         // Adopt the size the window ACTUALLY became. The main process clamps to
         // its own view of the work area, which can differ from
         // window.screen.availWidth on a multi-monitor setup; without adopting
@@ -3036,6 +3147,7 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
               typeof applied?.width === 'number' ? applied.width : latest.width;
             const settledHeight =
               typeof applied?.height === 'number' ? applied.height : latest.height;
+            overlayWindowWidthRef.current = settledWidth;
             setCustomWindowWidth(settledWidth);
             shellWidth.set(settledWidth);
             if (pinsHeight) {
@@ -3140,7 +3252,7 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
   useEffect(() => {
     let lastSent = -1;
     const send = (w: number) => {
-      const panelRight = Math.round((OVERLAY_WINDOW_WIDTH + w) / 2);
+      const panelRight = Math.round((overlayWindowWidthRef.current + w) / 2);
       if (panelRight === lastSent) return;
       lastSent = panelRight;
       window.electronAPI?.sendOverlayToggleAnchor?.({ panelRight }).catch(() => {});
@@ -3148,7 +3260,7 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
     send(shellWidth.get());
     const unsubscribe = shellWidth.on('change', send);
     return () => unsubscribe();
-  }, [shellWidth, OVERLAY_WINDOW_WIDTH]);
+  }, [shellWidth]);
 
   // Hover hit-test → margins click-through. The fixed window is wider than
   // the collapsed panel (66px transparent margin each side); while the
@@ -3170,16 +3282,16 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
     window.electronAPI?.setOverlayHoverInteractive?.(true).catch(() => {});
     const PAD = 8;
     const onMouseMove = (e: MouseEvent) => {
-      const margin = (OVERLAY_WINDOW_WIDTH - shellWidth.get()) / 2;
-      const inside =
-        e.clientX >= margin - PAD && e.clientX <= OVERLAY_WINDOW_WIDTH - margin + PAD;
+      const windowWidth = overlayWindowWidthRef.current;
+      const margin = (windowWidth - shellWidth.get()) / 2;
+      const inside = e.clientX >= margin - PAD && e.clientX <= windowWidth - margin + PAD;
       if (inside === interactive) return;
       interactive = inside;
       window.electronAPI?.setOverlayHoverInteractive?.(inside).catch(() => {});
     };
     window.addEventListener('mousemove', onMouseMove);
     return () => window.removeEventListener('mousemove', onMouseMove);
-  }, [shellWidth, OVERLAY_WINDOW_WIDTH]);
+  }, [shellWidth]);
 
   // Derive the resize-button icon state from the live shell width. Subscribing
   // to the motion value (rather than tracking each startTransition caller)
@@ -9367,7 +9479,7 @@ Provide only the answer, nothing else.`;
                 </div>
 
                 {/* Bottom Row */}
-                <div className="flex items-center justify-between mt-3 px-0.5">
+                <div className="flex items-center justify-between mt-3 px-0.5 relative z-[60]">
                   <div className="flex items-center gap-1.5">
                     <button
                       data-model-selector-toggle="true"
@@ -9523,6 +9635,12 @@ Provide only the answer, nothing else.`;
                 className="resize-handle resize-handle-e absolute top-4 bottom-4 right-0 z-50 w-4 no-drag touch-none"
                 onPointerDown={(e) => handleResizePointerDown('e', e)}
                 onDoubleClick={handleResizeReset}
+                // The strip covers the right 16px of the message list and is a
+                // SIBLING of the scroll container, so a wheel over it would
+                // otherwise do nothing at all. Forward it by hand.
+                onWheel={(e) => {
+                  scrollContainerRef.current?.scrollBy({ top: e.deltaY });
+                }}
                 title={t('Drag to resize width · double-click to reset')}
               />
               <div

--- a/src/components/NativelyInterface.tsx
+++ b/src/components/NativelyInterface.tsx
@@ -2097,9 +2097,20 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
   // (WindowHelper.getOverlayPanelLeftMargin) and the click-through hover gate —
   // all read it, so they cannot disagree about how wide the window is.
   // See src/lib/overlayCustomSize.mjs for the full rationale.
+  // Two different numbers, previously conflated into one:
+  //   customWindowWidth  — what the USER pinned. Persisted. Drives the REQUEST.
+  //   appliedWindowWidth — what the main process actually granted after its
+  //                        floor(workArea * 0.9) clamp. Session-only. Drives
+  //                        every geometry consumer, so the panel never renders
+  //                        wider than the window it lives in.
+  // Collapsing them made a clamp sticky: on a display too small for the 732
+  // default the clamped value became the renderer's "custom" width and was
+  // re-requested verbatim forever, so moving to a larger display never restored
+  // the default.
   const [customWindowWidth, setCustomWindowWidth] = useState<number | null>(
     restoredOverlaySize.width,
   );
+  const [appliedWindowWidth, setAppliedWindowWidth] = useState<number | null>(null);
   // The pinned window HEIGHT is a ref, not state: nothing RENDERS from it (the
   // scroll budget flows through the `verticalCap` motion value, and the size
   // reporters read it imperatively), so holding it in state would only add a
@@ -2111,7 +2122,11 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
   // are bit-identical to the constants they replace. Recomputed per render like
   // the old literals were — every dependency array that listed the literals
   // already lists these, so no memoisation is needed or wanted.
-  const SHELL_WIDTH_EXPANDED = customWindowWidth ?? OVERLAY_DEFAULT_WINDOW_WIDTH;
+  // What we ASK the OS for — the user's pin, else the default. Never the
+  // clamped result, or a clamp would latch permanently.
+  const REQUESTED_WINDOW_WIDTH = customWindowWidth ?? OVERLAY_DEFAULT_WINDOW_WIDTH;
+  // What the window actually IS. All panel/anchor/hover-gate geometry uses this.
+  const SHELL_WIDTH_EXPANDED = appliedWindowWidth ?? REQUESTED_WINDOW_WIDTH;
   const SHELL_WIDTH_COLLAPSED = collapsedWidthFor(SHELL_WIDTH_EXPANDED);
   // The OS overlay window's width. Equals SHELL_WIDTH_EXPANDED always (the
   // panel fills the window edge-to-edge when expanded), and at its default
@@ -2125,6 +2140,9 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
   // — re-sending the hover-gate handshake IPC each time.
   const overlayWindowWidthRef = useRef(OVERLAY_WINDOW_WIDTH);
   overlayWindowWidthRef.current = OVERLAY_WINDOW_WIDTH;
+  // The size reporters ask for this, not for the effective width.
+  const requestedWindowWidthRef = useRef(REQUESTED_WINDOW_WIDTH);
+  requestedWindowWidthRef.current = REQUESTED_WINDOW_WIDTH;
   // The PANEL always starts COLLAPSED. A restored custom size sizes the
   // WINDOW, not the panel's expand state — seeding the panel with the window
   // width would boot it visually expanded while codeExpandedRef and
@@ -2140,6 +2158,13 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
   // ≤ the budget the OS window will be granted, so the footer (model selector /
   // settings / send) can never be cropped below the clamped window edge.
   const verticalCap = useMotionValue(Infinity);
+  // 1 while the user has pinned a window height. widthDerivedScrollMax tops out
+  // at 560, and the shell is an auto-height column, so with the width bound
+  // still applied the PANEL could never exceed chrome+560 however tall the
+  // WINDOW was told to be — leaving a tall transparent strip below the panel
+  // that still swallowed clicks (the hover gate tests clientX only). When a
+  // height is pinned, the measured cap is the only bound that should apply.
+  const heightIsPinned = useMotionValue(0);
   // scrollMaxH is the chat viewport's MAX-HEIGHT, derived from the LIVE
   // `shellWidth` motion value (the panel's actual animating width) mins'd against
   // the measured vertical budget cap. Binding it to the live width means the
@@ -2153,14 +2178,18 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
   // verticalScrollCap helper instead of an ad-hoc `height - 160`, and — because
   // verticalCap is a motion value — makes a pure-height drag (the `s` handle,
   // which never changes shellWidth) actually recompute the scroll budget.
-  const scrollMaxH = useTransform([shellWidth, verticalCap], ([w, cap]: number[]) =>
-    Math.min(
-      widthDerivedScrollMax(w, {
-        collapsedWidth: SHELL_WIDTH_COLLAPSED,
-        expandedWidth: SHELL_WIDTH_EXPANDED,
-      }),
-      cap,
-    ),
+  const scrollMaxH = useTransform(
+    [shellWidth, verticalCap, heightIsPinned],
+    ([w, cap, pinned]: number[]) =>
+      pinned
+        ? cap
+        : Math.min(
+            widthDerivedScrollMax(w, {
+              collapsedWidth: SHELL_WIDTH_COLLAPSED,
+              expandedWidth: SHELL_WIDTH_EXPANDED,
+            }),
+            cap,
+          ),
   );
   // NOTE: the resize toggle and the TopPill no longer render in this window at
   // all — each lives in its OWN tiny BrowserWindow (see
@@ -2432,11 +2461,20 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
     if (!applied) return;
     const { width, height } = applied;
     if (typeof width === 'number' && width > 0 && width !== overlayWindowWidthRef.current) {
+      // The PANEL has to move with the window. Leaving shellWidth alone let a
+      // width restored from a bigger display sit wider than the window it was
+      // clamped into: the hover gate then computes a NEGATIVE margin and
+      // reports the whole window interactive, and the streamed panelRight
+      // points past the window's own right edge. Setting it is also the only
+      // thing that re-anchors the toggle and popover windows at all — that
+      // stream fires from shellWidth's 'change', nothing else.
+      const wasExpanded = shellWidth.get() >= overlayWindowWidthRef.current - 1;
       // Written before the state update so the toggle-anchor stream and the
       // hover gate — both of which read this ref — are correct immediately,
       // not one render late.
       overlayWindowWidthRef.current = width;
-      setCustomWindowWidth(width);
+      setAppliedWindowWidth(width);
+      shellWidth.set(wasExpanded ? width : collapsedWidthFor(width));
     }
     // Only reconcile the height when the user actually pinned one; otherwise
     // the window is content-sized and there is nothing to hold.
@@ -2449,7 +2487,7 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
       customOverlayHeightRef.current = height;
       measureVerticalCapRef.current?.();
     }
-  }, []);
+  }, [shellWidth]);
 
   // Single canonical size-reporter. Width is ALWAYS the fixed
   // OVERLAY_WINDOW_WIDTH (the OS window never width-resizes — the CSS panel
@@ -2496,7 +2534,7 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
     // width setBounds on every frame of the spring (re-rastering a transparent
     // blurred window) and would desynchronise the toggle anchor, the popover
     // margin and the hover gate, all of which are computed against the window.
-    const width = overlayWindowWidthRef.current;
+    const width = requestedWindowWidthRef.current;
     // A user-pinned height wins over measured content: the chat scrolls inside
     // the chosen size rather than growing the window (measureVerticalCap has
     // already bounded the scroll area to match).
@@ -2577,7 +2615,8 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
       });
     }
     verticalCap.set(nextCap);
-  }, [attachedContext.length, verticalCap]);
+    heightIsPinned.set(grantableHeight !== null ? 1 : 0);
+  }, [attachedContext.length, verticalCap, heightIsPinned]);
   measureVerticalCapRef.current = measureVerticalCap;
 
   // NOTE: the old per-frame "chase" subscriber that pushed the live shell width
@@ -2700,7 +2739,7 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
       // Window width, not panel width — see reportShellSize. During the spring
       // this is constant, so the main process still sees widthDelta 0 and the
       // resize collapses to a pure height-only, top-anchored setBounds.
-      const width = overlayWindowWidthRef.current;
+      const width = requestedWindowWidthRef.current;
       const targetHeight = customOverlayHeightRef.current || height;
       if (window.electronAPI?.updateContentDimensionsCentered) {
         void window.electronAPI
@@ -3011,12 +3050,22 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
 
       const startX = e.clientX;
       const startY = e.clientY;
-      // Start from the WINDOW width, not the live panel width: the drag resizes
-      // the window, and the panel follows it.
-      const startWidth = OVERLAY_WINDOW_WIDTH;
+      // The panel fills the window for the duration of a drag, so in CLIENT
+      // coordinates the panel's right edge IS the window width. Seeding from
+      // the pointer's x therefore makes that edge track the cursor with no
+      // constant offset. Seeding from OVERLAY_WINDOW_WIDTH instead (732) while
+      // the panel sat collapsed (600, centred, right edge at 666) made the very
+      // first 1px move jump the panel 132px wider and left the handle
+      // permanently ~67px off the pointer for the rest of the drag.
+      const widthDriven = direction === 'e' || direction === 'se';
+      const startWidth = widthDriven ? Math.round(e.clientX) : OVERLAY_WINDOW_WIDTH;
       // Whether the HEIGHT was already pinned before this drag. An east-only
       // drag must not silently freeze the height as a side effect of widening.
       const pinsHeight = pinsHeightFor(direction, customOverlayHeightRef.current !== null);
+      // Mirror of pinsHeight. writeCustomOverlaySize's contract is that each
+      // axis is pinned by the handle that actually drove it; persisting a width
+      // after a pure `s` drag would silently freeze it too.
+      const pinsWidth = customWindowWidth !== null || widthDriven;
       const startHeight =
         customOverlayHeightRef.current ??
         contentRef.current?.offsetHeight ??
@@ -3082,6 +3131,12 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
       const RESIZE_REPORT_INTERVAL_MS = 33;
       let lastSentAt = 0;
 
+      // Pointer TRAVEL, not "the computed frame differs from the start frame".
+      // computeResizeFrame clamps the pass-through height to the measured
+      // floor, so on a short chat the very first frame already differs at ZERO
+      // delta — which made an ordinary click pin and persist a size.
+      const DRAG_THRESHOLD_PX = 3;
+
       const move = (event: PointerEvent) => {
         if (!isResizingRef.current) return;
         // Self-healing net: if the button is already up we missed the pointerup
@@ -3093,10 +3148,16 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
           end();
           return;
         }
+        const dx = event.clientX - startX;
+        const dy = event.clientY - startY;
+        if (!moved) {
+          if (Math.abs(dx) <= DRAG_THRESHOLD_PX && Math.abs(dy) <= DRAG_THRESHOLD_PX) return;
+          moved = true;
+        }
         const next = computeResizeFrame({
           direction,
-          dx: event.clientX - startX,
-          dy: event.clientY - startY,
+          dx,
+          dy,
           startWidth,
           startHeight,
           maxWidth,
@@ -3104,7 +3165,6 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
           minHeight,
         });
         if (next.width === latest.width && next.height === latest.height) return;
-        moved = true;
         applyLocal(next);
         const now = Date.now();
         if (now - lastSentAt < RESIZE_REPORT_INTERVAL_MS) return;
@@ -3148,7 +3208,8 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
             const settledHeight =
               typeof applied?.height === 'number' ? applied.height : latest.height;
             overlayWindowWidthRef.current = settledWidth;
-            setCustomWindowWidth(settledWidth);
+            setAppliedWindowWidth(settledWidth);
+            if (pinsWidth) setCustomWindowWidth(settledWidth);
             shellWidth.set(settledWidth);
             if (pinsHeight) {
               customOverlayHeightRef.current = settledHeight;
@@ -3157,7 +3218,10 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
             if (
               !writeCustomOverlaySize(
                 typeof window !== 'undefined' ? window.localStorage : null,
-                { width: settledWidth, height: pinsHeight ? settledHeight : null },
+                {
+                  width: pinsWidth ? settledWidth : null,
+                  height: pinsHeight ? settledHeight : null,
+                },
               )
             ) {
               console.warn(
@@ -3190,12 +3254,15 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
     clearCustomOverlaySize(typeof window !== 'undefined' ? window.localStorage : null);
     customOverlayHeightRef.current = null;
     setCustomWindowWidth(null);
+    setAppliedWindowWidth(null);
     manualWidthOverrideRef.current = null;
     shellWidth.set(collapsedWidthFor(OVERLAY_DEFAULT_WINDOW_WIDTH));
-    // No manual re-report needed: clearing the state changes
-    // OVERLAY_WINDOW_WIDTH, which changes reportShellSize's identity, which
-    // re-runs the sizing effect with the DEFAULT width. Reporting here instead
-    // would send the stale width captured in this render's closure.
+    // No manual re-report needed: the sizing effect lists `customWindowWidth`
+    // in its deps, so clearing it re-runs that effect and reports the DEFAULT
+    // width. (reportShellSize's own identity no longer changes with the width —
+    // it reads a ref — so it is the effect dep, not the callback identity, that
+    // does this now.) Reporting here instead would send the stale width
+    // captured in this render's closure.
   }, [shellWidth]);
 
   // ── Aux-window bridge ─────────────────────────────────────────────────────

--- a/src/components/ui/OverlayBanner.tsx
+++ b/src/components/ui/OverlayBanner.tsx
@@ -172,7 +172,7 @@ export const OverlayBanner: React.FC<OverlayBannerProps> = ({
     className={`relative no-drag flex flex-wrap items-center gap-x-3 gap-y-2 px-3 py-2 rounded-xl border border-amber-500/25 bg-amber-500/10 ${className}`.trim()}
     {...rest}
   >
-    <div className="flex items-start gap-2 flex-1 min-w-[220px]">
+    <div className="flex items-start gap-2 flex-[1_1_220px] min-w-0 max-w-full">
       <span className="shrink-0 flex h-[22px] w-[22px] items-center justify-center rounded-full bg-amber-500/20">
         {icon ?? <DefaultWarningIcon />}
       </span>

--- a/src/index.css
+++ b/src/index.css
@@ -2779,6 +2779,10 @@ body {
 .resize-handle {
   -webkit-app-region: no-drag;
   touch-action: none;
+  /* Replaces preventDefault() on pointerdown, which would have suppressed the
+     compatibility mouse events that `dblclick` (the reset gesture) needs. */
+  user-select: none;
+  -webkit-user-select: none;
 }
 .resize-handle-e { cursor: ew-resize; }
 .resize-handle-s { cursor: ns-resize; }
@@ -2787,10 +2791,12 @@ body {
 .resize-handle-se::after {
   content: '';
   position: absolute;
-  right: 5px;
-  bottom: 5px;
-  width: 9px;
-  height: 9px;
+  /* Kept inside the 12px strip below the footer controls, which now sit above
+     the handles (z-60) — so the chevron is never painted over. */
+  right: 3px;
+  bottom: 3px;
+  width: 7px;
+  height: 7px;
   border-right: 1.5px solid currentColor;
   border-bottom: 1.5px solid currentColor;
   border-bottom-right-radius: 3px;

--- a/src/index.css
+++ b/src/index.css
@@ -2754,6 +2754,18 @@ body {
   cursor: default;
 }
 
+.overlay-shell-surface {
+  container-type: inline-size;
+  container-name: overlay-shell;
+}
+
+.overlay-input-placeholder-compact { display: none; }
+
+@container overlay-shell (max-width: 560px) {
+  .overlay-input-placeholder-full { display: none; }
+  .overlay-input-placeholder-compact { display: inline; }
+}
+
 .drag-region {
   -webkit-app-region: drag;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -2754,7 +2754,14 @@ body {
   cursor: default;
 }
 
-.overlay-shell-surface {
+/* Container query root for the overlay chat shell.
+   Scoped to its OWN class rather than .overlay-shell-surface: that class is
+   also on the settings popup, the model-selector panel and the settings
+   overlay, and `container-type: inline-size` brings layout + style containment
+   with it (a new stacking context, a new containing block for fixed-position
+   descendants, a new BFC). Only the chat shell needs to be queryable, so only
+   the chat shell becomes a container. */
+.overlay-shell-container {
   container-type: inline-size;
   container-name: overlay-shell;
 }
@@ -2764,6 +2771,37 @@ body {
 @container overlay-shell (max-width: 560px) {
   .overlay-input-placeholder-full { display: none; }
   .overlay-input-placeholder-compact { display: inline; }
+}
+
+/* Resize handles. The hit strips are invisible; the cursor is the entire
+   affordance, so without these rules the feature is undiscoverable. `se` gets a
+   faint corner chevron on hover — the one handle worth advertising. */
+.resize-handle {
+  -webkit-app-region: no-drag;
+  touch-action: none;
+}
+.resize-handle-e { cursor: ew-resize; }
+.resize-handle-s { cursor: ns-resize; }
+.resize-handle-se { cursor: nwse-resize; }
+
+.resize-handle-se::after {
+  content: '';
+  position: absolute;
+  right: 5px;
+  bottom: 5px;
+  width: 9px;
+  height: 9px;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  border-bottom-right-radius: 3px;
+  opacity: 0;
+  transition: opacity 140ms ease;
+  pointer-events: none;
+}
+.resize-handle-se:hover::after { opacity: 0.35; }
+
+@media (prefers-reduced-motion: reduce) {
+  .resize-handle-se::after { transition: none; }
 }
 
 .drag-region {

--- a/src/lib/__tests__/overlayCustomSize.test.mjs
+++ b/src/lib/__tests__/overlayCustomSize.test.mjs
@@ -1,0 +1,252 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  OVERLAY_DEFAULT_WINDOW_WIDTH,
+  OVERLAY_DEFAULT_COLLAPSED_WIDTH,
+  OVERLAY_MIN_WINDOW_WIDTH,
+  OVERLAY_MIN_WINDOW_HEIGHT,
+  OVERLAY_MAX_WINDOW_WIDTH,
+  CUSTOM_WIDTH_STORAGE_KEY,
+  CUSTOM_HEIGHT_STORAGE_KEY,
+  parseStoredDimension,
+  readCustomOverlaySize,
+  writeCustomOverlaySize,
+  clearCustomOverlaySize,
+  maxWindowWidthFor,
+  maxWindowHeightFor,
+  collapsedWidthFor,
+  computeResizeFrame,
+} from '../overlayCustomSize.mjs';
+
+/** Minimal in-memory localStorage stand-in. */
+function makeStorage(initial = {}) {
+  const map = new Map(Object.entries(initial));
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => map.set(k, String(v)),
+    removeItem: (k) => map.delete(k),
+    _map: map,
+  };
+}
+
+/** A storage that throws on every access (private mode / denied site data). */
+function makeHostileStorage() {
+  return {
+    getItem() {
+      throw new Error('denied');
+    },
+    setItem() {
+      throw new Error('denied');
+    },
+    removeItem() {
+      throw new Error('denied');
+    },
+  };
+}
+
+describe('overlayCustomSize', () => {
+  describe('parseStoredDimension', () => {
+    test('accepts an in-range numeric string', () => {
+      assert.equal(parseStoredDimension('900', 360, 2560), 900);
+    });
+    test('rounds a fractional value', () => {
+      assert.equal(parseStoredDimension('900.6', 360, 2560), 901);
+    });
+    test('rejects absent / blank / whitespace', () => {
+      assert.equal(parseStoredDimension(null, 360, 2560), null);
+      assert.equal(parseStoredDimension(undefined, 360, 2560), null);
+      assert.equal(parseStoredDimension('', 360, 2560), null);
+      assert.equal(parseStoredDimension('   ', 360, 2560), null);
+    });
+    test('rejects non-numeric garbage', () => {
+      assert.equal(parseStoredDimension('wide', 360, 2560), null);
+      assert.equal(parseStoredDimension('NaN', 360, 2560), null);
+      assert.equal(parseStoredDimension('Infinity', 360, 2560), null);
+    });
+    test('rejects out-of-range values rather than clamping them', () => {
+      // Clamping a corrupt value would silently adopt it; a stored size we do
+      // not recognise must fall back to the default geometry.
+      assert.equal(parseStoredDimension('10', 360, 2560), null);
+      assert.equal(parseStoredDimension('99999', 360, 2560), null);
+    });
+  });
+
+  describe('readCustomOverlaySize', () => {
+    test('reads both dimensions', () => {
+      const storage = makeStorage({
+        [CUSTOM_WIDTH_STORAGE_KEY]: '900',
+        [CUSTOM_HEIGHT_STORAGE_KEY]: '640',
+      });
+      assert.deepEqual(readCustomOverlaySize(storage), { width: 900, height: 640 });
+    });
+    test('width and height are independent', () => {
+      const storage = makeStorage({ [CUSTOM_WIDTH_STORAGE_KEY]: '900' });
+      assert.deepEqual(readCustomOverlaySize(storage), { width: 900, height: null });
+    });
+    test('empty storage yields the default geometry', () => {
+      assert.deepEqual(readCustomOverlaySize(makeStorage()), { width: null, height: null });
+    });
+    test('a throwing storage yields the default geometry, not an exception', () => {
+      assert.deepEqual(readCustomOverlaySize(makeHostileStorage()), {
+        width: null,
+        height: null,
+      });
+    });
+    test('absent storage yields the default geometry', () => {
+      assert.deepEqual(readCustomOverlaySize(null), { width: null, height: null });
+      assert.deepEqual(readCustomOverlaySize(undefined), { width: null, height: null });
+    });
+    test('a corrupt entry does not poison the other dimension', () => {
+      const storage = makeStorage({
+        [CUSTOM_WIDTH_STORAGE_KEY]: 'garbage',
+        [CUSTOM_HEIGHT_STORAGE_KEY]: '640',
+      });
+      assert.deepEqual(readCustomOverlaySize(storage), { width: null, height: 640 });
+    });
+  });
+
+  describe('write / clear round-trip', () => {
+    test('a written size reads back identically', () => {
+      const storage = makeStorage();
+      assert.equal(writeCustomOverlaySize(storage, { width: 900, height: 640 }), true);
+      assert.deepEqual(readCustomOverlaySize(storage), { width: 900, height: 640 });
+    });
+    test('fractional values round on the way in', () => {
+      const storage = makeStorage();
+      writeCustomOverlaySize(storage, { width: 900.4, height: 640.7 });
+      assert.deepEqual(readCustomOverlaySize(storage), { width: 900, height: 641 });
+    });
+    test('clear restores auto-sizing', () => {
+      const storage = makeStorage();
+      writeCustomOverlaySize(storage, { width: 900, height: 640 });
+      assert.equal(clearCustomOverlaySize(storage), true);
+      assert.deepEqual(readCustomOverlaySize(storage), { width: null, height: null });
+    });
+    test('a null dimension means "not pinned" and removes that key', () => {
+      // Widening with the east handle must not silently freeze the height too.
+      const storage = makeStorage();
+      writeCustomOverlaySize(storage, { width: 900, height: 640 });
+      writeCustomOverlaySize(storage, { width: 1000, height: null });
+      assert.deepEqual(readCustomOverlaySize(storage), { width: 1000, height: null });
+    });
+    test('a refused write is reported, not swallowed', () => {
+      assert.equal(
+        writeCustomOverlaySize(makeHostileStorage(), { width: 900, height: 640 }),
+        false,
+      );
+      assert.equal(clearCustomOverlaySize(makeHostileStorage()), false);
+    });
+  });
+
+  describe('maxWindowWidthFor / maxWindowHeightFor', () => {
+    test('mirrors the main-process floor(workArea * 0.9) clamp', () => {
+      // WindowHelper.setOverlayDimensionsAnchored clamps to this exact value;
+      // if the renderer used a different bound it would persist a width the
+      // window can never be given.
+      assert.equal(maxWindowWidthFor(1920), 1728);
+      assert.equal(maxWindowHeightFor(1080), 972);
+    });
+    test('falls back to the absolute ceiling when the display is unknown', () => {
+      assert.equal(maxWindowWidthFor(0), OVERLAY_MAX_WINDOW_WIDTH);
+      assert.equal(maxWindowWidthFor(NaN), OVERLAY_MAX_WINDOW_WIDTH);
+    });
+    test('never returns below the minimum on a tiny display', () => {
+      assert.equal(maxWindowWidthFor(200), OVERLAY_MIN_WINDOW_WIDTH);
+    });
+  });
+
+  describe('collapsedWidthFor', () => {
+    test('the DEFAULT window width reproduces the historical 600 exactly', () => {
+      // This is the regression guard for "resizing changed the default look".
+      assert.equal(
+        collapsedWidthFor(OVERLAY_DEFAULT_WINDOW_WIDTH),
+        OVERLAY_DEFAULT_COLLAPSED_WIDTH,
+      );
+    });
+    test('scales proportionally so the side margin keeps its ratio', () => {
+      assert.equal(collapsedWidthFor(1200), 984);
+    });
+    test('converges on the window width for a very narrow overlay', () => {
+      // Below the minimum window width the collapsed/expanded distinction is
+      // meaningless — a tiny overlay should have no dead side margin at all.
+      assert.equal(collapsedWidthFor(366), OVERLAY_MIN_WINDOW_WIDTH);
+      assert.equal(collapsedWidthFor(OVERLAY_MIN_WINDOW_WIDTH), OVERLAY_MIN_WINDOW_WIDTH);
+    });
+    test('never exceeds the window it sits in', () => {
+      for (const w of [360, 500, 732, 1200, 2560]) {
+        assert.ok(collapsedWidthFor(w) <= w, `collapsed ${collapsedWidthFor(w)} > window ${w}`);
+      }
+    });
+  });
+
+  describe('computeResizeFrame', () => {
+    const start = { startWidth: 732, startHeight: 500 };
+
+    test('east drags width only', () => {
+      assert.deepEqual(
+        computeResizeFrame({ direction: 'e', dx: 100, dy: 80, ...start }),
+        { width: 832, height: 500 },
+      );
+    });
+    test('south drags height only', () => {
+      assert.deepEqual(
+        computeResizeFrame({ direction: 's', dx: 100, dy: 80, ...start }),
+        { width: 732, height: 580 },
+      );
+    });
+    test('south-east drags both', () => {
+      assert.deepEqual(
+        computeResizeFrame({ direction: 'se', dx: 100, dy: 80, ...start }),
+        { width: 832, height: 580 },
+      );
+    });
+    test('a negative delta shrinks', () => {
+      assert.deepEqual(
+        computeResizeFrame({ direction: 'se', dx: -100, dy: -80, ...start }),
+        { width: 632, height: 420 },
+      );
+    });
+    test('clamps to the floors', () => {
+      const frame = computeResizeFrame({ direction: 'se', dx: -9999, dy: -9999, ...start });
+      assert.equal(frame.width, OVERLAY_MIN_WINDOW_WIDTH);
+      assert.equal(frame.height, OVERLAY_MIN_WINDOW_HEIGHT);
+    });
+    test('clamps to the caller-supplied display ceiling', () => {
+      const frame = computeResizeFrame({
+        direction: 'se',
+        dx: 9999,
+        dy: 9999,
+        ...start,
+        maxWidth: maxWindowWidthFor(1920),
+        maxHeight: maxWindowHeightFor(1080),
+      });
+      // Not availWidth - 40: the renderer must stop where the MAIN PROCESS
+      // clamps, or the persisted width drifts from the applied one forever.
+      assert.equal(frame.width, 1728);
+      assert.equal(frame.height, 972);
+    });
+    test('a ceiling below the floor still yields the floor (tiny display)', () => {
+      const frame = computeResizeFrame({
+        direction: 'se',
+        dx: 9999,
+        dy: 9999,
+        ...start,
+        maxWidth: 100,
+        maxHeight: 100,
+      });
+      assert.equal(frame.width, OVERLAY_MIN_WINDOW_WIDTH);
+      assert.equal(frame.height, OVERLAY_MIN_WINDOW_HEIGHT);
+    });
+    test('output is always integral', () => {
+      const frame = computeResizeFrame({
+        direction: 'se',
+        dx: 10.4,
+        dy: 10.6,
+        startWidth: 732.3,
+        startHeight: 500.2,
+      });
+      assert.equal(frame.width, Math.round(frame.width));
+      assert.equal(frame.height, Math.round(frame.height));
+    });
+  });
+});

--- a/src/lib/__tests__/overlayCustomSize.test.mjs
+++ b/src/lib/__tests__/overlayCustomSize.test.mjs
@@ -14,7 +14,9 @@ import {
   clearCustomOverlaySize,
   maxWindowWidthFor,
   maxWindowHeightFor,
+  minWindowHeightFor,
   collapsedWidthFor,
+  pinsHeightFor,
   computeResizeFrame,
 } from '../overlayCustomSize.mjs';
 
@@ -179,6 +181,50 @@ describe('overlayCustomSize', () => {
     });
   });
 
+  describe('pinsHeightFor', () => {
+    test('height-driving directions pin the height', () => {
+      assert.equal(pinsHeightFor('s', false), true);
+      assert.equal(pinsHeightFor('se', false), true);
+    });
+    test('an east-only drag does NOT pin the height', () => {
+      // Regression guard: computeResizeFrame clamps the pass-through height to
+      // the display budget, so an 'e' drag on an overlay that is already taller
+      // than the budget yields a CHANGED height. Treating that as a pin would
+      // freeze the height as a side effect of merely widening the window.
+      assert.equal(pinsHeightFor('e', false), false);
+      const frame = computeResizeFrame({
+        direction: 'e',
+        dx: 50,
+        dy: 0,
+        startWidth: 732,
+        startHeight: 2000,
+        maxHeight: maxWindowHeightFor(1080),
+      });
+      assert.equal(frame.height, 972, 'height is clamped even on an east drag');
+      assert.notEqual(frame.height, 2000);
+    });
+    test('an already-pinned height stays pinned through a width-only drag', () => {
+      assert.equal(pinsHeightFor('e', true), true);
+    });
+  });
+
+  describe('minWindowHeightFor', () => {
+    test('derives the floor from measured chrome, not a constant', () => {
+      // The shell is overflow-hidden: dragging shorter than
+      // chrome + a usable scroll viewport clips the footer.
+      assert.equal(minWindowHeightFor(180), 300);
+      assert.equal(minWindowHeightFor(240, 150), 390);
+    });
+    test('never returns below the window minimum for tiny chrome', () => {
+      assert.equal(minWindowHeightFor(0), OVERLAY_MIN_WINDOW_HEIGHT);
+      assert.equal(minWindowHeightFor(50), OVERLAY_MIN_WINDOW_HEIGHT);
+    });
+    test('unmeasured chrome falls back to the window minimum', () => {
+      assert.equal(minWindowHeightFor(NaN), OVERLAY_MIN_WINDOW_HEIGHT);
+      assert.equal(minWindowHeightFor(-1), OVERLAY_MIN_WINDOW_HEIGHT);
+    });
+  });
+
   describe('computeResizeFrame', () => {
     const start = { startWidth: 732, startHeight: 500 };
 
@@ -224,6 +270,28 @@ describe('overlayCustomSize', () => {
       // clamps, or the persisted width drifts from the applied one forever.
       assert.equal(frame.width, 1728);
       assert.equal(frame.height, 972);
+    });
+    test('honours a caller-supplied measured floor above the constant', () => {
+      const frame = computeResizeFrame({
+        direction: 'se',
+        dx: 0,
+        dy: -9999,
+        startWidth: 732,
+        startHeight: 600,
+        minHeight: minWindowHeightFor(180),
+      });
+      assert.equal(frame.height, 300, 'cannot be dragged shorter than chrome + scroll');
+    });
+    test('a measured floor below the constant never lowers the constant', () => {
+      const frame = computeResizeFrame({
+        direction: 'se',
+        dx: 0,
+        dy: -9999,
+        startWidth: 732,
+        startHeight: 600,
+        minHeight: 50,
+      });
+      assert.equal(frame.height, OVERLAY_MIN_WINDOW_HEIGHT);
     });
     test('a ceiling below the floor still yields the floor (tiny display)', () => {
       const frame = computeResizeFrame({

--- a/src/lib/overlayCustomSize.d.mts
+++ b/src/lib/overlayCustomSize.d.mts
@@ -40,6 +40,7 @@ export function clearCustomOverlaySize(
   storage: OverlaySizeStorage | null | undefined,
 ): boolean;
 
+export function minWindowHeightFor(chromeHeight: number, minScroll?: number): number;
 export function maxWindowWidthFor(availWidth: number): number;
 export function maxWindowHeightFor(availHeight: number): number;
 export function collapsedWidthFor(windowWidth: number): number;
@@ -54,7 +55,13 @@ export interface ComputeResizeFrameParams {
   startHeight: number;
   maxWidth?: number;
   maxHeight?: number;
+  minHeight?: number;
 }
+
+export function pinsHeightFor(
+  direction: OverlayResizeDirection,
+  heightAlreadyPinned: boolean,
+): boolean;
 
 export function computeResizeFrame(
   params: ComputeResizeFrameParams,

--- a/src/lib/overlayCustomSize.d.mts
+++ b/src/lib/overlayCustomSize.d.mts
@@ -1,0 +1,61 @@
+export const OVERLAY_DEFAULT_WINDOW_WIDTH: number;
+export const OVERLAY_DEFAULT_COLLAPSED_WIDTH: number;
+export const OVERLAY_MIN_WINDOW_WIDTH: number;
+export const OVERLAY_MIN_WINDOW_HEIGHT: number;
+export const OVERLAY_MAX_WINDOW_WIDTH: number;
+export const OVERLAY_MAX_WINDOW_HEIGHT: number;
+export const OVERLAY_WORK_AREA_BUDGET: number;
+export const CUSTOM_WIDTH_STORAGE_KEY: string;
+export const CUSTOM_HEIGHT_STORAGE_KEY: string;
+
+export function clamp(n: number, lo: number, hi: number): number;
+
+export function parseStoredDimension(
+  raw: string | null | undefined,
+  lo: number,
+  hi: number,
+): number | null;
+
+export interface CustomOverlaySize {
+  width: number | null;
+  height: number | null;
+}
+
+export interface OverlaySizeStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+export function readCustomOverlaySize(
+  storage: OverlaySizeStorage | null | undefined,
+): CustomOverlaySize;
+
+export function writeCustomOverlaySize(
+  storage: OverlaySizeStorage | null | undefined,
+  size: { width: number | null; height: number | null },
+): boolean;
+
+export function clearCustomOverlaySize(
+  storage: OverlaySizeStorage | null | undefined,
+): boolean;
+
+export function maxWindowWidthFor(availWidth: number): number;
+export function maxWindowHeightFor(availHeight: number): number;
+export function collapsedWidthFor(windowWidth: number): number;
+
+export type OverlayResizeDirection = 'e' | 's' | 'se';
+
+export interface ComputeResizeFrameParams {
+  direction: OverlayResizeDirection;
+  dx: number;
+  dy: number;
+  startWidth: number;
+  startHeight: number;
+  maxWidth?: number;
+  maxHeight?: number;
+}
+
+export function computeResizeFrame(
+  params: ComputeResizeFrameParams,
+): { width: number; height: number };

--- a/src/lib/overlayCustomSize.mjs
+++ b/src/lib/overlayCustomSize.mjs
@@ -1,0 +1,223 @@
+/**
+ * Pure helpers for the overlay's USER-CHOSEN window size (unit-tested).
+ *
+ * Why this exists
+ * ---------------
+ * The overlay OS window has historically been a FIXED width (732 =
+ * WindowHelper.OVERLAY_DEFAULT_WIDTH), with the panel animating 600↔732 purely
+ * in CSS, centered inside it. That invariant is load-bearing: three separate
+ * subsystems derive their geometry from "the window is 732 wide" —
+ *
+ *   1. the toggle aux window's anchor      (panelRight = (windowW + panelW) / 2)
+ *   2. the settings/model popover margin   (WindowHelper.getOverlayPanelLeftMargin)
+ *   3. the click-through hover gate        (margin = (windowW - panelW) / 2)
+ *
+ * — and a width setBounds on a transparent, backdrop-blurred window re-rasters
+ * and flickers on macOS, because Chromium does not sync setBounds to renderer
+ * paint.
+ *
+ * Making the overlay user-resizable does NOT mean giving up that invariant. It
+ * means the window width becomes a value the user can change (rarely, by
+ * dragging) instead of a compile-time constant — and every one of the three
+ * consumers above reads that same value. Within a session the width is still
+ * fixed for the entire expand/collapse spring, so there is still no width
+ * setBounds during an animation. That is what these helpers encode.
+ *
+ * Everything here is pure so the geometry can be tested without a display:
+ * see src/lib/__tests__/overlayCustomSize.test.mjs.
+ */
+
+/** The window's birth width. MUST equal WindowHelper.OVERLAY_DEFAULT_WIDTH. */
+export const OVERLAY_DEFAULT_WINDOW_WIDTH = 732;
+/** The panel's collapsed width at the DEFAULT window width. */
+export const OVERLAY_DEFAULT_COLLAPSED_WIDTH = 600;
+/** Floor for a user-chosen width — below this the footer chrome cannot lay out. */
+export const OVERLAY_MIN_WINDOW_WIDTH = 360;
+/** Floor for a user-chosen height. MUST equal WindowHelper.OVERLAY_MIN_HEIGHT. */
+export const OVERLAY_MIN_WINDOW_HEIGHT = 216;
+/** Absolute sanity ceilings, applied before any display-derived clamp. */
+export const OVERLAY_MAX_WINDOW_WIDTH = 2560;
+export const OVERLAY_MAX_WINDOW_HEIGHT = 2560;
+
+/**
+ * The fraction of the work area the MAIN PROCESS will grant
+ * (WindowHelper.setOverlayDimensionsAnchored clamps to floor(workArea * 0.9)).
+ * The renderer mirrors it so a drag stops exactly where the window will stop,
+ * instead of racing past the clamp and persisting a width that can never be
+ * applied.
+ */
+export const OVERLAY_WORK_AREA_BUDGET = 0.9;
+
+export const CUSTOM_WIDTH_STORAGE_KEY = 'natively_custom_overlay_width';
+export const CUSTOM_HEIGHT_STORAGE_KEY = 'natively_custom_overlay_height';
+
+/** Clamp n into [lo, hi]. */
+export function clamp(n, lo, hi) {
+  return Math.min(Math.max(n, lo), hi);
+}
+
+/**
+ * Parse one persisted dimension. Returns null for absent, blank, non-numeric,
+ * or out-of-range values — a corrupt localStorage entry must fall back to the
+ * default geometry, never poison the window size.
+ */
+export function parseStoredDimension(raw, lo, hi) {
+  if (raw === null || raw === undefined) return null;
+  const text = String(raw).trim();
+  if (text === '') return null;
+  const value = Number(text);
+  if (!Number.isFinite(value)) return null;
+  const rounded = Math.round(value);
+  if (rounded < lo || rounded > hi) return null;
+  return rounded;
+}
+
+/**
+ * Read the persisted custom size. `storage` is any localStorage-like object;
+ * a throwing or absent storage (private mode, denied site data) yields the
+ * default geometry rather than an exception.
+ *
+ * Width and height are independent: a user may have pinned only one.
+ */
+export function readCustomOverlaySize(storage) {
+  const result = { width: null, height: null };
+  if (!storage) return result;
+  try {
+    result.width = parseStoredDimension(
+      storage.getItem(CUSTOM_WIDTH_STORAGE_KEY),
+      OVERLAY_MIN_WINDOW_WIDTH,
+      OVERLAY_MAX_WINDOW_WIDTH,
+    );
+    result.height = parseStoredDimension(
+      storage.getItem(CUSTOM_HEIGHT_STORAGE_KEY),
+      OVERLAY_MIN_WINDOW_HEIGHT,
+      OVERLAY_MAX_WINDOW_HEIGHT,
+    );
+  } catch {
+    return { width: null, height: null };
+  }
+  return result;
+}
+
+/**
+ * Persist a custom size. A `null` dimension means "not pinned" and REMOVES that
+ * key, so widening the overlay with the east handle does not silently freeze
+ * its height as well — the two axes are pinned independently, by the handle
+ * that actually drove them.
+ *
+ * Returns true only if the writes landed — a denied or quota-exhausted storage
+ * is reported, not swallowed, so the caller can tell the user the size is
+ * session-only.
+ */
+export function writeCustomOverlaySize(storage, size) {
+  if (!storage) return false;
+  try {
+    if (size.width === null || size.width === undefined) {
+      storage.removeItem(CUSTOM_WIDTH_STORAGE_KEY);
+    } else {
+      storage.setItem(CUSTOM_WIDTH_STORAGE_KEY, String(Math.round(size.width)));
+    }
+    if (size.height === null || size.height === undefined) {
+      storage.removeItem(CUSTOM_HEIGHT_STORAGE_KEY);
+    } else {
+      storage.setItem(CUSTOM_HEIGHT_STORAGE_KEY, String(Math.round(size.height)));
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Forget the custom size — the overlay returns to auto-sizing. */
+export function clearCustomOverlaySize(storage) {
+  if (!storage) return false;
+  try {
+    storage.removeItem(CUSTOM_WIDTH_STORAGE_KEY);
+    storage.removeItem(CUSTOM_HEIGHT_STORAGE_KEY);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The widest window the main process will actually grant on this display,
+ * mirroring WindowHelper's floor(workArea.width * 0.9) clamp. Falls back to the
+ * absolute ceiling when the display size is unknown (the main process clamps
+ * again regardless, and the applied size is echoed back).
+ */
+export function maxWindowWidthFor(availWidth) {
+  if (!Number.isFinite(availWidth) || availWidth <= 0) return OVERLAY_MAX_WINDOW_WIDTH;
+  return clamp(
+    Math.floor(availWidth * OVERLAY_WORK_AREA_BUDGET),
+    OVERLAY_MIN_WINDOW_WIDTH,
+    OVERLAY_MAX_WINDOW_WIDTH,
+  );
+}
+
+/** Height counterpart of maxWindowWidthFor. */
+export function maxWindowHeightFor(availHeight) {
+  if (!Number.isFinite(availHeight) || availHeight <= 0) return OVERLAY_MAX_WINDOW_HEIGHT;
+  return clamp(
+    Math.floor(availHeight * OVERLAY_WORK_AREA_BUDGET),
+    OVERLAY_MIN_WINDOW_HEIGHT,
+    OVERLAY_MAX_WINDOW_HEIGHT,
+  );
+}
+
+/**
+ * The panel's COLLAPSED width for a given window width.
+ *
+ * Scaled proportionally rather than pinned at the historical 600, so the
+ * transparent side margin keeps the same ratio the hover gate and the aux
+ * window anchor were tuned for. A user who widens the overlay to 1200 gets a
+ * proportionally wider collapsed panel (984) rather than a 600px panel adrift
+ * in 300px of dead margin on each side.
+ *
+ * At the default 732 this returns exactly 600, so the default path is
+ * bit-identical to the pre-resize behaviour.
+ */
+export function collapsedWidthFor(windowWidth) {
+  const ratio = OVERLAY_DEFAULT_COLLAPSED_WIDTH / OVERLAY_DEFAULT_WINDOW_WIDTH;
+  return clamp(
+    Math.round(windowWidth * ratio),
+    Math.min(OVERLAY_MIN_WINDOW_WIDTH, windowWidth),
+    windowWidth,
+  );
+}
+
+/**
+ * Geometry for one pointer-move frame of a resize drag.
+ *
+ * Only EAST-side directions exist ('e', 's', 'se'). West-side handles would
+ * need the window's X origin to move, which setOverlayDimensionsAnchored
+ * deliberately never does (an X move flashes for a frame on macOS because
+ * Chromium does not sync setBounds to paint). Growing rightward from a
+ * left-anchored window is the only direction that is artifact-free, so those
+ * are the only handles offered.
+ */
+export function computeResizeFrame(params) {
+  const {
+    direction,
+    dx,
+    dy,
+    startWidth,
+    startHeight,
+    maxWidth = OVERLAY_MAX_WINDOW_WIDTH,
+    maxHeight = OVERLAY_MAX_WINDOW_HEIGHT,
+  } = params;
+  const widthDriven = direction === 'e' || direction === 'se';
+  const heightDriven = direction === 's' || direction === 'se';
+  return {
+    width: clamp(
+      Math.round(widthDriven ? startWidth + dx : startWidth),
+      OVERLAY_MIN_WINDOW_WIDTH,
+      Math.max(OVERLAY_MIN_WINDOW_WIDTH, maxWidth),
+    ),
+    height: clamp(
+      Math.round(heightDriven ? startHeight + dy : startHeight),
+      OVERLAY_MIN_WINDOW_HEIGHT,
+      Math.max(OVERLAY_MIN_WINDOW_HEIGHT, maxHeight),
+    ),
+  };
+}

--- a/src/lib/overlayCustomSize.mjs
+++ b/src/lib/overlayCustomSize.mjs
@@ -141,6 +141,16 @@ export function clearCustomOverlaySize(storage) {
 }
 
 /**
+ * The shortest the overlay may be dragged, given how tall its non-scrolling
+ * chrome currently measures. Below this the overflow-hidden shell would lay out
+ * taller than its own window and clip the footer.
+ */
+export function minWindowHeightFor(chromeHeight, minScroll = 120) {
+  if (!Number.isFinite(chromeHeight) || chromeHeight < 0) return OVERLAY_MIN_WINDOW_HEIGHT;
+  return Math.max(OVERLAY_MIN_WINDOW_HEIGHT, Math.ceil(chromeHeight) + minScroll);
+}
+
+/**
  * The widest window the main process will actually grant on this display,
  * mirroring WindowHelper's floor(workArea.width * 0.9) clamp. Falls back to the
  * absolute ceiling when the display size is unknown (the main process clamps
@@ -187,6 +197,20 @@ export function collapsedWidthFor(windowWidth) {
 }
 
 /**
+ * Does this drag PIN the window height?
+ *
+ * Only a height-driving direction does — or a drag that started with the height
+ * already pinned. This matters because computeResizeFrame also CLAMPS the
+ * pass-through height to the display budget, so an east-only drag that starts
+ * taller than that budget produces a changed height without the user ever
+ * having asked for a height pin. Treating that as a pin would freeze the
+ * overlay's height as a side effect of merely widening it.
+ */
+export function pinsHeightFor(direction, heightAlreadyPinned) {
+  return Boolean(heightAlreadyPinned) || direction === 's' || direction === 'se';
+}
+
+/**
  * Geometry for one pointer-move frame of a resize drag.
  *
  * Only EAST-side directions exist ('e', 's', 'se'). West-side handles would
@@ -205,7 +229,13 @@ export function computeResizeFrame(params) {
     startHeight,
     maxWidth = OVERLAY_MAX_WINDOW_WIDTH,
     maxHeight = OVERLAY_MAX_WINDOW_HEIGHT,
+    // The floor is a CALLER-SUPPLIED measurement, not a constant: the shell is
+    // overflow-hidden, so its real minimum is (measured chrome + a usable
+    // scroll viewport). A fixed 216 floor lets a tall-chrome build be dragged
+    // shorter than its own footer and clip it.
+    minHeight = OVERLAY_MIN_WINDOW_HEIGHT,
   } = params;
+  const heightFloor = Math.max(OVERLAY_MIN_WINDOW_HEIGHT, Math.round(minHeight));
   const widthDriven = direction === 'e' || direction === 'se';
   const heightDriven = direction === 's' || direction === 'se';
   return {
@@ -216,8 +246,8 @@ export function computeResizeFrame(params) {
     ),
     height: clamp(
       Math.round(heightDriven ? startHeight + dy : startHeight),
-      OVERLAY_MIN_WINDOW_HEIGHT,
-      Math.max(OVERLAY_MIN_WINDOW_HEIGHT, maxHeight),
+      heightFloor,
+      Math.max(heightFloor, maxHeight),
     ),
   };
 }

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -37,6 +37,14 @@ export interface ElectronAPI {
     width: number
     height: number
   }) => Promise<void>
+  // X-anchored overlay resize. Resolves with the size the main process
+  // ACTUALLY applied after its floor(workArea * 0.9) clamp — the renderer
+  // adopts that value so its panel width, toggle anchor and hover-gate margin
+  // never drift from the real window. Optional: older preloads lack it.
+  updateContentDimensionsCentered?: (dimensions: {
+    width: number
+    height: number
+  }) => Promise<{ width: number; height: number } | undefined>
   // Overlay aux windows (pill / resize toggle) coordination
   sendOverlayUiState?: (state: Record<string, unknown>) => Promise<void>
   onOverlayUiState?: (


### PR DESCRIPTION
## Summary

- Add functional east, west, south, southwest, and southeast overlay resize handles.
- Persist custom overlay dimensions across launches.
- Prevent duplicate Windows mouse/pointer resize sessions.
- Wrap quick actions and use a compact prompt at narrow widths to prevent clipping.

## Validation

- npm run build:electron
- npm run build

This PR is based on the synchronized fork main and is separate from the merged NVIDIA NIM work.