### PR TITLE
Auto Answer: rejoin contractions the relay splits, and raise the answer floor to 0.30

### DIFF
--- a/docs/autopilot/auto-answer-v3-progress.md
+++ b/docs/autopilot/auto-answer-v3-progress.md
@@ -1652,3 +1652,33 @@ Fixed by adding the delegation, and pinned by a new test (`AutoAnswerHostWiring.
 the `new SimpleAutoAnswerEngine({…})` literal in main.ts and asserts every `this.intelligenceManager.X(` it
 calls is actually declared on IntelligenceManager — the whole class of silent host-hook mismatch, not just
 this instance. Mutation-probed by deleting the delegation again (1 fail).
+
+### Live session 2026-08-26 21:18 — all four mechanisms fired; one seam bug found
+
+75 s of interviewer speech, **5 answers**, versus 1 per 4–7 minutes before this week.
+
+| mechanism | evidence |
+| --- | --- |
+| deferred verdict | fired **3×** (`1-q3`, `1-q13`, `1-q18`) — each a positive verdict superseded by an interim, held, applied 50–170 ms later |
+| speculative prefetch | `Auto Answer prefetch fired while the judge decides` — **twice**, its first ever execution |
+| mid-word seam | `we're going to probably just jump` correctly closed across a `prob|ably` cut |
+| mic echo latch | zero `mic_echo`, zero `user_answering` — clean audio, nothing to suppress |
+
+Latency, candidate → dispatch: 0.94 / 1.17 / 0.87 / 0.94 / 1.26 s. Answer TFFT 1243–2081 ms
+(median ≈ 1960). No parked dispatch despite the prefetch now being live.
+
+**Bug found by the trace: contractions were still split.** The seam rule required word characters on
+*both* sides of the cut, and an apostrophe is not `\w`, so the relay's `we|'re` and `I'|m` cuts survived as
+`"so we 're going"` and `"this interview. I' m just curious"`. An apostrophe now counts as
+word-continuation on either side, while two apostrophes meeting still never glue and the sentence seam
+(`probability.|So`) is untouched.
+
+Mutation-probed: reverting to word-characters-only fails (1), and dropping the both-apostrophes guard fails (1)
+— the second probe initially PASSED, and a direct `isMidWordCut` unit test was added to cover it rather than
+leaving a guard nothing exercised. 57/57, typecheck clean.
+
+**Two quality observations, not fixed** (both are policy calls, not defects):
+* `1-q2` answered *"How are you doing today?"* and `1-q3` answered *"How are you?"* five seconds apart. The
+  duplicate guard compares `lastAnsweredText` exactly, so near-duplicates pass.
+* `1-q13` fired at **a=0.4** on *"I recommend maybe sharing your screen."* — the same weak band flagged in the
+  replay analysis. Everything at 0.9 was a real ask.

--- a/electron/intelligence/autoAnswer/AutoAnswerText.ts
+++ b/electron/intelligence/autoAnswer/AutoAnswerText.ts
@@ -80,7 +80,15 @@ export function isMidWordCut(finalText: string, latestInterim: string): boolean 
     if (!latestInterim.startsWith(finalText)) return false;   // the STT revised it: no claim
     const before = finalText[finalText.length - 1];
     const after = latestInterim[finalText.length];
-    return /\w/.test(before) && /\w/.test(after);
+    // A contraction may be cut on EITHER side of its apostrophe — the live
+    // session split "we|'re going" and "I'|m just curious" — so an apostrophe
+    // counts as word-continuation. Requiring at least one true word character
+    // keeps the sentence seam ("…probability.|So just these") unglued, which
+    // is the case the word-character test exists for.
+    const word = (c: string) => /\w/.test(c);
+    const apos = (c: string) => c === "'" || c === '\u2019';
+    if (apos(before) && apos(after)) return false;
+    return (word(before) || apos(before)) && (word(after) || apos(after));
 }
 
 /** Join relay finals, closing the seam where `glueNext` marks a split word. */

--- a/electron/intelligence/autoAnswer/SimpleAutoAnswer.ts
+++ b/electron/intelligence/autoAnswer/SimpleAutoAnswer.ts
@@ -123,13 +123,21 @@ export const ENDPOINT_CONFIRM_MS = 350;
 /** Below this many NEW words (and no '?') we wait for more speech instead of calling. */
 export const MIN_NEW_WORDS = 4;
 /**
- * Fire at anything above this. Set by the user (2026-08-25): "if the
- * percentage is above 20 then surely show the answer". Everything between
- * this and the old per-mode bars used to become a card asking permission;
- * that card is gone, so this is the only line left — above it the answer is
- * drafted, below it nothing happens.
+ * Fire at anything above this. The offer card is gone, so this is the only
+ * line left in the dispatch decision — above it the answer is drafted, below
+ * it nothing happens.
+ *
+ * 0.20 (user, 2026-08-25) → 0.30 (user, 2026-08-26).
+ *
+ * Worth knowing before tuning it again: the judge's output is effectively
+ * QUANTIZED. Across every session captured so far it has returned only
+ * 0 (×132), 0.1 (×69), 0.4 (×5), 0.8 (×2), 0.9 (×19) and 1.0 (×13) — nothing
+ * has ever landed between 0.2 and 0.3, so this move changes no dispatch that
+ * has actually occurred. The weak band that produced the one questionable
+ * answer of the 2026-08-26 session ("I recommend maybe sharing your screen.")
+ * is 0.4, and only a floor above 0.4 removes it.
  */
-export const ANSWER_FLOOR = 0.20;
+export const ANSWER_FLOOR = 0.30;
 /** Judge-unavailable fallback on punctuation-less providers: interrogative-led utterances. */
 export const FALLBACK_INTERROGATIVE = /^(?:(?:ok(?:ay)?|so|and|now|alright|well)[,.!\s]+)*(?:how|what|why|when|where|which|who|whose|can|could|would|should|do|does|did|are|is|will|have you|tell me|tell us|walk me|walk us|explain|describe)\b/i;
 /**

--- a/electron/intelligence/autoAnswer/__tests__/AutoAnswerSimple.test.mjs
+++ b/electron/intelligence/autoAnswer/__tests__/AutoAnswerSimple.test.mjs
@@ -24,6 +24,7 @@ import { FakeClock } from './fakeClock.mjs';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 const Simple = require(path.resolve(__dirname, '../../../../dist-electron/electron/intelligence/autoAnswer/SimpleAutoAnswer.js'));
+const { isMidWordCut } = require(path.resolve(__dirname, '../../../../dist-electron/electron/intelligence/autoAnswer/AutoAnswerText.js'));
 const { SimpleAutoAnswerEngine, STABILITY_MS, ENDPOINT_CONFIRM_MS, RETRY_MS, RETRY_TTL_MS, HELD_MAX_AGE_MS, ECHO_MODE_HOLD_MS, EARLY_JUDGE_MS } = Simple;
 
 const flush = () => new Promise((r) => setImmediate(r));
@@ -766,6 +767,31 @@ test('a final cut mid-word is rejoined, and a final cut at a space is not', asyn
   assert.doesNotMatch(judged, /you tobe/, 'never glues across a real space');
 });
 
+test('a contraction cut on either side of its apostrophe is rejoined', async () => {
+  const h = makeSimple(async () => YES());
+  // Verbatim from the live session 2026-08-26: the relay cut "we|'re" and
+  // "I'|m", and an apostrophe is not a \\w, so both survived as "so we 're"
+  // and "this interview. I' m just curious".
+  h.interviewer("All right, so we're going to kind of just jump right into the problem.", false);
+  await h.advance(40);
+  h.interviewer('All right, so we');                    // cut BEFORE the apostrophe
+  await h.advance(40);
+  h.interviewer("'re going to kind of jump in. I'm just curious", false);
+  await h.advance(40);
+  h.interviewer("'re going to kind of jump in. I'");    // cut AFTER the apostrophe
+  await h.advance(40);
+  h.interviewer('m just curious: are you familiar with CoderPad?', false);
+  await h.advance(40);
+  h.interviewer('m just curious: are you familiar with CoderPad?');
+  await h.advance(STABILITY_MS + 400);
+
+  const judged = h.state.judgeCalls.at(-1).candidateText;
+  assert.match(judged, /so we're going/, "closes we|'re");
+  assert.doesNotMatch(judged, /we 're/, 'no "we \'re"');
+  assert.match(judged, /I'm just curious/, "closes I'|m");
+  assert.doesNotMatch(judged, /I' m/, 'no "I\' m"');
+});
+
 test('a cut after punctuation is never glued, even with no space in the interim', async () => {
   const h = makeSimple(async () => YES());
   // The relay sometimes emits no space after a sentence: "…probability.So".
@@ -792,4 +818,24 @@ test('a revised interim makes no seam claim (fall back to a plain space)', async
   await h.advance(STABILITY_MS + 400);
   const judged = h.state.judgeCalls.at(-1).candidateText;
   assert.match(judged, /the hardest bug you have shipped/, 'joined with a space, unchanged behaviour');
+});
+
+test('isMidWordCut: the seam rule, case by case', () => {
+  // GLUE — a word, or a contraction cut on either side of its apostrophe.
+  assert.equal(isMidWordCut('Um, we\'re going to prob', 'Um, we\'re going to probably just jump'), true);
+  assert.equal(isMidWordCut('All right, so we', "All right, so we're going to jump in"), true);
+  assert.equal(isMidWordCut("this interview. I'", "this interview. I'm just curious"), true);
+  assert.equal(isMidWordCut('and where it gets interest', 'and where it gets interesting is'), true);
+
+  // DON'T — a real space, a sentence seam, an em-dash, or two apostrophes
+  // meeting (which is never a split word, only punctuation abutting).
+  assert.equal(isMidWordCut('be able to get a', 'be able to get a random value'), false);
+  assert.equal(isMidWordCut('of equal probability.', 'of equal probability.So just these'), false);
+  assert.equal(isMidWordCut('a couple—', 'a couple—Code'), false);
+  assert.equal(isMidWordCut("it'", "it''x"), false, 'two apostrophes are not a split word');
+
+  // NO CLAIM — the interim was revised, or there is nothing after the cut.
+  assert.equal(isMidWordCut('So tell me about', 'something else entirely'), false);
+  assert.equal(isMidWordCut('exactly this', 'exactly this'), false);
+  assert.equal(isMidWordCut('', 'anything'), false);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "natively",
-  "version": "2.8.6",
+  "version": "2.8.7",
   "main": "dist-electron/electron/main.js",
   "engines": {
     "node": ">=22.6.0"


### PR DESCRIPTION
Two follow-ups from the first live session on the merged Auto Answer engine.

## Contractions were still being split

The seam repair landed in #502 required word characters on **both** sides of a relay cut — and an apostrophe is not `\w`. The relay cuts on either side of one:

```
final "All right, so we"  + interim "…so we're going"    →  "so we 're going"
final "…interview. I'"    + interim "…I'm just curious"  →  "this interview. I' m just"
```

Both reached the judge, and the answer, in that mangled form. An apostrophe now counts as word-continuation on either side, with two guards kept: two apostrophes meeting never glue (punctuation abutting, not a split word), and at least one side must still be a true word character — which is what keeps the sentence seam `"…probability.|So just these"` unglued.

Mutation-probed both ways. The both-apostrophes guard probe **initially passed**, so rather than leave defensive logic nothing exercised, a direct `isMidWordCut` unit test was added at the right level.

## `ANSWER_FLOOR` 0.20 → 0.30

User decision, with the distribution recorded next to the constant because it matters for the next tuning pass. Across every session captured, the judge's answerability has only ever been:

`0` ×132 · `0.1` ×69 · `0.4` ×5 · `0.8` ×2 · `0.9` ×19 · `1.0` ×13

Nothing has landed between 0.2 and 0.3, so this changes no dispatch that has actually occurred. The weak band is **0.4**, and only a floor above it would remove that — deliberately not done; those answers were judged acceptable.

## The session that produced both

75 s of interviewer speech, **5 answers** — against roughly one per 4–7 minutes before this week. Every mechanism from #502 fired in production:

| mechanism | evidence |
| --- | --- |
| deferred verdict | **3×** — positive verdicts superseded by an interim, held, applied 50–170 ms later |
| speculative prefetch | **2×** — its first ever execution (the delegation fix in #502 is what made it reachable) |
| seam repair | closed `prob\|ably` correctly |
| mic echo latch | zero `mic_echo`, zero `user_answering` on clean audio |

Candidate → dispatch: 0.87 / 0.94 / 0.94 / 1.17 / 1.26 s. Answer TFFT 1243–2081 ms. **No dispatch parked behind the now-live prefetch** — the contention risk flagged in #502 did not materialise.

## Validation

57/57 Auto Answer tests on the fake clock, zero real sleeps · `typecheck:electron` clean · every new guard mutation-probed.

`Requires physical Windows verification` — no platform-specific paths touched (pure TypeScript text handling and one constant). macOS exercised live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152gbX1iF4XbYS62fzkmSLc
