### PR TITLE
chore(gitignore): stop tracking local pitch + research artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -533,7 +533,13 @@ benchmark-results/
 #   undefined/           written by a bug that resolved a path to the literal
 #                        string "undefined" — if this reappears, fix the caller
 #   natively_debug.size* one-off debug dumps
+#   pitch/               investor pitch deck + DPIIT notes (business material,
+#                        and this repo is public — a deck does not belong in it)
+#   researc              a personal chat transcript, saved by a shell redirect
+#                        that lost its filename. Kept locally, never committed.
 /natively-control/
 /chargeback_evidence/
 /undefined/
 /natively_debug.size*
+/pitch/
+/researc


### PR DESCRIPTION
Two untracked items were sitting in the working tree and turning up in every `git status`:

| Item | What it is |
|---|---|
| `pitch/` | Investor pitch deck, DPIIT notes, and a 282 KB PDF |
| `researc` | A 22 KB personal chat transcript, saved by a shell redirect that lost its filename |

Neither is application code, and this repo is public — committing either would publish business material permanently into git history. They join the existing **"working-directory artifacts"** block at the bottom of `.gitignore`, which already covers `natively-control/` and `chargeback_evidence/` for exactly the same reason.

The files stay on disk. Only the tracking noise goes away.

## Validation

`.gitignore`-only change — no code, no build, no platform surface touched. macOS and Windows are unaffected identically.

```
$ git check-ignore -v researc pitch/pitch-deck.pdf
.gitignore:545:/researc	researc
.gitignore:544:/pitch/	pitch/pitch-deck.pdf
```

`git status` is clean afterwards apart from the pre-existing `natively-api` gitlink (untracked scratch files inside the submodule; its recorded pointer is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsosiiexLej7S5JLUYmqhc