### PR TITLE
chore(repo): track natively-api as a registered submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,6 @@ FIXES.md
 python-installer.pkg
 Sales20260405-60-494j8t.csv
 /Sales20260405-60-494j8t.csv
-natively-api
-/natively-api
 /natively
 natively/
 .natively

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "premium"]
 	path = premium
 	url = https://github.com/Natively-AI-assistant/natively-premium.git
+[submodule "natively-api"]
+	path = natively-api
+	url = https://github.com/evinjohnn/natively-api.git


### PR DESCRIPTION
## What

`natively-api` was recorded in the parent index as a gitlink (`160000 6217f1f`) but had **no `.gitmodules` entry**. The parent `.gitignore` also listed the path twice.

This PR adds the missing submodule registration and drops the two ignore rules.

```
.gitignore  | 2 --
.gitmodules | 3 +++
```

## Why

Two problems fell out of the orphan gitlink:

1. **Fresh clones got an empty directory.** With no URL recorded, `git submodule update --init` and `git clone --recurse-submodules` had nothing to fetch, so `natively-api/` came down empty.
2. **AI IDEs skipped the API server code.** The code is on disk, but IDEs honour `.gitignore` when indexing, so `natively-api` / `/natively-api` in the parent ignore file kept the server source out of the index — which is the actual motivation here: making the API code visible alongside the app for compatibility checks.

## Verification

- `git ls-remote https://github.com/evinjohnn/natively-api.git main` → `6217f1f…`, exactly the commit the parent pins, so a recursive clone lands on the right code.
- `git submodule status` reports both submodules clean and in sync (`6217f1f natively-api`, `ae7b4ba premium`).
- `git check-ignore natively-api` → no longer ignored.
- Other `natively*` ignore rules were left untouched; the bare `natively` pattern matches only a path component of exactly that name, not `natively-api`.

## Not affected

`natively-api` keeps its own history and push target, so the Railway deploy from `evinjohnn/natively-api@main` is unchanged. No secrets are newly tracked — submodule contents are not stored in this repo, and `natively-api/.gitignore` already covers `.env`, `node_modules`, and `log.txt`.

## Note for reviewers

The submodule URL points at `evinjohnn/natively-api`, a different owner than `premium` (`Natively-AI-assistant/natively-premium`). That reflects where the repo actually lives today — worth confirming it is the intended long-term home before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsosiiexLej7S5JLUYmqhc