### PR TITLE
perf(llm): load the two stream-guard modules in parallel

### DIFF
--- a/electron/LLMHelper.ts
+++ b/electron/LLMHelper.ts
@@ -5529,8 +5529,17 @@ let isMultimodal = !!(imagePaths?.length);
     // The ceiling is per-SURFACE: the live cap is calibrated from what_to_answer
     // answers and is far too tight for a whole-meeting summary, which the batch
     // callers reach through streamChatLongForm.
-    const { MAX_STREAM_OUTPUT_CHARS, MAX_SUMMARY_OUTPUT_CHARS } = await import('./llm/liveDeadlines');
-    const { testOutputCharCeiling } = await import('./llm/streamFaultInjection');
+    // Loaded TOGETHER: the two imports are independent, so awaiting them in
+    // sequence costs an extra microtask hop on every streamed turn for nothing
+    // (react-doctor server-sequential-independent-await). This is the hot path —
+    // every answer passes through it.
+    const [
+      { MAX_STREAM_OUTPUT_CHARS, MAX_SUMMARY_OUTPUT_CHARS },
+      { testOutputCharCeiling },
+    ] = await Promise.all([
+      import('./llm/liveDeadlines'),
+      import('./llm/streamFaultInjection'),
+    ]);
     // Test switch (dev-only, opt-in) lets the cap be provoked without waiting
     // for a model to actually loop. Null in any packaged build.
     const outputCeiling = testOutputCharCeiling()
@@ -5629,8 +5638,12 @@ let isMultimodal = !!(imagePaths?.length);
     state: { chars: number; truncated?: boolean },
     label: string,
   ): AsyncGenerator<string, void, unknown> {
-    const { MAX_STREAM_OUTPUT_CHARS } = await import('./llm/liveDeadlines');
-    const { testOutputCharCeiling } = await import('./llm/streamFaultInjection');
+    // Same independent-await pair as streamChat above — one Promise.all rather
+    // than two sequential awaits on the per-chunk cap path.
+    const [{ MAX_STREAM_OUTPUT_CHARS }, { testOutputCharCeiling }] = await Promise.all([
+      import('./llm/liveDeadlines'),
+      import('./llm/streamFaultInjection'),
+    ]);
     const ceiling = testOutputCharCeiling() ?? MAX_STREAM_OUTPUT_CHARS;
     for await (const chunk of inner) {
       yield chunk;


### PR DESCRIPTION
Both output-cap sites in `LLMHelper` awaited `liveDeadlines` and `streamFaultInjection` in sequence. The two imports are independent, so that costs an extra microtask hop on **every streamed turn** for nothing (react-doctor `server-sequential-independent-await`). This is the hot path — every answer passes through it.

```ts
// before
const { MAX_STREAM_OUTPUT_CHARS, MAX_SUMMARY_OUTPUT_CHARS } = await import('./llm/liveDeadlines');
const { testOutputCharCeiling } = await import('./llm/streamFaultInjection');

// after
const [
  { MAX_STREAM_OUTPUT_CHARS, MAX_SUMMARY_OUTPUT_CHARS },
  { testOutputCharCeiling },
] = await Promise.all([
  import('./llm/liveDeadlines'),
  import('./llm/streamFaultInjection'),
]);
```

The lone `streamFaultInjection` import in `trackCommit` has no partner and is left alone.

## Provenance

Ported from the unmerged `fix/stream-fault-injection` (PR #464, closed). Its sibling commit — the fault-injection switches themselves — is **already on main** by another route; only this follow-up was left behind.

A straight cherry-pick would have conflicted: the `streamChat` site now also destructures `MAX_SUMMARY_OUTPUT_CHARS`, added after that branch was cut, so the first hunk was re-derived rather than replayed.

Behaviour is unchanged — same modules, same bindings, same order of use.

## Validation

- `Build validated on macOS` — `tsc -p electron/tsconfig.json --noEmit`, **0 errors**
- `Covered by automated tests` — `StreamFaultInjection` 8/8 (including *"both output-cap sites honour the test ceiling"*, which pins exactly these two sites), `RunawayStreamOutputCap` 20/20, `CodingRegenCeiling` 3/3, `PostCommitNoProviderSwitch` 10/10
- **Caveat:** `RunawayStreamOutputCap` imports the built bundle from `dist-electron`, which predates this edit, so its *runtime* assertions exercised the pre-change build. Its source-assertion half did read the patched `.ts`. A rebuild closes that gap; since this is a semantically identical refactor the residual risk is low, but CI building from source is the real check.
- **Platform-neutral** — no platform-specific code path is touched, so a green macOS run is sufficient here (unlike its companion PR #506).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJS2xjF8uDPMa4EpXey5FL
