### PR TITLE
fix(stealth): keep the meeting overlay hidden from screen captures

### DIFF
--- a/electron/WindowHelper.ts
+++ b/electron/WindowHelper.ts
@@ -269,14 +269,27 @@ export class WindowHelper {
   }
 
   private applyContentProtection(enable: boolean): void {
-    const windows = [
-      this.launcherWindow,
-      this.overlayWindow,
-      this.pillWindow,
-      this.toggleWindow,
-      this.popoverCatcher,
-    ];
-    windows.forEach((win) => {
+    // The meeting overlay chrome (overlay body + pill + toggle) is a ghost
+    // surface: it must NEVER appear in a screen capture, independent of
+    // undetectable/dock mode. "Undetectable mode" governs Dock/taskbar
+    // masquerading and the launcher's capture visibility — NOT the overlay's
+    // screen-share invisibility, which is the app's core promise and is always
+    // wanted while a meeting overlay is up. Coupling the two let the overlay
+    // leak into a shared screen whenever undetectable mode was off (its
+    // default), re-exposing it via `NSWindowSharingReadOnly` and overriding the
+    // unconditional `NSWindowSharingNone` the native stealth module applies to
+    // exactly these three windows. Force it on for them regardless of `enable`.
+    const overlayChrome = [this.overlayWindow, this.pillWindow, this.toggleWindow];
+    overlayChrome.forEach((win) => {
+      if (win && !win.isDestroyed()) {
+        win.setContentProtection(true);
+      }
+    });
+    // The launcher and popover catcher are not meeting chrome; they follow the
+    // undetectable-mode toggle (the launcher is the main window shown outside a
+    // meeting, and the native module deliberately does NOT force-hide it).
+    const undetectableFollowers = [this.launcherWindow, this.popoverCatcher];
+    undetectableFollowers.forEach((win) => {
       if (win && !win.isDestroyed()) {
         win.setContentProtection(enable);
       }
@@ -788,7 +801,12 @@ export class WindowHelper {
       // "still steals focus" reports — the bundle is only read at launch).
       console.log('[WindowHelper] Windows no-activate policy applied to overlay');
     }
-    this.overlayWindow.setContentProtection(this.contentProtection);
+    // Always protected: the overlay is a ghost surface that must never show in a
+    // screen capture, regardless of undetectable/dock mode (see
+    // applyContentProtection). This mirrors the native module's unconditional
+    // NSWindowSharingNone and closes the leak on builds where that native binary
+    // is unavailable (e.g. an Intel prebuild mismatch).
+    this.overlayWindow.setContentProtection(true);
     // Apply the current mouse-interaction policy to the NEW window. Without
     // this, a window (re)created while stealth passthrough is ON would start
     // fully interactive — silently breaking passthrough until the next toggle.
@@ -1593,7 +1611,10 @@ export class WindowHelper {
       [this.toggleWindow, 'overlay-toggle'],
     ];
     for (const [win, name] of auxPairs) {
-      win.setContentProtection(this.contentProtection);
+      // Always protected, like the overlay body — the pill/toggle are the
+      // on-screen meeting chrome and must never leak into a shared screen
+      // regardless of undetectable/dock mode (see applyContentProtection).
+      win.setContentProtection(true);
       if (process.platform === 'darwin') {
         win.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
         win.setHiddenInMissionControl(true);
@@ -2243,7 +2264,11 @@ export class WindowHelper {
       });
 
       // Restore opacity before showing (it may have been zeroed by hideMainWindow).
-      if (process.platform === 'win32' && this.contentProtection) {
+      // The overlay is ALWAYS content-protected (see applyContentProtection), so on
+      // Windows the opacity shield must run on every overlay show — not only in
+      // undetectable mode — or the first frame leaks before DWM applies the
+      // capture-exclusion flag.
+      if (process.platform === 'win32') {
         // Opacity Shield: Show at 0 opacity first to prevent frame leak.
         // The aux windows (pill/toggle) show via the overlay's 'show' event,
         // so shield them the same way — they carry the same on-screen chrome.
@@ -2273,20 +2298,18 @@ export class WindowHelper {
           }
         }, 60);
       } else {
+        // macOS / Linux path (Windows always takes the shielded branch above).
         // Restore opacity (may have been zeroed pre-screenshot by hideMainWindow)
         this.overlayWindow.setOpacity(1);
         this.pillWindow?.setOpacity(1);
         this.toggleWindow?.setOpacity(1);
-        this.overlayWindow.setContentProtection(this.contentProtection);
-        // Re-assert z-order BEFORE show on Windows — DWM processes setAlwaysOnTop
-        // synchronously, so calling it before show() ensures the window lands at the
-        // correct z-level on first paint. Calling it after focus() would leave a brief
-        // window where the HWND is focused at the wrong z-level (issue #136).
-        // Skipped on macOS — calling setAlwaysOnTop triggers [NSApp activate] which
-        // steals focus from Zoom/browser even when showInactive() was used.
-        if (process.platform === 'win32') {
-          this.overlayWindow.setAlwaysOnTop(true, 'screen-saver');
-        }
+        // Always protected — the overlay must never appear in a screen capture,
+        // regardless of undetectable/dock mode (see applyContentProtection).
+        this.overlayWindow.setContentProtection(true);
+        // No setAlwaysOnTop here: this branch is macOS/Linux only (Windows always
+        // takes the shielded branch above, which re-asserts z-order itself). On
+        // macOS calling setAlwaysOnTop would trigger [NSApp activate] and steal
+        // focus from Zoom/browser even when showInactive() was used.
         if (inactive) this.overlayWindow.showInactive();
         else this.overlayWindow.show();
         // Same synchronous block as the body's show (see the win32 branch) so

--- a/electron/audio/__tests__/OverlayAlwaysContentProtected.test.mjs
+++ b/electron/audio/__tests__/OverlayAlwaysContentProtected.test.mjs
@@ -25,6 +25,16 @@
 // `enable` — so a refactor that drops one window into the mode-dependent group
 // (or flips its argument to `enable`/`false`) fails here instead of silently
 // re-introducing the screen-capture leak.
+//
+// IMPORTANT — why the positive assertions are scoped to a specific method body
+// rather than run against the whole file: `applyContentProtection` itself now
+// contains the literal text `win.setContentProtection(true)`, and the overlay
+// show path contains `this.overlayWindow.setContentProtection(true)`. A
+// whole-source regex for either string therefore passes even when the *creation*
+// site it claims to guard has been reverted to `this.contentProtection` (verified
+// with a mutation probe: reverting both creation sites still gave 8/8 green).
+// Each positive check below is anchored to the body of the method that owns the
+// site, so a revert there actually fails the test.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -39,14 +49,12 @@ const source = readFileSync(windowHelperPath, 'utf8');
 const OVERLAY_CHROME = ['this.overlayWindow', 'this.pillWindow', 'this.toggleWindow'];
 
 /**
- * Extract the body of `applyContentProtection(enable: boolean): void { ... }`
- * via brace-balancing. Mirrors the extractor in
- * SetContentProtectionDedupe.test.mjs.
+ * Extract a method body via brace-balancing from the first match of `sigRe`.
+ * Mirrors the extractor in SetContentProtectionDedupe.test.mjs.
  */
-function extractApplyContentProtectionBody(src) {
-    const sigRe = /(?:public\s+|private\s+|protected\s+)?applyContentProtection\s*\(\s*enable\s*:\s*boolean\s*\)\s*:\s*void\s*\{/;
+function extractMethodBody(src, sigRe, label) {
     const m = sigRe.exec(src);
-    assert.ok(m, 'could not locate applyContentProtection signature in WindowHelper');
+    assert.ok(m, `could not locate ${label} in WindowHelper`);
     let i = m.index + m[0].length;
     let depth = 1;
     const start = i;
@@ -56,7 +64,7 @@ function extractApplyContentProtectionBody(src) {
         else if (ch === '}') depth--;
         i++;
     }
-    assert.equal(depth, 0, 'unbalanced braces while extracting applyContentProtection');
+    assert.equal(depth, 0, `unbalanced braces while extracting ${label}`);
     return src.slice(start, i - 1);
 }
 
@@ -83,8 +91,27 @@ function parseProtectionGroups(body) {
     return groups;
 }
 
-const body = extractApplyContentProtectionBody(source);
+const body = extractMethodBody(
+    source,
+    /(?:public\s+|private\s+|protected\s+)?applyContentProtection\s*\(\s*enable\s*:\s*boolean\s*\)\s*:\s*void\s*\{/,
+    'applyContentProtection',
+);
 const groups = parseProtectionGroups(body);
+
+// The overlay body is created here (createWindow builds the launcher AND the
+// overlay); the pill/toggle are created in createOverlayAuxWindows. Scoping the
+// creation assertions to these bodies is what makes them bite — see the note at
+// the top of this file.
+const createWindowBody = extractMethodBody(
+    source,
+    /(?:public\s+|private\s+|protected\s+)?createWindow\s*\(\s*\)\s*:\s*void\s*\{/,
+    'createWindow',
+);
+const createAuxBody = extractMethodBody(
+    source,
+    /(?:public\s+|private\s+|protected\s+)?createOverlayAuxWindows\s*\(\s*startUrl\s*:\s*string\s*\)\s*:\s*void\s*\{/,
+    'createOverlayAuxWindows',
+);
 
 test('applyContentProtection maps at least two window groups (chrome + followers)', () => {
     assert.ok(
@@ -138,7 +165,8 @@ test('applyContentProtection keeps the launcher on the undetectable-mode toggle 
 
 test('the overlay body is never protected via this.contentProtection', () => {
     // The exact leak: creating/showing the overlay with the undetectable-mode
-    // value flips sharingType back to ReadOnly in normal mode.
+    // value flips sharingType back to ReadOnly in normal mode. Whole-source on
+    // purpose — no site anywhere may reintroduce it.
     assert.ok(
         !/this\.overlayWindow\.setContentProtection\s*\(\s*this\.contentProtection\s*\)/.test(source),
         `BUG: WindowHelper still calls ` +
@@ -148,20 +176,44 @@ test('the overlay body is never protected via this.contentProtection', () => {
     );
 });
 
-test('the overlay is created/shown with content protection forced on', () => {
+test('the overlay body is CREATED with content protection forced on', () => {
+    // Scoped to createWindow so the show-path call sites cannot satisfy it.
     assert.ok(
-        /this\.overlayWindow\.setContentProtection\s*\(\s*true\s*\)/.test(source),
-        `BUG: the overlay window is not created/shown with \`setContentProtection(true)\`. It ` +
-        `must be protected from the first frame, independent of undetectable mode.`,
+        /this\.overlayWindow\.setContentProtection\s*\(\s*true\s*\)/.test(createWindowBody),
+        `BUG: the overlay window is not created with \`setContentProtection(true)\` in ` +
+        `createWindow. It must be protected from the first frame, independent of undetectable ` +
+        `mode — a show-site call is too late and does not cover a window created while hidden.`,
     );
 });
 
-test('the pill/toggle aux windows are protected with a literal true, not this.contentProtection', () => {
+test('the overlay body is SHOWN with content protection forced on', () => {
+    // switchToOverlay re-asserts protection on both the Windows (opacity-shield)
+    // and macOS/Linux branches. Scoped so the creation site cannot satisfy it.
+    const switchToOverlayBody = extractMethodBody(
+        source,
+        /(?:public\s+|private\s+|protected\s+)?switchToOverlay\s*\(\s*inactive\s*\??\s*:\s*boolean[^)]*\)\s*:\s*void\s*\{/,
+        'switchToOverlay',
+    );
+    const forced = switchToOverlayBody.match(
+        /this\.overlayWindow\.setContentProtection\s*\(\s*true\s*\)/g,
+    );
+    assert.equal(
+        forced?.length,
+        2,
+        `BUG: switchToOverlay has ${forced?.length ?? 0} \`setContentProtection(true)\` call(s) ` +
+        `on the overlay, expected 2 (the win32 opacity-shield branch and the macOS/Linux branch). ` +
+        `Both show paths must force protection on before the first painted frame.`,
+    );
+});
+
+test('the pill/toggle aux windows are CREATED with a literal true, not this.contentProtection', () => {
+    // Scoped to createOverlayAuxWindows so applyContentProtection's own
+    // `win.setContentProtection(true)` cannot satisfy it.
     assert.ok(
-        /win\.setContentProtection\s*\(\s*true\s*\)/.test(source),
+        /win\.setContentProtection\s*\(\s*true\s*\)/.test(createAuxBody),
         `BUG: the overlay aux windows (pill/toggle) are not protected with ` +
-        `\`win.setContentProtection(true)\` at creation. They are on-screen meeting chrome and ` +
-        `must never leak into a shared screen.`,
+        `\`win.setContentProtection(true)\` at creation in createOverlayAuxWindows. They are ` +
+        `on-screen meeting chrome and must never leak into a shared screen.`,
     );
     assert.ok(
         !/win\.setContentProtection\s*\(\s*this\.contentProtection\s*\)/.test(source),

--- a/electron/audio/__tests__/OverlayAlwaysContentProtected.test.mjs
+++ b/electron/audio/__tests__/OverlayAlwaysContentProtected.test.mjs
@@ -1,0 +1,115 @@
+// Regression test for: the meeting overlay leaking into screen captures.
+//
+// Bug (issue: "Natively is visible on Google Meet calls"): the overlay chrome
+// (overlay body + pill + toggle) is a ghost surface that must NEVER appear in a
+// screen capture — that is the app's core promise, and the native stealth module
+// force-applies NSWindowSharingNone to exactly those three windows regardless of
+// mode. But the JS side coupled the overlay's screen-capture invisibility to
+// `this.contentProtection`, which only tracks *undetectable/dock* mode. With
+// undetectable mode off (its default), every overlay show called
+// `setContentProtection(false)`, flipping sharingType back to
+// NSWindowSharingReadOnly and re-exposing the overlay — overriding the native
+// module and leaking the overlay onto the shared screen.
+//
+// Fix: the overlay chrome is ALWAYS content-protected, independent of
+// undetectable mode. `applyContentProtection` forces it on for the overlay/pill/
+// toggle group and only lets the launcher/popover follow `enable`; the creation
+// and show sites pass `true` rather than `this.contentProtection`.
+//
+// Strategy: source-level static check on WindowHelper.ts. The helper instantiates
+// BrowserWindow on import and pulls in Electron main-process APIs, so it cannot be
+// cleanly unit-tested in isolation (same approach as
+// SetContentProtectionDedupe.test.mjs). We extract the applyContentProtection body
+// via brace-balancing and assert the invariant, and we assert the leak-prone call
+// `this.overlayWindow.setContentProtection(this.contentProtection)` is gone.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const windowHelperPath = path.resolve(__dirname, '../../../electron/WindowHelper.ts');
+const source = readFileSync(windowHelperPath, 'utf8');
+
+/**
+ * Extract the body of `applyContentProtection(enable: boolean): void { ... }`
+ * via brace-balancing. Mirrors the extractor in
+ * SetContentProtectionDedupe.test.mjs.
+ */
+function extractApplyContentProtectionBody(src) {
+    const sigRe = /(?:public\s+|private\s+|protected\s+)?applyContentProtection\s*\(\s*enable\s*:\s*boolean\s*\)\s*:\s*void\s*\{/;
+    const m = sigRe.exec(src);
+    assert.ok(m, 'could not locate applyContentProtection signature in WindowHelper');
+    let i = m.index + m[0].length;
+    let depth = 1;
+    const start = i;
+    while (i < src.length && depth > 0) {
+        const ch = src[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') depth--;
+        i++;
+    }
+    assert.equal(depth, 0, 'unbalanced braces while extracting applyContentProtection');
+    return src.slice(start, i - 1);
+}
+
+const body = extractApplyContentProtectionBody(source);
+
+test('applyContentProtection references all three overlay-chrome windows', () => {
+    for (const field of ['this.overlayWindow', 'this.pillWindow', 'this.toggleWindow']) {
+        assert.ok(
+            body.includes(field),
+            `BUG: applyContentProtection no longer references ${field}. The overlay ` +
+            `chrome (overlay body + pill + toggle) must be handled here so it can be ` +
+            `force-protected independent of undetectable mode.`,
+        );
+    }
+});
+
+test('applyContentProtection force-enables protection with a literal true', () => {
+    assert.ok(
+        /\.\s*setContentProtection\s*\(\s*true\s*\)/.test(body),
+        `BUG: applyContentProtection has no \`setContentProtection(true)\` call. The ` +
+        `overlay chrome must be content-protected unconditionally — coupling it to ` +
+        `\`enable\` re-exposes the overlay in screen shares whenever undetectable ` +
+        `mode is off (its default).`,
+    );
+});
+
+test('the overlay body is never protected via this.contentProtection', () => {
+    // The exact leak: showing/creating the overlay with the undetectable-mode
+    // value flips sharingType back to ReadOnly in normal mode.
+    assert.ok(
+        !/this\.overlayWindow\.setContentProtection\s*\(\s*this\.contentProtection\s*\)/.test(source),
+        `BUG: WindowHelper still calls ` +
+        `\`this.overlayWindow.setContentProtection(this.contentProtection)\`. The ` +
+        `overlay must always be protected (pass \`true\`); gating it on ` +
+        `undetectable mode leaks the overlay onto shared screens.`,
+    );
+});
+
+test('the overlay is created with content protection forced on', () => {
+    assert.ok(
+        /this\.overlayWindow\.setContentProtection\s*\(\s*true\s*\)/.test(source),
+        `BUG: the overlay window is not created/shown with ` +
+        `\`setContentProtection(true)\`. It must be protected from the first frame, ` +
+        `independent of undetectable mode.`,
+    );
+});
+
+test('the pill/toggle aux windows are protected with a literal true, not this.contentProtection', () => {
+    assert.ok(
+        /win\.setContentProtection\s*\(\s*true\s*\)/.test(source),
+        `BUG: the overlay aux windows (pill/toggle) are not protected with ` +
+        `\`win.setContentProtection(true)\`. They are on-screen meeting chrome and ` +
+        `must never leak into a shared screen.`,
+    );
+    assert.ok(
+        !/win\.setContentProtection\s*\(\s*this\.contentProtection\s*\)/.test(source),
+        `BUG: the overlay aux windows are still protected via ` +
+        `\`win.setContentProtection(this.contentProtection)\`, which re-exposes them ` +
+        `in normal mode.`,
+    );
+});

--- a/electron/audio/__tests__/OverlayAlwaysContentProtected.test.mjs
+++ b/electron/audio/__tests__/OverlayAlwaysContentProtected.test.mjs
@@ -19,9 +19,12 @@
 // Strategy: source-level static check on WindowHelper.ts. The helper instantiates
 // BrowserWindow on import and pulls in Electron main-process APIs, so it cannot be
 // cleanly unit-tested in isolation (same approach as
-// SetContentProtectionDedupe.test.mjs). We extract the applyContentProtection body
-// via brace-balancing and assert the invariant, and we assert the leak-prone call
-// `this.overlayWindow.setContentProtection(this.contentProtection)` is gone.
+// SetContentProtectionDedupe.test.mjs). We parse the applyContentProtection body
+// and assert the actual MAPPING — each overlay-chrome window is iterated by a
+// forEach that applies `setContentProtection(true)`, while the launcher follows
+// `enable` — so a refactor that drops one window into the mode-dependent group
+// (or flips its argument to `enable`/`false`) fails here instead of silently
+// re-introducing the screen-capture leak.
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -32,6 +35,8 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const windowHelperPath = path.resolve(__dirname, '../../../electron/WindowHelper.ts');
 const source = readFileSync(windowHelperPath, 'utf8');
+
+const OVERLAY_CHROME = ['this.overlayWindow', 'this.pillWindow', 'this.toggleWindow'];
 
 /**
  * Extract the body of `applyContentProtection(enable: boolean): void { ... }`
@@ -55,47 +60,99 @@ function extractApplyContentProtectionBody(src) {
     return src.slice(start, i - 1);
 }
 
-const body = extractApplyContentProtectionBody(source);
+/**
+ * Parse applyContentProtection into { members, arg } groups: each window-array
+ * literal paired with the argument the immediately-following
+ * `setContentProtection(...)` call applies to it. This binds each window to the
+ * protection value it actually receives, rather than checking for the array and
+ * the literal `true` independently (which a per-window regression could slip
+ * past).
+ */
+function parseProtectionGroups(body) {
+    const groups = [];
+    const arrayRe = /\[([^\][]*)\]/g; // window arrays contain no nested brackets
+    let m;
+    while ((m = arrayRe.exec(body)) !== null) {
+        const members = m[1].split(',').map((s) => s.trim()).filter(Boolean);
+        if (!members.some((x) => x.startsWith('this.'))) continue; // not a window array
+        const after = body.slice(m.index + m[0].length);
+        const callMatch = /\.\s*setContentProtection\s*\(\s*([A-Za-z0-9_.]+)\s*\)/.exec(after);
+        if (!callMatch) continue;
+        groups.push({ members, arg: callMatch[1] });
+    }
+    return groups;
+}
 
-test('applyContentProtection references all three overlay-chrome windows', () => {
-    for (const field of ['this.overlayWindow', 'this.pillWindow', 'this.toggleWindow']) {
+const body = extractApplyContentProtectionBody(source);
+const groups = parseProtectionGroups(body);
+
+test('applyContentProtection maps at least two window groups (chrome + followers)', () => {
+    assert.ok(
+        groups.length >= 2,
+        `BUG: applyContentProtection no longer splits windows into an always-protected ` +
+        `overlay-chrome group and a mode-dependent follower group (found ${groups.length} ` +
+        `window group(s)). Parsed groups: ${JSON.stringify(groups)}`,
+    );
+});
+
+for (const win of OVERLAY_CHROME) {
+    test(`applyContentProtection protects ${win} unconditionally (setContentProtection(true))`, () => {
+        const owning = groups.filter((g) => g.members.includes(win));
         assert.ok(
-            body.includes(field),
-            `BUG: applyContentProtection no longer references ${field}. The overlay ` +
-            `chrome (overlay body + pill + toggle) must be handled here so it can be ` +
-            `force-protected independent of undetectable mode.`,
+            owning.length > 0,
+            `BUG: ${win} is not handled in applyContentProtection. It is on-screen meeting ` +
+            `chrome and must be force-protected there, independent of undetectable mode.`,
+        );
+        for (const g of owning) {
+            assert.equal(
+                g.arg,
+                'true',
+                `BUG: ${win} receives \`setContentProtection(${g.arg})\` in applyContentProtection, ` +
+                `not \`true\`. The overlay chrome must be protected unconditionally — coupling it to ` +
+                `\`enable\` (undetectable mode) re-exposes the overlay in screen shares whenever ` +
+                `undetectable mode is off (its default).`,
+            );
+        }
+    });
+}
+
+test('applyContentProtection keeps the launcher on the undetectable-mode toggle (enable)', () => {
+    // Sanity that the split is real: the launcher is NOT meeting chrome and must
+    // still follow the toggle, so we are not just blanket-forcing everything true.
+    const owning = groups.filter((g) => g.members.includes('this.launcherWindow'));
+    assert.ok(
+        owning.length > 0,
+        'BUG: applyContentProtection no longer references this.launcherWindow — the launcher ' +
+        'must follow undetectable mode.',
+    );
+    for (const g of owning) {
+        assert.equal(
+            g.arg,
+            'enable',
+            `BUG: the launcher receives \`setContentProtection(${g.arg})\` instead of following ` +
+            `\`enable\`. It is the main window shown outside a meeting and the native module ` +
+            `deliberately does not force-hide it.`,
         );
     }
 });
 
-test('applyContentProtection force-enables protection with a literal true', () => {
-    assert.ok(
-        /\.\s*setContentProtection\s*\(\s*true\s*\)/.test(body),
-        `BUG: applyContentProtection has no \`setContentProtection(true)\` call. The ` +
-        `overlay chrome must be content-protected unconditionally — coupling it to ` +
-        `\`enable\` re-exposes the overlay in screen shares whenever undetectable ` +
-        `mode is off (its default).`,
-    );
-});
-
 test('the overlay body is never protected via this.contentProtection', () => {
-    // The exact leak: showing/creating the overlay with the undetectable-mode
+    // The exact leak: creating/showing the overlay with the undetectable-mode
     // value flips sharingType back to ReadOnly in normal mode.
     assert.ok(
         !/this\.overlayWindow\.setContentProtection\s*\(\s*this\.contentProtection\s*\)/.test(source),
         `BUG: WindowHelper still calls ` +
-        `\`this.overlayWindow.setContentProtection(this.contentProtection)\`. The ` +
-        `overlay must always be protected (pass \`true\`); gating it on ` +
-        `undetectable mode leaks the overlay onto shared screens.`,
+        `\`this.overlayWindow.setContentProtection(this.contentProtection)\`. The overlay must ` +
+        `always be protected (pass \`true\`); gating it on undetectable mode leaks the overlay ` +
+        `onto shared screens.`,
     );
 });
 
-test('the overlay is created with content protection forced on', () => {
+test('the overlay is created/shown with content protection forced on', () => {
     assert.ok(
         /this\.overlayWindow\.setContentProtection\s*\(\s*true\s*\)/.test(source),
-        `BUG: the overlay window is not created/shown with ` +
-        `\`setContentProtection(true)\`. It must be protected from the first frame, ` +
-        `independent of undetectable mode.`,
+        `BUG: the overlay window is not created/shown with \`setContentProtection(true)\`. It ` +
+        `must be protected from the first frame, independent of undetectable mode.`,
     );
 });
 
@@ -103,13 +160,12 @@ test('the pill/toggle aux windows are protected with a literal true, not this.co
     assert.ok(
         /win\.setContentProtection\s*\(\s*true\s*\)/.test(source),
         `BUG: the overlay aux windows (pill/toggle) are not protected with ` +
-        `\`win.setContentProtection(true)\`. They are on-screen meeting chrome and ` +
+        `\`win.setContentProtection(true)\` at creation. They are on-screen meeting chrome and ` +
         `must never leak into a shared screen.`,
     );
     assert.ok(
         !/win\.setContentProtection\s*\(\s*this\.contentProtection\s*\)/.test(source),
         `BUG: the overlay aux windows are still protected via ` +
-        `\`win.setContentProtection(this.contentProtection)\`, which re-exposes them ` +
-        `in normal mode.`,
+        `\`win.setContentProtection(this.contentProtection)\`, which re-exposes them in normal mode.`,
     );
 });


### PR DESCRIPTION
## Summary
The meeting **overlay chrome** (overlay body + pill + toggle) is a ghost surface that must never appear in a screen capture — the app's core promise. The native stealth module (`native-module/src/stealth_window.rs`) force-applies `NSWindowSharingNone` to exactly those three windows regardless of mode, and deliberately leaves the launcher alone.

The JS side, however, coupled the overlay's screen-capture invisibility to `this.contentProtection`, which only tracks **undetectable/dock mode** — a separate concern (Dock/taskbar masquerading, per the changelog). With undetectable mode **off (its default)**, every overlay show called `setContentProtection(false)`, flipping `sharingType` back to `NSWindowSharingReadOnly` and re-exposing the overlay, overriding the native module. On builds where the native binary isn't loaded (e.g. an Intel prebuild mismatch, as in the report) nothing forced it hidden at all — so the overlay appeared in the shared screen.

This PR decouples the overlay chrome's content protection from undetectable mode: the overlay/pill/toggle are now **always** protected, while the launcher and popover catcher still follow the toggle. On Windows, the opacity shield now runs on every overlay show so the capture-exclusion flag lands before the first painted frame.

Fixes #500

## Type of Change
- [x] 🐛 Bug Fix
- [ ] ✨ New Feature
- [ ] 🎨 Refactor / Style Update
- [ ] 📝 Documentation
- [ ] ⚡ Performance Improvement
- [ ] 🛠️ Chore / Tooling

## Testing & Environment
- [x] Verified on macOS (Node v20.20.2)

**Automated checks run:**
- `node --test electron/audio/__tests__/OverlayAlwaysContentProtected.test.mjs electron/audio/__tests__/SetContentProtectionDedupe.test.mjs` → **11/11 pass** (5 new + 6 existing content-protection tests).
- `npm run typecheck:electron` → **clean for this change.** The only two errors are pre-existing and environmental — missing `premium/electron/knowledge/*` modules because the private `premium` submodule isn't checked out in this environment (`IntelligenceEngine.ts`, `resolveCompanySearchProvider.ts` — neither touched by this PR).

> Note: I could not run the app end-to-end (the `premium` submodule and native/Rust build are unavailable here), so the manual Google Meet screen-share repro below should be confirmed by a maintainer.

### Verification Steps
1. Launch Natively **without** undetectable mode (the default) and start a meeting so the overlay is visible.
2. Join a Google Meet call and share **Entire Screen**.
3. Observe the shared feed from a second device/participant view — the Natively overlay (body + pill) must **not** be visible.
4. Toggle undetectable mode on/off during the meeting — the overlay stays hidden from capture throughout (only the Dock/taskbar presence changes).

## Visuals (Optional)
No visible UI change inside the app; the change only affects whether the overlay is excluded from external screen capture, which can't be shown in an in-app screenshot.

## Checklist
- [x] My code follows the code style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new errors or warnings (`typecheck:electron` clean apart from the pre-existing missing-submodule errors)
- [x] Relevant tests have been performed / updated (added `OverlayAlwaysContentProtected.test.mjs`; 11/11 pass)
