### PR TITLE
polish(launcher): give the list ⇄ meeting-notes navigation a real transition

### DIFF
--- a/src/components/Launcher.tsx
+++ b/src/components/Launcher.tsx
@@ -9,7 +9,7 @@ import { useToggleInit } from './settings/useToggleInit';
 import MeetingDetails from './MeetingDetails';
 import TopSearchPill from './TopSearchPill';
 import GlobalChatOverlay from './GlobalChatOverlay';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence, useReducedMotion, type TargetAndTransition } from 'framer-motion';
 import { FeatureSpotlight } from './FeatureSpotlight';
 import { analytics } from '../lib/analytics/analytics.service'; // Added analytics import
 import { useShortcuts } from '../hooks/useShortcuts';
@@ -408,6 +408,59 @@ const Launcher: React.FC<LauncherProps> = ({ onStartMeeting, onOpenSettings, onO
         return `${mm}:00`;
     };
 
+    // ── List ⇄ meeting-notes navigation transition ─────────────────────────────
+    // Cover/uncover model: the details panel is ALWAYS the upper layer (z-20) and
+    // the list is ALWAYS the lower layer (z-10). Details slides in from the right
+    // and leaves to the right; the list never moves laterally, it only recedes by
+    // scaling *up* past the clip box. Scaling up (rather than the usual iOS scale
+    // down) is deliberate: the container clips the overflow, so no edge of the
+    // window is ever uncovered mid-transition — important because this is a
+    // transparent Electron overlay where an uncovered edge is a hole to the
+    // desktop, not a background colour.
+    //
+    // Because direction is decided by *which layer mounts*, not by which meeting
+    // is selected, handleOpenMeeting / handleForward / handleBack all produce the
+    // correct motion with no direction state to keep in sync.
+    const prefersReducedMotion = useReducedMotion();
+    // iOS/Ionic panel curve — strong ease-out, no overshoot.
+    const NAV_EASE: [number, number, number, number] = [0.32, 0.72, 0, 1];
+
+    // Opacity resolves well before the transform so the slide reads as a settle
+    // rather than a fade; the panel is opaque for most of the movement.
+    const detailsEnter: TargetAndTransition = prefersReducedMotion
+        ? { opacity: 1, transition: { duration: 0.12, ease: 'linear' } }
+        : {
+            opacity: 1,
+            transform: 'translateX(0px)',
+            transition: {
+                transform: { duration: 0.34, ease: NAV_EASE },
+                opacity: { duration: 0.2, ease: 'easeOut' },
+            },
+        };
+    const detailsExit: TargetAndTransition = prefersReducedMotion
+        ? { opacity: 0, pointerEvents: 'none', transition: { duration: 0.12, ease: 'linear' } }
+        : {
+            opacity: 0,
+            transform: 'translateX(20px)',
+            pointerEvents: 'none',
+            transition: {
+                transform: { duration: 0.26, ease: NAV_EASE },
+                opacity: { duration: 0.22, ease: 'easeOut' },
+            },
+        };
+    const detailsInitial: TargetAndTransition = prefersReducedMotion
+        ? { opacity: 0 }
+        : { opacity: 0, transform: 'translateX(24px)' };
+
+    // The list layer keeps opacity 1 throughout — it is covered by an opaque
+    // details panel, so cross-dissolving it too would only muddy the blend.
+    const listRecede: TargetAndTransition = prefersReducedMotion
+        ? {}
+        : { transform: 'scale(1.03)', transition: { duration: 0.3, ease: NAV_EASE } };
+    const listSettle: TargetAndTransition = prefersReducedMotion
+        ? {}
+        : { transform: 'scale(1)', transition: { duration: 0.34, ease: NAV_EASE } };
+
     return (
         <div className="h-full w-full flex flex-col bg-bg-primary text-text-primary font-sans overflow-hidden selection:bg-accent-secondary/30">
             {/* 1. Header (Static) */}
@@ -721,15 +774,17 @@ const Launcher: React.FC<LauncherProps> = ({ onStartMeeting, onOpenSettings, onO
                 {!isDetectable && (
                     <div className={`absolute inset-1 border-2 border-dashed rounded-2xl pointer-events-none z-[100] ${isLight ? 'border-black/15' : 'border-white/20'}`} />
                 )}
-                <AnimatePresence mode="wait">
+                {/* initial={false} — the panel that is present on first paint must not
+                    animate in: the launcher is opened by a global shortcut many times a
+                    day, and an entrance animation there only makes it feel slower. */}
+                <AnimatePresence initial={false}>
                     {selectedMeeting ? (
                         <motion.div
                             key="details"
-                            className="flex-1 overflow-hidden"
-                            initial={{ opacity: 0 }}
-                            animate={{ opacity: 1 }}
-                            exit={{ opacity: 0 }}
-                            transition={{ duration: 0.15 }}
+                            className="absolute inset-0 z-20 overflow-hidden"
+                            initial={detailsInitial}
+                            animate={detailsEnter}
+                            exit={detailsExit}
                         >
                             <MeetingDetails
                                 meeting={selectedMeeting}
@@ -740,11 +795,10 @@ const Launcher: React.FC<LauncherProps> = ({ onStartMeeting, onOpenSettings, onO
                     ) : (
                         <motion.div
                             key="launcher"
-                            className="flex-1 flex flex-col overflow-hidden"
-                            initial={{ opacity: 0 }}
-                            animate={{ opacity: 1 }}
-                            exit={{ opacity: 0 }}
-                            transition={{ duration: 0.15 }}
+                            className="absolute inset-0 z-10 flex flex-col overflow-hidden"
+                            initial={listRecede}
+                            animate={listSettle}
+                            exit={listRecede}
                         >
 
                             {/* Main Area - Fixed Top, Scrollable Bottom */}


### PR DESCRIPTION
Moving between the launcher list and a meeting's notes had no real animation — it read as a blink.

## The cause

The only transition site was a single `AnimatePresence mode="wait"` doing a 0.15s opacity-only fade. `mode="wait"` serialises the two fades: the old panel dissolves to nothing, a dead gap follows, then the new one fades up. No direction, no continuity.

## The fix — a cover/uncover model

The details panel is always the upper layer (`z-20`), the list always the lower one (`z-10`). Details slides in from the right and leaves to the right; the list never moves laterally, it only recedes by scaling **up** to `1.03`.

Scaling *up* rather than the conventional iOS scale-down is deliberate. This is a transparent Electron overlay, so a layer that shrinks uncovers an edge of the container — and an uncovered edge here is a hole to the desktop, not a background colour. Scaling outward stays clipped by the existing `overflow-hidden` and can never expose one.

The list keeps `opacity: 1` throughout: it sits under an opaque details panel (`bg-bg-secondary` / `bg-bg-elevated`, opaque hex in both themes), so cross-dissolving both would only muddy the blend.

## Three things worth a reviewer's attention

**Both branches became `absolute inset-0`.** This is load-bearing, not cosmetic. With `mode="wait"` gone the two children mount simultaneously, and as `flex-1` siblings in a `flex-col` parent they would stack vertically and make the panel jump mid-transition. The parent was already `relative`.

**Direction is structural, not stateful.** It falls out of *which layer mounts*, not out of `selectedMeeting` truthiness — so `handleOpenMeeting` and `handleForward` both mount details (enters from the right) and `handleBack` unmounts it (exits right). All three are correct. A sibling-slide model would have needed a `navDirection` to avoid animating backwards on forward-nav; here that bug is unrepresentable rather than guarded against.

**Timing.** Curve `[0.32, 0.72, 0, 1]` (iOS panel curve, strong ease-out, no overshoot). Enter: transform 340ms, opacity 200ms — opacity resolving first is intentional, so the panel is opaque for most of the travel and the motion reads as a *settle* rather than a fade. Exit is faster (260/220ms): the system responding should outpace the user deciding.

`useReducedMotion` is added, matching the existing pattern in `MeetingDetails` and `App`, collapsing to a 120ms linear crossfade with no transforms.

## Cross-platform

Renderer-only React/CSS. No `process.platform` branching introduced — macOS and Windows render an identical transition.

- `Tested physically on Windows` — the transition was confirmed in the running app.
- `Reviewed but not executed on macOS`
- Commands run: `npm run typecheck:ts7` (clean).

The reduced-motion branch has not been observed with the OS setting enabled.

## Scope

One file, +66/−12. `MeetingDetails.tsx`, the header, and the back/forward buttons are untouched.

## Known, not fixed

Opening meeting B directly from meeting A still swaps instantly — the search pill calls `handleOpenMeeting` from outside the `AnimatePresence`, so `key="details"` never changes. Pre-existing, not a regression; fixing it means keying on meeting id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ErxmiyQsfvm1rAdSQ3QuyG
