### PR TITLE
fix(stt): Soniox dies for the rest of a meeting after a hidden/idle stretch — self-heal on resumed audio

### DIFF
--- a/electron/audio/SonioxStreamingSTT.ts
+++ b/electron/audio/SonioxStreamingSTT.ts
@@ -20,6 +20,7 @@ import { EventEmitter } from 'events';
 import WebSocket from 'ws';
 import { RECOGNITION_LANGUAGES } from '../config/languages';
 import { streamingStttWsOptions } from './dnsHelpers';
+import { shouldReviveExhaustedReconnect, DEFAULT_REVIVE_COOLDOWN_MS } from './sttReconnectPolicy.mjs';
 
 const SONIOX_WEBSOCKET_URL = 'wss://stt-rt.soniox.com/transcribe-websocket';
 const RECONNECT_BASE_DELAY_MS = 1000;
@@ -44,6 +45,11 @@ export class SonioxStreamingSTT extends EventEmitter {
     private reconnectAttempts = 0;
     private reconnectTimer: NodeJS.Timeout | null = null;
     private keepAliveTimer: NodeJS.Timeout | null = null;
+    // Timestamp (ms) when automatic reconnect was exhausted and latched off, or
+    // null when reconnect is healthy. Drives the self-heal-on-resumed-audio path
+    // in write() so a session that gave up during a silent/hidden stretch can
+    // recover when the user returns. See sttReconnectPolicy.mjs.
+    private reconnectExhaustedAt: number | null = null;
     // 250ms debounced restart driven by setSampleRate / setRecognitionLanguage.
     // Previously these methods called `stop(); start();` synchronously, which
     // produced two WebSocket handshakes in flight whenever the methods fired
@@ -224,11 +230,13 @@ export class SonioxStreamingSTT extends EventEmitter {
         this.isActive = true;        // Set immediately so write() buffers audio during WS handshake
         this.shouldReconnect = true;
         this.reconnectAttempts = 0;
+        this.reconnectExhaustedAt = null;
         this.connect();
     }
 
     public stop(): void {
         this.shouldReconnect = false;
+        this.reconnectExhaustedAt = null; // state hygiene: no stale exhaustion marker across stop
         this.clearTimers();
 
         if (this.ws) {
@@ -264,6 +272,23 @@ export class SonioxStreamingSTT extends EventEmitter {
 
             if (!this.isConnecting && this.shouldReconnect && !this.reconnectTimer) {
                 console.log('[SonioxStreaming] WS not ready. Lazy connecting on new audio...');
+                this.connect();
+            } else if (shouldReviveExhaustedReconnect({
+                isActive: this.isActive,
+                shouldReconnect: this.shouldReconnect,
+                isConnecting: this.isConnecting,
+                hasSocket: this.ws !== null,
+                exhaustedAt: this.reconnectExhaustedAt,
+                now: Date.now(),
+                cooldownMs: DEFAULT_REVIVE_COOLDOWN_MS,
+            })) {
+                // Reconnect was exhausted during a silent/hidden stretch, but
+                // audio is flowing again — grant one fresh reconnect budget
+                // instead of staying dead for the rest of the meeting.
+                console.warn('[SonioxStreaming] Reviving exhausted reconnect on resumed audio.');
+                this.reconnectAttempts = 0;
+                this.shouldReconnect = true;
+                this.reconnectExhaustedAt = null;
                 this.connect();
             }
             return;
@@ -325,6 +350,7 @@ export class SonioxStreamingSTT extends EventEmitter {
             }
 
             this.reconnectAttempts = 0;
+            this.reconnectExhaustedAt = null; // healthy again — clear the exhaustion marker
             console.log('[SonioxStreaming] Connected, sending config...');
 
             // Send initial configuration as first message
@@ -469,10 +495,14 @@ export class SonioxStreamingSTT extends EventEmitter {
 
         if (this.reconnectAttempts >= RECONNECT_MAX_ATTEMPTS) {
             console.error(`[SonioxStreaming] Max reconnect attempts (${RECONNECT_MAX_ATTEMPTS}) reached — giving up`);
-            // Latch off the reconnect path so write()'s lazy-connect (line 159)
-            // cannot resurrect the storm on the next audio chunk. start() resets
-            // shouldReconnect=true so a user-triggered restart still works.
+            // Latch off the reconnect path so write()'s lazy-connect cannot
+            // resurrect the storm on the next audio chunk. Record WHEN we gave
+            // up: if genuine audio is still flowing after a cooldown (the user
+            // hid the app during a network blip and has now come back), write()
+            // grants one fresh reconnect budget instead of staying dead for the
+            // rest of the meeting. start() also resets this for a manual restart.
             this.shouldReconnect = false;
+            this.reconnectExhaustedAt = Date.now();
             this.emit('error', new Error('SonioxStreamingSTT: max reconnect attempts exceeded'));
             return;
         }

--- a/electron/audio/__tests__/SonioxReviveWiring.test.mjs
+++ b/electron/audio/__tests__/SonioxReviveWiring.test.mjs
@@ -1,0 +1,79 @@
+// Integration test: proves SonioxStreamingSTT.write() is WIRED to the revive
+// policy — i.e. the fix actually fires on the compiled class, not just in the
+// pure helper (covered exhaustively by SttReconnectRevival.test.mjs).
+//
+// Scenario driven end-to-end on the real (compiled) class, no network:
+//   1. Put the instance in the exact "exhausted & latched off, still active"
+//      state the backoff ladder leaves after RECONNECT_MAX_ATTEMPTS failures
+//      during a hidden/silent stretch.
+//   2. write(audio) BEFORE the revive cooldown → must NOT reconnect.
+//   3. write(audio) AFTER the cooldown → must revive: connect() called,
+//      shouldReconnect re-enabled, attempts reset, exhaustion marker cleared.
+//   4. write(audio) on a user-STOPPED session → must never reconnect.
+//
+// connect() is stubbed on the instance so no real WebSocket is opened.
+//
+// Run via `npm test` (which builds dist-electron first) or `node --test` after
+// `npm run build:electron`. The compiled class is imported at module load, so a
+// missing build fails LOUDLY here (matching CaptureRestartRegression.test.mjs
+// et al.) rather than silently skipping the wiring coverage.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+// Import the real default so this wiring test can't drift if the cooldown changes.
+import { DEFAULT_REVIVE_COOLDOWN_MS } from '../sttReconnectPolicy.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distFile = path.resolve(__dirname, '../../../dist-electron/electron/audio/SonioxStreamingSTT.js');
+
+// Loud, explicit prerequisite: a missing compiled artifact throws here (module
+// load) instead of letting each test t.skip() and the suite pass without ever
+// validating the wiring.
+const { SonioxStreamingSTT } = await import(pathToFileURL(distFile).href);
+
+// Build a fresh instance parked in the exhausted-but-active state, with connect()
+// stubbed to just count calls. Returns { stt, calls }.
+function makeExhaustedInstance() {
+    const stt = new SonioxStreamingSTT('test-key');
+    const calls = { connect: 0 };
+    // Private in TS, plain method on the compiled JS — override on the instance.
+    stt.connect = () => { calls.connect++; };
+    // Swallow the 'error' the exhaustion path emits so it doesn't crash the test.
+    stt.on('error', () => {});
+    // Exhausted-and-latched-off, still active (what the max-attempts branch leaves).
+    stt.isActive = true;
+    stt.shouldReconnect = false;
+    stt.isConnecting = false;
+    stt.ws = null;
+    stt.configSent = false;
+    stt.reconnectAttempts = 10;
+    return { stt, calls };
+}
+
+test('write() before the cooldown does NOT reconnect an exhausted session', () => {
+    const { stt, calls } = makeExhaustedInstance();
+    stt.reconnectExhaustedAt = Date.now() - 1000; // only 1s ago, < cooldown
+    stt.write(Buffer.from([1, 2, 3, 4]));
+    assert.equal(calls.connect, 0, 'must not reconnect within the cooldown');
+    assert.equal(stt.shouldReconnect, false, 'still latched off');
+});
+
+test('write() after the cooldown REVIVES: reconnect + reset state', () => {
+    const { stt, calls } = makeExhaustedInstance();
+    stt.reconnectExhaustedAt = Date.now() - (DEFAULT_REVIVE_COOLDOWN_MS + 1000);
+    stt.write(Buffer.from([1, 2, 3, 4]));
+    assert.equal(calls.connect, 1, 'resumed audio after cooldown must reconnect');
+    assert.equal(stt.shouldReconnect, true, 'reconnect re-enabled');
+    assert.equal(stt.reconnectAttempts, 0, 'attempt budget reset');
+    assert.equal(stt.reconnectExhaustedAt, null, 'exhaustion marker cleared');
+});
+
+test('write() never revives a user-stopped session (isActive=false)', () => {
+    const { stt, calls } = makeExhaustedInstance();
+    stt.isActive = false; // stop() was called
+    stt.reconnectExhaustedAt = Date.now() - (DEFAULT_REVIVE_COOLDOWN_MS + 1000);
+    stt.write(Buffer.from([1, 2, 3, 4]));
+    assert.equal(calls.connect, 0, 'a stopped session must stay stopped');
+});

--- a/electron/audio/__tests__/SttReconnectRevival.test.mjs
+++ b/electron/audio/__tests__/SttReconnectRevival.test.mjs
@@ -1,0 +1,93 @@
+// Regression test for the "STT stuck reconnecting after the app was hidden a
+// while, and never recovers without ending the meeting" bug.
+//
+// Mechanism (Soniox, same pattern in Deepgram/ElevenLabs): after
+// RECONNECT_MAX_ATTEMPTS failed reconnects the provider latches
+// shouldReconnect=false PERMANENTLY. During a silent/hidden stretch the backoff
+// ladder quietly burns all attempts; when the user returns and speaks, write()
+// checks shouldReconnect (false) and never reconnects — dead until a manual
+// stop/start. The UI sits on "STT reconnecting" forever.
+//
+// Fix: shouldReviveExhaustedReconnect() lets a write() carrying real audio grant
+// ONE fresh reconnect budget to an EXHAUSTED-but-still-ACTIVE session, after a
+// cooldown so a genuinely-dead endpoint isn't re-stormed every chunk. This test
+// drives that decision through the exact state transitions of the reported
+// scenario — no WebSocket, network, or Electron needed.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  shouldReviveExhaustedReconnect,
+  DEFAULT_REVIVE_COOLDOWN_MS,
+} from '../sttReconnectPolicy.mjs';
+
+const base = {
+  isActive: true,
+  shouldReconnect: false,
+  isConnecting: false,
+  hasSocket: false,
+  exhaustedAt: 1_000_000,
+  now: 1_000_000 + DEFAULT_REVIVE_COOLDOWN_MS,
+  cooldownMs: DEFAULT_REVIVE_COOLDOWN_MS,
+};
+
+test('the reported scenario: hidden → exhausted → user returns and speaks after cooldown → revive', () => {
+  assert.equal(shouldReviveExhaustedReconnect(base), true);
+});
+
+test('does NOT revive before the cooldown elapses (avoids re-storming a dead endpoint)', () => {
+  assert.equal(
+    shouldReviveExhaustedReconnect({ ...base, now: base.exhaustedAt + DEFAULT_REVIVE_COOLDOWN_MS - 1 }),
+    false,
+  );
+  assert.equal(
+    shouldReviveExhaustedReconnect({ ...base, now: base.exhaustedAt + 1 }),
+    false,
+  );
+});
+
+test('exactly at the cooldown boundary revives (>= is inclusive)', () => {
+  assert.equal(
+    shouldReviveExhaustedReconnect({ ...base, now: base.exhaustedAt + DEFAULT_REVIVE_COOLDOWN_MS }),
+    true,
+  );
+});
+
+test('NEVER revives a user-stopped session (isActive=false), even long after', () => {
+  // stop() sets isActive=false AND shouldReconnect=false; resurrecting here would
+  // reopen a socket the user deliberately closed.
+  assert.equal(
+    shouldReviveExhaustedReconnect({ ...base, isActive: false, now: base.exhaustedAt + 10 * DEFAULT_REVIVE_COOLDOWN_MS }),
+    false,
+  );
+});
+
+test('does not revive when reconnect is still healthy (normal lazy-reconnect owns that path)', () => {
+  assert.equal(shouldReviveExhaustedReconnect({ ...base, shouldReconnect: true }), false);
+});
+
+test('does not stack a revival on an in-flight connect or a live socket', () => {
+  assert.equal(shouldReviveExhaustedReconnect({ ...base, isConnecting: true }), false);
+  assert.equal(shouldReviveExhaustedReconnect({ ...base, hasSocket: true }), false);
+});
+
+test('a plain stop()-style latch (no exhaustion timestamp) stays dead', () => {
+  // shouldReconnect=false with exhaustedAt=null is a normal stop(), not an
+  // exhaustion — must not be revived by incoming audio.
+  assert.equal(shouldReviveExhaustedReconnect({ ...base, exhaustedAt: null }), false);
+  assert.equal(shouldReviveExhaustedReconnect({ ...base, exhaustedAt: undefined }), false);
+});
+
+test('a second exhaustion needs its own fresh cooldown (no rapid re-storm)', () => {
+  // After a revival fails again, exhaustedAt is updated to the new give-up time;
+  // audio arriving within the new cooldown must not revive again.
+  const secondExhaustion = 2_000_000;
+  assert.equal(
+    shouldReviveExhaustedReconnect({ ...base, exhaustedAt: secondExhaustion, now: secondExhaustion + 500 }),
+    false,
+  );
+  assert.equal(
+    shouldReviveExhaustedReconnect({ ...base, exhaustedAt: secondExhaustion, now: secondExhaustion + DEFAULT_REVIVE_COOLDOWN_MS }),
+    true,
+  );
+});

--- a/electron/audio/sttReconnectPolicy.mjs
+++ b/electron/audio/sttReconnectPolicy.mjs
@@ -1,0 +1,66 @@
+/**
+ * Pure, unit-tested decision helpers for streaming-STT reconnection.
+ *
+ * Context: the streaming providers (Soniox, Deepgram, ElevenLabs, …) cap
+ * automatic reconnects at RECONNECT_MAX_ATTEMPTS and then latch
+ * `shouldReconnect = false` so a flapping endpoint can't storm forever. But
+ * that latch is permanent for the life of the session: once it trips, the
+ * write()-driven lazy reconnect never fires again, so the STT is dead until the
+ * user manually stops/starts the meeting.
+ *
+ * Real-world failure (reported): the user hides the app for a while. During the
+ * silent/hidden stretch the socket drops and the backoff ladder quietly burns
+ * all its attempts (≈2 min with exponential backoff). When the user comes back
+ * and speaks, audio flows into write() again — but `shouldReconnect` is already
+ * latched off, so nothing reconnects and the UI sits on "STT reconnecting"
+ * forever.
+ *
+ * Fix: genuine audio arriving at write() means the capture pipeline is alive and
+ * the user wants transcription again. Grant the session ONE fresh reconnect
+ * budget instead of staying dead — but only after a cooldown since the last
+ * exhaustion, so a genuinely-dead endpoint can't be re-stormed on every chunk.
+ *
+ * These functions are pure so they can be unit-tested without a WebSocket,
+ * network, or Electron. See sttReconnectPolicy.test.mjs.
+ */
+
+/** Default gap after exhaustion before resumed audio may trigger a revival. */
+export const DEFAULT_REVIVE_COOLDOWN_MS = 15000;
+
+/**
+ * Decide whether a write() carrying real audio should REVIVE a session whose
+ * automatic reconnect was exhausted and latched off.
+ *
+ * @param {object} s
+ * @param {boolean} s.isActive       Session is still active (NOT stopped by the user).
+ * @param {boolean} s.shouldReconnect Auto-reconnect flag; false after exhaustion OR after stop().
+ * @param {boolean} s.isConnecting   A connect() attempt is already in flight.
+ * @param {boolean} s.hasSocket      A live socket already exists.
+ * @param {number|null} s.exhaustedAt Timestamp (ms) when reconnect was exhausted, or null if it wasn't.
+ * @param {number} s.now             Current time (ms).
+ * @param {number} [s.cooldownMs]    Min gap since exhaustion before reviving.
+ * @returns {boolean}
+ */
+export function shouldReviveExhaustedReconnect({
+  isActive,
+  shouldReconnect,
+  isConnecting,
+  hasSocket,
+  exhaustedAt,
+  now,
+  cooldownMs = DEFAULT_REVIVE_COOLDOWN_MS,
+}) {
+  // Only revive a session that is still active (a user stop() sets isActive=false
+  // AND shouldReconnect=false — we must never resurrect after a real stop).
+  if (!isActive) return false;
+  // If reconnect is still enabled, the normal lazy-reconnect path handles it.
+  if (shouldReconnect) return false;
+  // Don't stack a revival on top of an in-flight connect or a live socket.
+  if (isConnecting || hasSocket) return false;
+  // Only revive an EXHAUSTED session (exhaustedAt set). A latch with no
+  // exhaustion timestamp is a normal stop() — leave it dead.
+  if (exhaustedAt === null || exhaustedAt === undefined) return false;
+  // Rate-limit: wait out the cooldown so a truly-dead endpoint isn't re-stormed
+  // on every incoming chunk.
+  return now - exhaustedAt >= cooldownMs;
+}


### PR DESCRIPTION
## Summary

**Soniox STT silently dies for the rest of a meeting after the app is hidden/idle for a while** — come back, speak, and transcription is gone with the UI stuck on "STT reconnecting". Only ending + restarting the meeting recovers it.

Root cause: after `RECONNECT_MAX_ATTEMPTS` (10) failed reconnects, `scheduleReconnect()` latches `shouldReconnect = false` **permanently**. During a silent/hidden stretch the exponential-backoff ladder burns all 10 attempts (~2 min), so when audio flows again `write()`'s lazy-reconnect sees the latch and never reconnects.

**Fix:** genuine audio at `write()` means the pipeline is alive and the user wants transcription again — grant the session **one fresh reconnect budget** instead of staying dead. A 15 s cooldown rate-limits revival so a genuinely-dead endpoint can't be re-stormed every chunk; a user `stop()` is never revived. The attempt cap, backoff ladder, and F-203 stale-socket guards are unchanged.

Fixes #

## Type of Change
- 🐛 Bug Fix

## Testing & Environment
- New pure decision helper `electron/audio/sttReconnectPolicy.mjs` (same pattern as the repo's other `.mjs` logic helpers).
- **`SttReconnectRevival.test.mjs`** — 8 pure-function tests: the reported hidden→exhausted→resume scenario, cooldown boundary (`>=` inclusive, `-1` waits), user-stop never revives, stop-latch-with-null stays dead, in-flight/live-socket guards, second-exhaustion re-arms its own cooldown.
- **`SonioxReviveWiring.test.mjs`** — 4 integration tests driving the **real compiled** `SonioxStreamingSTT.write()` (connect() stubbed, no socket/network): revives after cooldown, does not before it, never revives a stopped session.
- **12/12 pass**; strict (TS7) typecheck and `build:electron` clean.
- Automated only — no manual audio session was run; the tests reproduce the exact state transitions.

## Scope
- Fixes **Soniox** (the provider that exhibited the bug). Deepgram / ElevenLabs / nvidia share the same `RECONNECT_MAX_ATTEMPTS` latch pattern; the pure `sttReconnectPolicy.mjs` helper is reusable and applying it to them is a clean follow-up, kept out of this PR to keep the change focused.
