### PR TITLE
fix(tests): five suites never ran on Windows — `await import()` needs a file:// URL

### DIFF
--- a/electron/audio/__tests__/MeetingLifecycleDbLiveness2026_08_07.test.mjs
+++ b/electron/audio/__tests__/MeetingLifecycleDbLiveness2026_08_07.test.mjs
@@ -36,7 +36,7 @@ import path from 'node:path';
 import fs from 'node:fs';
 import os from 'node:os';
 import Module from 'node:module';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '../../..');
@@ -66,10 +66,14 @@ Module._load = function patchedLoad(request) {
     return origLoad.apply(this, arguments);
 };
 
-const { NativelyProSTT } = await import(
-    path.join(repoRoot, 'dist-electron/electron/audio/NativelyProSTT.js'));
-const { MeetingLifecycleQueue } = await import(
-    path.join(repoRoot, 'dist-electron/electron/audio/meetingLifecycleQueue.js'));
+// WINDOWS (2026-08-29): `await import()` needs a file:// URL, not a bare
+// absolute path. On POSIX `import('/Users/…')` happens to resolve; on Windows
+// `import('C:\\…')` throws ERR_UNSUPPORTED_ESM_URL_SCHEME, and because these
+// imports run at MODULE LOAD the whole file fails before a single test runs —
+// which is why this file showed up as one opaque file-level ✖ in the Windows
+// leg rather than as a failing assertion. `pathToFileURL` is the fix.
+const { NativelyProSTT } = await import(pathToFileURL(path.join(repoRoot, 'dist-electron/electron/audio/NativelyProSTT.js')).href);
+const { MeetingLifecycleQueue } = await import(pathToFileURL(path.join(repoRoot, 'dist-electron/electron/audio/meetingLifecycleQueue.js')).href);
 
 const settle = (ms) => new Promise(r => setTimeout(r, ms));
 

--- a/electron/services/__tests__/LexicalFloorScaleF23.test.mjs
+++ b/electron/services/__tests__/LexicalFloorScaleF23.test.mjs
@@ -18,12 +18,17 @@
 // Only the mis-scaled threshold is corrected.
 
 import { test, describe } from 'node:test';
+import { pathToFileURL } from 'node:url';
 import assert from 'node:assert/strict';
 import path from 'node:path';
 
-const { ModeHybridRetriever } = await import(
-  path.resolve(process.cwd(), 'dist-electron/electron/services/modes/ModeHybridRetriever.js')
-);
+// WINDOWS (2026-08-29): `await import()` needs a file:// URL, not a bare
+// absolute path. On POSIX `import('/Users/…')` happens to resolve; on Windows
+// `import('C:\\…')` throws ERR_UNSUPPORTED_ESM_URL_SCHEME, and because these
+// imports run at MODULE LOAD the whole file fails before a single test runs —
+// which is why this file showed up as one opaque file-level ✖ in the Windows
+// leg rather than as a failing assertion. `pathToFileURL` is the fix.
+const { ModeHybridRetriever } = await import(pathToFileURL(path.resolve(process.cwd(), 'dist-electron/electron/services/modes/ModeHybridRetriever.js')).href);
 
 const P = ModeHybridRetriever.prototype;
 

--- a/electron/services/__tests__/LexicalTokensNumerals.test.mjs
+++ b/electron/services/__tests__/LexicalTokensNumerals.test.mjs
@@ -13,12 +13,17 @@
 // functional drift would have silently mis-fused FTS and vector scores.
 
 import { test, describe } from 'node:test';
+import { pathToFileURL } from 'node:url';
 import assert from 'node:assert/strict';
 import path from 'node:path';
 
-const { wordsOf, numeralTokens } = await import(
-  path.resolve(process.cwd(), 'dist-electron/electron/services/modes/lexicalTokens.js')
-);
+// WINDOWS (2026-08-29): `await import()` needs a file:// URL, not a bare
+// absolute path. On POSIX `import('/Users/…')` happens to resolve; on Windows
+// `import('C:\\…')` throws ERR_UNSUPPORTED_ESM_URL_SCHEME, and because these
+// imports run at MODULE LOAD the whole file fails before a single test runs —
+// which is why this file showed up as one opaque file-level ✖ in the Windows
+// leg rather than as a failing assertion. `pathToFileURL` is the fix.
+const { wordsOf, numeralTokens } = await import(pathToFileURL(path.resolve(process.cwd(), 'dist-electron/electron/services/modes/lexicalTokens.js')).href);
 
 describe('numeral equivalence', () => {
   const has = (text, tok) => wordsOf(text).includes(tok);

--- a/electron/services/__tests__/LitellmModelLabel2026_08_06.test.mjs
+++ b/electron/services/__tests__/LitellmModelLabel2026_08_06.test.mjs
@@ -17,14 +17,18 @@ import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '../../..');
 
-const { litellmModelLabel, prettifyModelId } = await import(
-  path.join(root, 'src/utils/modelUtils.ts')
-);
+// WINDOWS (2026-08-29): `await import()` needs a file:// URL, not a bare
+// absolute path. On POSIX `import('/Users/…')` happens to resolve; on Windows
+// `import('C:\\…')` throws ERR_UNSUPPORTED_ESM_URL_SCHEME, and because these
+// imports run at MODULE LOAD the whole file fails before a single test runs —
+// which is why this file showed up as one opaque file-level ✖ in the Windows
+// leg rather than as a failing assertion. `pathToFileURL` is the fix.
+const { litellmModelLabel, prettifyModelId } = await import(pathToFileURL(path.join(root, 'src/utils/modelUtils.ts')).href);
 
 describe('litellmModelLabel', () => {
   test('strips our routing prefix AND the proxy upstream, leaving the model name', () => {

--- a/electron/services/__tests__/LocalEmbedBatchF22.test.mjs
+++ b/electron/services/__tests__/LocalEmbedBatchF22.test.mjs
@@ -16,12 +16,17 @@
 // minutes. The end-to-end proof is recorded in 10_BENCHMARK_RESULTS.md.
 
 import { test, describe } from 'node:test';
+import { pathToFileURL } from 'node:url';
 import assert from 'node:assert/strict';
 import path from 'node:path';
 
-const { ModeHybridRetriever } = await import(
-  path.resolve(process.cwd(), 'dist-electron/electron/services/modes/ModeHybridRetriever.js')
-);
+// WINDOWS (2026-08-29): `await import()` needs a file:// URL, not a bare
+// absolute path. On POSIX `import('/Users/…')` happens to resolve; on Windows
+// `import('C:\\…')` throws ERR_UNSUPPORTED_ESM_URL_SCHEME, and because these
+// imports run at MODULE LOAD the whole file fails before a single test runs —
+// which is why this file showed up as one opaque file-level ✖ in the Windows
+// leg rather than as a failing assertion. `pathToFileURL` is the fix.
+const { ModeHybridRetriever } = await import(pathToFileURL(path.resolve(process.cwd(), 'dist-electron/electron/services/modes/ModeHybridRetriever.js')).href);
 
 /** Records the size of every batch handed to the embedder. */
 function makeHarness(providerName) {
@@ -91,8 +96,7 @@ describe('F22 — indexing batch is provider-aware', () => {
     // The property is "batching embedded EVERY chunk", so it is now asserted
     // against the chunker's actual output instead of a magic number — which
     // also makes it immune to the next legitimate chunking change.
-    const { semanticChunks } = await import(
-      path.resolve(process.cwd(), 'dist-electron/electron/services/modes/semanticChunker.js'));
+    const { semanticChunks } = await import(pathToFileURL(path.resolve(process.cwd(), 'dist-electron/electron/services/modes/semanticChunker.js')).href);
     const expected = semanticChunks(BIG_DOC).length;
     assert.ok(expected > 1, 'the fixture must produce multiple chunks for this test to mean anything');
 


### PR DESCRIPTION
Found by reading the Windows leg of #520's Build Smoke run rather than its conclusion. The leg reports **success** because `npm test` carries `continue-on-error` there — the 28 failures inside it are invisible unless you open the log.

**Five of the 28 are one bug.** Each file does `await import(path.resolve(...))` with a bare absolute path. On POSIX `import('/Users/…')` happens to resolve; on Windows `import('C:\…')` throws `ERR_UNSUPPORTED_ESM_URL_SCHEME` — and because these imports run at **module load**, the whole file dies before a single test executes. That's why each shows up as one opaque file-level ✖ with no assertion behind it.

So these five suites have never verified anything on Windows:

```
electron/audio/__tests__/MeetingLifecycleDbLiveness2026_08_07.test.mjs
electron/services/__tests__/LexicalFloorScaleF23.test.mjs
electron/services/__tests__/LexicalTokensNumerals.test.mjs
electron/services/__tests__/LitellmModelLabel2026_08_06.test.mjs
electron/services/__tests__/LocalEmbedBatchF22.test.mjs
```

Among them is LocalEmbedBatchF22's *"batching is not truncation"* — the guard that every chunk of a document actually gets embedded.

`pathToFileURL` is the whole fix. The pattern is **pre-existing** (present at `ff079caa`, before the retrieval branch); I copied the broken idiom while editing LocalEmbedBatchF22 for T9, which is how it surfaced.

The other 23 Windows failures are a different mix (keyring/credential store, cropper windows, Go toolchain, packaged `resourcesPath`) and aren't touched here. The workflow's own TODO — *"fix the remaining 41 Windows failures in npm test, then drop its continue-on-error"* — moves five closer.

No production code. All five pass on macOS after the change (27/27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014D8QkwcTrpGVPmkWHrp4Nz