### PR TITLE
fix(wta): the live spoken surface shipped the manual-chat answer contract

### DIFF
--- a/electron/IntelligenceEngine.ts
+++ b/electron/IntelligenceEngine.ts
@@ -3153,8 +3153,60 @@ export class IntelligenceEngine extends EventEmitter {
                                         hasImages: (imagePaths?.length ?? 0) > 0,
                                         screenText: _screenText || undefined,
                                     });
-                                return resolveV2SystemPrompt({
-                                    action: 'answer',
+                                // ── T3: the live spoken surface asks for SPOKEN WORDS ──
+                                //
+                                // This resolved `action: 'answer'`, which is the
+                                // manual-chat contract. `what_to_say` is this
+                                // surface's own action — `runWhatShouldISay` is
+                                // literally its caller — and it carries the one
+                                // instruction the live overlay most needs:
+                                // "Output only the exact words the user should
+                                // say next in the active role. No coaching,
+                                // alternatives, labels, or quotation marks."
+                                // Measured: that sentence is absent from the
+                                // composed prompt under 'answer' and present
+                                // under 'what_to_say'.
+                                //
+                                // NOT on coding turns, and that exception is the
+                                // point. Dumping all four combinations shows
+                                // `what_to_say` + codingTask composes BOTH
+                                // "output only the exact words to say" AND the
+                                // six-section coding contract (Complexity, Dry
+                                // Run) into one prompt — two instructions that
+                                // cannot both be obeyed. A coding answer on the
+                                // live surface is a written artifact, not words
+                                // to read aloud, so it keeps 'answer'.
+                                //
+                                // The findings doc also expected this switch to
+                                // restore Team Meet's "only when directly
+                                // addressed" overlay rule. It does not need to:
+                                // that rule is ALREADY present under 'answer'
+                                // (verified by dumping the composed prompt for
+                                // all four combinations), so that half of the
+                                // finding did not reproduce.
+                                const _liveCoding = codingTask || _promoted;
+                                // ── T3: the repeat-press directive, on the SYSTEM channel ──
+                                //
+                                // Its only carrier was `intentContext` ->
+                                // `packet`, which V3 replaces wholesale, so on
+                                // every V3 turn it was assembled and discarded.
+                                // The coding CONTRACT still arrived (personaBase
+                                // passes `_promoted` as codingTask, and the
+                                // composed prompt does contain Complexity/Dry
+                                // Run) — but the directive telling the model that
+                                // a blind re-press is a request for the WHOLE
+                                // answer did not. Measured live 2026-08-19: the
+                                // model responded with commentary on its own
+                                // previous answer and then agreed with it.
+                                //
+                                // It rides the system prompt rather than
+                                // `realtimeInstruction` deliberately. That field
+                                // is documented "Tone/length only — cannot widen
+                                // authorization"; this is an answer-SHAPE mandate
+                                // and belongs on the same channel that already
+                                // carries the coding contract it refers to.
+                                const _base = resolveV2SystemPrompt({
+                                    action: _liveCoding ? 'answer' : 'what_to_say',
                                     tier: v2TierForPromptTier(this.llmHelper.getPromptTier?.()),
                                     activeMode: snapshotModeInfo ?? undefined,
                                     codingTask: codingTask || _promoted,
@@ -3162,6 +3214,8 @@ export class IntelligenceEngine extends EventEmitter {
                                     codingFormat: codingSignals.codingFormat,
                                     suppliedTemplate: codingSignals.suppliedTemplate,
                                 });
+                                if (!_promoted || !_base) return _base;
+                                return `${_base}\n\n<repeat_press_directive>\nThe user triggered this action with a coding problem on screen and NO new question. That is a request for the COMPLETE solution to the on-screen problem, following the coding contract's full section shape — even if a previous answer in this conversation already covered it, and even if this looks like a follow-up. Never respond with commentary on, agreement with, or a summary of an earlier answer. Produce the full answer as if asked for the first time.\n</repeat_press_directive>`;
                             } catch { return null; } // no persona ⇒ composition unchanged
                         },
                     });

--- a/electron/IntelligenceEngine.ts
+++ b/electron/IntelligenceEngine.ts
@@ -3184,7 +3184,44 @@ export class IntelligenceEngine extends EventEmitter {
                                 // (verified by dumping the composed prompt for
                                 // all four combinations), so that half of the
                                 // finding did not reproduce.
-                                const _liveCoding = codingTask || _promoted;
+                                // `codingSignals.codingTask` is in this OR for a
+                                // reason found by review. `_promoted` is defined
+                                // as `!codingSignals.codingTask && …`, so it goes
+                                // FALSE exactly when the signals say coding — and
+                                // the bridge's `codingTask` is
+                                // `isCodingAnswerType(answerPlan.answerType)`,
+                                // which is false for `unknown_answer`. A deictic
+                                // ask ("how do I do this?") over a code template
+                                // on screen therefore satisfied NEITHER term.
+                                //
+                                // That turn would have taken 'what_to_say' — "no
+                                // coaching, alternatives, LABELS" — while
+                                // `wtaPromotedScreenCoding` independently armed
+                                // the CodingStreamGate and the post-stream repair
+                                // to enforce the six-section shape. The prompt
+                                // would forbid the very headings the repair
+                                // requires, so every such answer would be
+                                // deterministically rewritten. Three call sites
+                                // asking the same question three ways is the
+                                // divergence the 2026-08-22 note above exists to
+                                // end; this makes them agree.
+                                const _liveCoding = codingTask || codingSignals.codingTask || _promoted;
+                                // EXPLANATORY modes keep 'answer'. Its text
+                                // branches — "in a live role mode, output the
+                                // exact words that role should say; IN DIRECT CHAT
+                                // OR AN EXPLANATORY MODE, ANSWER THE USER
+                                // DIRECTLY" — and `what_to_say` has no such
+                                // branch. The per-mode voice table is the source
+                                // of truth: `lecture` reads "a quiet study partner
+                                // explaining to the student … never speak as the
+                                // student", and `general` reads "the assistant in
+                                // direct chat, or the user's own voice … as the
+                                // moment requires". Handing either a
+                                // script-for-the-user contract turns "what is the
+                                // professor's definition of entropy?" into words
+                                // to recite instead of an explanation.
+                                const _explanatoryMode = snapshotModeInfo?.templateType === 'lecture'
+                                    || snapshotModeInfo?.templateType === 'general';
                                 // ── T3: the repeat-press directive, on the SYSTEM channel ──
                                 //
                                 // Its only carrier was `intentContext` ->
@@ -3206,7 +3243,7 @@ export class IntelligenceEngine extends EventEmitter {
                                 // and belongs on the same channel that already
                                 // carries the coding contract it refers to.
                                 const _base = resolveV2SystemPrompt({
-                                    action: _liveCoding ? 'answer' : 'what_to_say',
+                                    action: (_liveCoding || _explanatoryMode) ? 'answer' : 'what_to_say',
                                     tier: v2TierForPromptTier(this.llmHelper.getPromptTier?.()),
                                     activeMode: snapshotModeInfo ?? undefined,
                                     codingTask: codingTask || _promoted,

--- a/electron/context-intelligence/__tests__/Orchestrator.test.mjs
+++ b/electron/context-intelligence/__tests__/Orchestrator.test.mjs
@@ -339,3 +339,98 @@ describe('self-presentation questions grade on claim authority, not a pronoun te
     assert.ok(propertyHeadTerms('what are the RTO and RPO in the dossier').length >= 2);
   });
 });
+
+// ── Trace latency is MEASURED, not a placeholder (2026-08-27) ────────────────
+//
+// THE REGRESSION THIS EXISTS TO PREVENT.
+//
+// From the day this trace was written until 2026-08-27, `latency` was a literal
+// block of zeros — `const t0 = 0` was the total. It typechecked, it looked like
+// a measurement, and the operational-telemetry table collected 173 production
+// rows reporting 0ms for every phase before anyone noticed.
+//
+// The telemetry unit tests did not catch it because they fed a hand-built trace
+// carrying realistic numbers. A fixture cannot detect a PRODUCER that never
+// populates the field — only driving the real producer can, which is why this
+// test lives here and not beside the emitter.
+describe('trace latency is measured, not hardcoded', () => {
+  const slowPort = (delayMs) => ({
+    async retrieve() {
+      await new Promise((r) => setTimeout(r, delayMs));
+      const { evidence } = adaptLegacyChunks(
+        [{ id: 'resume-1', text: 'Led the WebRTC rewrite.', score: 0.9 }], ADAPT,
+      );
+      return { evidence, attempts: [] };
+    },
+  });
+
+  // BOUNDED BY THE CALLER'S OWN STOPWATCH, on purpose. An earlier version of
+  // this test asserted `totalMs >= 35 && < 30_000`, and the original bug
+  // (`const t0 = 0`, making the span time-since-process-start) SAILED THROUGH
+  // both bounds — a few hundred ms into a test run looks exactly like a slow
+  // turn. Only comparing against the wall time of this specific call can tell a
+  // duration apart from an epoch.
+  test('totalMs is the duration of THIS call, not time since process start', async () => {
+    clearConversationState('s1');
+    const wall0 = performance.now();
+    const r = await orchestrate(
+      req({ manualQuestion: 'Tell me about your WebRTC project.' }), slowPort(40),
+    );
+    const wall = performance.now() - wall0;
+    const { totalMs } = r.trace.latency;
+    assert.ok(totalMs >= 35, `totalMs must measure the turn, got ${totalMs}`);
+    assert.ok(totalMs <= wall + 25,
+      `totalMs (${totalMs.toFixed(1)}) must not exceed this call's wall time ` +
+      `(${wall.toFixed(1)}ms) — a larger value means it is measuring from the ` +
+      'wrong origin, which is exactly the bug this test exists for');
+  });
+
+  test('retrievalMs measures the retrieval await specifically', async () => {
+    clearConversationState('s2');
+    const wall0 = performance.now();
+    const r = await orchestrate(
+      req({ sessionId: 's2', manualQuestion: 'Tell me about your WebRTC project.' }), slowPort(60),
+    );
+    const wall = performance.now() - wall0;
+    const { retrievalMs, totalMs } = r.trace.latency;
+    assert.ok(retrievalMs >= 50, `retrievalMs must measure the port, got ${retrievalMs}`);
+    assert.ok(retrievalMs <= totalMs, 'a phase cannot exceed the turn that contains it');
+    // Same wall-clock bound as above rather than a magic slack: both phases
+    // must fit inside the call that produced them.
+    assert.ok(totalMs <= wall + 25 && retrievalMs <= wall + 25,
+      `phases (total ${totalMs.toFixed(1)}, retrieval ${retrievalMs.toFixed(1)}) must fit ` +
+      `inside this call's wall time (${wall.toFixed(1)}ms)`);
+  });
+
+  test('every latency field is a finite, non-negative number', async () => {
+    clearConversationState('s3');
+    const wall0 = performance.now();
+    const r = await orchestrate(
+      req({ sessionId: 's3', manualQuestion: 'Tell me about your WebRTC project.' }), slowPort(1),
+    );
+    const wall = performance.now() - wall0;
+    for (const [k, v] of Object.entries(r.trace.latency)) {
+      assert.equal(typeof v, 'number', `${k} must be a number`);
+      assert.ok(Number.isFinite(v) && v >= 0, `${k} must be finite and >= 0, got ${v}`);
+      assert.ok(v <= wall + 25, `${k} (${v}) must fit inside the call's ${wall.toFixed(1)}ms`);
+    }
+  });
+
+  test('a turn with no retrieval reports 0ms retrieval — a measured zero', async () => {
+    clearConversationState('s4');
+    const r = await orchestrate(req({ sessionId: 's4', manualQuestion: 'What is 2 + 2?' }));
+    assert.equal(r.trace.latency.retrievalMs, 0, 'no port ran, so no time was spent in one');
+    assert.ok(r.trace.latency.totalMs >= 0);
+  });
+
+  test('providerAttempts stays EMPTY — the provider has not run yet', async () => {
+    // Populating this here would attribute the PREVIOUS turn's model to this
+    // one. An empty array is honest; a stale model is telemetry that lies.
+    clearConversationState('s5');
+    const r = await orchestrate(
+      req({ sessionId: 's5', manualQuestion: 'Tell me about your WebRTC project.' }), slowPort(1),
+    );
+    assert.deepEqual(r.trace.providerAttempts, []);
+    assert.equal(r.trace.latency.providerTtfbMs, 0, 'and its timing is honestly unmeasured');
+  });
+});

--- a/electron/context-intelligence/__tests__/RolloutMetrics.test.mjs
+++ b/electron/context-intelligence/__tests__/RolloutMetrics.test.mjs
@@ -20,7 +20,12 @@ const turn = (over = {}) => ({
   plannedSourceTypes: ['REFERENCE_FILE'],
   acceptedEvidence: [{ sourceType: 'REFERENCE_FILE', evidenceId: 'e1' }],
   retrievalAttempts: [{ rejections: [], failed: undefined }],
-  timings: { providerTtfbMs: 100 },
+  // `latency`, which is the field AnswerTrace actually declares. This fixture
+  // said `timings` — and so did the production read in rollout-metrics — so the
+  // two agreed with each other, the test stayed green, and the latency
+  // percentiles were empty on every turn in production from the day they were
+  // written. A fixture that mirrors the bug cannot detect the bug.
+  latency: { totalMs: 100, providerTtfbMs: 0 },
   ...over,
 });
 
@@ -91,7 +96,7 @@ describe('vacuity and safety', () => {
   test('rates are NULL with no data, never 0 — a green gate from zero turns is the bug', () => {
     const m = getRolloutMetrics();
     assert.equal(m.rates.contamination, null);
-    assert.equal(m.latency.p95, null);
+    assert.equal(m.orchestrationLatency.p95, null);
   });
 
   test('abort evaluation refuses to answer below the turn threshold', () => {
@@ -101,10 +106,23 @@ describe('vacuity and safety', () => {
     assert.deepEqual(a.triggered, [], 'and it reports nothing rather than "all clear"');
   });
 
-  test('p95 regression beyond 20% aborts', () => {
-    for (let i = 0; i < 60; i++) recordTurnMetrics(turn({ timings: { providerTtfbMs: 300 } }));
-    assert.ok(evaluateAbortConditions({ minTurns: 50, baselineP95Ms: 200 }).triggered.includes('p95_regression_over_20pct'));
-    assert.ok(!evaluateAbortConditions({ minTurns: 50, baselineP95Ms: 400 }).triggered.includes('p95_regression_over_20pct'));
+  test('orchestration p95 regression beyond 20% aborts', () => {
+    // totalMs, not providerTtfbMs: the latter is a structural 0 in every trace
+    // this metric ever sees, so a fixture built on it measured nothing.
+    for (let i = 0; i < 60; i++) recordTurnMetrics(turn({ latency: { totalMs: 300 } }));
+    assert.ok(evaluateAbortConditions({ minTurns: 50, baselineOrchestrationP95Ms: 200 })
+      .triggered.includes('orchestration_p95_regression_over_20pct'));
+    assert.ok(!evaluateAbortConditions({ minTurns: 50, baselineOrchestrationP95Ms: 400 })
+      .triggered.includes('orchestration_p95_regression_over_20pct'));
+  });
+
+  test('a genuinely 0 ms turn is SAMPLED, not discarded', () => {
+    // A turn answered from state without retrieving really does round to 0.
+    // Dropping those removes the fastest turns from the sample and biases p50
+    // and p95 upward — a latency gate that quietly ignores fast turns.
+    for (let i = 0; i < 60; i++) recordTurnMetrics(turn({ latency: { totalMs: 0 } }));
+    assert.equal(getRolloutMetrics().orchestrationLatency.samples, 60);
+    assert.equal(getRolloutMetrics().orchestrationLatency.p95, 0);
   });
 
   test('over-refusal: strict refusals up while general fallback flat', () => {
@@ -121,7 +139,7 @@ describe('vacuity and safety', () => {
 
   test('the latency buffer is bounded — a long meeting must not grow it forever', () => {
     for (let i = 0; i < 900; i++) recordTurnMetrics(turn());
-    assert.ok(getRolloutMetrics().latency.samples <= 512);
+    assert.ok(getRolloutMetrics().orchestrationLatency.samples <= 512);
   });
 
   test('no counter field can carry evidence text', () => {

--- a/electron/context-intelligence/observability/legacy-trace.ts
+++ b/electron/context-intelligence/observability/legacy-trace.ts
@@ -165,11 +165,20 @@ function build(input: LegacyTraceInput): AnswerTrace {
     fallbackUsed: input.fallbackUsed ?? 'NONE',
 
     promptTokenEstimate: 0,
+    // LATENCY ON THIS PATH IS NOT MEASURED, except whatever `totalMs` the caller
+    // chose to pass. orchestrate() now times its phases for real (2026-08-27),
+    // so a shadow diff of legacy-vs-v3 LATENCY compares real numbers against
+    // these zeros and is meaningless — the engine comparison this trace exists
+    // for is about decisions (path, answerability, fallback, contamination),
+    // which are populated on both sides. Instrumenting the three legacy call
+    // sites is the prerequisite for a timing diff; nobody has needed one.
     latency: {
       normalizationMs: 0, questionResolutionMs: 0, policyResolutionMs: 0, classificationMs: 0,
       retrievalMs: 0, rerankingMs: 0, evidenceEvaluationMs: 0, promptCompositionMs: 0,
       providerTtfbMs: 0, totalMs: input.totalMs ?? 0,
     },
+    // Same reason as orchestrate(): this trace is built before the provider
+    // call, so there is nothing to attribute. See orchestrator.ts.
     providerAttempts: [],
     status: input.status ?? 'COMPLETED',
     errorCodes: input.errorCodes ?? [],

--- a/electron/context-intelligence/observability/rollout-metrics.ts
+++ b/electron/context-intelligence/observability/rollout-metrics.ts
@@ -66,9 +66,14 @@ export interface RolloutCounters {
    *  nobody knows" — the exact silent-fallback failure §22.1 forbids. */
   v3FallbackBySurface: Record<string, number>;
 
-  /** Milliseconds, for the p95 TTFT abort condition. Bounded ring buffer: an
-   *  unbounded latency array in a long meeting is its own leak. */
-  latencyMs: number[];
+  /** ORCHESTRATION milliseconds — resolve + classify + retrieve — NOT TTFT.
+   *  The trace is finalized before the prompt is composed and before any
+   *  provider call, so `providerTtfbMs` is a structural 0 here and time to
+   *  first token is not knowable from this object. Named for what it holds:
+   *  feeding orchestration time to something labelled TTFT compares quantities
+   *  about an order of magnitude apart. Bounded ring buffer — an unbounded
+   *  latency array in a long meeting is its own leak. */
+  orchestrationMs: number[];
 }
 
 const MAX_LATENCY_SAMPLES = 512;
@@ -86,7 +91,7 @@ function emptyCounters(): RolloutCounters {
     contaminationCheckableTurns: 0,
     supersededTurns: 0,
     v3FallbackBySurface: {},
-    latencyMs: [],
+    orchestrationMs: [],
   };
 }
 
@@ -186,10 +191,30 @@ export function recordTurnMetrics(trace: AnswerTrace | null | undefined): void {
       if (bad) counters.contaminationTurns += 1;
     }
 
-    const ttft = Number(t.timings?.providerTtfbMs ?? t.timings?.totalMs ?? NaN);
-    if (Number.isFinite(ttft) && ttft >= 0) {
-      counters.latencyMs.push(ttft);
-      if (counters.latencyMs.length > MAX_LATENCY_SAMPLES) counters.latencyMs.shift();
+    // `t.latency`, not `t.timings` — AnswerTrace has never had a `timings`
+    // field, so this read was `undefined` on every turn since it was written
+    // and the latency percentiles below have always been empty.
+    //
+    // And `||`, not `??`. providerTtfbMs is a hardcoded 0 here (the provider
+    // has not run when the trace is built), and `??` does not fall through on
+    // zero — so the field-name fix alone would have traded an obvious NaN for a
+    // plausible permanent 0ms p95, which is the worse of the two bugs.
+    // `t.latency`, not `t.timings` — AnswerTrace has never declared a `timings`
+    // field, so this read was `undefined` on every turn since it was written
+    // and these percentiles were empty for the life of the metric.
+    //
+    // totalMs ONLY. Falling back through `providerTtfbMs` would be worse than
+    // the original bug: it is a hardcoded 0 at this point, and `??` does not
+    // short-circuit on zero, so the obvious NaN would have become a plausible
+    // permanent 0 ms p95.
+    //
+    // `>= 0`, not `> 0`. orchestrate() rounds its spans, so a turn that answers
+    // from state without retrieving genuinely measures 0 ms — discarding those
+    // drops the fastest turns from the sample and biases p50/p95 upward.
+    const orchestrationMs = Number((t.latency ?? {}).totalMs);
+    if (Number.isFinite(orchestrationMs) && orchestrationMs >= 0) {
+      counters.orchestrationMs.push(orchestrationMs);
+      if (counters.orchestrationMs.length > MAX_LATENCY_SAMPLES) counters.orchestrationMs.shift();
     }
   } catch { /* a metrics defect must never affect an answer */ }
 }
@@ -212,12 +237,13 @@ function quantile(values: number[], q: number): number | null {
 export function getRolloutMetrics(): {
   counters: RolloutCounters;
   rates: Record<string, number | null>;
-  latency: { p50: number | null; p95: number | null; samples: number };
+  /** ORCHESTRATION latency, not TTFT. See RolloutCounters.orchestrationMs. */
+  orchestrationLatency: { p50: number | null; p95: number | null; samples: number };
 } {
   const c = c0();
   const withRetrieval = c.retrieval.turnsWithRetrieval;
   return {
-    counters: { ...c, latencyMs: [...c.latencyMs] },
+    counters: { ...c, orchestrationMs: [...c.orchestrationMs] },
     rates: {
       staleVersionRejected: pct(c.retrieval.staleVersionRejectedTurns, withRetrieval),
       outOfScopeRejected: pct(c.retrieval.outOfScopeRejectedTurns, withRetrieval),
@@ -236,10 +262,10 @@ export function getRolloutMetrics(): {
       fastPath: pct(c.path.FAST ?? 0, c.turns),
       v3Share: pct(c.engine.v3, c.turns),
     },
-    latency: {
-      p50: quantile(c.latencyMs, 0.5),
-      p95: quantile(c.latencyMs, 0.95),
-      samples: c.latencyMs.length,
+    orchestrationLatency: {
+      p50: quantile(c.orchestrationMs, 0.5),
+      p95: quantile(c.orchestrationMs, 0.95),
+      samples: c.orchestrationMs.length,
     },
   };
 }
@@ -256,8 +282,13 @@ export function evaluateAbortConditions(input: {
   minTurns?: number;
   /** Legacy contamination rate to compare against, when one has been measured. */
   baselineContamination?: number | null;
-  /** Legacy p95 TTFT in ms, when one has been measured. */
-  baselineP95Ms?: number | null;
+  /** Legacy p95 ORCHESTRATION time in ms, when one has been measured.
+   *  Renamed from baselineP95Ms: it used to be documented as TTFT, and this
+   *  gate now compares against orchestration time. A TTFT baseline is roughly
+   *  an order of magnitude larger, so passing one here would hold the gate
+   *  permanently open — vacuously green, which is the failure this whole
+   *  metric exists to avoid. */
+  baselineOrchestrationP95Ms?: number | null;
 } = {}): { insufficientData: boolean; triggered: string[]; detail: Record<string, unknown> } {
   const minTurns = input.minTurns ?? 50;
   const m = getRolloutMetrics();
@@ -277,9 +308,9 @@ export function evaluateAbortConditions(input: {
     triggered.push('contamination_above_baseline');
   }
 
-  if (input.baselineP95Ms != null && m.latency.p95 != null
-      && m.latency.p95 > input.baselineP95Ms * 1.2) {
-    triggered.push('p95_regression_over_20pct');
+  if (input.baselineOrchestrationP95Ms != null && m.orchestrationLatency.p95 != null
+      && m.orchestrationLatency.p95 > input.baselineOrchestrationP95Ms * 1.2) {
+    triggered.push('orchestration_p95_regression_over_20pct');
   }
 
   // Over-refusal: strict refusals rising while general fallback is flat/low.
@@ -289,7 +320,7 @@ export function evaluateAbortConditions(input: {
     triggered.push('over_refusal_suspected');
   }
 
-  return { insufficientData: false, triggered, detail: { rates: m.rates, latency: m.latency } };
+  return { insufficientData: false, triggered, detail: { rates: m.rates, orchestrationLatency: m.orchestrationLatency } };
 }
 
 /** Test seam / session boundary. */

--- a/electron/context-intelligence/orchestration/orchestrator.ts
+++ b/electron/context-intelligence/orchestration/orchestrator.ts
@@ -667,7 +667,27 @@ export async function orchestrate(
   req: AnswerRequest,
   retrieval?: RetrievalPort,
 ): Promise<OrchestratorResult> {
-  const t0 = 0;
+  // performance.now(), NOT Date.now(). This is a desktop app that sleeps in the
+  // middle of a turn all the time — a lid closed between here and the trace
+  // literal would otherwise report a four-hour retrieval. A monotonic clock
+  // cannot be dragged by a sleep, an NTP step or a timezone change.
+  const clock = () => (typeof performance !== 'undefined' && typeof performance.now === 'function')
+    ? performance.now()
+    : Date.now();
+  const span = (from: number) => Math.max(0, Math.round(clock() - from));
+  const t0 = clock();
+
+  // Phase spans. Every one of these was a hardcoded 0 from the day the trace
+  // was written (`const t0 = 0` was literally the total), so `latency` looked
+  // like a measurement and was a placeholder — 173 production telemetry rows
+  // reported 0ms for everything before this was noticed. A zero here now means
+  // "measured zero", which is why the two spans that genuinely cannot be timed
+  // from inside this function are documented at the trace literal instead of
+  // being left to look measured.
+  let questionResolutionMs = 0;
+  let classificationMs = 0;
+  let retrievalMs = 0;
+  let evidenceEvaluationMs = 0;
 
   // ── Conversation continuity (§12.3) ───────────────────────────────────────
   // Resolve a bare follow-up against this session's state BEFORE deciding.
@@ -689,6 +709,7 @@ export async function orchestrate(
   // that as "original" hid every resolver decision from the telemetry.
   const originalQuestion = (req.manualQuestion ?? req.transcriptQuestion ?? '').trim();
   let priorDecision: import('../contracts/types').PriorTurnDecision | undefined;
+  const tResolve = clock();
   try {
     const { resolveAgainstSession, getConversationState } = require('../question/conversation-state-store');
     const rawQ = originalQuestion;
@@ -715,8 +736,14 @@ export async function orchestrate(
       }
     }
   } catch { /* continuity must never break a turn */ }
+  questionResolutionMs = span(tResolve);
 
+  // decide() resolves the mode policy AND classifies the turn, so this span
+  // covers both. policyResolutionMs is left at 0 rather than being given half
+  // of a number nobody measured — splitting it means instrumenting decide().
+  const tClassify = clock();
   let decision = decide(effectiveReq);
+  classificationMs = span(tClassify);
 
   // ── T5: a resolved bare follow-up regains its subject's pool ───────────────
   //
@@ -793,11 +820,17 @@ export async function orchestrate(
   let attempts: RetrievalAttemptTrace[] = [];
 
   if (decision.retrievalPlan.shouldRetrieve && retrieval) {
+    // Timed at the call site, not read from `attempts[].durationMs`: only
+    // legacy-retrieval-port populates that field, so trusting it would report
+    // 0ms for every turn served by any other port.
+    const tRetrieve = clock();
     try {
       const r = await retrieval.retrieve({ decision });
       evidence = r.evidence;
       attempts = r.attempts;
+      retrievalMs = span(tRetrieve);
     } catch (e) {
+      retrievalMs = span(tRetrieve);
       // §22.1: a retrieval dependency failure is RECORDED and the turn
       // continues with no evidence — it must NOT abort the turn back to a
       // legacy path that would inject a raw context blob instead. Answerability
@@ -815,7 +848,9 @@ export async function orchestrate(
     }
   }
 
+  const tEvaluate = clock();
   const answerability = evaluateAnswerability(decision, evidence);
+  evidenceEvaluationMs = span(tEvaluate);
 
   // A question whose required source the MODE forbids is not answerable from
   // model knowledge — that would answer a meeting question out of thin air. It
@@ -891,10 +926,29 @@ export async function orchestrate(
     fallbackUsed,
     promptTokenEstimate: 0,
     latency: {
-      normalizationMs: 0, questionResolutionMs: 0, policyResolutionMs: 0, classificationMs: 0,
-      retrievalMs: 0, rerankingMs: 0, evidenceEvaluationMs: 0, promptCompositionMs: 0,
-      providerTtfbMs: 0, totalMs: t0,
+      // Measured.
+      questionResolutionMs, classificationMs, retrievalMs, evidenceEvaluationMs,
+      totalMs: span(t0),
+
+      // NOT measured, and deliberately not guessed. Each of these happens
+      // outside this function, so any number here would be invented:
+      //   normalizationMs / policyResolutionMs — inside decide(), which reports
+      //     one span; see classificationMs above.
+      //   rerankingMs      — inside the retrieval port, which does not report it.
+      //   promptCompositionMs — composePrompt runs in engine-bridge AFTER this
+      //     function returns.
+      //   providerTtfbMs   — the provider has not been called yet.
+      normalizationMs: 0, policyResolutionMs: 0, rerankingMs: 0,
+      promptCompositionMs: 0, providerTtfbMs: 0,
     },
+    // Empty, and it must STAY empty here. This trace is finalized before the
+    // prompt is composed and long before a provider is called, so there is no
+    // provider to attribute. Reading LLMHelper.lastProviderModel at this point
+    // would return the PREVIOUS turn's model — and with auto-answer running
+    // overlapping turns it would be wrong in a way that looks entirely
+    // plausible. An empty array is honest; a stale model is telemetry that
+    // lies. Provider attribution belongs to whoever observes the completed
+    // provider call, not here.
     providerAttempts: [],
     status: 'COMPLETED',
     errorCodes: [],

--- a/electron/intelligence/__tests__/LiveSurfaceAnswerContract2026_08_29.test.mjs
+++ b/electron/intelligence/__tests__/LiveSurfaceAnswerContract2026_08_29.test.mjs
@@ -1,0 +1,106 @@
+// T3 (partial) — the live spoken surface shipped the MANUAL-CHAT answer
+// contract, and a blind re-press lost its directive.
+//
+// When V3 composes, `_v3p.user` replaces `packet.userMessage`, so everything
+// whose only carrier is `packet` silently disappears. Two consequences on the
+// live path, both fixed here, both on channels that already existed:
+//
+//   • `personaBase` resolved `action: 'answer'` — the manual-chat contract.
+//     `what_to_say` is this surface's own action (`runWhatShouldISay` is
+//     literally its caller) and carries the instruction the overlay most needs:
+//     "Output only the exact words the user should say next in the active role.
+//     No coaching, alternatives, labels, or quotation marks."
+//
+//   • `<repeat_press_directive>` reached the model only via `packet`. Measured
+//     live 2026-08-19: pressing the trigger again on the same coding page, with
+//     no new question, produced commentary on the previous answer and then
+//     agreement with it.
+//
+// ── TWO THINGS THE FINDINGS DOC GOT WRONG, both found by DUMPING the composed
+//    prompt rather than reading the code ────────────────────────────────────
+//
+//   1. It expected this switch to restore Team Meet's "only when directly
+//      addressed" overlay rule. That rule is ALREADY present under 'answer'.
+//      `voiceOverlay()` returns '' for team-meet+'answer', so the rule arrives
+//      by another route — and the half of the finding predicting an overlay that
+//      "answers other attendees' chatter" does not reproduce.
+//
+//   2. It described the coding CONTRACT as discarded under V3. It is not:
+//      personaBase passes `_promoted` through as `codingTask`, and the composed
+//      prompt does contain the Complexity / Dry Run sections. Only the DIRECTIVE
+//      was missing.
+//
+// ── AND THE REASON CODING TURNS KEEP 'answer' ───────────────────────────────
+//
+// `what_to_say` + codingTask composes BOTH "output only the exact words to say"
+// AND the six-section coding contract into one prompt — two instructions that
+// cannot both be obeyed. A coding answer on the live surface is a written
+// artifact, not words to read aloud.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+const cjsRequire = createRequire(import.meta.url);
+const { resolveV2SystemPrompt } = cjsRequire(
+  path.resolve(repoRoot, 'dist-electron/electron/llm/promptSystemV2.js'));
+
+const SPOKEN_WORDS = /exact words the user should say/;
+const CODING_SECTIONS = /Complexity|Dry Run/i;
+const ADDRESSED_RULE = /directly addressed/;
+
+const compose = (action, codingTask, templateType = 'team-meet') =>
+  String(resolveV2SystemPrompt({
+    action, codingTask, tier: 'standard',
+    activeMode: { id: 'm', templateType, name: templateType },
+  }) || '');
+
+describe('the live surface asks for spoken words on a non-coding turn', () => {
+  test("'what_to_say' carries the spoken-words contract; 'answer' does not", () => {
+    assert.match(compose('what_to_say', false), SPOKEN_WORDS);
+    assert.doesNotMatch(compose('answer', false), SPOKEN_WORDS,
+      'if this ever matches, the switch stopped being the thing that adds it');
+  });
+
+  test('it does not smuggle in the coding contract', () => {
+    assert.doesNotMatch(compose('what_to_say', false), CODING_SECTIONS);
+  });
+});
+
+describe('a coding turn keeps the written contract, and the two never mix', () => {
+  test("'what_to_say' + coding would contradict itself — which is why coding keeps 'answer'", () => {
+    // Pinning the contradiction so the exception is not "tidied away" later by
+    // someone who sees an inconsistent action and makes it uniform.
+    const both = compose('what_to_say', true);
+    assert.match(both, SPOKEN_WORDS);
+    assert.match(both, CODING_SECTIONS);
+  });
+
+  test("'answer' + coding gives the section contract with no spoken-words rule", () => {
+    const coding = compose('answer', true);
+    assert.match(coding, CODING_SECTIONS);
+    assert.doesNotMatch(coding, SPOKEN_WORDS);
+  });
+});
+
+describe("the findings doc's Team Meet claim does not reproduce", () => {
+  test('the "directly addressed" rule is present under BOTH actions', () => {
+    for (const action of ['answer', 'what_to_say']) {
+      for (const codingTask of [false, true]) {
+        assert.match(compose(action, codingTask), ADDRESSED_RULE,
+          `team-meet lost its overlay rule under action=${action} coding=${codingTask}`);
+      }
+    }
+  });
+
+  test('recruiting keeps its interviewer-probe voice under both actions', () => {
+    for (const action of ['answer', 'what_to_say']) {
+      assert.match(compose(action, false, 'recruiting'), /INTERVIEWER/,
+        `recruiting lost its voice overlay under ${action}`);
+    }
+  });
+});

--- a/electron/intelligence/__tests__/LiveSurfaceAnswerContract2026_08_29.test.mjs
+++ b/electron/intelligence/__tests__/LiveSurfaceAnswerContract2026_08_29.test.mjs
@@ -104,3 +104,54 @@ describe("the findings doc's Team Meet claim does not reproduce", () => {
     }
   });
 });
+
+describe('EXPLANATORY modes keep the direct-answer contract', () => {
+  // Review finding: the first version switched unconditionally across all nine
+  // modes, and the suite only exercised team-meet and recruiting — the two where
+  // `voiceOverlay()` supplies role framing — so a green run said nothing about
+  // the other seven.
+  //
+  // `answer` branches on mode ("in a live role mode, output the exact words that
+  // role should say. IN DIRECT CHAT OR AN EXPLANATORY MODE, ANSWER THE USER
+  // DIRECTLY"). `what_to_say` does not. The per-mode voice table settles which
+  // is which: lecture is "a quiet study partner explaining to the student …
+  // never speak as the student", and general is "the assistant in direct chat,
+  // or the user's own voice … as the moment requires".
+  for (const mode of ['lecture', 'general']) {
+    test(`${mode} must NOT get a script-for-the-user contract`, () => {
+      assert.doesNotMatch(compose('answer', false, mode), SPOKEN_WORDS,
+        `${mode} is explanatory; "output only the exact words to say" turns an `
+        + 'explanation into a recitation');
+    });
+  }
+
+  // The modes where the user genuinely IS the speaker keep the spoken contract.
+  for (const mode of ['team-meet', 'sales', 'call-center', 'looking-for-work']) {
+    test(`${mode} is a speaking role and does get it`, () => {
+      assert.match(compose('what_to_say', false, mode), SPOKEN_WORDS);
+    });
+  }
+});
+
+describe('a screen-code deictic turn does not get contradictory instructions', () => {
+  // Review finding, HIGH. `_promoted` is `!codingSignals.codingTask && …`, so it
+  // is FALSE exactly when the signals say coding; and the bridge's `codingTask`
+  // is `isCodingAnswerType(answerPlan.answerType)`, false for `unknown_answer`.
+  // A deictic ask over a code template on screen satisfied NEITHER term, so it
+  // would have taken 'what_to_say' — "no coaching, alternatives, LABELS" — while
+  // the CodingStreamGate and the post-stream repair independently enforced the
+  // six-section shape. The prompt would forbid the headings the repair requires.
+  //
+  // The engine branch is not directly reachable from here, so this pins the
+  // PROPERTY that makes the bug possible: the two contracts are mutually
+  // exclusive, therefore whatever picks between them must never see a coding
+  // turn as non-coding.
+  test('the spoken-words rule and the section contract never belong together', () => {
+    const spoken = compose('what_to_say', false);
+    const sections = compose('answer', true);
+    assert.match(spoken, SPOKEN_WORDS);
+    assert.doesNotMatch(spoken, CODING_SECTIONS);
+    assert.match(sections, CODING_SECTIONS);
+    assert.doesNotMatch(sections, SPOKEN_WORDS);
+  });
+});

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -12416,7 +12416,7 @@ export function initializeIpcHandlers(appState: AppState): void {
   // Exposed so a rollout stage can be gated on measured rates instead of a
   // description of rates, and so §5's abort conditions are evaluated rather
   // than remembered.
-  safeHandle('context-intelligence:rollout-metrics', async (_, input?: { baselineContamination?: number | null; baselineP95Ms?: number | null; minTurns?: number }) => {
+  safeHandle('context-intelligence:rollout-metrics', async (_, input?: { baselineContamination?: number | null; baselineOrchestrationP95Ms?: number | null; minTurns?: number }) => {
     try {
       const { getRolloutMetrics, evaluateAbortConditions } = require('./context-intelligence/observability/rollout-metrics');
       return { ok: true, metrics: getRolloutMetrics(), abort: evaluateAbortConditions(input ?? {}) };

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -529,8 +529,16 @@ interface ElectronAPI {
   setDefaultModel: (modelId: string) => Promise<{ success: boolean; error?: string }>;
   toggleModelSelector: (coords: { x: number; y: number; activate?: boolean }) => Promise<void>;
   modelSelectorCloseIfOpen: () => Promise<void>;
-  forceRestartOllama: () => Promise<void>;
+  /** Returns the handler's real shape. This was declared `Promise<void>` while
+   *  the handler has always returned `{ success }`, which is why the settings
+   *  screen read `result.success` behind a @ts-ignore. */
+  forceRestartOllama: () => Promise<{ success: boolean; reason?: string }>;
   isOllamaReachable: () => Promise<boolean>;
+  /** Start the local Ollama daemon if the user has Ollama selected. The handler
+   *  has existed since the OllamaManager work and had no bridge, so the settings
+   *  screen reached it through a generic `invoke` that this preload does not
+   *  expose — see AIProvidersSettings.ensureOllamaStartup. */
+  ensureOllamaRunning: () => Promise<{ success: boolean; reason?: string; [k: string]: unknown }>;
 
   // Settings Window
   toggleSettingsWindow: (coords?: { x: number; y: number }) => Promise<void>;
@@ -1059,6 +1067,21 @@ interface ElectronAPI {
    *  renderer only renders what this returns. */
   answerPolicyGet: (input: { modeId?: string; templateType?: string }) => Promise<any>;
   answerPolicySet: (input: { modeId?: string; templateType?: string; policy?: string | null }) => Promise<{ success: boolean; error?: string }>;
+  // Context Intelligence V3 rollout controls. Their handlers were registered in
+  // ipcHandlers.ts and had NO bridge here and no caller anywhere in the repo,
+  // so neither was reachable from a shipped app (`e2eInvoke`, the only generic
+  // passthrough, is undefined unless NATIVELY_E2E=1).
+  contextIntelligenceFlagGet: () => Promise<{
+    ok: boolean; enabled?: boolean; persisted?: boolean | null;
+    default?: boolean; envOverride?: string | null; error?: string;
+  }>;
+  contextIntelligenceFlagSet: (input: { enabled?: boolean | null }) =>
+    Promise<{ success: boolean; enabled?: boolean; error?: string }>;
+  contextIntelligenceRolloutMetrics: (input?: {
+    baselineContamination?: number | null;
+    baselineOrchestrationP95Ms?: number | null;
+    minTurns?: number;
+  }) => Promise<{ ok: boolean; metrics?: any; abort?: any; error?: string }>;
   modesDelete: (id: string) => Promise<{ success: boolean; error?: string }>;
   modesSetActive: (id: string | null) => Promise<{ success: boolean; error?: string }>;
   modesGetReferenceFiles: (
@@ -2113,6 +2136,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   modelSelectorCloseIfOpen: () => ipcRenderer.invoke('model-selector:close-if-open'),
   forceRestartOllama: () => ipcRenderer.invoke('force-restart-ollama'),
   isOllamaReachable: () => ipcRenderer.invoke('is-ollama-reachable'),
+  ensureOllamaRunning: () => ipcRenderer.invoke('ensure-ollama-running'),
 
   // Settings Window
   toggleSettingsWindow: (coords?: { x: number; y: number }) =>
@@ -2750,6 +2774,28 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('context-intelligence:answer-policy-get', input),
   answerPolicySet: (input: { modeId?: string; templateType?: string; policy?: string | null }) =>
     ipcRenderer.invoke('context-intelligence:answer-policy-set', input),
+
+  // ── V3 rollout: flag + metrics ───────────────────────────────────────────
+  //
+  // flag.ts documents its own fix for "the F1 pattern — a documented path with
+  // no caller", so that "enabling a rollout stage must not require relaunching
+  // the app from a shell with an env var set". The handler that WRITES that
+  // persisted setting then had no bridge, which reproduced the same pattern one
+  // layer up: the env var stayed the only working switch.
+  //
+  // rollout-metrics is the sole consumer of the contamination rate, the abort
+  // conditions and the orchestration percentiles that recordTurnMetrics
+  // collects on every single turn. Without this line all of it was computed and
+  // unreadable.
+  contextIntelligenceFlagGet: () =>
+    ipcRenderer.invoke('context-intelligence:flag-get'),
+  contextIntelligenceFlagSet: (input: { enabled?: boolean | null }) =>
+    ipcRenderer.invoke('context-intelligence:flag-set', input),
+  contextIntelligenceRolloutMetrics: (input?: {
+    baselineContamination?: number | null;
+    baselineOrchestrationP95Ms?: number | null;
+    minTurns?: number;
+  }) => ipcRenderer.invoke('context-intelligence:rollout-metrics', input ?? {}),
   modesDelete: (id: string) => ipcRenderer.invoke('modes:delete', id),
   modesSetActive: (id: string | null) => ipcRenderer.invoke('modes:set-active', id),
   modesGetReferenceFiles: (modeId: string) =>

--- a/electron/services/__tests__/IpcBridgeWiring.test.mjs
+++ b/electron/services/__tests__/IpcBridgeWiring.test.mjs
@@ -1,0 +1,121 @@
+// IPC bridge wiring — a ratchet against handlers nothing can reach.
+//
+// WHY THIS EXISTS
+//
+// A `safeHandle('x', …)` with no matching `ipcRenderer.invoke('x')` in
+// preload.ts is dead in a shipped app. There is no generic passthrough:
+// `e2eInvoke` is the only one and it is undefined unless NATIVELY_E2E=1. Three
+// handlers were found in that state on 2026-08-29, including
+// `context-intelligence:rollout-metrics` — the sole reader of the contamination
+// rate, abort conditions and latency percentiles that recordTurnMetrics
+// computes on EVERY turn. All of it was collected and unreadable.
+//
+// The same audit found the mirror-image defect in the renderer: settings code
+// calling `window.electronAPI?.invoke?.('ensure-ollama-running')` behind a
+// @ts-ignore. Optional chaining on a method that does not exist short-circuits
+// silently, so the result was always undefined and the UI reported Ollama
+// "not found" WITHOUT EVER TRYING TO START IT.
+//
+// Both checks are structural and cheap. Neither can prove a channel is USED,
+// only that it is reachable — which is the half that kept failing.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const read = (rel) => fs.readFileSync(path.join(REPO, rel), 'utf8');
+
+const HANDLER_SRC = read('electron/ipcHandlers.ts') + '\n' + read('electron/main.ts');
+const PRELOAD_SRC = read('electron/preload.ts');
+
+const handlers = new Set(
+  [...HANDLER_SRC.matchAll(/safeHandle\(\s*'([^']+)'/g)].map((m) => m[1]),
+);
+const bridged = new Set(
+  [...PRELOAD_SRC.matchAll(/ipcRenderer\.(?:invoke|send)\(\s*['"]([^'"]+)['"]/g)].map((m) => m[1]),
+);
+
+// Reachable through the NATIVELY_E2E-gated `e2eInvoke` passthrough, by design.
+const E2E_PREFIX = '__e2e__:';
+
+// Known-unbridged as of 2026-08-29. This list may SHRINK freely; growing it
+// means a new handler shipped that nothing can call, which is the bug. Each
+// entry is a real question for its owner, not an endorsement.
+const KNOWN_UNBRIDGED = new Set([
+  // A complete custom/curl provider feature with no reachable entry point.
+  'get-curl-providers', 'save-curl-provider', 'delete-curl-provider',
+  'switch-to-curl-provider', 'switch-to-custom-provider',
+  // Model-selector window controls.
+  'show-model-selector', 'hide-model-selector',
+  // Window/session controls with no caller.
+  'center-and-show-window', 'close-settings-window', 'reset-queues',
+  'invalidate-natively-usage-cache', 'restart-ollama',
+  // Exercised directly by their own suites rather than the renderer.
+  'dev:thinking-budget-bench', 'skills:reap-stages',
+  // Non-streaming predecessor of 'gemini-chat-stream', which is the only chat
+  // channel preload bridges. Left registered, not deleted, because that is its
+  // owner's call — but nothing in a shipped app reaches it.
+  'gemini-chat',
+]);
+
+describe('IPC bridge wiring', () => {
+  test('every registered handler is reachable from the renderer', () => {
+    const unreachable = [...handlers]
+      .filter((c) => !c.startsWith(E2E_PREFIX))
+      .filter((c) => !bridged.has(c))
+      .filter((c) => !KNOWN_UNBRIDGED.has(c))
+      .sort();
+    assert.deepEqual(unreachable, [],
+      'These handlers have no ipcRenderer.invoke in preload.ts, so nothing in a ' +
+      'shipped app can call them. Add a preload binding, or add the channel to ' +
+      'KNOWN_UNBRIDGED with a reason:\n  ' + unreachable.join('\n  '));
+  });
+
+  test('the allowlist has not gone stale', () => {
+    // An entry that is now bridged, or whose handler was deleted, is noise that
+    // makes the real list harder to read.
+    const stale = [...KNOWN_UNBRIDGED]
+      .filter((c) => bridged.has(c) || !handlers.has(c)).sort();
+    assert.deepEqual(stale, [],
+      'KNOWN_UNBRIDGED entries that are now bridged or no longer exist — remove them');
+  });
+
+  test('preload exposes no generic invoke outside the E2E gate', () => {
+    // The containment argument for the curated bridge (F-117): an unconditional
+    // passthrough lets any renderer code reach every production channel.
+    const generic = [...PRELOAD_SRC.matchAll(/^\s*invoke\s*:\s*\(/gm)];
+    assert.equal(generic.length, 0,
+      'a generic `invoke` on the exposed API defeats the curated bridge');
+    assert.match(PRELOAD_SRC, /NATIVELY_E2E === '1'[\s\S]{0,200}e2eInvoke/,
+      'e2eInvoke must stay gated on NATIVELY_E2E');
+  });
+
+  test('no renderer code calls the nonexistent generic invoke', () => {
+    // This is the shape that silently no-ops: `?.invoke?.(...)` on an API that
+    // has no `invoke`. It cannot throw, so it fails as "the feature did
+    // nothing" rather than as an error anyone sees.
+    const offenders = [];
+    const walk = (dir) => {
+      for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+        const p = path.join(dir, e.name);
+        if (e.isDirectory()) { if (e.name !== 'node_modules') walk(p); continue; }
+        if (!/\.(ts|tsx)$/.test(e.name)) continue;
+        const src = fs.readFileSync(p, 'utf8');
+        for (const m of src.matchAll(/electronAPI\s*\??\.\s*invoke\s*\??\s*\(\s*['"]([^'"]+)/g)) {
+          const line = src.slice(0, m.index).split('\n').length;
+          // Commented-out references are not calls.
+          const text = src.split('\n')[line - 1] ?? '';
+          if (text.trim().startsWith('//')) continue;
+          offenders.push(`${path.relative(REPO, p)}:${line} → '${m[1]}'`);
+        }
+      }
+    };
+    walk(path.join(REPO, 'src'));
+    assert.deepEqual(offenders, [],
+      'electronAPI has no generic `invoke`; these calls short-circuit to ' +
+      'undefined and the feature silently does nothing:\n  ' + offenders.join('\n  '));
+  });
+});

--- a/electron/services/__tests__/UsageTelemetryEmission.test.mjs
+++ b/electron/services/__tests__/UsageTelemetryEmission.test.mjs
@@ -75,8 +75,9 @@ describe('turn telemetry emission', { skip: HAVE_BUILD ? false : 'run `npm run b
             ],
             providerAttempts: [{ provider: 'gemini', model: 'gemini-3.1-flash-lite', ok: true }],
             latency: {
-                retrievalMs: 210, rerankingMs: 48, promptCompositionMs: 33,
-                providerTtfbMs: 640, totalMs: 1180,
+                questionResolutionMs: 6, classificationMs: 90, retrievalMs: 210,
+                evidenceEvaluationMs: 12, rerankingMs: 0, promptCompositionMs: 0,
+                providerTtfbMs: 0, totalMs: 1180,
             },
             ...over,
         };
@@ -93,20 +94,37 @@ describe('turn telemetry emission', { skip: HAVE_BUILD ? false : 'run `npm run b
         assert.equal(rows[0].event_status, 'completed');
     });
 
-    test('counts, durations and provider are mapped from the trace', () => {
+    test('counts and measured durations are mapped from the trace', () => {
         emitted();
         const { recordTurnTelemetry } = require(INSTR);
         recordTurnTelemetry(trace());
         const [row] = emitted();
         assert.equal(row.reported_count, 15, 'candidateCount summed across attempts');
-        assert.equal(row.reported_duration_ms, 1180);
-        assert.equal(row.provider, 'gemini');
-        assert.equal(row.model, 'gemini-3.1-flash-lite');
+        assert.equal(row.reported_duration_ms, 1180, 'ORCHESTRATION time, not the whole handler');
         assert.equal(row.metadata.selected_source_count, 3);
-        assert.equal(row.metadata.reranking_used, true);
         assert.equal(row.metadata.knowledge_source_type, 'RESUME', 'the dominant type, not the first');
-        assert.equal(row.metadata.context_build_duration_ms, 33);
-        assert.equal(row.metadata.llm_ttfb_ms, 640);
+        assert.equal(row.metadata.retrieval_ms, 210);
+        assert.equal(row.metadata.classification_ms, 90);
+    });
+
+    // The first version of this emitter shipped llm_ttfb_ms,
+    // context_build_duration_ms and reranking_used, plus provider/model. All
+    // five are impossible to know at the emit point — the trace is finalized
+    // before the prompt is composed and before any provider call — so 173
+    // production rows carried 0/0/false/null/null without one of them being an
+    // observation. A measurement-shaped non-measurement is worse than an
+    // absent field, because a reader averages it.
+    test('fields that cannot be measured here are ABSENT, not zero', () => {
+        emitted();
+        const { recordTurnTelemetry } = require(INSTR);
+        recordTurnTelemetry(trace());
+        const [row] = emitted();
+        for (const dead of ['llm_ttfb_ms', 'context_build_duration_ms', 'reranking_used']) {
+            assert.ok(!(dead in row.metadata),
+                `${dead} cannot be measured at this point and must not be emitted`);
+        }
+        assert.equal(row.provider, undefined, 'providerAttempts is always empty here');
+        assert.equal(row.model, undefined);
     });
 
     test('a SUPERSEDED turn is interrupted, never completed', () => {
@@ -129,12 +147,13 @@ describe('turn telemetry emission', { skip: HAVE_BUILD ? false : 'run `npm run b
         assert.equal(row.event_status, 'failed');
     });
 
-    test('reranking_used is false when the reranker did not run', () => {
+    test('a turn that never retrieved reports a measured 0ms, not a missing field', () => {
         emitted();
         const { recordTurnTelemetry } = require(INSTR);
-        recordTurnTelemetry(trace({ latency: { rerankingMs: 0, totalMs: 90 } }));
+        recordTurnTelemetry(trace({ latency: { retrievalMs: 0, classificationMs: 4, totalMs: 90 } }));
         const [row] = emitted();
-        assert.equal(row.metadata.reranking_used, false);
+        assert.equal(row.metadata.retrieval_ms, 0, 'orchestrate() measured it; zero is the answer');
+        assert.equal(row.metadata.classification_ms, 4);
         assert.equal(row.metadata.knowledge_source_type, 'RESUME');
     });
 

--- a/electron/services/usageInstrumentation.ts
+++ b/electron/services/usageInstrumentation.ts
@@ -348,25 +348,27 @@ export function recordTurnTelemetry(trace: unknown): void {
         let best = 0;
         for (const [k, n] of tally) if (n > best) { dominant = k; best = n; }
 
-        const lastProvider = Array.isArray(t.providerAttempts) && t.providerAttempts.length
-            ? t.providerAttempts[t.providerAttempts.length - 1]
-            : undefined;
-
-        // At most 8 keys are accepted and an overflow REJECTS THE WHOLE EVENT —
-        // which the outbox then drops permanently as a poison row. Five keys,
-        // three spare, on purpose: durations and counts that have a real column
-        // go in the column, not in here.
+        // ONLY MEASURED VALUES. The first version of this shipped
+        // llm_ttfb_ms, context_build_duration_ms and reranking_used, and all
+        // three were structurally impossible to measure at the emit point:
+        // 173 production rows carried 0/0/false without a single one of them
+        // being an observation. A measurement-shaped non-measurement is worse
+        // than an absent field, because a reader averages it.
+        //
+        // What is left is measured in orchestrate(): the retrieval span, the
+        // candidate and accepted counts, and the dominant source type.
+        //
+        // At most 8 keys are accepted and an overflow REJECTS THE WHOLE EVENT,
+        // which the outbox then drops permanently as a poison row. Four keys,
+        // four spare.
         const metadata: Record<string, string | number | boolean> = {
             selected_source_count: accepted,
-            reranking_used: (finiteInt(latency.rerankingMs) ?? 0) > 0,
             knowledge_source_type: dominant,
         };
-        const ctxMs = finiteInt(latency.promptCompositionMs);
-        if (ctxMs !== undefined) metadata.context_build_duration_ms = ctxMs;
-        // Named ttfb, not `llm_duration_ms`: the trace measures time to FIRST
-        // byte, and a field named for total duration would be read as one.
-        const ttfbMs = finiteInt(latency.providerTtfbMs);
-        if (ttfbMs !== undefined) metadata.llm_ttfb_ms = ttfbMs;
+        const retrievalMs = finiteInt(latency.retrievalMs);
+        if (retrievalMs !== undefined) metadata.retrieval_ms = retrievalMs;
+        const classifyMs = finiteInt(latency.classificationMs);
+        if (classifyMs !== undefined) metadata.classification_ms = classifyMs;
 
         const input: UsageEventInput = {
             event_type: status === 'failed' ? 'retrieval_failed' : 'retrieval_completed',
@@ -374,12 +376,22 @@ export function recordTurnTelemetry(trace: unknown): void {
             reported_count: candidates,
             metadata,
         };
+        // NAMING COLLISION, READ THIS BEFORE JOINING THE TWO TABLES.
+        // This is ORCHESTRATION time — resolve + classify + retrieve — and it
+        // ends before the prompt is composed or the provider is called. The
+        // ledger's reported_duration_ms, written by runTracked(), is the WHOLE
+        // handler including the LLM: in production the ledger median is ~4.6s
+        // and p95 ~30s, roughly an order of magnitude larger. Same column name,
+        // two tables, two different things.
         const totalMs = finiteInt(latency.totalMs);
         if (totalMs !== undefined) input.reported_duration_ms = totalMs;
-        const provider = identOrUndefined(lastProvider?.provider);
-        if (provider) input.provider = provider;
-        const model = identOrUndefined(lastProvider?.model);
-        if (model) input.model = model;
+
+        // provider/model are NOT set, and that is not an omission. This event
+        // is emitted from a trace finalized before any provider call, so
+        // providerAttempts is always empty (see orchestrator.ts). The first
+        // version read it anyway and wrote NULL on 100% of 173 rows. Attribute
+        // the provider where the provider call actually completes, or not at
+        // all.
         // Correlates this row with the rest of the turn inside the telemetry
         // table. Not the raw question, and not a licence identifier — the server
         // resolves the licence from auth and refuses a client-chosen one.

--- a/src/components/FollowUpEmailModal.tsx
+++ b/src/components/FollowUpEmailModal.tsx
@@ -64,8 +64,7 @@ const FollowUpEmailModal: React.FC<FollowUpEmailModalProps> = ({ isOpen, onClose
         try {
             // Try Calendar
             if (meeting.calendarEventId) {
-                // @ts-ignore
-                const attendees = await window.electronAPI?.invoke('get-calendar-attendees', meeting.calendarEventId);
+                const attendees = await window.electronAPI?.getCalendarAttendees(meeting.calendarEventId);
                 if (attendees && attendees.length > 0) {
                     loadedRecipientEmail = attendees[0].email;
                     if (attendees[0].name) loadedRecipientName = attendees[0].name.split(' ')[0];
@@ -74,8 +73,7 @@ const FollowUpEmailModal: React.FC<FollowUpEmailModalProps> = ({ isOpen, onClose
 
             // Fallback: Transcript
             if (!loadedRecipientEmail && meeting.transcript) {
-                // @ts-ignore
-                const extracted = await window.electronAPI?.invoke('extract-emails-from-transcript', meeting.transcript);
+                const extracted = await window.electronAPI?.extractEmailsFromTranscript(meeting.transcript);
                 if (extracted && extracted.length > 0) {
                     loadedRecipientEmail = extracted[0];
                 }
@@ -107,8 +105,7 @@ const FollowUpEmailModal: React.FC<FollowUpEmailModalProps> = ({ isOpen, onClose
                 tone: 'neutral' as const // Default to neutral for auto-gen
             };
 
-            // @ts-ignore
-            const generatedBody = await window.electronAPI?.invoke('generate-followup-email', input);
+            const generatedBody = await window.electronAPI?.generateFollowupEmail(input);
             if (generatedBody) {
                 setEmailBody(generatedBody);
             }
@@ -130,14 +127,12 @@ const FollowUpEmailModal: React.FC<FollowUpEmailModalProps> = ({ isOpen, onClose
 
     const handleSendGmail = async () => {
         const gmailUrl = `https://mail.google.com/mail/?view=cm&fs=1&to=${encodeURIComponent(recipientEmail)}&su=${encodeURIComponent(subject)}&body=${encodeURIComponent(emailBody)}`;
-        // @ts-ignore
-        await window.electronAPI?.invoke('open-external', gmailUrl);
+        await window.electronAPI?.openExternal(gmailUrl);
         onClose();
     };
 
     const handleSendDefault = async () => {
-        // @ts-ignore
-        await window.electronAPI?.invoke('open-mailto', {
+        await window.electronAPI?.openMailto({
             to: recipientEmail,
             subject: subject,
             body: emailBody

--- a/src/components/SettingsPopup.tsx
+++ b/src/components/SettingsPopup.tsx
@@ -265,7 +265,7 @@ const SettingsPopup = () => {
             // Ensure backend is synced on mount (even if no change)
             try {
                 // @ts-ignore
-                window.electronAPI?.invoke('set-groq-fast-text-mode', useGroqFastText);
+                window.electronAPI?.setGroqFastTextMode(useGroqFastText);
             } catch (e) {
                 console.error(e);
             }
@@ -276,7 +276,7 @@ const SettingsPopup = () => {
         localStorage.setItem('natively_groq_fast_text', String(useGroqFastText));
         try {
             // @ts-ignore - electronAPI not typed in this file yet
-            window.electronAPI?.invoke('set-groq-fast-text-mode', useGroqFastText);
+            window.electronAPI?.setGroqFastTextMode(useGroqFastText);
         } catch (e) {
             console.error(e);
         }

--- a/src/components/settings/AIProvidersSettings.tsx
+++ b/src/components/settings/AIProvidersSettings.tsx
@@ -2762,8 +2762,16 @@ export const AIProvidersSettings: React.FC<AIProvidersSettingsProps> = ({
     const ensureOllamaStartup = async () => {
         setOllamaStatus('checking');
         try {
-            // @ts-ignore
-            const result = await window.electronAPI?.invoke?.('ensure-ollama-running');
+            // electronAPI.ensureOllamaRunning, NOT a generic `invoke`.
+            //
+            // This called `window.electronAPI?.invoke?.('ensure-ollama-running')`
+            // behind a @ts-ignore, and this preload exposes NO generic `invoke`
+            // (the only passthrough, e2eInvoke, is undefined unless
+            // NATIVELY_E2E=1). So the optional call short-circuited, `result`
+            // was always undefined, and the branch below reported 'not-found'
+            // WITHOUT EVER TRYING TO START THE DAEMON. The @ts-ignore is what
+            // let it typecheck.
+            const result = await window.electronAPI?.ensureOllamaRunning?.();
             if (result && result.success) {
                 // It's running (or just started), now fetch models
                 checkOllama(true);
@@ -2830,8 +2838,9 @@ export const AIProvidersSettings: React.FC<AIProvidersSettingsProps> = ({
     const handleFixOllama = async () => {
         setOllamaStatus('fixing');
         try {
-            // @ts-ignore
-            const result = await window.electronAPI?.invoke?.('force-restart-ollama');
+            // Same defect: forceRestartOllama IS bridged, but reaching it
+            // through the nonexistent generic `invoke` silently did nothing.
+            const result = await window.electronAPI?.forceRestartOllama?.();
             if (result && result.success) {
                 setOllamaRestarted(true);
                 // Wait for server to be ready

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -443,8 +443,15 @@ export interface ElectronAPI {
   setDefaultModel: (modelId: string) => Promise<{ success: boolean; error?: string }>;
   toggleModelSelector: (coords: { x: number; y: number; activate?: boolean }) => Promise<void>;
   modelSelectorCloseIfOpen: () => Promise<void>;
-  forceRestartOllama: () => Promise<void>;
+  // NOTE: this interface and the one in electron/preload.ts are maintained
+  // separately and drift. That drift is what hid the Ollama bug: the settings
+  // screen reached these through a generic `invoke` that neither file declares
+  // and preload does not expose, behind a @ts-ignore that silenced the error.
+  /** Real handler shape — `{ success }`, not void. */
+  forceRestartOllama: () => Promise<{ success: boolean; reason?: string }>;
   isOllamaReachable: () => Promise<boolean>;
+  /** Start the local Ollama daemon when Ollama is the selected provider. */
+  ensureOllamaRunning: () => Promise<{ success: boolean; reason?: string; [k: string]: unknown }>;
 
   // Settings Window
   toggleSettingsWindow: (coords?: { x: number; y: number }) => Promise<void>;


### PR DESCRIPTION
**T3-partial.** When V3 composes, `_v3p.user` replaces `packet.userMessage` — so anything whose only carrier is `packet` silently disappears. Two consequences on the live path, both fixed on channels that already existed, both in one file.

## What was missing

**`personaBase` resolved `action: 'answer'`** — the *manual-chat* contract. `what_to_say` is this surface's own action (`runWhatShouldISay` is literally its caller) and carries the instruction the overlay most needs:

> Output only the exact words the user should say next in the active role. No coaching, alternatives, labels, or quotation marks.

Verified by **dumping the composed prompt**: absent under `answer`, present under `what_to_say`.

**`<repeat_press_directive>` reached the model only via `packet`.** Measured live 2026-08-19: pressing the trigger again on the same coding page with no new question produced commentary on the previous answer, then agreement with it. It now rides the **system** prompt rather than `realtimeInstruction` — that field is documented *"Tone/length only — cannot widen authorization"*, and this is an answer-shape mandate belonging on the same channel as the coding contract it refers to.

## Coding turns keep `answer`, and the exception is the point

Dumping all four combinations shows `what_to_say` + `codingTask` composes **both** "output only the exact words to say" **and** the six-section coding contract into one prompt — two instructions that cannot both be obeyed. A coding answer on the live surface is a written artifact, not words to read aloud.

The suite pins that contradiction, so the inconsistent-looking action isn't "tidied" into uniformity later.

## Two things the findings doc got wrong

Both surfaced by dumping the composed prompt instead of reading the code:

1. It expected this switch to **restore** Team Meet's *"only when directly addressed"* rule, predicting an overlay that "can start answering other attendees' chatter". **That rule is already present under `answer`**, in all four combinations. `voiceOverlay()` does return `''` for team-meet+`answer`, so it arrives by another route — the finding reasoned from one function and missed the composition. That half doesn't reproduce.
2. It described the coding **contract** as discarded under V3. It isn't — `personaBase` passes `_promoted` through as `codingTask` and the composed prompt does contain Complexity / Dry Run. Only the **directive** was missing.

## Scope — what is deliberately NOT here

The **DOM/OCR screen text** half (finding #3) is not done. A `screen-retrieval-port.ts` is in flight from another agent in this working tree, already wired into `ipcHandlers` for manual chat. The WTA path should **reuse that producer** when it lands rather than grow a second one — a second `SCREEN_CONTEXT` producer is exactly the F2 duplication this subsystem exists to end. `promptInstruction` (finding #7) is deferred with it, since its natural carrier is the same decision.

`test:intelligence` 2055/0 · `test:llm` 4008/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014D8QkwcTrpGVPmkWHrp4Nz