### PR TITLE
fix(rag): RAGManager silently dropped most of the embedding config on startup

### DIFF
--- a/electron/rag/EmbeddingProviderResolver.ts
+++ b/electron/rag/EmbeddingProviderResolver.ts
@@ -30,7 +30,12 @@ export class EmbeddingProviderResolver {
   /** Cloud providers get a bounded probe-retry before we demote (hysteresis). */
   private static readonly CLOUD_PROBE_ATTEMPTS = 3;
   private static readonly CLOUD_PROBE_BACKOFF_MS = 400;
-  private static readonly CLOUD_PROVIDER_NAMES = new Set(['openai', 'gemini']);
+  // 'natively' added 2026-08-30. It is a billed network round-trip like the
+  // other two, so a single 429 or blip must not demote it — demotion changes the
+  // active embedding SPACE and strands every persisted vector, which is the
+  // thrash this hysteresis exists to prevent. Omitting it gave the managed tier
+  // ONE probe attempt where openai/gemini get three.
+  private static readonly CLOUD_PROVIDER_NAMES = new Set(['openai', 'gemini', 'natively']);
 
   /**
    * Probe a provider's availability. For CLOUD providers (which require a real

--- a/electron/rag/RAGManager.ts
+++ b/electron/rag/RAGManager.ts
@@ -7,6 +7,7 @@ import { LLMHelper } from '../LLMHelper';
 import { preprocessTranscript, RawSegment } from './TranscriptPreprocessor';
 import { chunkTranscript } from './SemanticChunker';
 import { VectorStore } from './VectorStore';
+import type { AppAPIConfig } from './EmbeddingProviderResolver';
 import { EmbeddingPipeline } from './EmbeddingPipeline';
 import { RAGRetriever } from './RAGRetriever';
 import { LiveRAGIndexer } from './LiveRAGIndexer';
@@ -62,7 +63,7 @@ async function* raceGeneratorWithDeadline(
     }
 }
 
-export interface RAGManagerConfig {
+export interface RAGManagerConfig extends Partial<AppAPIConfig> {
     db: Database.Database;
     // dbPath/extPath are unused by VectorStore now (it runs on `db` directly —
     // see VectorStore.ts's header comment for why the worker-thread design
@@ -71,13 +72,33 @@ export interface RAGManagerConfig {
     // out-of-process search path doesn't have to re-thread them.
     dbPath: string;
     extPath: string;
-    openaiKey?: string;
-    geminiKey?: string;
-    geminiKeys?: string[];   // optional pool for embedding key-rotation + 429 cooldown
-    ollamaUrl?: string;
-    providerDataScopes?: ProviderDataScopePolicy;
-    explicitKeyManagement?: boolean;
+    /**
+     * The embedding configuration, forwarded WHOLE (2026-08-30).
+     *
+     * This used to re-declare six fields by hand — openaiKey, geminiKey,
+     * geminiKeys, ollamaUrl, providerDataScopes, explicitKeyManagement — and the
+     * constructor re-listed the same six into `embeddingPipeline.initialize()`.
+     * `buildEmbeddingConfig()` returns an `AppAPIConfig` with far more than
+     * that (nativelyApiKey, nativelyTrialToken, nativelyApiUrl,
+     * ollamaEmbeddingModel/Dims, the per-provider model+dims hints, and the
+     * embeddingMode/embeddingProvider choice), and `main.ts` spreads it straight
+     * in — so every field outside the hand-written six was SILENTLY DROPPED on a
+     * normal app start.
+     *
+     * TypeScript could not catch it: spreading a typed variable into an object
+     * literal skips excess-property checking, so `typecheck:electron` stayed
+     * green while the managed-embedding tier and the user's chosen Ollama
+     * embedding model were never configured at all. The feature only appeared
+     * if the user later re-entered an OpenAI/Gemini key, because
+     * `initializeEmbeddings` forwards with `{...keys}` and therefore carried
+     * everything by accident.
+     *
+     * Carrying the type instead of a copy of its field names is what stops this
+     * recurring — the same lesson `embeddingConfigIdentity.ts` was written for,
+     * one layer down.
+     */
 }
+
 
 /**
  * RAGManager - Central orchestrator for RAG operations
@@ -118,14 +139,14 @@ export class RAGManager {
         this.retriever = new RAGRetriever(this.vectorStore, this.embeddingPipeline);
         this.liveIndexer = new LiveRAGIndexer(this.vectorStore, this.embeddingPipeline);
 
-        this.embeddingPipeline.initialize({
-            openaiKey: config.openaiKey,
-            geminiKey: config.geminiKey,
-            geminiKeys: config.geminiKeys,
-            ollamaUrl: config.ollamaUrl,
-            providerDataScopes: config.providerDataScopes,
-            explicitKeyManagement: config.explicitKeyManagement,
-        }).then(() => {
+        // Forward the WHOLE embedding config. Hand-listing fields here is what
+        // dropped nativelyApiKey / nativelyTrialToken / nativelyApiUrl /
+        // ollamaEmbeddingModel / ollamaEmbeddingDims and the embeddingMode +
+        // embeddingProvider choice on every normal app start — see
+        // RAGManagerConfig's note. `db`/`dbPath`/`extPath` are this class's own
+        // and are the only fields the pipeline must not see.
+        const { db: _db, dbPath: _dbPath, extPath: _extPath, ...embeddingConfig } = config;
+        this.embeddingPipeline.initialize(embeddingConfig).then(() => {
             // Backfill provider metadata for meetings that were embedded before the
             // embedding_provider column was written (or where the write failed silently).
             this._backfillEmbeddingProviderMetadata();
@@ -158,7 +179,11 @@ export class RAGManager {
         return this.embeddingPipeline;
     }
 
-    initializeEmbeddings(keys: { openaiKey?: string, geminiKey?: string, geminiKeys?: string[], ollamaUrl?: string, providerDataScopes?: ProviderDataScopePolicy, explicitKeyManagement?: boolean }): void {
+    // `AppAPIConfig`, not a hand-written subset. This path already FORWARDED
+    // everything at runtime via `{...keys}` — which is precisely why the managed
+    // tier worked here and not in the constructor — but its type named only six
+    // fields, so it read as though the rest were unsupported.
+    initializeEmbeddings(keys: AppAPIConfig): void {
         const initPromise = this.embeddingPipeline.initialize({
             ...keys,
             explicitKeyManagement: keys.explicitKeyManagement,

--- a/electron/rag/__tests__/EmbeddingConfigStateAwareness.test.mjs
+++ b/electron/rag/__tests__/EmbeddingConfigStateAwareness.test.mjs
@@ -75,10 +75,31 @@ describe('EmbeddingProviderResolver explicit key-management policy', () => {
     assert.doesNotMatch(initArgs, /process\.env\.(OPENAI_API_KEY|GOOGLE_API_KEY|GEMINI_API_KEY)/, 'Settings reinit must not resurrect removed UI keys from process.env');
   });
 
-  test('RAGManager forwards explicitKeyManagement into EmbeddingPipeline.initialize()', () => {
+  // REWRITTEN 2026-08-30. This asserted three literal spellings —
+  // `explicitKeyManagement?: boolean`, `explicitKeyManagement: config.…`,
+  // `explicitKeyManagement: keys.…` — which pinned in place the very hand-listing
+  // that was the bug. RAGManagerConfig re-declared six embedding fields by name
+  // and the constructor re-listed the same six into `initialize()`, so anything
+  // `buildEmbeddingConfig()` produces beyond those six was silently dropped on a
+  // normal app start. A test that REQUIRED the hand-list could only hold that in
+  // place.
+  //
+  // The property worth guarding is the opposite one: the config is forwarded
+  // WHOLE, so no future field can be dropped by omission. That subsumes
+  // explicitKeyManagement rather than weakening the guarantee.
+  test('RAGManager forwards the WHOLE embedding config into EmbeddingPipeline.initialize()', () => {
     const source = read('electron/rag/RAGManager.ts');
-    assert.match(source, /explicitKeyManagement\?:\s*boolean/, 'RAGManager config/input should accept explicitKeyManagement');
-    assert.match(source, /explicitKeyManagement:\s*config\.explicitKeyManagement/, 'constructor path should forward explicitKeyManagement');
-    assert.match(source, /explicitKeyManagement:\s*keys\.explicitKeyManagement/, 'initializeEmbeddings path should forward explicitKeyManagement');
+
+    assert.match(source, /RAGManagerConfig extends Partial<AppAPIConfig>/,
+      'the config must carry the pipeline TYPE, not a copy of some of its field names');
+    assert.match(source, /this\.embeddingPipeline\.initialize\(embeddingConfig\)/,
+      'the constructor must forward the rest-spread, not a hand-listed subset');
+    assert.match(source, /const \{ db: _db, dbPath: _dbPath, extPath: _extPath, \.\.\.embeddingConfig \} = config/,
+      'only RAGManager-owned fields may be withheld from the pipeline');
+    assert.match(source, /initializeEmbeddings\(keys: AppAPIConfig\)/,
+      'the second entry point must take the same type; a narrower one reads as though the rest were unsupported');
+
+    assert.doesNotMatch(source, /explicitKeyManagement:\s*config\.explicitKeyManagement/,
+      'hand-listing it again would reintroduce the drift this test now guards against');
   });
 });


### PR DESCRIPTION
`main.ts` builds the embedding config with `buildEmbeddingConfig()` and spreads it into `new RAGManager({ db, dbPath, extPath, ...config })`. But `RAGManagerConfig` re-declared only **six** embedding fields by hand, and the constructor re-listed the same six into `embeddingPipeline.initialize()`.

Everything else `buildEmbeddingConfig()` produces was **dropped on every normal app start** — the managed-embedding credentials, the resolved provider/mode choice, and the user's chosen Ollama embedding model and dimensions.

```
grep -c nativelyApiKey electron/rag/RAGManager.ts   ->  0
```

**TypeScript could not catch it.** Spreading a typed variable into an object literal skips excess-property checking, so `typecheck:electron` stayed green while the feature was never configured at all. It appeared to work only if the user later re-entered an OpenAI/Gemini key — because `initializeEmbeddings` forwards with `{...keys}` and therefore carried everything *by accident*. That's why one entry point worked and the other didn't.

## The fix

Carry the **type**, not a copy of some of its field names:

- `RAGManagerConfig extends Partial<AppAPIConfig>`
- the constructor rest-spreads everything except `db`/`dbPath`/`extPath`, which are RAGManager's own
- `initializeEmbeddings` takes `AppAPIConfig` too — it already forwarded everything at runtime, but its hand-written parameter type read as though the rest were unsupported

Same lesson `embeddingConfigIdentity.ts` was written for, one layer down.

## Also

`'natively'` added to `EmbeddingProviderResolver.CLOUD_PROVIDER_NAMES`. It's a billed network round-trip like openai and gemini, so it needs the same probe hysteresis — omitting it gave the managed tier **one** attempt where the others get three, and a demotion changes the active embedding *space* and strands every persisted vector. Exactly the thrash that hysteresis exists to prevent.

## A test that was holding the bug in place

`EmbeddingConfigStateAwareness` asserted three literal spellings, including `explicitKeyManagement: config.explicitKeyManagement` — it **required the hand-list**. It now asserts the stronger property: the config is forwarded whole, so no future field can be dropped by omission.

A test that mandates the shape of a defect cannot catch it.

## Verified in isolation

Applied to a clean worktree at `main` with **none** of the in-flight embedding work present:

- typecheck clean
- rag suite **289 pass / 4 fail** — byte-identical to the same worktree on plain `main`, where those four are missing bundled model assets a worktree doesn't materialize

No regression.

Found by `/code-review high`; the finding was real and is reproduced above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014D8QkwcTrpGVPmkWHrp4Nz