### PR TITLE
fix(deps): bump onnxruntime-node to 1.23.0 to fix broken Linux CUDA install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,8 +47,8 @@
         "mammoth": "^1.11.0",
         "marked": "^18.0.4",
         "node-llama-cpp": "^3.20.0",
-        "onnxruntime-common": "1.22.0",
-        "onnxruntime-node": "1.22.0",
+        "onnxruntime-common": "1.23.0",
+        "onnxruntime-node": "1.23.0",
         "openai": "^6.22.0",
         "pdf-parse": "2.4.5",
         "qrcode": "^1.5.4",
@@ -17802,15 +17802,15 @@
       }
     },
     "node_modules/onnxruntime-common": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.22.0.tgz",
-      "integrity": "sha512-vcuaNWgtF2dGQu/EP5P8UI5rEPEYqXG2sPPe5j9lg2TY/biJF8eWklTMwlDO08iuXq48xJo0awqIpK5mPG+IxA==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.23.0.tgz",
+      "integrity": "sha512-Auz8S9D7vpF8ok7fzTobvD1XdQDftRf/S7pHmjeCr3Xdymi4z1C7zx4vnT6nnUjbpelZdGwda0BmWHCCTMKUTg==",
       "license": "MIT"
     },
     "node_modules/onnxruntime-node": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.22.0.tgz",
-      "integrity": "sha512-QaAqr7PFekrmEsmu1rpw7OxJYyG+iACjNHoNtQIVt9Oh7st8WDPIIUe6KhF9l35HVJTJd9CV1rePoPmKhSV26g==",
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.23.0.tgz",
+      "integrity": "sha512-j7QVuR4ouektZjOopKtXcIGsB3C6R9kVbgS10lc2e5SxoWMUhmCwxNl4qBslpWJaPrFxvrQrQaQLQdqku8V19w==",
       "hasInstallScript": true,
       "license": "MIT",
       "os": [
@@ -17821,7 +17821,7 @@
       "dependencies": {
         "adm-zip": "^0.5.16",
         "global-agent": "^3.0.0",
-        "onnxruntime-common": "1.22.0"
+        "onnxruntime-common": "1.23.0"
       }
     },
     "node_modules/onnxruntime-web": {

--- a/package.json
+++ b/package.json
@@ -344,8 +344,8 @@
     "mammoth": "^1.11.0",
     "marked": "^18.0.4",
     "node-llama-cpp": "^3.20.0",
-    "onnxruntime-common": "1.22.0",
-    "onnxruntime-node": "1.22.0",
+    "onnxruntime-common": "1.23.0",
+    "onnxruntime-node": "1.23.0",
     "openai": "^6.22.0",
     "pdf-parse": "2.4.5",
     "qrcode": "^1.5.4",
@@ -377,7 +377,7 @@
     "sqlite-vec-windows-x64": "^0.1.7-alpha.2"
   },
   "overrides": {
-    "onnxruntime-node": "1.22.0",
+    "onnxruntime-node": "1.23.0",
     "react-reconciler": {
       "react": "$react"
     }


### PR DESCRIPTION
## Summary

`onnxruntime-node@1.22.0` is pinned exactly (dependency + `overrides`) in this repo, and its `script/install-metadata.js` maps the `linux/x64:cuda12` install manifest to `runtimes/win-x64/native/*.so` instead of `runtimes/linux-x64/native/*.so`. `npm install` on any Linux/x64 machine downloads the `Microsoft.ML.OnnxRuntime.Gpu.Linux` NuGet package and then fails looking for Windows-shaped paths inside a Linux package:

```
Error: Failed to find runtimes/win-x64/native/libonnxruntime_providers_cuda.so in NuGet package
```

I confirmed this by downloading `onnxruntime-node@1.22.0` from the npm registry and inspecting `script/install-metadata.js` directly — the `linux/x64:cuda12` manifest entries do read `runtimes/win-x64/native/...`. This is an upstream packaging bug (not something introduced by this repo), fixed as of `onnxruntime-node@1.23.0`, where the same manifest entries correctly read `runtimes/linux-x64/native/...`.

This PR bumps the pinned version (both the `dependencies` entry and the matching `overrides` entry, to keep the existing single-resolved-version guarantee) from `1.22.0` → `1.23.0`, and bumps `onnxruntime-common` alongside it since `onnxruntime-node@1.23.0` requires it in lockstep.

I also diffed the published `.d.ts` files (`index.d.ts`, `binding.d.ts`) between `1.22.0` and `1.23.0` — they are byte-identical except for the version string, so this is a drop-in upgrade with no API surface change for the rest of the codebase (`electron/audio/whisper/*`, `electron/utils/onnx*`, etc.).

Fixes #408

## Test plan

- [x] Downloaded both `onnxruntime-node@1.22.0` and `@1.23.0` tarballs from the npm registry and confirmed `script/install-metadata.js`'s `linux/x64:cuda12` manifest changes from `runtimes/win-x64/native/...` (broken) to `runtimes/linux-x64/native/...` (correct) between those versions.
- [x] Diffed `dist/index.d.ts` and `dist/binding.d.ts` between the two versions — no changes besides the version string.
- [x] Regenerated `package-lock.json` (`npm install --package-lock-only`) — diff is limited to the `onnxruntime-common`/`onnxruntime-node` version, resolved URL, and integrity hash; no other packages affected.
- [x] Have not run a full native build in this environment (Windows host, no CUDA/Linux box available) — a maintainer or CI run on Linux is the fastest way to confirm `npm install` now succeeds end-to-end with CUDA support.