### PR TITLE
docs(companion): stop claiming the extension never auto-captures

### DIFF
--- a/natively-browser/README.md
+++ b/natively-browser/README.md
@@ -1,9 +1,17 @@
 # Natively Page Context — companion browser extension
 
 A minimal, privacy-correct Manifest V3 extension that sends the **active tab's
-readable content** to your local Natively desktop app, **once, on demand**. It
-never runs in the background, never auto-captures, and only ever talks to your
-own machine over loopback.
+readable content** to your local Natively desktop app, once per capture, and
+only ever talks to your own machine over loopback.
+
+Capture is either explicit (hotkey or the popup's **Capture this page** button)
+or automatic: when **Auto-detect coding problems** / **Auto-attach coding
+context** are enabled in Natively's **Settings → Sync → Smart Browser
+Context** (on by default), the desktop can request the active tab's content
+before generating an answer on a page it classifies as a coding/interview
+problem, with no click or hotkey press required. See
+[Capture](#capture) below for both paths and how to turn automatic capture
+off.
 
 It is part of the [Natively](../) monorepo and is licensed under the
 **Natively Personal Use Source License v1.0**, same as the desktop app. Source
@@ -99,6 +107,15 @@ changes. You only re-pair if you click **Rotate token** in Settings.
   isn't reachable, the desktop takes a screenshot instead.
 - **From the popup:** click the toolbar icon → **Capture this page** (works while
   Chrome is focused).
+- **Automatic (default on):** when the desktop's **Smart Browser Context**
+  settings have **Auto-detect coding problems** and **Auto-attach coding
+  context** enabled (`electron/services/SettingsManager.ts`'s
+  `getBrowserContextSettings()` — both default `true`), the desktop asks the
+  extension for the active tab's content before answering, on a page it
+  classifies as a coding/interview problem — no hotkey, popup click, or other
+  user action required for that request. Turn this off in Natively
+  **Settings → Sync → Smart Browser Context**, or use only the manual hotkey/
+  popup capture above.
 
 Each capture pushes **once**. The desktop shows a "Captured: \<title\>" chip and
 consumes it on the next "What to say".

--- a/natively-browser/src/manifest.json
+++ b/natively-browser/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Natively Companion",
   "version": "1.1.0",
-  "description": "Official companion extension for Natively. Securely sends active tab content to your local workspace on demand.",
+  "description": "Sends the active tab's content to your local Natively app — manually or automatically for detected coding pages (configurable).",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvXiNEU3gKhfDitCs6yRT5YYNfe2j+AEUsKPbO9igNHCvvpgXAjNXqL8U+tCgZNoOflFduXMN27EhV5WsYtrGiBM4Be6DO8bxjmmNHkmsnFOsW5NeLMpwdOfUtV9peOv+J0Oztys/YuMBT8SHOKmBUK2/B4vxiWxEyuPKGkfAQ5a/6MQZnygDwTaVtQSiP0H58aOcZxsKjSKceplSM1MdgmXL/VKOsp+mtTdxWO29zC61RwEn/mupx7Srh/JDU6F9dICkviL3Sahltoer3xRkBls1exR66vOBLqqbedDLcQBuGX8p8UXxbH7e7zs1QzJhGSol/E1qmyg1SJ8uhzgAnQIDAQAB",
   "minimum_chrome_version": "114",
   "permissions": ["activeTab", "scripting", "storage", "alarms", "tabs"],


### PR DESCRIPTION
## Summary

`natively-browser/README.md` and `natively-browser/src/manifest.json` describe capture as happening **"once, on demand"** and say the extension **"never auto-captures."** That's no longer true of the current implementation:

- `electron/services/SettingsManager.ts`'s `getBrowserContextSettings()` (`autoDetectCoding` / `autoAttachCoding`) defaults **both to `true`**.
- `src/components/NativelyInterface.tsx` requests automatic browser context from the extension before generating an answer, on a page it classifies as a coding/interview problem.
- `natively-browser/src/service-worker.ts` performs that automatic extraction and `POST`s it to the desktop's `/dom` endpoint — with no hotkey press or popup click from the user.

So on a default install, an eligible coding/interview page's content can be captured without the user ever triggering a manual capture, directly contradicting the current copy.

This PR is documentation-only — it does not change the auto-attach default or any capture logic, since that's a product/UX call for the maintainers, not something a docs PR should decide. It:

- Rewrites the README intro to describe both capture paths (manual hotkey/popup vs. automatic-by-default) instead of claiming capture is always on-demand.
- Adds an **Automatic (default on)** bullet to the README's `## Capture` section explaining exactly when it fires, which settings gate it (`Settings → Sync → Smart Browser Context`), and how to turn it off.
- Trims `manifest.json`'s `description` (which feeds the `chrome://extensions` page and would feed a Chrome Web Store listing) so it no longer repeats the on-demand-only claim, while staying under the ~132-char store limit.

Fixes #515

## Test plan

- [x] `node -e "JSON.parse(require('fs').readFileSync('natively-browser/src/manifest.json'))"` — manifest still parses as valid JSON.
- [x] Re-read `electron/services/SettingsManager.ts` (`getBrowserContextSettings`, lines ~341-360) and `src/components/NativelyInterface.tsx` (~5345-5358) to confirm the new wording matches actual current behavior, not just the issue's repro.
- [x] Grepped the rest of the repo (`README`/`tsx`/`json`) for the same "never auto-captures" / absolute "on demand" phrasing — the two files changed here were the only occurrences.
- [x] Have not loaded the rebuilt extension in Chrome to view the new `chrome://extensions` description string rendered, since this is a plain string-length/JSON check, not a build-dependent one.