### PR TITLE
fix(companion): don't force-open the popup on a background permission nudge

### DIFF
--- a/natively-browser/src/service-worker.ts
+++ b/natively-browser/src/service-worker.ts
@@ -774,10 +774,15 @@ export function badgeForCaptureOutcome(kind: string): { text: string; title: str
 }
 
 /**
- * Surface a hotkey capture failure on the toolbar icon: badge + title, and
- * (Chrome 127+) try to open the popup outright so the grant is one click away.
- * openPopup throws when the browser window isn't focused or a popup is already
- * open — that's fine, the badge still marks the icon the desktop pill points at.
+ * Surface a hotkey capture failure on the toolbar icon: badge + title only.
+ * This is only reached from the desktop-push path (handleCaptureDom), which
+ * has no user gesture — forcibly calling chrome.action.openPopup() here would
+ * pull focus off the page the user is looking at (and be page-observable via
+ * blur/focus) for a capture the user never initiated. The popup's own
+ * "Capture" button (the `case 'capture'` message handler below) already runs
+ * inside a real user gesture and grants access without needing this nudge to
+ * open anything — the badge/title alone is enough to point the user at the
+ * icon.
  */
 function nudgeGrantViaAction(kind: string): void {
   const badge = badgeForCaptureOutcome(kind);
@@ -787,9 +792,6 @@ function nudgeGrantViaAction(kind: string): void {
     void chrome.action.setBadgeBackgroundColor?.({ color: '#f59e0b' });
     void chrome.action.setTitle({ title: badge.title });
   } catch (_) { /* badge is best-effort */ }
-  try {
-    void chrome.action.openPopup?.().catch(() => {});
-  } catch (_) { /* pre-127 or unfocused window */ }
 }
 
 /** Clear the grant nudge (a capture succeeded or the origin was granted). */


### PR DESCRIPTION
## Summary

When a desktop-triggered capture (hotkey / auto-context) lacks host permission for the active tab, `natively-browser/src/service-worker.ts`'s `nudgeGrantViaAction()` set the toolbar badge/title *and* called:

```ts
void chrome.action.openPopup?.().catch(() => {});
```

`nudgeGrantViaAction()` has exactly one caller: `handleCaptureDom()`, reached from the WebSocket `capture-dom` message the **desktop** pushes on a hotkey press or auto-context request — there is no user gesture on that path. On supported Chrome versions, `openPopup()` there actually opens the extension's popup and moves focus off the page, which the page can observe via `blur`/`focus` or `document.hasFocus()` — turning a background capture attempt the user never asked for into something page-visible.

The popup's own manual capture flow (`case 'capture':` in the `chrome.runtime.onMessage` handler, a few dozen lines below) never goes through `nudgeGrantViaAction()` at all — it calls `captureActiveTab()` directly, inside the real user gesture of clicking the extension icon and then its Capture button. So removing `openPopup()` from the background nudge doesn't touch how manual capture grants permission; it only stops the *unprompted* background path from stealing focus.

## Fix

Drop the `openPopup()` call and its stale doc comment from `nudgeGrantViaAction()`; keep the badge + title (`badgeForCaptureOutcome()`, already covered by `service-worker.test.mjs`) as the only surfaced nudge, matching the issue's expected behavior: "retain the toolbar badge/title and wait for the user to click the icon before opening interactive UI."

Fixes #516

## Test plan

- [x] `cd natively-browser && npm run typecheck` — clean.
- [x] `cd natively-browser && npm test` — 181/181 passing, no regressions (this function isn't itself unit-tested since it touches `chrome.action.*`, guarded by the existing `hasChrome` check that keeps the pure-module tests from needing a chrome mock — but `badgeForCaptureOutcome()`, the piece it depends on, is and still passes).
- [x] `cd natively-browser && npm run build` — bundles cleanly.
- [x] Have not manually reproduced the issue's Chrome Web Store repro steps (1-13) in a real paired Chrome + Natively desktop session in this environment — the code-path trace above (single caller, no user gesture, popup's own flow unaffected) is what I'm relying on instead.