### PR TITLE
fix(auto-answer): reveal prefetched answers on adoption; user speech no longer silences the engine

### DIFF
--- a/docs/autopilot/auto-answer-v3-progress.md
+++ b/docs/autopilot/auto-answer-v3-progress.md
@@ -1682,3 +1682,37 @@ leaving a guard nothing exercised. 57/57, typecheck clean.
   duplicate guard compares `lastAnsweredText` exactly, so near-duplicates pass.
 * `1-q13` fired at **a=0.4** on *"I recommend maybe sharing your screen."* — the same weak band flagged in the
   replay analysis. Everything at 0.9 was a real ask.
+
+---
+
+## 2026-09-03 — live session gen 13: both real questions lost to the prefetch; user channel made inert
+
+Packaged 2.8.8, Auto Answer on, general mode, a real call. Telemetry (`logs/telemetry.jsonl` under the
+app's user-data directory — the packaged app persists nothing else) shows 13 candidates, two positive
+verdicts, zero answers shown:
+
+| id | verdict | what happened |
+| --- | --- | --- |
+| `13-q4` | technical_question, a=0.9, `held_applied` → `decision: auto` | The prefetch had FINISHED 2 s earlier. Its text went to a `.catch`-only caller and was dropped; the dispatch "adopted" a stream that no longer existed and returned. Independently, completion had stamped `lastTriggerTime`, so the planner would have refused the adoption as a `cooldown` repeat of itself. |
+| `13-q6` | technical_question, a=1.0, `held_applied` | The prefetch was STILL STREAMING. `canAutoAnswer` saw mode `what_to_say` and said busy; the dispatch parked; 195 ms later `13-q7` bumped `judgeSeq` and the retry exited with no telemetry and no log. |
+
+The remaining candidates were `stale` — continuous speech, working as designed.
+
+**Fixes (all shared logic, no platform branch):**
+1. `IntelligenceEngine.completeSpeculativeRun` keeps a finished prefetch's text (`speculativeAnswer`, gated
+   by the existing `speculativeText` window) and no longer stamps `lastTriggerTime`; adoption stamps it.
+2. Adoption (`handleSuggestionTriggerInner`) distinguishes a prefetch still streaming (revealed at
+   completion), one already finished (`revealSpeculativeAnswer` now), and one that aborted (fresh run).
+3. `canAutoAnswer` accepts a dispatch while the engine's OWN prefetch is live — that dispatch is the adopter.
+4. `SimpleAutoAnswer.deliver` reports a park dropped by supersession as `auto_answer_ignored`
+   (`superseded_while_parked`) with a log line. Never a silent exit again.
+
+**Policy change (user decision, same day):** the user channel is INERT. The user answers the moment the
+question lands, so their own speech no longer cancels a stream, clears a candidate, or drops a parked or
+held verdict. The 2026-08-24 lenient-mic policy and the echo latch (`ECHO_*`, `GENUINE_ANSWER_MIN_WORDS`)
+are gone with it; `USER_BACKCHANNEL` stays as the interviewer-side prefilter.
+
+Pinned in `AutoAnswerSimple.test.mjs` (rewritten user-channel tests, loud park drop) and the new
+`AutoAnswerPrefetchReveal2026_09_03.test.mjs` (finished prefetch revealed, in-flight prefetch adopted and
+revealed at completion, cooldown not stamped, manual press never leaks a prefetch). Auto Answer suites
+85/85, electron typecheck clean. Not yet run against a live call.

--- a/electron/IntelligenceEngine.ts
+++ b/electron/IntelligenceEngine.ts
@@ -2,6 +2,7 @@
 // LLM mode routing and orchestration.
 // Extracted from IntelligenceManager to decouple LLM logic from state management.
 
+import type { SessionWriteDecision } from './llm/FinalAnswerGenerationPolicy';
 import { EventEmitter } from 'events';
 import { LLMHelper } from './LLMHelper';
 import { SessionTracker, TranscriptSegment, SuggestionTrigger, ContextItem } from './SessionTracker';
@@ -168,6 +169,16 @@ export interface IntelligenceModeEvents {
     'dynamic_action_emitted': (action: DynamicAction) => void;
 }
 
+/** A speculative prefetch that completed unadopted, held for the dispatch that may adopt it. */
+interface SpeculativeAnswer {
+    generationId: number;
+    question: string;
+    confidence: number;
+    text: string;
+    /** The run's own session-write decision (e.g. do_not_store for a truncated stream); undefined on the legacy answerLLM path. */
+    writeDecision: SessionWriteDecision | undefined;
+}
+
 export class IntelligenceEngine extends EventEmitter {
     // Mode state
     private activeMode: IntelligenceMode = 'idle';
@@ -297,7 +308,7 @@ export class IntelligenceEngine extends EventEmitter {
      * nothing (live session 2026-09-03, 13-q4). Held here, gated by the same
      * speculativeText / expiry window, so adoption can reveal it instead.
      */
-    private speculativeAnswer: { generationId: number; question: string; confidence: number; text: string } | null = null;
+    private speculativeAnswer: SpeculativeAnswer | null = null;
     // epoch ms after which speculativeText is stale; Infinity while stream is still running
     private speculativeTextExpiry: number = Infinity;
     private readonly SPECULATIVE_DEBOUNCE_MS = 350;
@@ -973,8 +984,11 @@ export class IntelligenceEngine extends EventEmitter {
      * prefetch as a "cooldown" repeat of itself (live session 2026-09-03).
      * The speculativeText window still throttles a second prefetch.
      */
-    private completeSpeculativeRun(generationId: number, question: string | undefined, confidence: number, text: string): string {
-        const finished = { generationId, question: question || 'inferred', confidence, text };
+    private completeSpeculativeRun(
+        generationId: number, question: string | undefined, confidence: number, text: string,
+        writeDecision: SessionWriteDecision | undefined,
+    ): string {
+        const finished: SpeculativeAnswer = { generationId, question: question || 'inferred', confidence, text, writeDecision };
         const adoptedInFlight = this.automaticGenerationId === generationId && this.currentGenerationId === generationId;
         if (adoptedInFlight) {
             this.speculativeText = null;
@@ -993,12 +1007,15 @@ export class IntelligenceEngine extends EventEmitter {
     /**
      * Show a prefetched answer the dispatch adopted. Mirrors the tail of the
      * live path in the smallest honest way: the always-on artifact cleanup,
-     * the session record, one token emit to open the row, then the final.
-     * Validation and repair passes are skipped — a speculative run was
-     * generated from the same prompt as a live one, and a late answer that
-     * exists beats a validated one that never shows.
+     * the session record under the run's own write decision, one token emit
+     * to open the row, then the final. Validation and repair passes are
+     * skipped — a speculative run was generated from the same prompt as a
+     * live one, and a late answer that exists beats a validated one that
+     * never shows. The write decision is NOT skipped: a prefetch the provider
+     * cut short is shown, like any truncated live answer, but it must not
+     * become prior_assistant_responses evidence for the next turn.
      */
-    private revealSpeculativeAnswer(finished: { generationId: number; question: string; confidence: number; text: string }, automatic: boolean): void {
+    private revealSpeculativeAnswer(finished: SpeculativeAnswer, automatic: boolean): void {
         let text = finished.text;
         try {
             const cleaned = cleanAnswerArtifacts(text);
@@ -1016,8 +1033,12 @@ export class IntelligenceEngine extends EventEmitter {
         this.automaticGenerationId = automatic ? generationId : null;
         console.log(`[IntelligenceEngine] Revealing the prefetched answer (${text.length} chars, prefetch gen ${finished.generationId} → ${generationId})`);
         this.emit('suggested_answer_token', text, finished.question, finished.confidence, generationId);
-        this.session.addAssistantMessage(text, undefined, 'what_to_answer');
-        this.session.pushUsage({ type: 'assist', timestamp: Date.now(), question: finished.question, answer: text });
+        this.session.addAssistantMessage(text, finished.writeDecision, 'what_to_answer');
+        if (finished.writeDecision?.policy !== 'do_not_store') {
+            this.session.pushUsage({ type: 'assist', timestamp: Date.now(), question: finished.question, answer: text });
+        } else {
+            console.warn(`[IntelligenceEngine] Prefetched answer revealed but not stored (${finished.writeDecision.reason ?? 'do_not_store'})`);
+        }
         this.emit('suggested_answer', text, finished.question, finished.confidence, generationId);
     }
 
@@ -1468,7 +1489,7 @@ export class IntelligenceEngine extends EventEmitter {
                     return null;
                 }
                 if (isSpeculative) {
-                    return this.completeSpeculativeRun(generationId, question, confidence, answer || buildGracefulRetry(question));
+                    return this.completeSpeculativeRun(generationId, question, confidence, answer || buildGracefulRetry(question), undefined);
                 }
                 if (answer && IntelligenceEngine.isNonAnswerSentinel(answer)) {
                     this.setMode('idle');
@@ -5144,7 +5165,7 @@ export class IntelligenceEngine extends EventEmitter {
             }
 
             if (isSpeculative) {
-                return this.completeSpeculativeRun(generationId, question, confidence, fullAnswer);
+                return this.completeSpeculativeRun(generationId, question, confidence, fullAnswer, wtaWriteDecision);
             }
 
             // Keep the RAW answer (with the hidden <verification_spec>) for

--- a/electron/IntelligenceEngine.ts
+++ b/electron/IntelligenceEngine.ts
@@ -289,6 +289,15 @@ export class IntelligenceEngine extends EventEmitter {
     // the first final turn while questionLedgerShadow is enabled.
     private questionLedgerShadow: import('./llm/questionLedger').QuestionLedger | null = null;
     private speculativeText: string | null = null;
+    /**
+     * A speculative prefetch that COMPLETED before anything adopted it. A
+     * speculative stream never renders (the judge may still say no), so its
+     * text used to be returned to a `.catch`-only caller and lost; the
+     * dispatch then "adopted" a stream that no longer existed and showed
+     * nothing (live session 2026-09-03, 13-q4). Held here, gated by the same
+     * speculativeText / expiry window, so adoption can reveal it instead.
+     */
+    private speculativeAnswer: { generationId: number; question: string; confidence: number; text: string } | null = null;
     // epoch ms after which speculativeText is stale; Infinity while stream is still running
     private speculativeTextExpiry: number = Infinity;
     private readonly SPECULATIVE_DEBOUNCE_MS = 350;
@@ -756,7 +765,17 @@ export class IntelligenceEngine extends EventEmitter {
      * and are allowed to supersede.
      */
     canAutoAnswer(): boolean {
-        if (this.activeMode !== 'idle' && this.activeMode !== 'assist') return false;
+        if (this.activeMode !== 'idle' && this.activeMode !== 'assist') {
+            // The engine's OWN speculative prefetch is not "busy": the dispatch
+            // that arrives now is the one that adopts it. Refusing it parked a
+            // 1.0-answerability verdict until the next candidate superseded it
+            // (live session 2026-09-03, 13-q6). A manual press or an automatic
+            // run has no speculative identity and still refuses.
+            const ownPrefetchLive = this.activeMode === 'what_to_say'
+                && this.speculativeGenerationId !== null
+                && this.speculativeGenerationId === this.currentGenerationId;
+            if (!ownPrefetchLive) return false;
+        }
         if (Date.now() - this.lastTriggerTime < this.automaticTriggerCooldown) return false;
         return true;
     }
@@ -824,19 +843,38 @@ export class IntelligenceEngine extends EventEmitter {
                 this.speculativeText = null;
                 this.speculativeTextExpiry = Infinity;
                 this.speculativeQuestionId = null;
+                const finished = this.speculativeAnswer;
+                this.speculativeAnswer = null;
                 if (similarity >= this.SPECULATIVE_SIMILARITY_THRESHOLD) {
-                    console.log(`[IntelligenceEngine] Speculative stream accepted (Jaccard=${similarity.toFixed(2)}) — continuing`);
                     this.lastTriggerTime = Date.now();
                     this.lastTriggerQuestion = trigger.lastQuestion ?? null;
-                    // The running speculative stream IS the automatic answer now.
-                    if (trigger.automatic) this.automaticGenerationId = this.currentGenerationId;
-                    return;
+                    const stillStreaming = this.activeMode === 'what_to_say'
+                        && this.speculativeGenerationId !== null
+                        && this.speculativeGenerationId === this.currentGenerationId;
+                    if (stillStreaming) {
+                        console.log(`[IntelligenceEngine] Speculative stream accepted (Jaccard=${similarity.toFixed(2)}) — continuing; revealed at completion`);
+                        // The running speculative stream IS the automatic answer
+                        // now. It never streamed to the UI, so completion reveals
+                        // it (see the isSpeculative completion branch).
+                        if (trigger.automatic) this.automaticGenerationId = this.currentGenerationId;
+                        return;
+                    }
+                    if (finished) {
+                        console.log(`[IntelligenceEngine] Speculative stream accepted (Jaccard=${similarity.toFixed(2)}) — already finished; revealing`);
+                        this.revealSpeculativeAnswer(finished, trigger.automatic === true);
+                        return;
+                    }
+                    // Accepted, but the stream neither runs nor finished (aborted
+                    // or errored between prefetch and dispatch): answer afresh.
+                    console.warn('[IntelligenceEngine] Speculative stream accepted but nothing to adopt (aborted?) — restarting');
+                } else {
+                    console.log(`[IntelligenceEngine] Speculative stream rejected (Jaccard=${similarity.toFixed(2)}) — restarting`);
                 }
-                console.log(`[IntelligenceEngine] Speculative stream rejected (Jaccard=${similarity.toFixed(2)}) — restarting`);
             } else {
                 console.log(`[IntelligenceEngine] Speculative result discarded (expired=${expired}, noQuestion=${!trigger.lastQuestion})`);
                 this.speculativeText = null;
                 this.speculativeTextExpiry = Infinity;
+                this.speculativeAnswer = null;
             }
             // IMPORTANT: no await between this increment and runWhatShouldISay below —
             // the increment must be synchronous with the new stream launch to preserve generation-id ordering.
@@ -922,6 +960,65 @@ export class IntelligenceEngine extends EventEmitter {
         console.log(`[IntelligenceEngine] Auto Answer prefetch fired while the judge decides`, { questionId, length: trimmed.length });
         this.runWhatShouldISay(trimmed, 0.9, undefined, { speculative: true })
             .catch(err => console.error('[IntelligenceEngine] Auto Answer prefetch error:', err));
+    }
+
+    /**
+     * A speculative run finished. It never rendered, so this is where its text
+     * is kept for adoption — or revealed at once if the dispatch already
+     * adopted the stream while it was in flight.
+     *
+     * Deliberately does NOT stamp lastTriggerTime / lastTriggerQuestion: the
+     * cooldown slot belongs to the real trigger (it is stamped on adoption).
+     * Stamping it here made the planner refuse the adoption of a just-finished
+     * prefetch as a "cooldown" repeat of itself (live session 2026-09-03).
+     * The speculativeText window still throttles a second prefetch.
+     */
+    private completeSpeculativeRun(generationId: number, question: string | undefined, confidence: number, text: string): string {
+        const finished = { generationId, question: question || 'inferred', confidence, text };
+        const adoptedInFlight = this.automaticGenerationId === generationId && this.currentGenerationId === generationId;
+        if (adoptedInFlight) {
+            this.speculativeText = null;
+            this.speculativeTextExpiry = Infinity;
+            this.speculativeQuestionId = null;
+            this.speculativeAnswer = null;
+        } else {
+            this.speculativeAnswer = finished;
+            this.speculativeTextExpiry = Date.now() + this.triggerCooldown + 500;
+        }
+        this.setMode('idle');
+        if (adoptedInFlight) this.revealSpeculativeAnswer(finished, true);
+        return text;
+    }
+
+    /**
+     * Show a prefetched answer the dispatch adopted. Mirrors the tail of the
+     * live path in the smallest honest way: the always-on artifact cleanup,
+     * the session record, one token emit to open the row, then the final.
+     * Validation and repair passes are skipped — a speculative run was
+     * generated from the same prompt as a live one, and a late answer that
+     * exists beats a validated one that never shows.
+     */
+    private revealSpeculativeAnswer(finished: { generationId: number; question: string; confidence: number; text: string }, automatic: boolean): void {
+        let text = finished.text;
+        try {
+            const cleaned = cleanAnswerArtifacts(text);
+            if (cleaned.trim().length >= 10) text = cleaned;
+        } catch (err) {
+            console.warn('[IntelligenceEngine] Prefetched answer cleanup failed; revealing it as generated:', err);
+        }
+        if (!text.trim()) {
+            console.warn('[IntelligenceEngine] Prefetched answer was empty — nothing to reveal');
+            return;
+        }
+        // The prefetch never emitted, so the renderer never saw its generation.
+        // Mint a fresh one: the engine is idle here, so nothing is superseded.
+        const generationId = ++this.currentGenerationId;
+        this.automaticGenerationId = automatic ? generationId : null;
+        console.log(`[IntelligenceEngine] Revealing the prefetched answer (${text.length} chars, prefetch gen ${finished.generationId} → ${generationId})`);
+        this.emit('suggested_answer_token', text, finished.question, finished.confidence, generationId);
+        this.session.addAssistantMessage(text, undefined, 'what_to_answer');
+        this.session.pushUsage({ type: 'assist', timestamp: Date.now(), question: finished.question, answer: text });
+        this.emit('suggested_answer', text, finished.question, finished.confidence, generationId);
     }
 
     /** Auto Answer V3: identity of the speculative cache, for keyed/embedding reuse. */
@@ -1123,6 +1220,7 @@ export class IntelligenceEngine extends EventEmitter {
         if (forceFresh && !isSpeculative) {
             this.speculativeText = null;
             this.speculativeTextExpiry = Infinity;
+            this.speculativeAnswer = null;
         }
 
         // Cooldown bypass: explicit images (user intent), speculative pre-fetch, or
@@ -1187,6 +1285,7 @@ export class IntelligenceEngine extends EventEmitter {
         if (isSpeculative) {
             this.speculativeText = question ?? null;
             this.speculativeTextExpiry = now + this.triggerCooldown + 5000;
+            this.speculativeAnswer = null;
         }
 
         // ── Live-path latency trace (click → first useful token → render) ──
@@ -1369,12 +1468,7 @@ export class IntelligenceEngine extends EventEmitter {
                     return null;
                 }
                 if (isSpeculative) {
-                    this.speculativeText = null;
-                    this.speculativeTextExpiry = Infinity;
-                    this.lastTriggerTime = Date.now();
-                    this.lastTriggerQuestion = question ?? null;
-                    this.setMode('idle');
-                    return answer || buildGracefulRetry(question);
+                    return this.completeSpeculativeRun(generationId, question, confidence, answer || buildGracefulRetry(question));
                 }
                 if (answer && IntelligenceEngine.isNonAnswerSentinel(answer)) {
                     this.setMode('idle');
@@ -5050,11 +5144,7 @@ export class IntelligenceEngine extends EventEmitter {
             }
 
             if (isSpeculative) {
-                this.lastTriggerTime = Date.now();
-                this.lastTriggerQuestion = question ?? null;
-                this.speculativeTextExpiry = this.lastTriggerTime + this.triggerCooldown + 500;
-                this.setMode('idle');
-                return fullAnswer;
+                return this.completeSpeculativeRun(generationId, question, confidence, fullAnswer);
             }
 
             // Keep the RAW answer (with the hidden <verification_spec>) for
@@ -6381,6 +6471,7 @@ export class IntelligenceEngine extends EventEmitter {
         }
         this.speculativeText = null;
         this.speculativeTextExpiry = Infinity;
+        this.speculativeAnswer = null;
     }
 
     /**

--- a/electron/intelligence/autoAnswer/AutoAnswerTypes.ts
+++ b/electron/intelligence/autoAnswer/AutoAnswerTypes.ts
@@ -115,6 +115,8 @@ export type AutoAnswerSkipReason =
     | 'user_barge_in'
     /** The user channel is carrying the interviewer's audio (speakers, not headphones). */
     | 'mic_echo'
+    /** A dispatch parked behind a busy engine was superseded by newer interviewer speech before the engine freed up. */
+    | 'superseded_while_parked'
     // Lifecycle reasons carried over from the PR #497 gate and the Phase 1 pending slot
     | 'no_question'
     | 'already_answered'

--- a/electron/intelligence/autoAnswer/SimpleAutoAnswer.ts
+++ b/electron/intelligence/autoAnswer/SimpleAutoAnswer.ts
@@ -21,10 +21,14 @@
  *    while it is in flight — the next stoppage re-judges with more context;
  *  - the judge prompt's static prefix enables implicit provider caching.
  *
- * Mic policy is LENIENT (2026-08-24 decision): only a genuine sustained
- * answer in the user's own words suppresses; echoes, fragments and
- * backchannels are ignored. Judge unavailable → almost-legacy fallback:
- * dispatch only when the stopped speech ends with '?'.
+ * The user channel is INERT (user decision 2026-09-03). The user answers the
+ * moment a question lands — nobody sits in silence waiting for the overlay —
+ * so their own speech never cancels a streaming answer, never clears a
+ * candidate and never drops a parked or deferred verdict. The mic is still
+ * transcribed (the judge sees both sides), it just has no vote here. This
+ * retired the 2026-08-24 "lenient mic" policy and its echo latch with it.
+ * Judge unavailable → almost-legacy fallback: dispatch only when the stopped
+ * speech ends with '?'.
  */
 
 import type { TranscriptSegment } from '../../SessionTracker';
@@ -34,70 +38,13 @@ import { systemClock } from './AutoAnswerClock';
 import {
     JUDGE_DEADLINE_MS, JUDGE_CONTEXT_TURNS, parseJudgeVerdict, routeForVerdict, type JudgeRequest,
 } from './AutoAnswerJudge';
-import { echoContainment, isMidWordCut, joinTranscriptParts, normalizeForCompare } from './AutoAnswerText';
-import { speculativeQuestionSimilarity } from '../../llm/speculativeSimilarity';
+import { isMidWordCut, joinTranscriptParts, normalizeForCompare } from './AutoAnswerText';
 import type { AutoAnswerThresholds } from './AutoAnswerPolicy';
 import { DEFAULT_THRESHOLDS } from './AutoAnswerPolicy';
 import type { AutoAnswerQuestion, AutoAnswerTelemetryEvent } from './AutoAnswerTypes';
 
-// ── Mic echo detection (live-run 2026-08-24, session 3). Unfitted placeholders. ──
-/** A user final matching an interviewer final this recent is the speakers echoing into the mic. */
-export const ECHO_WINDOW_MS = 5000;
-/** Token similarity at or above which a user final is that echo. */
-export const ECHO_SIMILARITY = 0.8;
-/** A user final whose tokens are (near-)contained in recent interviewer speech is a mic-caught fragment of it. */
-export const ECHO_FRAGMENT_CONTAINMENT = 0.85;
-/** Containment needs a few words to mean anything ("Yes." is contained in everything). */
-export const ECHO_FRAGMENT_MIN_WORDS = 2;
-/**
- * Echo mode engages when at least this many of the last ECHO_FLAG_WINDOW user
- * finals were echoes.
- *
- * These two were declared with the rest of the echo policy and then never
- * wired — the latch was specified and never implemented. A real bled session
- * (2026-08-26) shows why it matters: the per-utterance test caught 30 of 58
- * user finals, and the 24 it missed still each cleared the interviewer's
- * pending text as "the user is answering", so seven minutes of interview
- * produced twelve candidates and one answer.
- *
- * The per-utterance test asks "is THIS fragment an echo", which a
- * boundary-straddling fragment can always dodge. The latch asks the question
- * that actually matters — "is this microphone currently carrying the
- * interviewer?" — and while the answer is yes the user channel cannot close a
- * candidate at all. It re-evaluates on every user final, so it releases by
- * itself once the bleed stops (headphones plugged in, speaker volume down).
- */
-export const ECHO_ACTIVATE_COUNT = 2;
-export const ECHO_FLAG_WINDOW = 4;
-/**
- * Once engaged, echo mode is HELD for this long, refreshed by every further
- * echo — it is not a count over the last N finals.
- *
- * A pure count latch is self-defeating, and the bled session shows it exactly:
- * the fragments that dodge the per-utterance test are recorded as non-echoes,
- * so they push the real echoes out of a four-slot window and release the very
- * latch that was meant to catch them (`flags=[0010]`, `[0100]`, `[1000]` at
- * the three consecutive leaks). Holding on time instead means a run of dodged
- * fragments cannot unlatch it; only an actual stretch with no echo at all can,
- * which is what "the user unplugged the speakers" looks like. Two ECHO_WINDOW_MS.
- */
-export const ECHO_MODE_HOLD_MS = 10_000;
-/**
- * User-channel BACKCHANNELS (live run 8168240a, 2026-08-24): short listening
- * signals — affirmations, acknowledgements, laughter — possibly repeated
- * ("yeah, yeah.", "okay, right."). They are not the user answering.
- */
+/** Interviewer-side prefilter: a candidate that is nothing but acknowledgements never costs a judge call. */
 export const USER_BACKCHANNEL = /^(?:(?:yeah|yes|yep|yup|ya|mm-?hm+|mhm+|uh-?huh|ok(?:ay)?|right|sure|cool|got it|i see|nice|great|perfect|exactly|interesting|makes sense|sounds good|true|correct|wow|oh|ah|hm+|haha+|alright|of course|fair enough|no problem|totally|absolutely|definitely|indeed|good|fine)[\s,.!?-]*){1,4}$/i;
-/**
- * LENIENT MIC (user decision 2026-08-24, after live rounds 3/5/6 all showed
- * FALSE mic suppression): a user final counts as the user ANSWERING — closing
- * the candidate — only on strong evidence: non-echo, non-backchannel AND at
- * least this many words of their own. Blips below the floor never kill a
- * question (the old engine's mic-blindness is what made it feel reliable);
- * the trade-off is that a bare "Three years." answer no longer suppresses.
- */
-export const GENUINE_ANSWER_MIN_WORDS = 4;
-
 /** The interviewer must be quiet this long before the judge is consulted. Unfitted placeholder. */
 export const STABILITY_MS = 900;
 /**
@@ -247,7 +194,6 @@ export class SimpleAutoAnswerEngine {
     private lastInterviewerInterim = '';
     /** speakerId per interviewer final, when the STT diarizes. Keyed by normalized text. */
     private speakerByTurn = new Map<string, string>();
-    private recentInterviewerFinals: Array<{ text: string; at: number }> = [];
     private timer: ClockTimer | null = null;
     /** Fires EARLY_JUDGE_MS after the interviewer's last word: asks, never commits. */
     private earlyTimer: ClockTimer | null = null;
@@ -270,10 +216,6 @@ export class SimpleAutoAnswerEngine {
         id: string; key: string; text: string;
         answerability: number; act: AutoAnswerQuestion['dialogueAct']; at: number;
     } | null = null;
-    /** Echo verdicts for the last ECHO_FLAG_WINDOW user finals (the latch). */
-    private recentUserEcho: boolean[] = [];
-    /** Echo mode is engaged until this timestamp; refreshed by every echo. */
-    private echoModeUntil = 0;
     /** Punctuation provenance of the latest interviewer final ('provider' family = a missing '?' means something). */
     private punctuationGuaranteed = false;
     /** What last bumped judgeSeq, so a discarded verdict can say what killed it. */
@@ -338,8 +280,6 @@ export class SimpleAutoAnswerEngine {
                 return;
             }
             if (!text) return;
-            this.recentInterviewerFinals.push({ text, at: now });
-            while (this.recentInterviewerFinals.length > 8) this.recentInterviewerFinals.shift();
             this.punctuationGuaranteed = (segment as { punctuationSource?: string }).punctuationSource === 'provider' ||
                 (segment as { punctuationSource?: string }).punctuationSource === 'provider_final';
             const speaker = (segment as { speakerId?: string }).speakerId;
@@ -361,65 +301,11 @@ export class SimpleAutoAnswerEngine {
             return;
         }
 
-        // ── user channel: LENIENT (2026-08-24) ────────────────────────────
-        if (!text) return;
-        const recent = this.recentInterviewerFinals.filter(f => now - f.at <= ECHO_WINDOW_MS);
-        const words = text.split(/\s+/).filter(Boolean).length;
-        const isEcho = recent.some(f => speculativeQuestionSimilarity(f.text, text) >= ECHO_SIMILARITY)
-            || (words >= ECHO_FRAGMENT_MIN_WORDS && recent.length > 0
-                && echoContainment(text, recent.map(f => f.text).join(' ')) >= ECHO_FRAGMENT_CONTAINMENT);
-        if (segment.final) {
-            this.recentUserEcho.push(isEcho);
-            while (this.recentUserEcho.length > ECHO_FLAG_WINDOW) this.recentUserEcho.shift();
-            // Engage (and refresh) only on an ACTUAL echo that is corroborated
-            // by the recent window. Testing the count alone re-arms the latch
-            // from stale flags — a clean final would find two old `true`s
-            // still in the four slots and push the deadline out again, so the
-            // latch could never release and a genuine answer stayed muted.
-            if (isEcho && this.recentUserEcho.filter(Boolean).length >= ECHO_ACTIVATE_COUNT) {
-                this.echoModeUntil = now + ECHO_MODE_HOLD_MS;
-            }
-        }
-        // The latch: while the mic is demonstrably carrying the interviewer,
-        // nothing on this channel may close a candidate — a fragment that
-        // straddles two interviewer finals can always dodge the per-utterance
-        // test, and every dodge silently threw away a question.
-        const echoMode = now < this.echoModeUntil;
-        const genuine = !isEcho && !echoMode
-            && !USER_BACKCHANNEL.test(text) && words >= GENUINE_ANSWER_MIN_WORDS;
-        if (!segment.final) {
-            // Early barge-in (review 2026-08-25): V3 cancelled at the VAD
-            // edge; here a genuine-looking user INTERIM cancels the streaming
-            // answer seconds before its final would — still text-validated,
-            // so speaker bleed cannot trigger it.
-            if (genuine && this.host.answerStreamActive?.()) this.host.cancelAutomaticAnswer?.('user_barge_in');
-            return;
-        }
-        if (!genuine) {
-            const echoed = isEcho || (echoMode && words >= GENUINE_ANSWER_MIN_WORDS);
-            this.emit({ name: 'auto_answer_ignored', skipReason: echoed ? 'mic_echo' : 'backchannel' });
-            if (echoMode && !isEcho && words >= GENUINE_ANSWER_MIN_WORDS) {
-                this.host.log?.('[AutoAnswer:simple] mic echo mode — the user channel is carrying the interviewer');
-            }
-            return;
-        }
-        // A genuine sustained answer: the user took the floor. This must also
-        // kill anything in flight — the judge verdict being awaited AND a
-        // dispatch parked behind a busy engine both belong to a question the
-        // user is now answering themselves (review 2026-08-25).
-        if (this.host.answerStreamActive?.()) this.host.cancelAutomaticAnswer?.('user_barge_in');
-        this.bumpJudgeSeq('user_answering');
-        this.dropParked();
-        // A held verdict is keyed to a candidate PREFIX, not to judgeSeq, so
-        // the seq guard no longer protects it: drop it explicitly or it fires
-        // into a question the user has just answered themselves.
-        this.held = null;
-        if (this.pending.length > 0 || this.timer !== null) {
-            this.disarm();
-            this.pending = [];
-            this.lastJudgedKey = '';
-            this.emit({ name: 'auto_answer_ignored', skipReason: 'user_answering' });
-        }
+        // ── user channel: INERT (user decision 2026-09-03) ────────────────
+        // The user starts answering as soon as the question lands. Their
+        // speech must not cancel the stream, clear the candidate, or drop a
+        // parked / deferred verdict — the answer is wanted precisely while
+        // they are talking. Nothing to do on this channel.
     }
 
     // ── the stoppage ──────────────────────────────────────────────────────
@@ -659,7 +545,21 @@ export class SimpleAutoAnswerEngine {
         const deadline = this.clock.now() + RETRY_TTL_MS;
         const seqAtDeliver = this.judgeSeq;
         const attempt = () => {
-            if (!this.host.isMeetingActive() || this.judgeSeq !== seqAtDeliver) { this.parkedAttempt = null; return; }
+            if (!this.host.isMeetingActive() || this.judgeSeq !== seqAtDeliver) {
+                // Live session 2026-09-03 (13-q6): a verdict of 1.0 was parked
+                // behind the engine's own prefetch, the next candidate bumped
+                // the sequence, and this branch exited with nothing — no
+                // telemetry, no log, no answer. A park was armed, so its death
+                // is an outcome and must be reported like every other one.
+                const wasParked = this.parkedAttempt !== null;
+                this.parkedAttempt = null;
+                if (wasParked) {
+                    const reason = this.host.isMeetingActive() ? 'superseded_while_parked' : 'meeting_inactive';
+                    this.host.log?.(`[AutoAnswer:simple] parked dispatch for ${id} dropped: ${reason}${reason === 'superseded_while_parked' ? ` (by ${this.judgeSeqCause ?? 'unknown'})` : ''}`);
+                    this.emit({ name: 'auto_answer_ignored', questionId: id, skipReason: reason, answerability });
+                }
+                return;
+            }
             if (!this.host.engineAccepting()) {
                 if (this.clock.now() >= deadline) {
                     this.parkedAttempt = null;
@@ -760,10 +660,7 @@ export class SimpleAutoAnswerEngine {
         this.dropParked();
         this.clearFeedback();
         this.pending = [];
-        this.recentInterviewerFinals = [];
         this.lastInterviewerInterim = '';
-        this.recentUserEcho = [];
-        this.echoModeUntil = 0;
         this.lastInterviewerAt = 0;
         this.speakerByTurn.clear();
         this.lastJudgedKey = '';

--- a/electron/intelligence/autoAnswer/__tests__/AutoAnswerSimple.test.mjs
+++ b/electron/intelligence/autoAnswer/__tests__/AutoAnswerSimple.test.mjs
@@ -11,8 +11,8 @@
  *   '?' fallback          → 'judge unavailable → only a trailing ? fires'
  *   early ask             → 'the early ask replaces the commit ask…'
  *   mid-word seam         → 'a final cut mid-word is rejoined…'
- *   mic echo latch        → 'speaker bleed cannot shred a question…'
- *   latch release         → '…and it releases once the bleed stops'
+ *   inert user channel    → 'the user's own speech never suppresses…'
+ *   loud park drop        → 'a park dropped by supersession says so…'
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
@@ -25,7 +25,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 const Simple = require(path.resolve(__dirname, '../../../../dist-electron/electron/intelligence/autoAnswer/SimpleAutoAnswer.js'));
 const { isMidWordCut } = require(path.resolve(__dirname, '../../../../dist-electron/electron/intelligence/autoAnswer/AutoAnswerText.js'));
-const { SimpleAutoAnswerEngine, STABILITY_MS, ENDPOINT_CONFIRM_MS, RETRY_MS, RETRY_TTL_MS, HELD_MAX_AGE_MS, ECHO_MODE_HOLD_MS, EARLY_JUDGE_MS } = Simple;
+const { SimpleAutoAnswerEngine, STABILITY_MS, ENDPOINT_CONFIRM_MS, RETRY_MS, RETRY_TTL_MS, HELD_MAX_AGE_MS, EARLY_JUDGE_MS } = Simple;
 
 const flush = () => new Promise((r) => setImmediate(r));
 const YES = (over = {}) => JSON.stringify({ is_ask: true, directed_at_user: true, complete: true, act: 'question', answerability: 0.95, question_text: null, ...over });
@@ -179,22 +179,25 @@ test('busy engine: retries and dispatches when it frees up; gives up after the T
   assert.equal(g.clock.pendingCount(), 0, 'no leaked retry timer');
 });
 
-test('lenient mic: blips/echoes/backchannels ignored; a genuine sustained answer clears the candidate and barges in', async () => {
+test('the user\'s own speech never suppresses or cancels an automatic answer (user decision 2026-09-03)', async () => {
+  // The user answers the moment the question lands — they do not sit in
+  // silence waiting for the overlay. So the mic channel must be inert: no
+  // barge-in cancel, no "user is answering" skip, no cleared candidate.
   const h = makeSimple(async () => YES());
   h.interviewer('Okay, have you heard of the popular word game called wordle?');
   await h.advance(300);
-  h.user('Yeah.');                                          // blip — must not kill it
+  h.user('Yeah.');
   await h.advance(STABILITY_MS + 300);
   assert.equal(h.texts().length, 1, `skips: ${h.state.skips.join(',')}`);
 
   await h.advance(2000);
   h.interviewer('And how would you persist the game state across page reloads?');
   await h.advance(200);
-  h.user('I would probably use localStorage keyed by the date.');   // genuine answer
+  h.user('I would probably use localStorage keyed by the date.');   // the user starts answering at once
   await h.advance(STABILITY_MS + 500);
-  assert.equal(h.texts().length, 1, 'the second question is suppressed');
-  assert.ok(h.state.skips.includes('user_answering'));
-  assert.deepEqual(h.state.cancelled, ['user_barge_in'], 'the streaming first answer was barged in');
+  assert.equal(h.texts().length, 2, `the second question still answers (skips: ${h.state.skips.join(',')})`);
+  assert.ok(!h.state.skips.includes('user_answering'), 'the user talking is never a skip reason');
+  assert.deepEqual(h.state.cancelled, [], 'and never cancels the streaming answer');
 });
 
 test('judge unavailable → only a trailing ? fires (near-legacy fallback, no fire-on-everything)', async () => {
@@ -235,16 +238,15 @@ test('meeting stop clears everything; telemetry carries no transcript text', asy
 
 // ── Review fixes (2026-08-25): six confirmed findings, each pinned ────────
 
-test('review#2: a dispatch parked behind a busy engine dies when the user takes the floor', async () => {
+test('a dispatch parked behind a busy engine survives the user talking and fires when the engine frees up', async () => {
   const h = makeSimple(async () => YES(), { accepting: false });
   h.interviewer('Why did you choose PostgreSQL over the alternatives here?');
   await h.advance(STABILITY_MS + 200);                    // verdict auto → retry loop armed
   assert.deepEqual(h.texts(), []);
-  h.user('I chose it mainly for the ecosystem and tooling.');   // genuine answer
+  h.user('I chose it mainly for the ecosystem and tooling.');   // the user is already answering
   h.state.accepting = true;                               // engine frees up inside the TTL
   await h.advance(RETRY_MS * 4);
-  assert.deepEqual(h.texts(), [], `the parked dispatch must die with the user answering (skips: ${h.state.skips.join(',')})`);
-  assert.equal(h.clock.pendingCount(), 0, 'retry timer cancelled');
+  assert.equal(h.texts().length, 1, `the parked dispatch still fires (skips: ${h.state.skips.join(',')})`);
 });
 
 test('review#5: a transient judge failure clears the key — the next stoppage retries the same question', async () => {
@@ -273,21 +275,15 @@ test('review#6: interviewer INTERIMS supersede an in-flight verdict — no dispa
   assert.deepEqual(h.texts(), [], 'the verdict for the pre-resume text must not dispatch');
 });
 
-test('review#7: a genuine user INTERIM barges in the streaming answer — no waiting for the final', async () => {
+test('a user INTERIM never cancels the streaming answer either', async () => {
   const h = makeSimple(async () => YES());
   h.interviewer('Why did you choose PostgreSQL over the alternatives here?');
   await h.advance(STABILITY_MS + 200);
   assert.equal(h.texts().length, 1);
   assert.ok(h.state.streaming);
   h.engine.ingest({ speaker: 'user', text: 'Well I mostly picked it because of the', final: false, timestamp: h.clock.now(), origin: 'stt' });
-  assert.deepEqual(h.state.cancelled, ['user_barge_in'], 'cancelled at the interim, seconds before any final');
-  // A short or echoed interim never barges in.
-  const g = makeSimple(async () => YES());
-  g.interviewer('Why did you choose PostgreSQL over the alternatives here?');
-  await g.advance(STABILITY_MS + 200);
-  g.engine.ingest({ speaker: 'user', text: 'PostgreSQL over the alternatives here', final: false, timestamp: g.clock.now(), origin: 'stt' });  // echo
-  g.engine.ingest({ speaker: 'user', text: 'yeah', final: false, timestamp: g.clock.now(), origin: 'stt' });
-  assert.deepEqual(g.state.cancelled, []);
+  h.engine.ingest({ speaker: 'user', text: 'Well I mostly picked it because of the ecosystem and the tooling.', final: true, timestamp: h.clock.now(), origin: 'stt' });
+  assert.deepEqual(h.state.cancelled, [], 'the answer keeps streaming while the user talks');
 });
 
 test('review#4: punctuation provenance — no-\'?\' is negative evidence only when the provider guarantees marks', async () => {
@@ -560,11 +556,26 @@ test('onEngineIdle with nothing parked is inert, and a superseded park never fir
   const g = makeSimple(async () => YES(), { accepting: false });
   g.interviewer('Why did you choose PostgreSQL over the alternatives here?');
   await g.advance(STABILITY_MS + 200);
-  g.user('I picked it mainly for the ecosystem and the tooling around it.');   // user takes the floor
+  g.interviewer('and actually, let me rephrase that', false);   // the interviewer resumed: the park is stale
   g.state.accepting = true;
   g.engine.onEngineIdle();
   await flush(); await flush();
-  assert.deepEqual(g.texts(), [], 'the park died with the user answering');
+  assert.deepEqual(g.texts(), [], 'the park died with the interviewer resuming');
+  assert.ok(g.state.skips.includes('superseded_while_parked'), `a dropped park must say so (skips: ${g.state.skips.join(',')})`);
+});
+
+test('a park dropped by supersession says so — never a silent exit (live session 2026-09-03, 13-q6)', async () => {
+  // The real shape: verdict a=1.0 applied, engine busy with its own prefetch,
+  // dispatch parked; 195 ms later the next candidate bumped the sequence and
+  // the retry exited with no telemetry, no log, no answer.
+  const h = makeSimple(async () => YES({ answerability: 1 }), { accepting: false });
+  h.interviewer('Why did you choose PostgreSQL over the alternatives here?');
+  await h.advance(STABILITY_MS + 200);
+  assert.deepEqual(h.texts(), [], 'parked behind the busy engine');
+  assert.ok(!h.state.skips.includes('superseded_while_parked'), 'nothing dropped yet');
+  h.interviewer('And how does that interact with your caching layer?');   // new final supersedes
+  await h.advance(RETRY_MS + 50);                                          // the retry poll runs
+  assert.equal(h.state.skips.filter(s => s === 'superseded_while_parked').length, 1, `skips: ${h.state.skips.join(',')}`);
 });
 
 // ── deferred verdicts (live run 2026-08-25: 25 of 28 verdicts discarded) ─────
@@ -602,7 +613,7 @@ test('growth is never held across: a completed question re-judges rather than an
   assert.ok(/how you found it\?/.test(h.texts()[0]), 'the WHOLE question is answered');
 });
 
-test('the user taking the floor drops a deferred verdict (it is keyed to text, not to judgeSeq)', async () => {
+test('a deferred verdict survives the user talking over it', async () => {
   const resolvers = [];
   const h = makeSimple(() => new Promise((r) => resolvers.push(r)));
   h.interviewer('So how would you scale that service to ten times the traffic?');
@@ -612,14 +623,7 @@ test('the user taking the floor drops a deferred verdict (it is keyed to text, n
   await flush(); await flush();
   h.user('I would start by adding a read replica and caching the hot keys.');
   await h.advance(STABILITY_MS * 3);
-  assert.deepEqual(h.texts(), [], 'never answers a question the user answered themselves');
-  // Clearing `pending` alone does not cover this: the held verdict is keyed to
-  // TEXT, so an interviewer who repeats the sentence verbatim re-creates the
-  // matching key and would fire it. Only the explicit drop prevents that.
-  h.interviewer('So how would you scale that service to ten times the traffic?');
-  await h.advance(STABILITY_MS + 200);
-  assert.deepEqual(h.texts(), [], 'not even when the interviewer repeats it word for word');
-  assert.equal(resolvers.length, 2, 'the repeat is judged afresh, with the answer now in context');
+  assert.equal(h.texts().length, 1, `the held verdict still fires at the next stoppage (skips: ${h.state.skips.join(',')})`);
 });
 
 test('a deferred verdict expires, and a SILENT verdict is never deferred at all', async () => {
@@ -683,62 +687,6 @@ test('the dev content trace names the exact words judged, and the engine works w
   bare.ingest({ speaker: 'interviewer', text: 'And how would you shard that table once it stops fitting?', final: true, timestamp: clock.now(), origin: 'stt' });
   for (let i = 0; i < 14; i++) { clock.advance(100); await flush(); await flush(); }
   assert.equal(out.length, 1, 'dispatches identically with no content hook wired');
-});
-
-// ── mic echo (live session 2026-08-26: speakers, not headphones) ────────────
-
-/** The bled shape from the real session: the mic transcribes the SAME speech,
- *  segmented at different boundaries, so edge words arrive cut in half. */
-test('speaker bleed cannot shred a question: the interviewer pending survives', async () => {
-  const h = makeSimple(async () => YES({ question_text: 'how would you design the rate limiter?' }));
-  const bleed = [
-    ['So the next thing I want to ask you about is', 'So the next thing I want to ask you ab'],
-    ['how would you design the rate limit', 'out is how would you design the rate lim'],
-    ['er for that endpoint?', 'iter for that endpoint?'],
-  ];
-  for (const [heard, echoed] of bleed) {
-    h.interviewer(heard);
-    await h.advance(120);
-    h.user(echoed);                                   // the mic echo, offset by a fragment
-    await h.advance(200);
-  }
-  await h.advance(STABILITY_MS + 300);
-  assert.equal(h.state.skips.filter(s => s === 'user_answering').length, 0,
-    'an echo must never count as the user answering');
-  assert.ok(h.state.skips.includes('mic_echo'), 'and it is reported as what it is');
-  const judged = h.state.judgeCalls.at(-1).candidateText.replace(/\s+/g, ' ');
-  // Both channels cut words mid-token, so "rate limiter" reaches the judge as
-  // "rate limit er" — an STT artefact, not a pending-wipe. What matters is
-  // that ALL THREE finals are in one candidate.
-  assert.match(judged, /^So the next thing I want to ask you about is how would you design the rate limit ?er for that endpoint\?$/,
-    'the WHOLE question reaches the judge, not a shredded fragment');
-  assert.equal(h.texts().length, 1);
-});
-
-test('the echo latch holds through fragments that dodge the per-utterance test, and releases once the bleed stops', async () => {
-  const h = makeSimple(async () => YES());
-  // Two clear echoes engage it.
-  h.interviewer('We are going to talk about database indexing strategies today');
-  await h.advance(150);
-  h.user('We are going to talk about database indexing strategies today');
-  await h.advance(150);
-  h.interviewer('and then move on to caching and invalidation');
-  await h.advance(150);
-  h.user('and then move on to caching and invalidation');
-  await h.advance(150);
-  // A fragment that dodges containment must NOT release the latch — that
-  // self-defeating release is what let 24 echoes through in the real session.
-  h.user('completely unrelated words that share nothing at all here');
-  assert.ok(!h.state.skips.includes('user_answering'), 'held by time, not by a 4-slot count');
-
-  // …but real silence on the echo front releases it, so a genuine answer works.
-  await h.advance(ECHO_MODE_HOLD_MS + 1000);
-  h.interviewer('So how many years of Postgres experience do you have?');
-  await h.advance(200);
-  h.user('I have about four years of production Postgres experience overall.');
-  await h.advance(STABILITY_MS + 300);
-  assert.ok(h.state.skips.includes('user_answering'),
-    'once the bleed stops the mic is trusted again');
 });
 
 // ── relay mid-word cuts (live session 2026-08-26) ───────────────────────────

--- a/electron/services/__tests__/AutoAnswerPrefetchReveal2026_09_03.test.mjs
+++ b/electron/services/__tests__/AutoAnswerPrefetchReveal2026_09_03.test.mjs
@@ -41,18 +41,21 @@ const flush = () => new Promise((r) => setImmediate(r));
  * given the stream waits on it before its last chunk, so a test can hold a
  * prefetch open and dispatch INTO it.
  */
-async function makeEngine({ chunks = [ANSWER], gate = null } = {}) {
+async function makeEngine({ chunks = [ANSWER], gate = null, truncated = false } = {}) {
     const { IntelligenceEngine } = await import(pathToFileURL(enginePath).href);
     const { SessionTracker } = require(sessionPath);
     const session = new SessionTracker();
     const engine = new IntelligenceEngine({ setNegotiationCoachingHandler() {} }, session);
     engine.lastTriggerTime = 0;
     engine.whatToAnswerLLM = {
-        async *generateStream() {
+        async *generateStream(...args) {
             for (let i = 0; i < chunks.length; i++) {
                 if (gate && i === chunks.length - 1) await gate;
                 yield chunks[i];
             }
+            // The provider reports a cut-short stream through the trailing
+            // `wtaTruncation` box (same seam the live path reads).
+            if (truncated) args[13].truncated = true;
         },
     };
     // The planner classifies intent through the ONNX worker in production; the
@@ -123,6 +126,17 @@ test('13-q6: the engine accepts a dispatch while its OWN prefetch is streaming, 
     await flush();
     assert.equal(finals.length, 1, 'the adopted stream is revealed at completion');
     assert.equal(finals[0].answer, ANSWER);
+    engine.reset();
+});
+
+test('a TRUNCATED prefetch is shown on adoption but never stored as session evidence', async () => {
+    const { engine, session, finals } = await makeEngine({ truncated: true });
+    engine.prefetchAutoAnswer('q8', QUESTION);
+    await untilIdle(engine);
+    await dispatch(engine, 'q8');
+    assert.equal(finals.length, 1, 'the user still sees the partial text, as with a truncated live answer');
+    assert.equal(session.getFullUsage().length, 0, 'but an incomplete answer must not become prior_assistant_responses evidence');
+    assert.equal(session.getFullTranscript().some((seg) => seg.text === ANSWER), false, 'nor session transcript history');
     engine.reset();
 });
 

--- a/electron/services/__tests__/AutoAnswerPrefetchReveal2026_09_03.test.mjs
+++ b/electron/services/__tests__/AutoAnswerPrefetchReveal2026_09_03.test.mjs
@@ -1,0 +1,147 @@
+/**
+ * Auto Answer prefetch adoption — live session 2026-09-03 (meeting gen 13).
+ *
+ * Two real questions were judged answerable (a=0.9 and a=1.0) and neither was
+ * ever shown. Both died on the speculative prefetch:
+ *
+ *   13-q4  The prefetch FINISHED two seconds before the judge ruled. Its text
+ *          was returned to a `.catch`-only caller and discarded; the dispatch
+ *          then "adopted" a stream that no longer existed and returned. And
+ *          because completion stamped lastTriggerTime, the planner's 3 s
+ *          cooldown would have silenced the dispatch anyway.
+ *   13-q6  The prefetch was STILL STREAMING when the verdict landed. The
+ *          engine reported itself busy (mode what_to_say), the dispatch parked,
+ *          and the next candidate superseded it 195 ms later.
+ *
+ * A speculative stream never renders (by design — the judge may say no), so
+ * adoption is the ONLY moment it can become visible. These tests pin that a
+ * prefetch adopted in either state reaches the renderer and the session.
+ *
+ * Same poke-the-instance pattern as AutoAnswerEngineReview2026_08_24.test.mjs:
+ * a fake whatToAnswerLLM stream, the real runWhatShouldISay / adoption path.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const enginePath = path.resolve(__dirname, '../../../dist-electron/electron/IntelligenceEngine.js');
+const sessionPath = path.resolve(__dirname, '../../../dist-electron/electron/SessionTracker.js');
+const require = createRequire(import.meta.url);
+
+const QUESTION = 'Why did you choose PostgreSQL over the alternatives for this service?';
+const ANSWER = 'I picked PostgreSQL for the ecosystem and the tooling around it, and because the team already knew it well.';
+
+const flush = () => new Promise((r) => setImmediate(r));
+
+/**
+ * An engine whose What-to-Answer provider yields `chunks`. When `gate` is
+ * given the stream waits on it before its last chunk, so a test can hold a
+ * prefetch open and dispatch INTO it.
+ */
+async function makeEngine({ chunks = [ANSWER], gate = null } = {}) {
+    const { IntelligenceEngine } = await import(pathToFileURL(enginePath).href);
+    const { SessionTracker } = require(sessionPath);
+    const session = new SessionTracker();
+    const engine = new IntelligenceEngine({ setNegotiationCoachingHandler() {} }, session);
+    engine.lastTriggerTime = 0;
+    engine.whatToAnswerLLM = {
+        async *generateStream() {
+            for (let i = 0; i < chunks.length; i++) {
+                if (gate && i === chunks.length - 1) await gate;
+                yield chunks[i];
+            }
+        },
+    };
+    // The planner classifies intent through the ONNX worker in production; the
+    // decision under test is what happens AFTER it says "answer".
+    engine.planSuggestionTrigger = async () => ({ kind: 'answer', reason: 'answerable_question', confidence: 0.9 });
+    const finals = [];
+    const tokens = [];
+    engine.on('suggested_answer', (answer, question, confidence, generationId) => finals.push({ answer, question, generationId }));
+    engine.on('suggested_answer_token', (token) => tokens.push(token));
+    return { engine, session, finals, tokens };
+}
+
+/** Resolves once the engine reports idle (the speculative run finished). */
+function untilIdle(engine) {
+    return new Promise((resolve) => {
+        if (engine.getActiveMode() === 'idle') return resolve();
+        const handler = (mode) => { if (mode === 'idle') { engine.off('mode_changed', handler); resolve(); } };
+        engine.on('mode_changed', handler);
+    });
+}
+
+function dispatch(engine, id, reuseSpeculative = true) {
+    return engine.runAutoAnswer({
+        id, text: QUESTION, confidence: 0.9, answerability: 0.9, dialogueAct: 'technical_question',
+        isFollowUp: false, endpointSource: 'quiet_window', candidateGeneration: 1,
+    }, { reuseSpeculative, context: '' });
+}
+
+test('13-q4: a prefetch that finished before the judge ruled is revealed on dispatch, not discarded', async () => {
+    const { engine, session, finals, tokens } = await makeEngine();
+    engine.prefetchAutoAnswer('q4', QUESTION);
+    assert.equal(engine.getActiveMode(), 'what_to_say', 'the prefetch is streaming');
+    await untilIdle(engine);
+    assert.deepEqual(finals, [], 'a speculative stream never renders on its own');
+
+    await dispatch(engine, 'q4');
+    assert.equal(finals.length, 1, 'the dispatch reveals the finished prefetch');
+    assert.equal(finals[0].answer, ANSWER);
+    assert.equal(finals[0].question, QUESTION);
+    assert.ok(tokens.length >= 1 && tokens.join('') === ANSWER, 'the row is opened with the text, as the live path does');
+    assert.equal(session.getFullUsage().at(-1)?.answer, ANSWER, 'and it is on the session record like any shown answer');
+    engine.reset();
+});
+
+test('a finished prefetch does not stamp the trigger cooldown — the dispatch that adopts it is not silenced', async () => {
+    const { engine } = await makeEngine();
+    engine.prefetchAutoAnswer('q4', QUESTION);
+    await untilIdle(engine);
+    assert.equal(engine.lastTriggerTime, 0,
+        'the cooldown slot belongs to the real trigger; stamping it at completion made the planner refuse the adoption as "cooldown"');
+    engine.reset();
+});
+
+test('13-q6: the engine accepts a dispatch while its OWN prefetch is streaming, and reveals it when the stream ends', async () => {
+    let release;
+    const gate = new Promise((r) => { release = r; });
+    const { engine, finals } = await makeEngine({ chunks: [ANSWER.slice(0, 40), ANSWER.slice(40)], gate });
+    engine.prefetchAutoAnswer('q6', QUESTION);
+    await flush();
+    assert.equal(engine.getActiveMode(), 'what_to_say', 'the prefetch is in flight');
+    assert.equal(engine.canAutoAnswer(), true,
+        'a live prefetch is not "busy": the dispatch adopts it — refusing it parked the verdict until the next candidate killed it');
+
+    await dispatch(engine, 'q6');
+    assert.deepEqual(finals, [], 'adopted mid-stream: nothing to show until the stream finishes');
+    release();
+    await untilIdle(engine);
+    await flush();
+    assert.equal(finals.length, 1, 'the adopted stream is revealed at completion');
+    assert.equal(finals[0].answer, ANSWER);
+    engine.reset();
+});
+
+test('canAutoAnswer still refuses a MANUAL What-to-Answer stream', async () => {
+    const { engine } = await makeEngine();
+    engine.activeMode = 'what_to_say';          // a manual press, no speculative identity
+    assert.equal(engine.canAutoAnswer(), false);
+    engine.activeMode = 'idle';
+});
+
+test('an un-adopted prefetch stays hidden; a later manual press does not leak it', async () => {
+    const { engine, finals } = await makeEngine();
+    engine.prefetchAutoAnswer('q9', QUESTION);
+    await untilIdle(engine);
+    assert.deepEqual(finals, []);
+    // forceFresh is what the manual button sends; the stored prefetch must go with the cache.
+    const run = engine.runWhatShouldISay('Something else entirely?', 0.9, undefined, { skipCooldown: true, forceFresh: true });
+    await run;
+    assert.equal(finals.filter((f) => f.answer === ANSWER && f.question === QUESTION).length, 0,
+        'the prefetched answer is never shown under a different question');
+    engine.reset();
+});


### PR DESCRIPTION
## What broke

Live session on 2.8.8 with Auto Answer enabled (telemetry, meeting gen 13): 13 candidates, two judged answerable (`technical_question`, a=0.9 and a=1.0), **zero answers shown**. Both died on the speculative prefetch.

| id | verdict | what happened |
| --- | --- | --- |
| `13-q4` | a=0.9, `held_applied` → `decision: auto` | The prefetch had **finished** 2 s earlier. Its text was returned to a `.catch`-only caller and discarded; the dispatch then "adopted" a stream that no longer existed and returned. Completion had also stamped `lastTriggerTime`, so the planner would have refused the adoption as a `cooldown` repeat of itself. |
| `13-q6` | a=1.0, `held_applied` | The prefetch was **still streaming**. `canAutoAnswer` saw mode `what_to_say` and reported busy; the dispatch parked; 195 ms later the next candidate bumped `judgeSeq` and the retry exited with no telemetry, no log, no answer. |

A speculative stream never renders (the judge may still say no), so adoption is the only moment it can become visible. Neither adoption path ever made it visible.

## Fix

**`IntelligenceEngine`**
- `completeSpeculativeRun` keeps a finished prefetch's text (`speculativeAnswer`, gated by the existing `speculativeText` expiry window) and no longer stamps `lastTriggerTime` / `lastTriggerQuestion`. The cooldown slot belongs to the real trigger, which stamps it on adoption.
- Adoption in `handleSuggestionTriggerInner` now distinguishes: prefetch still streaming (revealed at completion), already finished (`revealSpeculativeAnswer` now), aborted (fresh run).
- `canAutoAnswer` accepts a dispatch while the engine's **own** prefetch is live. A manual press or an automatic run still refuses.

**`SimpleAutoAnswer`**
- A dispatch parked behind a busy engine that gets superseded now emits `auto_answer_ignored` with `superseded_while_parked` and a log line. Never a silent exit.

## Policy change: the user channel is inert

The user starts answering the moment a question lands; nobody sits in silence waiting for the overlay. Their own speech no longer cancels a streaming answer, clears a candidate, or drops a parked/held verdict. This retires the 2026-08-24 lenient-mic policy and the echo latch (`ECHO_*`, `GENUINE_ANSWER_MIN_WORDS`). `USER_BACKCHANNEL` stays as the interviewer-side prefilter. The mic is still transcribed; the judge sees both sides.

## Tests

- `AutoAnswerSimple.test.mjs`: user-channel tests rewritten to pin the inert policy; new loud-park-drop test modelled on `13-q6`.
- New `AutoAnswerPrefetchReveal2026_09_03.test.mjs`: finished prefetch revealed on dispatch; in-flight prefetch adopted and revealed at completion; completion does not stamp the cooldown; `canAutoAnswer` still refuses a manual stream; a manual press never leaks a stored prefetch.

All nine new assertions failed on `main` first.

## Validation

- Auto Answer suites (5 files): 85 pass, 0 fail
- `tsc -p electron/tsconfig.json --noEmit` (ts7): clean
- Wide run over `services`, `llm`, `intelligence`, `context-intelligence` tests: identical 125 pre-existing failures on this branch and on an untouched `main` worktree (missing native better-sqlite3, private premium submodule, ONNX classifier in this environment). This branch adds 5 passing tests.
- Shared engine logic only, no platform branch touched. Not yet exercised on a live call.

Progress entry added to `docs/autopilot/auto-answer-v3-progress.md`.
