### PR TITLE
Keep Natively visible when a Windows opacity transition is interrupted

### DIFF
--- a/electron/WindowHelper.ts
+++ b/electron/WindowHelper.ts
@@ -2540,6 +2540,33 @@ export class WindowHelper {
     menu.popup({ window: win, x: point.x, y: point.y });
   }
 
+  /**
+   * Flush the win32 opacity shield instead of discarding it.
+   *
+   * switchToOverlay / switchToLauncher show a window at opacity 0, call
+   * setContentProtection(true), and restore opacity 60ms later once DWM has
+   * applied the capture-exclusion flag. That restore lives in ONE shared
+   * this.opacityTimeout. minimizeWindow() / closeWindow() used to cancel it with
+   * a bare clearTimeout, so a minimize or a close-to-tray landing inside those
+   * 60ms dropped the pending setOpacity(1) and left the window shown-but-fully-
+   * transparent. The overlay chrome is skipTaskbar:true and the launcher joins it
+   * under undetectable mode, so there is no taskbar button to bring it back — the
+   * app is alive and unreachable. That is issue #529, reported on Windows 2.8.8,
+   * where #509 widened the shield from undetectable-only to the default Windows
+   * path.
+   *
+   * The isVisible() guard is what keeps this off the screenshot path — but not
+   * for the reason it looks like. hideMainWindow() zeroes opacity BEFORE hide()
+   * on win32; what saves us is that it is fully synchronous, so at every yield
+   * point (including the 40ms await in withScreenshotCaptureSession) those
+   * windows already read isVisible() === false. The only place a window sits
+   * visible-at-opacity-0 across a yield is the shield itself, which is exactly
+   * what we want to flush.
+   *
+   * NOT for the shield's own arm sites: they call setOpacity(0) and then cancel
+   * the previous timer, so routing them through here would un-zero the shield
+   * they just applied. They keep their bare clearTimeout.
+   */
   private finishOpacityShield(): void {
     if (!this.opacityTimeout) return;
     clearTimeout(this.opacityTimeout);
@@ -2552,6 +2579,23 @@ export class WindowHelper {
       this.toggleWindow,
     ]) {
       if (win && !win.isDestroyed() && win.isVisible()) win.setOpacity(1);
+    }
+
+    // The overlay's timer re-asserts z-order alongside the opacity restore,
+    // because DWM can silently demote the HWND across a hide/show. That timer
+    // will never run now, so the flush owes the same re-assert — otherwise an
+    // interrupted switch trades "invisible" for "visible but behind everything".
+    //
+    // Guarded on isVisible(), deliberately, and not on the timer's bare
+    // isDestroyed(): this pairs the re-assert with the opacity restore above. A
+    // hidden overlay was not un-shielded here, and the next switchToOverlay
+    // re-asserts its z-order on the way in regardless.
+    //
+    // The timer's focus() is NOT mirrored. We are on the way into a minimize or
+    // a close-to-tray; stealing focus there is the opposite of what was asked.
+    const overlay = this.overlayWindow;
+    if (overlay && !overlay.isDestroyed() && overlay.isVisible()) {
+      overlay.setAlwaysOnTop(true, 'screen-saver');
     }
   }
 

--- a/electron/WindowHelper.ts
+++ b/electron/WindowHelper.ts
@@ -1,7 +1,7 @@
 import { app, BrowserWindow, Menu, screen, systemPreferences } from 'electron';
 import fs from 'node:fs';
 import path from 'node:path';
-import { AppState } from './main';
+import type { AppState } from './main';
 import { KeybindManager } from './services/KeybindManager';
 import {
   LAUNCHER_ASPECT_RATIO,
@@ -2317,6 +2317,7 @@ export class WindowHelper {
 
         if (this.opacityTimeout) clearTimeout(this.opacityTimeout);
         this.opacityTimeout = setTimeout(() => {
+          this.opacityTimeout = null;
           if (this.overlayWindow && !this.overlayWindow.isDestroyed()) {
             this.overlayWindow.setOpacity(1);
             this.pillWindow?.setOpacity(1);
@@ -2415,6 +2416,7 @@ export class WindowHelper {
 
         if (this.opacityTimeout) clearTimeout(this.opacityTimeout);
         this.opacityTimeout = setTimeout(() => {
+          this.opacityTimeout = null;
           if (this.launcherWindow && !this.launcherWindow.isDestroyed()) {
             this.launcherWindow.setOpacity(1);
             if (!inactive) this.launcherWindow.focus();
@@ -2538,10 +2540,25 @@ export class WindowHelper {
     menu.popup({ window: win, x: point.x, y: point.y });
   }
 
+  private finishOpacityShield(): void {
+    if (!this.opacityTimeout) return;
+    clearTimeout(this.opacityTimeout);
+    this.opacityTimeout = null;
+
+    for (const win of [
+      this.launcherWindow,
+      this.overlayWindow,
+      this.pillWindow,
+      this.toggleWindow,
+    ]) {
+      if (win && !win.isDestroyed() && win.isVisible()) win.setOpacity(1);
+    }
+  }
+
   public minimizeWindow(): void {
     const win = this.launcherWindow;
     if (!win || win.isDestroyed()) return;
-    if (this.opacityTimeout) clearTimeout(this.opacityTimeout);
+    this.finishOpacityShield();
     win.minimize();
   }
 
@@ -2797,7 +2814,7 @@ export class WindowHelper {
   public closeWindow(): void {
     const win = this.launcherWindow;
     if (!win || win.isDestroyed()) return;
-    if (this.opacityTimeout) clearTimeout(this.opacityTimeout);
+    this.finishOpacityShield();
     // On Windows/Linux the 'close' event listener intercepts this
     // and hides to tray unless the app is actually quitting.
     win.close();

--- a/electron/audio/__tests__/OpacityShieldRecovery.test.mjs
+++ b/electron/audio/__tests__/OpacityShieldRecovery.test.mjs
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import Module from 'node:module';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const compiled = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../dist-electron/electron/WindowHelper.js',
+);
+const originalLoad = Module._load;
+Module._load = function patched(request) {
+  if (request === 'electron') {
+    return {
+      app: { isPackaged: false },
+      BrowserWindow: function BrowserWindow() {},
+      Menu: {},
+      screen: {},
+      systemPreferences: {},
+      globalShortcut: {},
+      ipcMain: {},
+    };
+  }
+  return originalLoad.apply(this, arguments);
+};
+const { WindowHelper } = await import(pathToFileURL(compiled));
+Module._load = originalLoad;
+
+test('minimize and close finish a pending opacity shield', () => {
+  const opacity = [];
+  const window = (name, { visible = true, destroyed = false } = {}) => ({
+    isDestroyed: () => destroyed,
+    isVisible: () => visible,
+    setOpacity: (value) => opacity.push([name, value]),
+    minimize() {},
+    close() {},
+  });
+  const helper = new WindowHelper({});
+  helper.launcherWindow = window('launcher');
+  helper.overlayWindow = window('overlay');
+  helper.pillWindow = window('pill', { visible: false });
+  helper.toggleWindow = window('toggle', { destroyed: true });
+
+  for (const action of ['minimizeWindow', 'closeWindow']) {
+    helper.opacityTimeout = setTimeout(
+      () => assert.fail(`${action} did not clear the shield timer`),
+      1_000,
+    );
+    helper[action]();
+    assert.equal(helper.opacityTimeout, null);
+  }
+
+  assert.deepEqual(opacity, [
+    ['launcher', 1],
+    ['overlay', 1],
+    ['launcher', 1],
+    ['overlay', 1],
+  ]);
+});

--- a/electron/audio/__tests__/OpacityShieldRecovery.test.mjs
+++ b/electron/audio/__tests__/OpacityShieldRecovery.test.mjs
@@ -27,11 +27,12 @@ const { WindowHelper } = await import(pathToFileURL(compiled));
 Module._load = originalLoad;
 
 test('minimize and close finish a pending opacity shield', () => {
-  const opacity = [];
+  const calls = [];
   const window = (name, { visible = true, destroyed = false } = {}) => ({
     isDestroyed: () => destroyed,
     isVisible: () => visible,
-    setOpacity: (value) => opacity.push([name, value]),
+    setOpacity: (value) => calls.push([name, 'opacity', value]),
+    setAlwaysOnTop: (on, level) => calls.push([name, 'alwaysOnTop', on, level]),
     minimize() {},
     close() {},
   });
@@ -50,10 +51,95 @@ test('minimize and close finish a pending opacity shield', () => {
     assert.equal(helper.opacityTimeout, null);
   }
 
+  // The invisible pill and the destroyed toggle are skipped. The overlay also
+  // gets the z-order re-assert its own timer would have done: DWM can demote the
+  // HWND across a hide/show, and that timer is not going to run any more.
+  assert.deepEqual(calls, [
+    ['launcher', 'opacity', 1],
+    ['overlay', 'opacity', 1],
+    ['overlay', 'alwaysOnTop', true, 'screen-saver'],
+    ['launcher', 'opacity', 1],
+    ['overlay', 'opacity', 1],
+    ['overlay', 'alwaysOnTop', true, 'screen-saver'],
+  ]);
+});
+
+// The case above filters pill and toggle out through the guards, so it never
+// pins WHICH windows the shield covers. Drop one and the flush strands it.
+test('the flush covers every window an arm site can shield', () => {
+  const opacity = [];
+  const window = (name) => ({
+    isDestroyed: () => false,
+    isVisible: () => true,
+    setOpacity: (value) => opacity.push([name, value]),
+    setAlwaysOnTop() {},
+    minimize() {},
+    close() {},
+  });
+  const helper = new WindowHelper({});
+  helper.launcherWindow = window('launcher');
+  helper.overlayWindow = window('overlay');
+  helper.pillWindow = window('pill');
+  helper.toggleWindow = window('toggle');
+
+  helper.opacityTimeout = setTimeout(() => assert.fail('shield timer survived'), 1_000);
+  helper.minimizeWindow();
+
+  assert.equal(helper.opacityTimeout, null);
   assert.deepEqual(opacity, [
     ['launcher', 1],
     ['overlay', 1],
-    ['launcher', 1],
-    ['overlay', 1],
+    ['pill', 1],
+    ['toggle', 1],
   ]);
+});
+
+// A hidden overlay is skipped whole — no opacity, and no z-order re-assert
+// either. It was not un-shielded here, and the next switchToOverlay re-asserts
+// on the way in, so touching it now would only reach past what the flush owns.
+test('a hidden overlay is left alone, z-order included', () => {
+  const calls = [];
+  const helper = new WindowHelper({});
+  helper.overlayWindow = {
+    isDestroyed: () => false,
+    isVisible: () => false,
+    setOpacity: () => calls.push('opacity'),
+    setAlwaysOnTop: () => calls.push('alwaysOnTop'),
+  };
+  helper.launcherWindow = {
+    isDestroyed: () => false,
+    isVisible: () => true,
+    setOpacity: () => calls.push('launcher-opacity'),
+    setAlwaysOnTop: () => calls.push('launcher-alwaysOnTop'),
+    minimize() {},
+  };
+
+  helper.opacityTimeout = setTimeout(() => assert.fail('shield timer survived'), 1_000);
+  helper.minimizeWindow();
+
+  assert.deepEqual(calls, ['launcher-opacity']);
+});
+
+// A flush with nothing pending must stay a no-op. That early return is the whole
+// reason the arm sites null the handle when their timer fires: without it every
+// later minimize would push opacity 1 onto whatever happens to be visible.
+test('finishing with no shield pending touches nothing', () => {
+  const calls = [];
+  const window = () => ({
+    isDestroyed: () => false,
+    isVisible: () => true,
+    setOpacity: (v) => calls.push(v),
+    setAlwaysOnTop: () => calls.push('aot'),
+    minimize() {},
+    close() {},
+  });
+  const helper = new WindowHelper({});
+  helper.launcherWindow = window();
+  helper.overlayWindow = window();
+  helper.opacityTimeout = null;
+
+  helper.minimizeWindow();
+  helper.closeWindow();
+
+  assert.deepEqual(calls, []);
 });


### PR DESCRIPTION
On Windows, the brief opacity shield could be interrupted by minimize or close-to-tray. The timer was cleared without restoring opacity, leaving Natively running but invisible.

This restores visible shielded windows before minimizing or closing, and clears completed timer handles. It also adds a behavior-level regression test through the real WindowHelper methods.

Tested on Windows:
- the regression test fails with the old cancellation behavior and passes with this change
- 38 focused Windows and opacity tests pass
- Electron type-check passes
- the production renderer build passes
- the app launches and enters overlay mode successfully

The full repository test command was also run. It still reports unrelated failures already present in the current checkout, including missing premium build artifacts and existing SQL, settings, and policy test failures.

Closes #529