### PR TITLE
fix(overlay): a pill hidden inside the shield came back as an invisible gap

### DIFF
--- a/electron/WindowHelper.ts
+++ b/electron/WindowHelper.ts
@@ -2555,13 +2555,30 @@ export class WindowHelper {
    * where #509 widened the shield from undetectable-only to the default Windows
    * path.
    *
-   * The isVisible() guard is what keeps this off the screenshot path — but not
-   * for the reason it looks like. hideMainWindow() zeroes opacity BEFORE hide()
-   * on win32; what saves us is that it is fully synchronous, so at every yield
-   * point (including the 40ms await in withScreenshotCaptureSession) those
-   * windows already read isVisible() === false. The only place a window sits
-   * visible-at-opacity-0 across a yield is the shield itself, which is exactly
-   * what we want to flush.
+   * Flushing early does NOT narrow the capture guarantee, which was the standing
+   * worry about this method. Measured on windows-latest: after
+   * setContentProtection(true), restoring opacity at t=0ms put 0 pixels of the
+   * window into a live getDisplayMedia capture, against a control that saw 81248
+   * pixels of the same window unprotected. DWM applies the exclusion before an
+   * opacity restore can matter, so the 60ms is not what is buying capture safety.
+   *
+   * The opacity restore is NOT gated on isVisible(), and that is load-bearing.
+   * It used to be, on the theory that skipping hidden windows kept the flush off
+   * the screenshot path. Two measurements on a real Windows kernel killed that:
+   *
+   *  - hideMainWindow() zeroes opacity BEFORE hide() on win32, but it is fully
+   *    synchronous, so at every yield point (including the 40ms await in
+   *    withScreenshotCaptureSession) those windows are already hidden. Setting
+   *    opacity 1 on a hidden window changes nothing anyone can capture, and every
+   *    show path re-sets opacity on the way in — measured, all four of them.
+   *  - The skip actively CAUSED a bug. applyOverlayAuxVisibility() re-shows the
+   *    pill and toggle but never touches their opacity, so a pill hidden inside
+   *    the shield window was skipped here at opacity 0 and then re-shown at
+   *    opacity 0 — an invisible gap in the overlay chrome that nothing repaired
+   *    until the next full switchToOverlay.
+   *
+   * The z-order re-assert below keeps its isVisible() guard: unlike opacity, it
+   * is not repairing state that a later show would otherwise inherit.
    *
    * NOT for the shield's own arm sites: they call setOpacity(0) and then cancel
    * the previous timer, so routing them through here would un-zero the shield
@@ -2578,7 +2595,7 @@ export class WindowHelper {
       this.pillWindow,
       this.toggleWindow,
     ]) {
-      if (win && !win.isDestroyed() && win.isVisible()) win.setOpacity(1);
+      if (win && !win.isDestroyed()) win.setOpacity(1);
     }
 
     // The overlay's timer re-asserts z-order alongside the opacity restore,
@@ -2586,10 +2603,9 @@ export class WindowHelper {
     // will never run now, so the flush owes the same re-assert — otherwise an
     // interrupted switch trades "invisible" for "visible but behind everything".
     //
-    // Guarded on isVisible(), deliberately, and not on the timer's bare
-    // isDestroyed(): this pairs the re-assert with the opacity restore above. A
-    // hidden overlay was not un-shielded here, and the next switchToOverlay
-    // re-asserts its z-order on the way in regardless.
+    // Still guarded on isVisible(), unlike the opacity restore above. Z-order is
+    // not state a later show inherits — switchToOverlay re-asserts it on the way
+    // in — so there is nothing to repair on a hidden window.
     //
     // The timer's focus() is NOT mirrored. We are on the way into a minimize or
     // a close-to-tray; stealing focus there is the opposite of what was asked.

--- a/electron/audio/__tests__/OpacityShieldRecovery.test.mjs
+++ b/electron/audio/__tests__/OpacityShieldRecovery.test.mjs
@@ -51,15 +51,22 @@ test('minimize and close finish a pending opacity shield', () => {
     assert.equal(helper.opacityTimeout, null);
   }
 
-  // The invisible pill and the destroyed toggle are skipped. The overlay also
-  // gets the z-order re-assert its own timer would have done: DWM can demote the
-  // HWND across a hide/show, and that timer is not going to run any more.
+  // The HIDDEN pill still gets its opacity back; only the DESTROYED toggle is
+  // skipped. Skipping hidden windows is what caused the invisible-pill gap:
+  // applyOverlayAuxVisibility() re-shows the pill without touching opacity, so a
+  // pill left at 0 here came back as a hole in the overlay chrome. Confirmed on a
+  // real Windows kernel, then re-run against this fix to confirm it closed.
+  //
+  // The overlay additionally gets the z-order re-assert its own timer would have
+  // done — DWM can demote the HWND across a hide/show and that timer is cancelled.
   assert.deepEqual(calls, [
     ['launcher', 'opacity', 1],
     ['overlay', 'opacity', 1],
+    ['pill', 'opacity', 1],
     ['overlay', 'alwaysOnTop', true, 'screen-saver'],
     ['launcher', 'opacity', 1],
     ['overlay', 'opacity', 1],
+    ['pill', 'opacity', 1],
     ['overlay', 'alwaysOnTop', true, 'screen-saver'],
   ]);
 });
@@ -94,10 +101,11 @@ test('the flush covers every window an arm site can shield', () => {
   ]);
 });
 
-// A hidden overlay is skipped whole — no opacity, and no z-order re-assert
-// either. It was not un-shielded here, and the next switchToOverlay re-asserts
-// on the way in, so touching it now would only reach past what the flush owns.
-test('a hidden overlay is left alone, z-order included', () => {
+// Opacity and z-order are guarded DIFFERENTLY, on purpose. A hidden window still
+// gets its opacity restored, because that value survives the hide and a later
+// show inherits it. Z-order does not: switchToOverlay re-asserts it on the way
+// in, so re-asserting on a hidden window would reach past what the flush owns.
+test('a hidden overlay gets opacity back but not the z-order re-assert', () => {
   const calls = [];
   const helper = new WindowHelper({});
   helper.overlayWindow = {
@@ -117,7 +125,7 @@ test('a hidden overlay is left alone, z-order included', () => {
   helper.opacityTimeout = setTimeout(() => assert.fail('shield timer survived'), 1_000);
   helper.minimizeWindow();
 
-  assert.deepEqual(calls, ['launcher-opacity']);
+  assert.deepEqual(calls, ['launcher-opacity', 'opacity']);
 });
 
 // A flush with nothing pending must stay a no-op. That early return is the whole


### PR DESCRIPTION
Follow-up to #542. One of five review findings survived verification; this fixes it.

`finishOpacityShield()` skipped windows that were not visible. `applyOverlayAuxVisibility()` re-shows the pill and toggle but never touches their opacity — so a pill hidden inside the 60 ms shield window was skipped by the flush at opacity 0, then re-shown at opacity 0. A hole in the overlay chrome, repaired by nothing until the next full `switchToOverlay`.

Opacity is now restored on every non-destroyed window. The z-order re-assert keeps its `isVisible()` guard, and the asymmetry is deliberate: opacity is state a later show inherits, z-order is not.

## How it was verified

A probe on `probe/windows-shield` drives the **real** `WindowHelper` methods against **real** `BrowserWindow`s on `windows-latest` — the constructor is `this.appState = appState`, so the helper takes a stub AppState and real windows. Controls run first and abort the job if opacity/z-order/visibility cannot be read back, so "REFUTED" can never be confused with "unobservable".

| finding | verdict on windows-latest |
|---|---|
| issue #529 | **CONFIRMED** — pre-PR flush left the overlay at opacity 0 |
| #1 missing z-order re-assert | **CONFIRMED** — #542 alone: opacity 1, alwaysOnTop false |
| merged #542 fix | **WORKS** — opacity 1, alwaysOnTop true |
| #5b invisible pill | **CONFIRMED** → **REFUTED** after this change |
| #2 flushing narrows capture | **REFUTED** — 0 px leaked at t=0ms vs an 81248 px control |
| #4 Settings/ModelSelector | **REFUTED** — neither discards a pending restore |
| #5 hideMainWindow gap | **REFUTED** — all four show paths restore opacity |

Two review claims of mine were wrong and are corrected in the comments: `hideMainWindow` zeroes opacity *before* `hide()` (the guard survives because the method is synchronous, not because of statement order), and the 60 ms wait is not what buys capture safety.

## Validation

- `typecheck:electron` clean
- 676 tests green across the audio, utils and window-related services globs
- probe re-run against this branch: `finding#5b` REFUTED, #529 and z-order regression checks still holding
- Reviewed on macOS; behaviour measured on windows-latest CI, not a physical Windows desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UmqxHK31BjZMwxAqXLQWeo