### PR TITLE
add Google Antigravity OAuth provider

### DIFF
--- a/electron/LLMHelper.ts
+++ b/electron/LLMHelper.ts
@@ -68,6 +68,7 @@ import { promisify } from 'util';
 import axios from 'axios';
 import { createProviderRateLimiters, RateLimiter } from './services/RateLimiter';
 import { CodexCliConfig, CodexCliService, DEFAULT_CODEX_CLI_CONFIG } from './services/CodexCliService';
+import { AntigravityService } from './services/AntigravityService';
 import { GROQ_PRIMARY_MODEL, groqFallbackFor, isGroqModelGone, groqReasoningParams } from './llm/groqModels';
 import { DirectAssistError } from './direct-assist/errors';
 import { DIRECT_ASSIST_CURRENT_TURN_SPEECH_MARKER } from './direct-assist/requestBuilder';
@@ -738,7 +739,7 @@ export class LLMHelper {
   private static readonly PROVIDER_LABEL_FAMILY: Readonly<Record<string, string>> = {
     gemini: 'gemini', groq: 'groq', natively: 'natively', openai: 'openai',
     claude: 'claude', deepseek: 'deepseek', litellm: 'litellm', codex: 'codex-cli',
-    custom_curl: 'custom', custom_provider: 'custom',
+    antigravity: 'antigravity', custom_curl: 'custom', custom_provider: 'custom',
   };
 
   /**
@@ -798,6 +799,7 @@ export class LLMHelper {
   /** Live, fail-OPEN: a credential-store failure must not start refusing turns
    *  that would otherwise have been answered. */
   private anyVisionProviderAvailable(): boolean {
+    if (!this.isProviderDisabled('antigravity') && AntigravityService.getInstance().getStatus().signedIn) return true;
     try {
       const { CredentialsManager } = require('./services/CredentialsManager');
       const cm = CredentialsManager.getInstance();
@@ -1547,6 +1549,26 @@ export class LLMHelper {
 
   private isCodexCliModel(modelId: string): boolean {
     return modelId === "codex-cli" || modelId.startsWith("codex-cli:");
+  }
+
+  private isAntigravityModel(model: string): boolean { return model.startsWith('antigravity:'); }
+
+  private getAntigravityModelId(model: string): string { return model.replace(/^antigravity:/, ''); }
+
+  private async *streamWithAntigravity(userPrompt: string, systemPrompt?: string, imagePaths?: string[], signal?: AbortSignal, model = this.currentModelId, direct = false): AsyncGenerator<string> {
+    if (this.isLocalOnlyMode) throw new Error('Cloud providers disabled in local-only mode');
+    // Direct Assist has already classified/stripped optional context. Its typed
+    // current question must not be reclassified as meeting transcript here.
+    this.assertOutboundScopes('antigravity', direct ? '' : userPrompt, imagePaths, direct ? this.inferEmbeddedMessageScopes(userPrompt) : []);
+    const images = [];
+    for (const imagePath of imagePaths || []) {
+      signal?.throwIfAborted();
+      images.push(await this.processImage(imagePath));
+    }
+    yield* AntigravityService.getInstance().stream({
+      model: this.getAntigravityModelId(model), userPrompt, systemPrompt, images, signal,
+      maxOutputTokens: getModelCapabilities(this.getAntigravityModelId(model), false).outputBudgetTokens,
+    });
   }
 
   private isCodexAvailable(): boolean {
@@ -3287,6 +3309,12 @@ let isMultimodal = !!(imagePaths?.length);
       // System prompts for OpenAI/Claude/Codex CLI (skipped if skipSystemPrompt)
       const openaiSystemPrompt = skipSystemPrompt ? undefined : this.injectLanguageInstruction(systemPromptOverride || OPENAI_SYSTEM_PROMPT);
       const claudeSystemPrompt = skipSystemPrompt ? undefined : this.injectLanguageInstruction(systemPromptOverride || CLAUDE_SYSTEM_PROMPT);
+
+      if (!this.useOllama && !this.customProvider && !this.activeCurlProvider && this.isAntigravityModel(this.currentModelId)) {
+        let text = '';
+        for await (const chunk of this.streamWithAntigravity(cloudUserContent, openaiSystemPrompt, cloudImagePaths)) text += chunk;
+        return text;
+      }
 
       // GROQ FAST TEXT OVERRIDE (Text-Only) — gated on picked model so Gemini/Claude/OpenAI
       // selections aren't silently routed to Groq. See streamChat() for matching gate.
@@ -7288,6 +7316,11 @@ let isMultimodal = !!(imagePaths?.length);
     markH4Stage('provider_dispatch_start', { model: this.currentModelId });
     _stage(`provider dispatch START (sysPrompt=${finalSystemPrompt.length}c, userContent=${userContent.length}c, model=${this.currentModelId})`);
 
+    if (!this.useOllama && !this.customProvider && !this.activeCurlProvider && this.isAntigravityModel(this.currentModelId)) {
+      yield* this.streamWithAntigravity(userContent, finalSystemPrompt, imagePaths, abortSignal);
+      return;
+    }
+
     // ── UNIFIED MULTIMODAL PATH ────────────────────────────────────────────
     // Every image-bearing request goes through the single streaming vision
     // fallback chain (OpenAI → Claude → Gemini → Groq → Natively → local) with
@@ -9659,8 +9692,9 @@ let isMultimodal = !!(imagePaths?.length);
     }
   }
 
-  public getCurrentProvider(): "ollama" | "gemini" | "custom" | "codex-cli" {
+  public getCurrentProvider(): "ollama" | "gemini" | "custom" | "codex-cli" | "antigravity" {
     if (this.customProvider) return "custom";
+    if (!this.useOllama && !this.activeCurlProvider && this.isAntigravityModel(this.currentModelId)) return "antigravity";
     if (this.isCodexCliModel(this.currentModelId)) return "codex-cli";
     return this.useOllama ? "ollama" : "gemini";
   }
@@ -9707,6 +9741,7 @@ let isMultimodal = !!(imagePaths?.length);
       // generic vendor predicates or the request escapes through the wrong
       // credential/client boundary.
       if (selected === 'natively') provider = 'natively';
+      else if (this.isAntigravityModel(selected)) provider = 'antigravity';
       else if (this.isCodexCliModel(selected)) {
         provider = 'codex-cli';
         model = this.getSelectedCodexCliModel(false);
@@ -9774,6 +9809,7 @@ let isMultimodal = !!(imagePaths?.length);
     switch (selection.provider) {
       case 'natively':
       case 'codex-cli':
+      case 'antigravity':
         return true;
       case 'custom':
         return customProviderSupportsVision(custom);
@@ -9891,7 +9927,9 @@ let isMultimodal = !!(imagePaths?.length);
     const directUserPrompt = deniedScopes.length
       ? this.stripDeniedScopedBlocksFromMessage(request.userPrompt, deniedScopes)
       : request.userPrompt;
-    const capabilityModel = provider === 'litellm'
+    const capabilityModel = provider === 'antigravity'
+      ? this.getAntigravityModelId(model)
+      : provider === 'litellm'
       ? model.replace(/^litellm\//, '')
       : provider === 'nvidia_nim'
         ? model.replace(/^nvidia_nim\//, '')
@@ -9958,6 +9996,9 @@ let isMultimodal = !!(imagePaths?.length);
         if (!this.isCodexAvailable()) throw new Error('Codex CLI provider not configured');
         yield* this.streamWithCodexCli(directUserPrompt, request.systemPrompt, false, imagePaths, abortSignal, model);
         return;
+      case 'antigravity':
+        yield* this.streamWithAntigravity(directUserPrompt, request.systemPrompt, imagePaths, abortSignal, model, true);
+        return;
       case 'custom':
         if (!custom) throw new Error('Custom provider not configured');
         if (this.isLocalOnlyMode && !customProviderIsLocal(custom)) {
@@ -9984,6 +10025,9 @@ let isMultimodal = !!(imagePaths?.length);
    * and never compare the result to option IDs (use {@link getCurrentModelId}).
    */
   public getCurrentModelDisplayName(): string {
+    if (!this.useOllama && !this.customProvider && !this.activeCurlProvider && this.isAntigravityModel(this.currentModelId)) {
+      return `${this.getAntigravityModelId(this.currentModelId)} (Antigravity)`;
+    }
     if (this.customProvider) return this.customProvider.name;
     if (this.activeCurlProvider) return this.activeCurlProvider.id;
     return this.useOllama ? this.ollamaModel : this.currentModelId;
@@ -10034,6 +10078,9 @@ let isMultimodal = !!(imagePaths?.length);
   }
 
   public getCapabilities(): ModelCapabilities {
+    if (!this.useOllama && !this.customProvider && !this.activeCurlProvider && this.isAntigravityModel(this.currentModelId)) {
+      return getModelCapabilities(this.getAntigravityModelId(this.currentModelId), false);
+    }
     return getModelCapabilities(this.getCurrentModel(), this.useOllama);
   }
 

--- a/electron/direct-assist/errors.ts
+++ b/electron/direct-assist/errors.ts
@@ -36,6 +36,15 @@ export function normalizeDirectAssistError(error: unknown): DirectAssistError {
   if (error instanceof DirectAssistError) return error;
 
   const candidate = error as any;
+  if (candidate?.name === 'AntigravityError') {
+    if (candidate.code === 'cancelled') return new DirectAssistError('CANCELLED', 'The request was cancelled.');
+    if (candidate.code === 'auth_required' || candidate.code === 'auth_revoked') {
+      return new DirectAssistError('AUTH_FAILED', 'Sign in to Google Antigravity again in Settings → AI Providers.');
+    }
+    if (candidate.code === 'storage') {
+      return new DirectAssistError('PROVIDER_ERROR', 'Google credentials could not be saved. Check credential storage in Settings and try again.');
+    }
+  }
   if (candidate?.name === 'AbortError' || candidate?.code === 'ABORT_ERR') {
     return new DirectAssistError('CANCELLED', 'The request was cancelled.');
   }

--- a/electron/direct-assist/requestBuilder.ts
+++ b/electron/direct-assist/requestBuilder.ts
@@ -171,7 +171,9 @@ export function buildDirectAssistRequest(input: DirectAssistRequestInput): Direc
     ?? explicitFormat
     ?? detectLatest(transcriptText, FORMAT_PATTERNS);
   const requestedMax = Number.isFinite(input.maxContextChars) ? Number(input.maxContextChars) : DEFAULT_MAX_CONTEXT_CHARS;
-  const capabilityModel = input.selection.provider === 'litellm'
+  const capabilityModel = input.selection.provider === 'antigravity'
+    ? input.selection.model.replace(/^antigravity:/, '')
+    : input.selection.provider === 'litellm'
     ? input.selection.model.replace(/^litellm\//, '')
     : input.selection.provider === 'nvidia_nim'
       ? input.selection.model.replace(/^nvidia_nim\//, '')

--- a/electron/direct-assist/types.ts
+++ b/electron/direct-assist/types.ts
@@ -15,6 +15,7 @@ export const DIRECT_ASSIST_PROVIDERS = [
   'litellm',
   'ollama',
   'codex-cli',
+  'antigravity',
   'custom',
   'curl',
 ] as const;

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -1,7 +1,7 @@
 // ipcHandlers.ts
 
 import * as crypto from 'crypto';
-import { AntigravityService } from './services/AntigravityService';
+import { AntigravityService, initializeAntigravityLifecycle } from './services/AntigravityService';
 import { buildEmbeddingConfig } from './rag/embeddingConfigIdentity';
 import { app, BrowserWindow, dialog, desktopCapturer, ipcMain, shell, systemPreferences } from 'electron';
 import { micSettingsUri } from '../src/lib/micPermissionPolicy.mjs';
@@ -11348,16 +11348,13 @@ export function initializeIpcHandlers(appState: AppState): void {
 
   // Google Antigravity OAuth uses the existing encrypted store and model settings.
   const antigravity = AntigravityService.getInstance();
-  antigravity.initialize();
-  app.once('before-quit', () => antigravity.dispose());
-  antigravity.on('status-changed', (status) => {
+  initializeAntigravityLifecycle(app, (status) => {
     for (const win of BrowserWindow.getAllWindows()) {
       if (!win.isDestroyed()) win.webContents.send('antigravity:status-changed', status);
     }
     broadcastCredentialsChanged();
     void refreshRuntimeDefaultIfUnavailable();
-  });
-  antigravity.on('models-changed', () => broadcastCredentialsChanged());
+  }, broadcastCredentialsChanged);
   safeHandle('antigravity:status', () => antigravity.getStatus());
   safeHandle('antigravity:start-login', async () => {
     try { await antigravity.startLogin(); return { success: true }; }

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -1,6 +1,7 @@
 // ipcHandlers.ts
 
 import * as crypto from 'crypto';
+import { AntigravityService } from './services/AntigravityService';
 import { buildEmbeddingConfig } from './rag/embeddingConfigIdentity';
 import { app, BrowserWindow, dialog, desktopCapturer, ipcMain, shell, systemPreferences } from 'electron';
 import { micSettingsUri } from '../src/lib/micPermissionPolicy.mjs';
@@ -204,6 +205,9 @@ export function initializeIpcHandlers(appState: AppState): void {
       const { CredentialsManager } = require('./services/CredentialsManager');
       const cm = CredentialsManager.getInstance();
       const defaultModel = cm.getDefaultModel();
+      const antigravityCatalog = defaultModel.startsWith('antigravity:') && AntigravityService.getInstance().getStatus().signedIn
+        ? await AntigravityService.getInstance().getModels().catch(() => null)
+        : null;
       const curlProviders = cm.getCurlProviders() || [];
       const legacyProviders = cm.getCustomProviders() || [];
       const allProviders = [...curlProviders, ...legacyProviders];
@@ -236,6 +240,7 @@ export function initializeIpcHandlers(appState: AppState): void {
       // isProviderEnabled() in AIProvidersSettings.tsx must use the same names.
       const providerFamily = (modelId: string): string => {
         if (modelId === 'natively') return 'natively';
+        if (modelId.startsWith('antigravity:')) return 'antigravity';
         if (modelId.startsWith('codex-cli')) return 'codex-cli';
         if (modelId.startsWith('litellm/')) return 'litellm';
         if (modelId.startsWith('nvidia_nim/')) return 'nvidia_nim';
@@ -289,6 +294,8 @@ export function initializeIpcHandlers(appState: AppState): void {
 
         if (modelId === 'natively') return has(cm.getNativelyApiKey());
         if (modelId.startsWith('codex-cli')) return codexConfig.enabled === true && codexSignedIn;
+        if (modelId.startsWith('antigravity:')) return AntigravityService.getInstance().getStatus().signedIn
+          && (antigravityCatalog === null || antigravityCatalog.some(({ id }) => modelId === `antigravity:${id}`));
         if (modelId.startsWith('litellm/')) return has(cm.getLitellmBaseURL());
         if (modelId.startsWith('nvidia_nim/')) return has(cm.getNvidiaNimApiKey());
         if (modelId.startsWith('ollama-')) return true; // live Ollama probe happens at execution time
@@ -352,7 +359,13 @@ export function initializeIpcHandlers(appState: AppState): void {
       const geminiNext = ['gemini-3.8-flash', 'gemini-3.7-flash', 'gemini-3.1-flash-lite']
         .find(id => modelAvailable(id));
 
-      const next = modelAvailable('natively') ? 'natively'
+      const antigravityFallback = AntigravityService.getInstance().getStatus().signedIn
+        && !cm.getDisabledProviders().includes('antigravity')
+        ? (antigravityCatalog ?? await AntigravityService.getInstance().getModels().catch(() => []))
+          .map(({ id }) => `antigravity:${id}`).find(modelAvailable)
+        : undefined;
+      const next = defaultModel.startsWith('antigravity:') && antigravityFallback ? antigravityFallback
+        : modelAvailable('natively') ? 'natively'
         : geminiNext ? geminiNext
         : modelAvailable('gpt-5.4') ? 'gpt-5.4'
         : modelAvailable('claude-sonnet-4-6') ? 'claude-sonnet-4-6'
@@ -360,6 +373,7 @@ export function initializeIpcHandlers(appState: AppState): void {
         : modelAvailable('deepseek-v4-flash') ? 'deepseek-v4-flash'
         : (codexConfig.enabled === true && codexSignedIn && modelAvailable('codex-cli')) ? 'codex-cli'
         : (litellmFallbackModel && modelAvailable(litellmFallbackModel)) ? litellmFallbackModel
+        : antigravityFallback ? antigravityFallback
         : allProviders.find((p: any) => modelAvailable(p?.id))?.id
           || null;
       if (!next) {
@@ -369,6 +383,7 @@ export function initializeIpcHandlers(appState: AppState): void {
         console.warn('[IPC] refreshRuntimeDefaultIfUnavailable: no available model (all providers disabled or unconfigured)');
         return null;
       }
+      if (cm.getDefaultModel() !== defaultModel) return null;
       cm.setDefaultModel(next);
       llmHelper.setModel(next, allProviders);
       // Same two listeners as every other model change. Converted alongside the
@@ -11330,6 +11345,33 @@ export function initializeIpcHandlers(appState: AppState): void {
   safeHandle('codex-cli:logout', async (_, config?: any) => runCodexAuthAction('logout', config));
   safeHandle('codex-cli:login', async (_, config?: any) => runCodexAuthAction('login', config));
   safeHandle('codex-cli:doctor', async (_, config?: any) => runCodexAuthAction('doctor', config));
+
+  // Google Antigravity OAuth uses the existing encrypted store and model settings.
+  const antigravity = AntigravityService.getInstance();
+  antigravity.initialize();
+  app.once('before-quit', () => antigravity.dispose());
+  antigravity.on('status-changed', (status) => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!win.isDestroyed()) win.webContents.send('antigravity:status-changed', status);
+    }
+    broadcastCredentialsChanged();
+    void refreshRuntimeDefaultIfUnavailable();
+  });
+  antigravity.on('models-changed', () => broadcastCredentialsChanged());
+  safeHandle('antigravity:status', () => antigravity.getStatus());
+  safeHandle('antigravity:start-login', async () => {
+    try { await antigravity.startLogin(); return { success: true }; }
+    catch (error: any) { return { success: false, error: error.message }; }
+  });
+  safeHandle('antigravity:cancel-login', () => antigravity.cancelLogin());
+  safeHandle('antigravity:sign-out', async () => {
+    try { return await antigravity.signOut(); }
+    catch (error: any) { return { success: false, error: error.message }; }
+  });
+  safeHandle('antigravity:models', async (_, force?: boolean) => {
+    try { return { success: true, models: await antigravity.getModels(force === true) }; }
+    catch (error: any) { return { success: false, models: [], error: error.message }; }
+  });
 
   // ── ChatGPT OAuth (new — replaces `codex login` CLI subprocess) ──────────
   // The renderer calls codex:start-login, which kicks off the PKCE flow,

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -100,7 +100,7 @@ interface ElectronAPI {
 
   // LLM Model Management
   getCurrentLlmConfig: () => Promise<{
-    provider: 'ollama' | 'gemini' | 'custom' | 'codex-cli';
+    provider: 'ollama' | 'gemini' | 'custom' | 'codex-cli' | 'antigravity';
     /**
      * @deprecated Use `modelId` for selection comparisons and `displayName`
      * for UI labels. Kept as an alias of `modelId` for back-compat.
@@ -691,6 +691,12 @@ interface ElectronAPI {
   // startLogin kicks off the PKCE flow + opens the system browser; the
   // renderer listens for codex:login:complete / :failed events to update UI.
   codexLoginStatus: () => Promise<{ success: boolean; signedIn: boolean; email?: string; expiresAt?: number; error?: string }>;
+  antigravityStatus: () => Promise<{ signedIn: boolean; inProgress: boolean; expiresAt?: number; projectId?: string; error?: string }>;
+  antigravityStartLogin: () => Promise<{ success: boolean; error?: string }>;
+  antigravityCancelLogin: () => Promise<void>;
+  antigravitySignOut: () => Promise<{ success: boolean; error?: string }>;
+  antigravityModels: (force?: boolean) => Promise<{ success: boolean; models: { id: string; label: string }[]; error?: string }>;
+  onAntigravityStatusChanged: (callback: (status: { signedIn: boolean; inProgress: boolean; expiresAt?: number; projectId?: string; error?: string }) => void) => () => void;
   codexStartLogin: () => Promise<{ success: boolean; email?: string; expiresAt?: number; error?: string }>;
   codexSignOut: () => Promise<{ success: boolean; error?: string }>;
   codexRefreshTokens: () => Promise<{ success: boolean; email?: string; expiresAt?: number; error?: string }>;
@@ -2321,6 +2327,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
   // The renderer listens for `codex:login:complete` / `:failed` /
   // `:signed-out` / `:tokens:refreshed` events for live UI updates.
   codexLoginStatus: () => ipcRenderer.invoke('codex:login-status'),
+  antigravityStatus: () => ipcRenderer.invoke('antigravity:status'),
+  antigravityStartLogin: () => ipcRenderer.invoke('antigravity:start-login'),
+  antigravityCancelLogin: () => ipcRenderer.invoke('antigravity:cancel-login'),
+  antigravitySignOut: () => ipcRenderer.invoke('antigravity:sign-out'),
+  antigravityModels: (force?: boolean) => ipcRenderer.invoke('antigravity:models', force),
+  onAntigravityStatusChanged: (callback) => {
+    const listener = (_: Electron.IpcRendererEvent, status: Parameters<typeof callback>[0]) => callback(status);
+    ipcRenderer.on('antigravity:status-changed', listener);
+    return () => ipcRenderer.removeListener('antigravity:status-changed', listener);
+  },
   codexStartLogin: () => ipcRenderer.invoke('codex:start-login'),
   codexSignOut: () => ipcRenderer.invoke('codex:sign-out'),
   codexRefreshTokens: () => ipcRenderer.invoke('codex:refresh-tokens'),

--- a/electron/services/AntigravityService.ts
+++ b/electron/services/AntigravityService.ts
@@ -1,0 +1,944 @@
+/**
+ * Google Antigravity OAuth and Code Assist transport.
+ *
+ * This is deliberately self contained.  The Android Voice-app is the wire
+ * reference; Electron only replaces its intent callback and token store with
+ * a loopback HTTP server and CredentialsManager.
+ */
+
+import { EventEmitter } from 'events';
+import * as http from 'http';
+import * as crypto from 'crypto';
+import { setTimeout as wait } from 'node:timers/promises';
+import { shell } from 'electron';
+
+export const ANTIGRAVITY_CLIENT_ID =
+  '1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com';
+// This is the installed client's public OAuth credential from the reference
+// app.  It is not a user's bearer token and is required by Google's exchange.
+export const ANTIGRAVITY_CLIENT_SECRET = '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';
+export const ANTIGRAVITY_AUTHORIZE_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
+export const ANTIGRAVITY_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+export const ANTIGRAVITY_REDIRECT_URI = 'http://localhost:51121/oauth-callback';
+export const ANTIGRAVITY_CALLBACK_PATH = '/oauth-callback';
+export const ANTIGRAVITY_CALLBACK_PORT = 51121;
+export const ANTIGRAVITY_SCOPES = [
+  'openid',
+  'https://www.googleapis.com/auth/cloud-platform',
+  'https://www.googleapis.com/auth/userinfo.email',
+  'https://www.googleapis.com/auth/userinfo.profile',
+  'https://www.googleapis.com/auth/cclog',
+  'https://www.googleapis.com/auth/experimentsandconfigs',
+] as const;
+export const GOOGLE_API_USER_AGENT = 'google-api-nodejs-client/9.15.1';
+export const ANTIGRAVITY_SETUP_CLIENT = 'google-cloud-sdk vscode_cloudshelleditor/0.1';
+export const ANTIGRAVITY_PROD_ENDPOINT = 'https://cloudcode-pa.googleapis.com';
+export const ANTIGRAVITY_DAILY_ENDPOINT = 'https://daily-cloudcode-pa.googleapis.com';
+export const ANTIGRAVITY_REFRESH_LEAD_MS = 60_000;
+export const ANTIGRAVITY_STREAM_URL =
+  `${ANTIGRAVITY_DAILY_ENDPOINT}/v1internal:streamGenerateContent?alt=sse`;
+
+export type AntigravityErrorCode =
+  | 'cancelled'
+  | 'browser'
+  | 'callback'
+  | 'token_exchange'
+  | 'token_refresh'
+  | 'auth_required'
+  | 'auth_revoked'
+  | 'setup'
+  | 'models'
+  | 'request'
+  | 'response'
+  | 'storage';
+
+export class AntigravityError extends Error {
+  public readonly code: AntigravityErrorCode;
+  public readonly status?: number;
+
+  constructor(code: AntigravityErrorCode, message: string, status?: number) {
+    super(message);
+    this.name = 'AntigravityError';
+    this.code = code;
+    this.status = status;
+  }
+}
+
+export interface AntigravityOAuthTokens {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+  projectId: string;
+}
+
+export interface AntigravityModel {
+  id: string;
+  label: string;
+}
+
+export interface AntigravityStatus {
+  signedIn: boolean;
+  inProgress: boolean;
+  expiresAt?: number;
+  projectId?: string;
+  error?: string;
+}
+
+export interface AntigravityImage {
+  mimeType: string;
+  data: string;
+}
+
+export interface AntigravityStreamInput {
+  model: string;
+  userPrompt: string;
+  systemPrompt?: string;
+  images?: readonly AntigravityImage[];
+  maxOutputTokens?: number;
+  signal?: AbortSignal;
+}
+
+export function resolveAntigravityWireModel(model: string): string {
+  const normalized = model.toLowerCase().replace(/^models\//, '');
+  if (normalized.startsWith('gemini-3.7-flash')) return 'gemini-3.7-flash-tiered';
+  if (normalized.startsWith('gemini-3.6-flash')) return 'gemini-3.6-flash-tiered';
+  if (normalized === 'gemini-3.1-pro-high' || normalized === 'gemini-3.1-pro') {
+    return 'gemini-pro-agent';
+  }
+  return normalized;
+}
+
+export function generateAntigravityPkce(): {
+  verifier: string;
+  challenge: string;
+  state: string;
+} {
+  const verifier = crypto.randomBytes(32).toString('base64url');
+  const challenge = crypto.createHash('sha256').update(verifier).digest('base64url');
+  return { verifier, challenge, state: crypto.randomUUID() };
+}
+
+export function buildAntigravityAuthorizationUrl(
+  pkce: { challenge: string; state: string },
+): string {
+  const params: Array<[string, string]> = [
+    ['client_id', ANTIGRAVITY_CLIENT_ID],
+    ['response_type', 'code'],
+    ['redirect_uri', ANTIGRAVITY_REDIRECT_URI],
+    ['scope', ANTIGRAVITY_SCOPES.join(' ')],
+    ['code_challenge', pkce.challenge],
+    ['code_challenge_method', 'S256'],
+    ['state', pkce.state],
+    ['access_type', 'offline'],
+    ['prompt', 'consent'],
+  ];
+  return `${ANTIGRAVITY_AUTHORIZE_URL}?${new URLSearchParams(params)}`;
+}
+
+function metadata(ideType: 'ANTIGRAVITY' | 'IDE_UNSPECIFIED'): Record<string, string> {
+  return { ideType, platform: 'PLATFORM_UNSPECIFIED', pluginType: 'GEMINI' };
+}
+
+export function antigravitySetupHeaders(accessToken: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${accessToken}`,
+    'User-Agent': GOOGLE_API_USER_AGENT,
+    'X-Goog-Api-Client': ANTIGRAVITY_SETUP_CLIENT,
+    'Client-Metadata': JSON.stringify(metadata('IDE_UNSPECIFIED')),
+  };
+}
+
+const ANTIGRAVITY_USER_AGENT = `antigravity/1.23.2 ${process.platform}/${process.arch}`;
+
+export function buildAntigravityRequestPayload(input: {
+  projectId: string;
+  model: string;
+  userPrompt: string;
+  systemPrompt?: string;
+  images?: readonly AntigravityImage[];
+  maxOutputTokens?: number;
+}): Record<string, unknown> {
+  const projectId = input.projectId.trim();
+  if (!projectId) throw new AntigravityError('request', 'Google account setup has no project yet. Sign in again.');
+
+  const contents: Array<Record<string, unknown>> = [
+    {
+      role: 'user',
+      parts: [{ text: `System instruction: ${input.systemPrompt || ''}` }],
+    },
+  ];
+  const parts: Array<Record<string, unknown>> = [{ text: input.userPrompt }];
+  for (const image of input.images || []) {
+    if (image.mimeType && image.data) {
+      parts.push({ inlineData: { mimeType: image.mimeType, data: image.data } });
+    }
+  }
+  contents.push({ role: 'user', parts });
+
+  const wireModel = resolveAntigravityWireModel(input.model);
+  const generationConfig: Record<string, unknown> = {
+    candidateCount: 1,
+    maxOutputTokens: Math.max(1, Math.floor(input.maxOutputTokens || 192)),
+    temperature: 0.45,
+  };
+  if (wireModel.startsWith('gemini')) {
+    generationConfig.thinkingConfig = wireModel.startsWith('gemini-2.5')
+      ? { thinkingBudget: 0 }
+      : { thinkingLevel: wireModel.includes('3.7') ? 'low' : 'minimal' };
+  }
+
+  return {
+    model: wireModel,
+    userAgent: 'antigravity',
+    requestType: 'agent',
+    project: projectId,
+    requestId: `agent-${crypto.randomUUID()}`,
+    request: { contents, generationConfig },
+  };
+}
+
+export function parseAntigravityModels(value: unknown): AntigravityModel[] {
+  const models = value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>).models
+    : undefined;
+  if (!models || typeof models !== 'object' || Array.isArray(models)) return [];
+
+  const result: AntigravityModel[] = [];
+  for (const [id, raw] of Object.entries(models as Record<string, unknown>)) {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) continue;
+    const item = raw as Record<string, unknown>;
+    const label = typeof item.displayName === 'string' ? item.displayName.trim() : '';
+    const quota = item.quotaInfo && typeof item.quotaInfo === 'object'
+      ? (item.quotaInfo as Record<string, unknown>).remainingFraction
+      : undefined;
+    if (!label || item.isInternal === true || !id || id.startsWith('gemini-3.5-flash')) continue;
+    if (id.toLowerCase().includes('image') || label.toLowerCase().includes('flash lite')) continue;
+    if (typeof quota !== 'number' || !Number.isFinite(quota) || quota <= 0) continue;
+    result.push({ id, label });
+  }
+  return result.sort((a, b) => {
+    const rank = (id: string) => id === 'gemini-3.6-flash-low' ? 0
+      : id === 'gemini-3-flash' ? 1
+        : id.includes('flash') ? 2 : 3;
+    return rank(a.id) - rank(b.id) || a.id.localeCompare(b.id);
+  });
+}
+
+export function parseAntigravityEvent(data: string): string {
+  let root: unknown;
+  try { root = JSON.parse(data); } catch { throw new AntigravityError('response', 'Google returned malformed streaming data.'); }
+  if (!root || typeof root !== 'object' || Array.isArray(root)) {
+    throw new AntigravityError('response', 'Google returned an invalid streaming response.');
+  }
+  const response = (root as Record<string, unknown>).response;
+  if (!response || typeof response !== 'object' || Array.isArray(response)) {
+    throw new AntigravityError('response', 'Google returned an invalid streaming response.');
+  }
+  const candidateList = (response as Record<string, unknown>).candidates;
+  if (!Array.isArray(candidateList) || candidateList.length === 0) return '';
+  const candidate = candidateList[0];
+  if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+    throw new AntigravityError('response', 'Google returned an invalid candidate.');
+  }
+  const content = (candidate as Record<string, unknown>).content;
+  const parts = content && typeof content === 'object' && !Array.isArray(content)
+    ? (content as Record<string, unknown>).parts
+    : undefined;
+  if (parts !== undefined && !Array.isArray(parts)) {
+    throw new AntigravityError('response', 'Google returned invalid response parts.');
+  }
+  const text = (parts || []).map((part) => {
+    if (!part || typeof part !== 'object' || Array.isArray(part)) return '';
+    const item = part as Record<string, unknown>;
+    return item.thought === true ? '' : typeof item.text === 'string' ? item.text : '';
+  }).join('');
+  return text;
+}
+
+function parseAntigravitySse(buffer: string, final = false): { events: string[]; remainder: string } {
+  if (buffer.length > 2 * 1024 * 1024) throw new AntigravityError('response', 'Google returned an oversized streaming response.');
+  const records = buffer.split(/\r?\n\r?\n/);
+  const remainder = final ? '' : records.pop()!;
+  const events = records.map(record => record.split(/\r?\n/)
+    .filter(line => line.startsWith('data:'))
+    .map(line => line.slice(5).replace(/^ /, '')).join('\n').trim()).filter(Boolean);
+  return { events, remainder };
+}
+
+// Voice-app parity: UnknownHostException retries are 4 normally and 12 for
+// model discovery, using 250/500/1000/2000 ms backoff. HTTP errors are not retried.
+function isDnsError(error: unknown): boolean {
+  let current: any = error;
+  for (let i = 0; i < 5 && current; i += 1) {
+    const code = typeof current.code === 'string' ? current.code : '';
+    if (code === 'ENOTFOUND' || code === 'EAI_AGAIN' || code === 'EAI_FAIL') return true;
+    if (typeof current.message === 'string' && /\b(?:ENOTFOUND|EAI_AGAIN|EAI_FAIL)\b/i.test(current.message)) return true;
+    current = current.cause;
+  }
+  return false;
+}
+
+export function dnsRetryDelayMillis(remainingRetries: number): number {
+  return 250 << Math.max(0, Math.min(3, 4 - remainingRetries));
+}
+
+const ANTIGRAVITY_FETCH_TIMEOUT_MS = 30_000;
+const ANTIGRAVITY_STREAM_TIMEOUT_MS = 60_000;
+
+async function fetchWithDnsRetry(
+  url: string,
+  init: RequestInit,
+  remainingRetries: number,
+  timeoutMs = ANTIGRAVITY_FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  let retries = remainingRetries;
+  const externalSignal = init.signal ?? undefined;
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const requestSignal = externalSignal
+    ? AbortSignal.any([externalSignal, timeoutSignal])
+    : timeoutSignal;
+  const requestInit = { ...init, signal: requestSignal };
+  while (true) {
+    try {
+      return await fetch(url, requestInit);
+    } catch (error) {
+      if (externalSignal?.aborted) throw new AntigravityError('cancelled', 'Google request cancelled.');
+      if (timeoutSignal.aborted) throw new AntigravityError('request', 'Google request timed out.');
+      if (!isDnsError(error) || retries <= 0) throw error;
+      try {
+        await wait(dnsRetryDelayMillis(retries), undefined, { signal: requestSignal });
+      } catch (waitError) {
+        if (timeoutSignal.aborted) throw new AntigravityError('request', 'Google request timed out.');
+        throw waitError;
+      }
+      retries -= 1;
+    }
+  }
+}
+
+async function responseJson(response: Response, phase: AntigravityErrorCode): Promise<any> {
+  // fetchWithDnsRetry's AbortSignal deadline also covers consuming the body.
+  const body = await response.text();
+  if (!response.ok) {
+    const status = response.status;
+    let oauthError: unknown;
+    try { oauthError = JSON.parse(body)?.error; } catch { /* Non-JSON errors are transient session failures. */ }
+    const permanent = phase === 'token_refresh' && (status === 400 || status === 401) && oauthError === 'invalid_grant';
+    const message = permanent
+      ? 'Google session expired. Sign in again.'
+      : status === 401
+        ? 'Google access was rejected. Refresh the session or sign in again.'
+        : status === 403
+          ? 'This Google account is not permitted to use Antigravity.'
+        : status === 429
+          ? 'Google quota is exhausted or temporarily limited. Try again later.'
+          : status >= 500
+            ? 'Google is temporarily unavailable. Try again shortly.'
+            : `${phase === 'models' ? 'Google model discovery' : 'Google request'} failed (HTTP ${status}).`;
+    throw new AntigravityError(
+      permanent ? 'auth_revoked' : phase,
+      message,
+      status,
+    );
+  }
+  try { return JSON.parse(body); } catch { throw new AntigravityError(phase, 'Google returned invalid JSON.'); }
+}
+
+interface CallbackServer {
+  portReady: Promise<void>;
+  callback: Promise<{ code?: string; state?: string; error?: string }>;
+  close(reason?: Error): void;
+}
+
+function startCallbackServer(): CallbackServer {
+  let resolveCallback!: (value: { code?: string; state?: string; error?: string }) => void;
+  let rejectCallback!: (error: Error) => void;
+  let settled = false;
+  const callback = new Promise<{ code?: string; state?: string; error?: string }>((resolve, reject) => {
+    resolveCallback = resolve;
+    rejectCallback = reject;
+  });
+  // A bind failure can close the server before startLogin awaits the callback;
+  // keep that cleanup rejection from becoming an unhandled promise rejection.
+  void callback.catch(() => undefined);
+  const server = http.createServer((request, response) => {
+    if (request.method !== 'GET') {
+      response.writeHead(405, { 'Content-Type': 'text/plain; charset=utf-8', Allow: 'GET' });
+      response.end('Method Not Allowed');
+      return;
+    }
+    const host = (request.headers.host || '').replace(/:\d+$/, '').toLowerCase();
+    if (host !== 'localhost' && host !== '127.0.0.1') {
+      response.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' });
+      response.end('Invalid callback host');
+      return;
+    }
+    let url: URL;
+    try { url = new URL(request.url || '/', 'http://localhost'); } catch {
+      response.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' });
+      response.end('Invalid callback');
+      return;
+    }
+    // Absolute HTTP request targets can disagree with Host; validate both.
+    if (url.protocol !== 'http:' || (url.hostname !== 'localhost' && url.hostname !== '127.0.0.1') ||
+      (url.port && url.port !== String(ANTIGRAVITY_CALLBACK_PORT))) {
+      response.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' });
+      response.end('Invalid callback origin');
+      return;
+    }
+    if (url.pathname !== ANTIGRAVITY_CALLBACK_PATH) {
+      response.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+      response.end('Not Found');
+      return;
+    }
+    response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    response.end('<!doctype html><title>Natively</title><p>You can close this tab and return to Natively.</p>');
+    if (settled) return;
+    settled = true;
+    resolveCallback({
+      code: url.searchParams.get('code') || undefined,
+      state: url.searchParams.get('state') || undefined,
+      error: url.searchParams.get('error') || undefined,
+    });
+  });
+  const portReady = new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => { server.off('listening', onListening); reject(error); };
+    const onListening = () => { server.off('error', onError); resolve(); };
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen(ANTIGRAVITY_CALLBACK_PORT, '127.0.0.1');
+  });
+  return {
+    portReady,
+    callback,
+    close(reason) {
+      if (!settled) {
+        settled = true;
+        rejectCallback(reason || new AntigravityError('cancelled', 'Google sign-in cancelled.'));
+      }
+      try { (server as any).closeAllConnections?.(); } catch { /* noop */ }
+      try { server.close(); } catch { /* already closed */ }
+    },
+  };
+}
+
+function extractProjectId(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim()) return value.trim();
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const id = (value as Record<string, unknown>).id;
+    if (typeof id === 'string' && id.trim()) return id.trim();
+  }
+  return undefined;
+}
+
+async function discoverProject(accessToken: string, signal: AbortSignal): Promise<string> {
+  const headers = antigravitySetupHeaders(accessToken);
+  const loadResponse = await fetchWithDnsRetry(
+    `${ANTIGRAVITY_PROD_ENDPOINT}/v1internal:loadCodeAssist`,
+    { method: 'POST', headers: { ...headers, 'Content-Type': 'application/json' }, body: JSON.stringify({ metadata: metadata('ANTIGRAVITY') }), signal },
+    4,
+  );
+  const loaded = await responseJson(loadResponse, 'setup');
+  const existing = extractProjectId(loaded?.cloudaicompanionProject);
+  if (existing) return existing;
+
+  let tierId = 'legacy-tier';
+  if (Array.isArray(loaded?.allowedTiers)) {
+    const tier = loaded.allowedTiers.find((item: any) => item?.isDefault === true && typeof item?.id === 'string' && item.id.trim());
+    if (tier) tierId = tier.id.trim();
+  }
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    const onboardResponse = await fetchWithDnsRetry(
+      `${ANTIGRAVITY_PROD_ENDPOINT}/v1internal:onboardUser`,
+      { method: 'POST', headers: { ...headers, 'Content-Type': 'application/json' }, body: JSON.stringify({ tierId, metadata: metadata('ANTIGRAVITY') }), signal },
+      4,
+    );
+    const onboarded = await responseJson(onboardResponse, 'setup');
+    const project = onboarded?.done === true
+      ? extractProjectId(onboarded?.response?.cloudaicompanionProject) : undefined;
+    if (project) return project;
+    if (attempt < 5) await wait(1_500, undefined, { signal });
+  }
+  throw new AntigravityError('setup', 'Google account setup did not finish. Try signing in again.');
+}
+
+export class AntigravityService extends EventEmitter {
+  private cachedTokens: AntigravityOAuthTokens | null = null;
+  private cachedModels: AntigravityModel[] | null = null;
+  private refreshInFlight: Promise<AntigravityOAuthTokens | null> | null = null;
+  private refreshController: AbortController | null = null;
+  private refreshTimer: ReturnType<typeof setTimeout> | null = null;
+  private activeLogin: { generation: number; server: CallbackServer; controller: AbortController } | null = null;
+  private requestControllers = new Set<AbortController>();
+  private generation = 0;
+  private signedOut = false;
+  private backgroundRefreshFailures = 0;
+  private lastError: string | undefined;
+
+  private constructor() { super(); }
+
+  public static getInstance(): AntigravityService {
+    const global = globalThis as unknown as Record<string, AntigravityService | undefined>;
+    if (!global.__nativelyAntigravityServiceV1__) global.__nativelyAntigravityServiceV1__ = new AntigravityService();
+    return global.__nativelyAntigravityServiceV1__;
+  }
+
+  public initialize(): void {
+    this.signedOut = false;
+    this.backgroundRefreshFailures = 0;
+    this.stopRefreshTimer();
+    this.cachedTokens = this.loadFromStorage();
+    this.lastError = undefined;
+    this.scheduleRefresh();
+    this.emit('status-changed', this.getStatus());
+  }
+
+  public dispose(): void {
+    this.generation += 1;
+    this.stopRefreshTimer();
+    this.activeLogin?.controller.abort();
+    this.activeLogin?.server.close(new AntigravityError('cancelled', 'Google sign-in cancelled.'));
+    this.activeLogin = null;
+    this.refreshController?.abort();
+    this.refreshController = null;
+    for (const controller of this.requestControllers) controller.abort();
+    this.requestControllers.clear();
+    this.refreshInFlight = null;
+  }
+
+  public getStatus(): AntigravityStatus {
+    const tokens = this.signedOut ? null : (this.cachedTokens || this.loadFromStorage());
+    return {
+      signedIn: Boolean(tokens?.accessToken && tokens.refreshToken && tokens.projectId),
+      inProgress: Boolean(this.activeLogin),
+      ...(tokens ? { expiresAt: tokens.expiresAt, projectId: tokens.projectId } : {}),
+      ...(this.lastError ? { error: this.lastError } : {}),
+    };
+  }
+
+  public cancelLogin(): boolean {
+    if (!this.activeLogin) return false;
+    this.generation += 1;
+    const active = this.activeLogin;
+    active.controller.abort();
+    active.server.close(new AntigravityError('cancelled', 'Google sign-in cancelled.'));
+    this.activeLogin = null;
+    this.lastError = 'Google sign-in cancelled.';
+    this.emit('status-changed', this.getStatus());
+    return true;
+  }
+
+  public async startLogin(): Promise<AntigravityOAuthTokens> {
+    if (this.activeLogin) throw new AntigravityError('callback', 'Google sign-in is already in progress.');
+    const generation = ++this.generation;
+    this.signedOut = false;
+    const server = startCallbackServer();
+    const controller = new AbortController();
+    const active = { generation, server, controller };
+    this.activeLogin = active;
+    this.lastError = undefined;
+    this.emit('status-changed', this.getStatus());
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    try {
+      try {
+        await server.portReady;
+      } catch (error) {
+        if ((error as any)?.code === 'EADDRINUSE') {
+          throw new AntigravityError('callback', 'Google sign-in callback port is busy. Close the other sign-in window and try again.');
+        }
+        throw error;
+      }
+      this.assertGeneration(generation);
+      const pkce = generateAntigravityPkce();
+      await shell.openExternal(buildAntigravityAuthorizationUrl(pkce)).catch(() => {
+        throw new AntigravityError('browser', 'Could not open the Google sign-in page.');
+      });
+      const callback = await new Promise<{ code?: string; state?: string; error?: string }>((resolve, reject) => {
+        timeout = setTimeout(() => reject(new AntigravityError('callback', 'Google sign-in timed out.')), 5 * 60_000);
+        server.callback.then(resolve, reject);
+      });
+      this.assertGeneration(generation);
+      if (callback.error) throw new AntigravityError('callback', 'Google sign-in was denied.');
+      if (callback.state !== pkce.state) throw new AntigravityError('callback', 'Google sign-in state did not match. Start again.');
+      if (!callback.code?.trim()) throw new AntigravityError('callback', 'Google returned no authorization code.');
+
+      const exchanged = await this.exchangeCode(callback.code, pkce.verifier, controller.signal);
+      this.assertGeneration(generation);
+      const projectId = await discoverProject(exchanged.accessToken, controller.signal);
+      this.assertGeneration(generation);
+      const tokens = { ...exchanged, projectId };
+      if (!this.saveToStorage(tokens)) throw new AntigravityError('storage', 'Google sign-in could not be saved. Check credential storage and try again.');
+      this.cachedTokens = tokens;
+      this.cachedModels = null;
+      this.lastError = undefined;
+      this.scheduleRefresh();
+      this.emit('status-changed', this.getStatus());
+      return tokens;
+    } catch (error) {
+      const normalized = this.normalizeError(error, 'Google sign-in failed.');
+      if (generation === this.generation) {
+        this.lastError = normalized.message;
+        this.emit('status-changed', this.getStatus());
+      }
+      throw normalized;
+    } finally {
+      if (timeout) clearTimeout(timeout);
+      controller.abort();
+      server.close();
+      if (this.activeLogin === active) this.activeLogin = null;
+      this.emit('status-changed', this.getStatus());
+    }
+  }
+
+  public signOut(): { success: boolean; error?: string } {
+    this.generation += 1;
+    this.signedOut = true;
+    this.stopRefreshTimer();
+    this.refreshController?.abort();
+    this.refreshController = null;
+    this.activeLogin?.controller.abort();
+    this.activeLogin?.server.close(new AntigravityError('cancelled', 'Google sign-in cancelled.'));
+    this.activeLogin = null;
+    for (const controller of this.requestControllers) controller.abort();
+    this.requestControllers.clear();
+    this.cachedTokens = null;
+    this.cachedModels = null;
+    const persisted = this.clearStorage();
+    this.lastError = persisted ? undefined : 'Google credentials could not be cleared from secure storage.';
+    this.emit('models-changed', []);
+    this.emit('status-changed', this.getStatus());
+    return persisted ? { success: true } : { success: false, error: this.lastError };
+  }
+
+  public async getAccessToken(): Promise<string | null> {
+    if (this.signedOut) return null;
+    const tokens = this.cachedTokens || this.loadFromStorage();
+    if (!tokens?.refreshToken) return null;
+    if (tokens.accessToken && tokens.expiresAt - Date.now() > ANTIGRAVITY_REFRESH_LEAD_MS) return tokens.accessToken;
+    return (await this.refreshTokens())?.accessToken || null;
+  }
+
+  public async refreshTokens(): Promise<AntigravityOAuthTokens | null> {
+    if (this.refreshInFlight) return this.refreshInFlight;
+    if (this.signedOut) return null;
+    const generation = this.generation;
+    const controller = new AbortController();
+    this.refreshController = controller;
+    const run = (async () => {
+      const previous = this.signedOut ? null : (this.cachedTokens || this.loadFromStorage());
+      if (!previous?.refreshToken) return null;
+      let response: Response;
+      try {
+        response = await fetchWithDnsRetry(ANTIGRAVITY_TOKEN_URL, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded', Accept: 'application/json', 'User-Agent': GOOGLE_API_USER_AGENT },
+          body: new URLSearchParams({
+            client_id: ANTIGRAVITY_CLIENT_ID,
+            client_secret: ANTIGRAVITY_CLIENT_SECRET,
+            refresh_token: previous.refreshToken.trim(),
+            grant_type: 'refresh_token',
+          }).toString(),
+          signal: controller.signal,
+        }, 4);
+      } catch (error) {
+        throw this.normalizeError(error, 'Google token refresh failed.');
+      }
+      let bundle: any;
+      try { bundle = await responseJson(response, 'token_refresh'); } catch (error) {
+        if (error instanceof AntigravityError && error.code === 'auth_revoked' && generation === this.generation) {
+          this.markSignedOut(error.message);
+        }
+        throw error;
+      }
+      if (generation !== this.generation) throw new AntigravityError('cancelled', 'Google request cancelled.');
+      if (typeof bundle?.access_token !== 'string' || !bundle.access_token) {
+        throw new AntigravityError('token_refresh', 'Google token refresh returned no access token.');
+      }
+      const refreshToken = typeof bundle.refresh_token === 'string' && bundle.refresh_token.trim()
+        ? bundle.refresh_token.trim() : previous.refreshToken;
+      const expiresIn = typeof bundle.expires_in === 'number' && Number.isFinite(bundle.expires_in)
+        ? bundle.expires_in : 3600;
+      if (expiresIn <= 0) throw new AntigravityError('token_refresh', 'Google returned an expired access token.');
+      const next = {
+        accessToken: bundle.access_token,
+        refreshToken,
+        expiresAt: Date.now() + expiresIn * 1000,
+        projectId: previous.projectId,
+      };
+      if (!this.saveToStorage(next)) throw new AntigravityError('storage', 'Google token refresh could not be saved.');
+      if (generation !== this.generation) throw new AntigravityError('cancelled', 'Google request cancelled.');
+      this.cachedTokens = next;
+      this.signedOut = false;
+      this.backgroundRefreshFailures = 0;
+      this.lastError = undefined;
+      this.scheduleRefresh();
+      this.emit('status-changed', this.getStatus());
+      return next;
+    })();
+    let wrapped!: Promise<AntigravityOAuthTokens | null>;
+    const handled = run.catch((error) => {
+      const normalized = this.normalizeError(error, 'Google token refresh failed.');
+      if (generation === this.generation && normalized.code !== 'cancelled') {
+        this.lastError = normalized.message;
+        this.emit('status-changed', this.getStatus());
+      }
+      throw normalized;
+    });
+    wrapped = handled.finally(() => {
+      if (this.refreshInFlight === wrapped) this.refreshInFlight = null;
+      if (this.refreshController === controller) this.refreshController = null;
+    });
+    this.refreshInFlight = wrapped;
+    return wrapped;
+  }
+
+  private async authenticatedFetch(url: string, init: RequestInit, token: string, retries: number, timeoutMs = ANTIGRAVITY_FETCH_TIMEOUT_MS): Promise<Response> {
+    const generation = this.generation;
+    const send = (accessToken: string) => fetchWithDnsRetry(url, {
+      ...init, headers: { 'Content-Type': 'application/json', 'User-Agent': ANTIGRAVITY_USER_AGENT,
+        ...init.headers, Authorization: `Bearer ${accessToken}` },
+    }, retries, timeoutMs);
+    try {
+      init.signal?.throwIfAborted();
+      const response = await send(token);
+      if (response.status !== 401) return response;
+      try { await response.body?.cancel(); } catch { /* noop */ }
+      this.assertGeneration(generation);
+      init.signal?.throwIfAborted();
+      const refreshed = await this.refreshTokens();
+      this.assertGeneration(generation);
+      init.signal?.throwIfAborted();
+      if (!refreshed) throw new AntigravityError('auth_required', 'Sign in with Google Antigravity first.');
+      return await send(refreshed.accessToken);
+    } catch (error) { throw this.normalizeError(error, 'Google request failed.'); }
+  }
+
+  public async getModels(force = false): Promise<AntigravityModel[]> {
+    if (this.signedOut) throw new AntigravityError('auth_required', 'Sign in with Google Antigravity first.');
+    if (!force && this.cachedModels) return this.cachedModels.map(model => ({ ...model }));
+    const generation = this.generation;
+    const token = await this.getAccessToken();
+    this.assertGeneration(generation);
+    if (!token) throw new AntigravityError('auth_required', this.lastError || 'Sign in with Google Antigravity first.');
+    const projectId = this.cachedTokens?.projectId || this.loadFromStorage()?.projectId;
+    if (!projectId) throw new AntigravityError('setup', 'Google account setup has no project. Sign in again.');
+    const request = this.registerRequest();
+    try {
+      const response = await this.authenticatedFetch(`${ANTIGRAVITY_DAILY_ENDPOINT}/v1internal:fetchAvailableModels`, {
+        method: 'POST', body: JSON.stringify({ project: projectId }), signal: request.signal,
+      }, token, 12);
+      let catalog: any;
+      try {
+        catalog = await responseJson(response, 'models');
+      } catch (error) {
+        const normalized = this.normalizeError(error, 'Google model discovery failed.');
+        throw normalized;
+      }
+      if (generation !== this.generation || this.signedOut) throw new AntigravityError('cancelled', 'Google request cancelled.');
+      const models = parseAntigravityModels(catalog);
+      this.cachedModels = models;
+      this.emit('models-changed', models.map(model => ({ ...model })));
+      return models.map(model => ({ ...model }));
+    } finally {
+      request.dispose();
+    }
+  }
+
+  public async *stream(input: AntigravityStreamInput): AsyncGenerator<string, void, unknown> {
+    if (this.signedOut) throw new AntigravityError('auth_required', 'Sign in with Google Antigravity first.');
+    const generation = this.generation;
+    const token = await this.getAccessToken();
+    this.assertGeneration(generation);
+    if (!token) throw new AntigravityError('auth_required', this.lastError || 'Sign in with Google Antigravity first.');
+    const projectId = this.cachedTokens?.projectId || this.loadFromStorage()?.projectId || '';
+    const payload = buildAntigravityRequestPayload({ ...input, projectId });
+    const request = this.registerRequest(input.signal);
+    let streamTimedOut = false;
+    const streamDeadline = setTimeout(() => { streamTimedOut = true; request.abort(); }, 60_000);
+    (streamDeadline as any).unref?.();
+    let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+    try {
+      const response = await this.authenticatedFetch(ANTIGRAVITY_STREAM_URL, {
+        method: 'POST', headers: { Accept: 'text/event-stream', 'x-request-source': 'local' },
+        body: JSON.stringify(payload), signal: request.signal,
+      }, token, 4, ANTIGRAVITY_STREAM_TIMEOUT_MS);
+      if (!response.ok) {
+        const status = response.status;
+        const message = status === 401
+          ? 'Google access was rejected. Refresh the session or sign in again.'
+          : status === 403
+            ? 'This Google account is not permitted to use Antigravity.'
+          : status === 429
+            ? 'Google quota is exhausted or temporarily limited. Try again later.'
+            : `Google request failed (HTTP ${status}).`;
+        const error = new AntigravityError('request', message, status);
+        throw error;
+      }
+      if (!response.body) throw new AntigravityError('response', 'Google returned an empty response.');
+
+      // The Voice-app reference also accepts a single JSON Code Assist response.
+      if (response.headers.get('content-type')?.includes('application/json')) {
+        const text = parseAntigravityEvent(await response.text());
+        this.assertGeneration(generation);
+        if (!text) throw new AntigravityError('response', 'Google returned no answer.');
+        yield text;
+        return;
+      }
+
+      reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      let emitted = false;
+      streamLoop: while (true) {
+        const item = await reader.read();
+        this.assertGeneration(generation);
+        if (request.signal.aborted) throw new AntigravityError('cancelled', 'Google request cancelled.');
+        buffer += item.done ? decoder.decode() : decoder.decode(item.value, { stream: true });
+        const parsed = parseAntigravitySse(buffer, item.done);
+        buffer = parsed.remainder;
+        for (const data of parsed.events) {
+          if (data === '[DONE]') break streamLoop;
+          const text = parseAntigravityEvent(data);
+          if (text) { emitted = true; yield text; }
+        }
+        if (item.done) break;
+      }
+      if (generation !== this.generation || this.signedOut) throw new AntigravityError('cancelled', 'Google request cancelled.');
+      if (!emitted) throw new AntigravityError('response', 'Google returned no answer.');
+    } catch (error) {
+      if (error instanceof AntigravityError && error.code === 'auth_revoked') throw error;
+      if (input.signal?.aborted || (request.signal.aborted && !streamTimedOut && this.generation !== generation)) {
+        throw new AntigravityError('cancelled', 'Google request cancelled.');
+      }
+      if (streamTimedOut) throw new AntigravityError('request', 'Google request timed out.');
+      throw this.normalizeError(error, 'Google returned malformed streaming data.');
+    } finally {
+      try { await reader?.cancel(); } catch { /* noop */ }
+      try { reader?.releaseLock(); } catch { /* noop */ }
+      clearTimeout(streamDeadline);
+      request.dispose();
+    }
+  }
+
+  private assertGeneration(generation: number): void {
+    if (generation !== this.generation) throw new AntigravityError('cancelled', 'Google request cancelled.');
+  }
+
+  private normalizeError(error: unknown, fallback: string): AntigravityError {
+    if (error instanceof AntigravityError) return error;
+    if ((error as any)?.name === 'AbortError') return new AntigravityError('cancelled', 'Google request cancelled.');
+    return new AntigravityError('request', fallback);
+  }
+
+  private registerRequest(externalSignal?: AbortSignal): {
+    signal: AbortSignal;
+    abort: () => void;
+    dispose: () => void;
+  } {
+    const controller = new AbortController();
+    const forwardAbort = () => controller.abort();
+    if (externalSignal?.aborted) controller.abort();
+    else externalSignal?.addEventListener('abort', forwardAbort, { once: true });
+    this.requestControllers.add(controller);
+    return {
+      signal: controller.signal,
+      abort: () => controller.abort(),
+      dispose: () => {
+        externalSignal?.removeEventListener('abort', forwardAbort);
+        this.requestControllers.delete(controller);
+      },
+    };
+  }
+
+  private markSignedOut(message: string): void {
+    this.generation += 1;
+    this.signedOut = true;
+    this.cachedTokens = null;
+    this.cachedModels = null;
+    this.stopRefreshTimer();
+    for (const controller of this.requestControllers) controller.abort();
+    this.lastError = message;
+    this.clearStorage();
+    this.emit('models-changed', []);
+    this.emit('status-changed', this.getStatus());
+  }
+
+  private getCredentialsManager(): any | null {
+    try { return require('./CredentialsManager').CredentialsManager.getInstance(); } catch { return null; }
+  }
+
+  private loadFromStorage(): AntigravityOAuthTokens | null {
+    try {
+      const raw = this.getCredentialsManager()?.getAntigravityOAuthTokens?.();
+      if (!raw || typeof raw.accessToken !== 'string' || typeof raw.refreshToken !== 'string' ||
+        typeof raw.expiresAt !== 'number' || typeof raw.projectId !== 'string' || !raw.projectId.trim()) return null;
+      return { ...raw, projectId: raw.projectId.trim() };
+    } catch { return null; }
+  }
+
+  private saveToStorage(tokens: AntigravityOAuthTokens): boolean {
+    try { return this.getCredentialsManager()?.setAntigravityOAuthTokens?.({ ...tokens }) === true; } catch { return false; }
+  }
+
+  private clearStorage(): boolean {
+    try { return this.getCredentialsManager()?.clearAntigravityOAuthTokens?.() === true; } catch { return false; }
+  }
+
+  private scheduleRefresh(retryDelay?: number): void {
+    this.stopRefreshTimer();
+    const tokens = this.signedOut ? null : (this.cachedTokens || this.loadFromStorage());
+    if (!tokens) return;
+    const delay = retryDelay ?? Math.max(1_000, tokens.expiresAt - Date.now() - ANTIGRAVITY_REFRESH_LEAD_MS);
+    this.refreshTimer = setTimeout(() => {
+      this.refreshTimer = null;
+      this.refreshTokens().catch(() => {
+        // A temporary outage should get a few bounded retries, while a revoked
+        // account is already cleared by refreshTokens(). Never create a hot loop.
+        if (!this.signedOut && this.cachedTokens && this.backgroundRefreshFailures < 3) {
+          this.backgroundRefreshFailures += 1;
+          this.scheduleRefresh(Math.min(30_000 * (2 ** (this.backgroundRefreshFailures - 1)), 120_000));
+        }
+      });
+    }, delay);
+    (this.refreshTimer as any).unref?.();
+  }
+
+  private stopRefreshTimer(): void {
+    if (this.refreshTimer) clearTimeout(this.refreshTimer);
+    this.refreshTimer = null;
+  }
+
+  private async exchangeCode(code: string, verifier: string, signal: AbortSignal): Promise<Omit<AntigravityOAuthTokens, 'projectId'>> {
+    let response: Response;
+    try {
+      response = await fetchWithDnsRetry(ANTIGRAVITY_TOKEN_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', Accept: 'application/json', 'User-Agent': GOOGLE_API_USER_AGENT },
+        body: new URLSearchParams({
+          client_id: ANTIGRAVITY_CLIENT_ID,
+          client_secret: ANTIGRAVITY_CLIENT_SECRET,
+          code,
+          grant_type: 'authorization_code',
+          redirect_uri: ANTIGRAVITY_REDIRECT_URI,
+          code_verifier: verifier,
+        }).toString(),
+        signal,
+      }, 4);
+    } catch (error) { throw this.normalizeError(error, 'Google token exchange failed.'); }
+    const bundle = await responseJson(response, 'token_exchange');
+    if (typeof bundle?.access_token !== 'string' || !bundle.access_token) {
+      throw new AntigravityError('token_exchange', 'Google token exchange returned no access token.');
+    }
+    if (typeof bundle.refresh_token !== 'string' || !bundle.refresh_token.trim()) {
+      throw new AntigravityError('token_exchange', 'Google did not return a refresh token. Sign in again.');
+    }
+    const expiresIn = typeof bundle.expires_in === 'number' && Number.isFinite(bundle.expires_in)
+      ? bundle.expires_in : 3600;
+    if (expiresIn <= 0) throw new AntigravityError('token_exchange', 'Google returned an expired access token.');
+    return {
+      accessToken: bundle.access_token,
+      refreshToken: bundle.refresh_token.trim(),
+      expiresAt: Date.now() + expiresIn * 1000,
+    };
+  }
+}

--- a/electron/services/AntigravityService.ts
+++ b/electron/services/AntigravityService.ts
@@ -11,6 +11,7 @@ import * as http from 'http';
 import * as crypto from 'crypto';
 import { setTimeout as wait } from 'node:timers/promises';
 import { shell } from 'electron';
+import type { CredentialsManager } from './CredentialsManager';
 
 export const ANTIGRAVITY_CLIENT_ID =
   '1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com';
@@ -225,34 +226,21 @@ export function parseAntigravityModels(value: unknown): AntigravityModel[] {
 }
 
 export function parseAntigravityEvent(data: string): string {
-  let root: unknown;
-  try { root = JSON.parse(data); } catch { throw new AntigravityError('response', 'Google returned malformed streaming data.'); }
-  if (!root || typeof root !== 'object' || Array.isArray(root)) {
-    throw new AntigravityError('response', 'Google returned an invalid streaming response.');
-  }
-  const response = (root as Record<string, unknown>).response;
+  let response: any;
+  try { response = JSON.parse(data)?.response; } catch { throw new AntigravityError('response', 'Google returned malformed streaming data.'); }
   if (!response || typeof response !== 'object' || Array.isArray(response)) {
     throw new AntigravityError('response', 'Google returned an invalid streaming response.');
   }
-  const candidateList = (response as Record<string, unknown>).candidates;
-  if (!Array.isArray(candidateList) || candidateList.length === 0) return '';
-  const candidate = candidateList[0];
+  if (!Array.isArray(response.candidates) || !response.candidates.length) return '';
+  const candidate = response.candidates[0];
   if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
     throw new AntigravityError('response', 'Google returned an invalid candidate.');
   }
-  const content = (candidate as Record<string, unknown>).content;
-  const parts = content && typeof content === 'object' && !Array.isArray(content)
-    ? (content as Record<string, unknown>).parts
-    : undefined;
+  const parts = candidate.content?.parts;
   if (parts !== undefined && !Array.isArray(parts)) {
     throw new AntigravityError('response', 'Google returned invalid response parts.');
   }
-  const text = (parts || []).map((part) => {
-    if (!part || typeof part !== 'object' || Array.isArray(part)) return '';
-    const item = part as Record<string, unknown>;
-    return item.thought === true ? '' : typeof item.text === 'string' ? item.text : '';
-  }).join('');
-  return text;
+  return (parts || []).map((part: any) => part?.thought !== true && typeof part?.text === 'string' ? part.text : '').join('');
 }
 
 function parseAntigravitySse(buffer: string, final = false): { events: string[]; remainder: string } {
@@ -727,13 +715,7 @@ export class AntigravityService extends EventEmitter {
       const response = await this.authenticatedFetch(`${ANTIGRAVITY_DAILY_ENDPOINT}/v1internal:fetchAvailableModels`, {
         method: 'POST', body: JSON.stringify({ project: projectId }), signal: request.signal,
       }, token, 12);
-      let catalog: any;
-      try {
-        catalog = await responseJson(response, 'models');
-      } catch (error) {
-        const normalized = this.normalizeError(error, 'Google model discovery failed.');
-        throw normalized;
-      }
+      const catalog = await responseJson(response, 'models');
       if (generation !== this.generation || this.signedOut) throw new AntigravityError('cancelled', 'Google request cancelled.');
       const models = parseAntigravityModels(catalog);
       this.cachedModels = models;
@@ -863,25 +845,22 @@ export class AntigravityService extends EventEmitter {
     this.emit('status-changed', this.getStatus());
   }
 
-  private getCredentialsManager(): any | null {
-    try { return require('./CredentialsManager').CredentialsManager.getInstance(); } catch { return null; }
+  private getCredentialsManager(): CredentialsManager {
+    // CredentialsManager reads app.getPath at module load; LLMHelper is also
+    // imported outside Electron, so defer that side effect until storage is used.
+    return (require('./CredentialsManager') as typeof import('./CredentialsManager')).CredentialsManager.getInstance();
   }
 
   private loadFromStorage(): AntigravityOAuthTokens | null {
-    try {
-      const raw = this.getCredentialsManager()?.getAntigravityOAuthTokens?.();
-      if (!raw || typeof raw.accessToken !== 'string' || typeof raw.refreshToken !== 'string' ||
-        typeof raw.expiresAt !== 'number' || typeof raw.projectId !== 'string' || !raw.projectId.trim()) return null;
-      return { ...raw, projectId: raw.projectId.trim() };
-    } catch { return null; }
+    return this.getCredentialsManager().getAntigravityOAuthTokens();
   }
 
   private saveToStorage(tokens: AntigravityOAuthTokens): boolean {
-    try { return this.getCredentialsManager()?.setAntigravityOAuthTokens?.({ ...tokens }) === true; } catch { return false; }
+    return this.getCredentialsManager().setAntigravityOAuthTokens(tokens);
   }
 
   private clearStorage(): boolean {
-    try { return this.getCredentialsManager()?.clearAntigravityOAuthTokens?.() === true; } catch { return false; }
+    return this.getCredentialsManager().clearAntigravityOAuthTokens();
   }
 
   private scheduleRefresh(retryDelay?: number): void {

--- a/electron/services/AntigravityService.ts
+++ b/electron/services/AntigravityService.ts
@@ -338,7 +338,7 @@ interface CallbackServer {
   close(reason?: Error): void;
 }
 
-function startCallbackServer(): CallbackServer {
+function startCallbackServer(expectedState: string): CallbackServer {
   let resolveCallback!: (value: { code?: string; state?: string; error?: string }) => void;
   let rejectCallback!: (error: Error) => void;
   let settled = false;
@@ -377,6 +377,11 @@ function startCallbackServer(): CallbackServer {
     if (url.pathname !== ANTIGRAVITY_CALLBACK_PATH) {
       response.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
       response.end('Not Found');
+      return;
+    }
+    if (url.searchParams.get('state') !== expectedState) {
+      response.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' });
+      response.end('Invalid callback state');
       return;
     }
     response.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
@@ -520,7 +525,8 @@ export class AntigravityService extends EventEmitter {
     if (this.activeLogin) throw new AntigravityError('callback', 'Google sign-in is already in progress.');
     const generation = ++this.generation;
     this.signedOut = false;
-    const server = startCallbackServer();
+    const pkce = generateAntigravityPkce();
+    const server = startCallbackServer(pkce.state);
     const controller = new AbortController();
     const active = { generation, server, controller };
     this.activeLogin = active;
@@ -537,7 +543,6 @@ export class AntigravityService extends EventEmitter {
         throw error;
       }
       this.assertGeneration(generation);
-      const pkce = generateAntigravityPkce();
       await shell.openExternal(buildAntigravityAuthorizationUrl(pkce)).catch(() => {
         throw new AntigravityError('browser', 'Could not open the Google sign-in page.');
       });
@@ -579,6 +584,13 @@ export class AntigravityService extends EventEmitter {
   }
 
   public signOut(): { success: boolean; error?: string } {
+    // Commit the durable change first. A failed disconnect must not appear to
+    // succeed in memory and then silently reconnect from retained tokens on restart.
+    if (!this.clearStorage()) {
+      this.lastError = 'Disconnect failed: Google credentials could not be cleared. Try disconnecting again.';
+      this.emit('status-changed', this.getStatus());
+      return { success: false, error: this.lastError };
+    }
     this.generation += 1;
     this.signedOut = true;
     this.stopRefreshTimer();
@@ -591,11 +603,10 @@ export class AntigravityService extends EventEmitter {
     this.requestControllers.clear();
     this.cachedTokens = null;
     this.cachedModels = null;
-    const persisted = this.clearStorage();
-    this.lastError = persisted ? undefined : 'Google credentials could not be cleared from secure storage.';
+    this.lastError = undefined;
     this.emit('models-changed', []);
     this.emit('status-changed', this.getStatus());
-    return persisted ? { success: true } : { success: false, error: this.lastError };
+    return { success: true };
   }
 
   public async getAccessToken(): Promise<string | null> {
@@ -920,4 +931,21 @@ export class AntigravityService extends EventEmitter {
       expiresAt: Date.now() + expiresIn * 1000,
     };
   }
+}
+
+let cleanupAntigravityLifecycle: (() => void) | undefined;
+
+export function initializeAntigravityLifecycle(app: EventEmitter, onStatus: (status: AntigravityStatus) => void, onModels: () => void): void {
+  const service = AntigravityService.getInstance();
+  cleanupAntigravityLifecycle?.();
+  service.initialize();
+  const onQuit = () => service.dispose();
+  app.once('before-quit', onQuit);
+  service.on('status-changed', onStatus);
+  service.on('models-changed', onModels);
+  cleanupAntigravityLifecycle = () => {
+    app.off('before-quit', onQuit);
+    service.off('status-changed', onStatus);
+    service.off('models-changed', onModels);
+  };
 }

--- a/electron/services/CredentialsManager.ts
+++ b/electron/services/CredentialsManager.ts
@@ -230,6 +230,13 @@ export interface StoredCredentials {
          */
         lastRefreshAt?: number;
     };
+    /** Google Antigravity OAuth bundle, persisted through the same encrypted store. */
+    antigravityOAuthTokens?: {
+        accessToken: string;
+        refreshToken: string;
+        expiresAt: number;
+        projectId: string;
+    };
 }
 
 export class CredentialsManager {
@@ -704,6 +711,58 @@ export class CredentialsManager {
         this.credentials.codexOAuthTokens = undefined;
         this.saveCredentials();
         console.log('[CredentialsManager] Codex OAuth tokens cleared');
+    }
+
+    /**
+     * Persisted Google Antigravity OAuth tokens. The service never exposes this
+     * bundle to the renderer; it reads it only to refresh and call Code Assist.
+     */
+    public getAntigravityOAuthTokens(): {
+        accessToken: string;
+        refreshToken: string;
+        expiresAt: number;
+        projectId: string;
+    } | null {
+        const tokens = this.credentials.antigravityOAuthTokens;
+        if (!tokens || typeof tokens.accessToken !== 'string' || !tokens.accessToken.trim() ||
+            typeof tokens.refreshToken !== 'string' || !tokens.refreshToken.trim() ||
+            !Number.isFinite(tokens.expiresAt) || typeof tokens.projectId !== 'string' || !tokens.projectId.trim()) {
+            return null;
+        }
+        return { ...tokens, projectId: tokens.projectId.trim() };
+    }
+
+    /** Checked write: failed/degraded storage leaves memory unchanged. */
+    public setAntigravityOAuthTokens(tokens: {
+        accessToken: string;
+        refreshToken: string;
+        expiresAt: number;
+        projectId: string;
+    }): boolean {
+        if (this.refuseWriteWhileDegraded('set Antigravity OAuth tokens')) return false;
+        if (!tokens.accessToken || !tokens.refreshToken || !tokens.projectId?.trim()) return false;
+        const previous = this.credentials.antigravityOAuthTokens;
+        this.credentials.antigravityOAuthTokens = { ...tokens, projectId: tokens.projectId.trim() };
+        if (this.saveCredentials()) {
+            console.log('[CredentialsManager] Antigravity OAuth tokens updated');
+            return true;
+        }
+        this.credentials.antigravityOAuthTokens = previous;
+        return false;
+    }
+
+    /** Checked clear: failed/degraded storage leaves the in-memory store intact. */
+    public clearAntigravityOAuthTokens(): boolean {
+        if (this.refuseWriteWhileDegraded('clear Antigravity OAuth tokens')) return false;
+        const previous = this.credentials.antigravityOAuthTokens;
+        if (!previous) return true;
+        this.credentials.antigravityOAuthTokens = undefined;
+        if (this.saveCredentials()) {
+            console.log('[CredentialsManager] Antigravity OAuth tokens cleared');
+            return true;
+        }
+        this.credentials.antigravityOAuthTokens = previous;
+        return false;
     }
 
     public getLitellmApiKey(): string | undefined {

--- a/electron/services/__tests__/AntigravityCredentials.test.mjs
+++ b/electron/services/__tests__/AntigravityCredentials.test.mjs
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import Module, { createRequire } from 'node:module';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const compiled = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../dist-electron/electron/services/CredentialsManager.js');
+
+test('Antigravity credentials survive encrypted save/restart and checked failures preserve other providers', () => {
+  const userData = fs.mkdtempSync(path.join(os.tmpdir(), 'antigravity-credentials-'));
+  const originalLoad = Module._load;
+  const previousSingleton = globalThis.__nativelyCredentialsManagerV1__;
+  Module._load = function (request, ...args) {
+    if (request === 'electron') return {
+      app: { getPath: () => userData, isPackaged: false, getVersion: () => 'test' },
+      safeStorage: { isEncryptionAvailable: () => false },
+    };
+    return originalLoad.call(this, request, ...args);
+  };
+  const fresh = () => {
+    delete require.cache[require.resolve(compiled)];
+    delete globalThis.__nativelyCredentialsManagerV1__;
+    const cm = require(compiled).CredentialsManager.getInstance();
+    cm.init();
+    return cm;
+  };
+  try {
+    let cm = fresh();
+    cm.setGeminiApiKey('unrelated-gemini-key');
+    const tokens = { accessToken: 'access-sentinel', refreshToken: 'refresh-sentinel', expiresAt: Date.now() + 3_600_000, projectId: 'account-project' };
+    assert.equal(cm.setAntigravityOAuthTokens(tokens), true);
+    const encrypted = fs.readFileSync(path.join(userData, 'credentials.fallback.enc'));
+    assert.equal(encrypted.includes(Buffer.from(tokens.accessToken)), false);
+    assert.equal(encrypted.includes(Buffer.from(tokens.refreshToken)), false);
+    cm = fresh();
+    assert.deepEqual(cm.getAntigravityOAuthTokens(), tokens);
+    const copy = cm.getAntigravityOAuthTokens();
+    copy.refreshToken = 'mutated';
+    assert.equal(cm.getAntigravityOAuthTokens().refreshToken, tokens.refreshToken);
+
+    const realSave = cm.saveCredentials;
+    cm.saveCredentials = () => false;
+    assert.equal(cm.setAntigravityOAuthTokens({ ...tokens, accessToken: 'rotated' }), false);
+    assert.deepEqual(cm.getAntigravityOAuthTokens(), tokens);
+    assert.equal(cm.clearAntigravityOAuthTokens(), false);
+    assert.deepEqual(cm.getAntigravityOAuthTokens(), tokens);
+    cm.saveCredentials = realSave;
+    assert.equal(cm.clearAntigravityOAuthTokens(), true);
+    cm = fresh();
+    assert.equal(cm.getAntigravityOAuthTokens(), null);
+    assert.equal(cm.getGeminiApiKey(), 'unrelated-gemini-key');
+  } finally {
+    Module._load = originalLoad;
+    globalThis.__nativelyCredentialsManagerV1__ = previousSingleton;
+    assert.equal(path.dirname(path.resolve(userData)), path.resolve(os.tmpdir()));
+    assert.ok(path.basename(userData).startsWith('antigravity-credentials-'));
+    fs.rmSync(userData, { recursive: true, force: true });
+  }
+});

--- a/electron/services/__tests__/AntigravityService.test.mjs
+++ b/electron/services/__tests__/AntigravityService.test.mjs
@@ -269,6 +269,9 @@ test('Antigravity callback validates host/state and releases the fixed listener'
     assert.ok(state);
     assert.equal(await requestCallback(`/oauth-callback?code=wrong&state=${state}`, { host: 'evil.test' }), 400);
     assert.equal(await requestCallback(`http://evil.test/oauth-callback?code=wrong&state=${state}`, { host: 'localhost:51121' }), 400);
+    assert.equal(await requestCallback('/oauth-callback?code=stale&state=old-attempt'), 400);
+    assert.equal(await requestCallback('/oauth-callback?code=missing-state'), 400);
+    assert.equal(service.getStatus().inProgress, true, 'unrelated callbacks must not consume the active login');
     assert.equal(await requestCallback(`/oauth-callback?code=auth-code&state=${state}`, { host: 'localhost:51121' }), 200);
     const tokens = await login;
     assert.equal(tokens.projectId, 'project-from-google');
@@ -287,6 +290,29 @@ const validTokens = () => ({ accessToken: 'access', refreshToken: 'refresh', exp
 const catalog = { models: { 'gemini-3-flash': { displayName: 'Flash', quotaInfo: { remainingFraction: 1 } } } };
 const answer = JSON.stringify({ response: { candidates: [{ content: { parts: [{ text: 'answer' }] }, finishReason: 'STOP' }] } });
 const collect = async stream => { let text = ''; for await (const chunk of stream) text += chunk; return text; };
+
+test('failed disconnect preserves connected state until credentials are actually cleared', async () => {
+  const mod = await loadService();
+  const stored = storageWith(validTokens());
+  const { service, oldGetter } = prepareService(mod, stored);
+  const clear = stored.clearAntigravityOAuthTokens;
+  stored.clearAntigravityOAuthTokens = () => false;
+  try {
+    assert.equal(service.signOut().success, false);
+    assert.equal(service.getStatus().signedIn, true);
+    assert.match(service.getStatus().error, /Disconnect failed/);
+    assert.equal(await service.getAccessToken(), 'access');
+    service.dispose();
+    service.initialize();
+    assert.equal(service.getStatus().signedIn, true, 'restart must agree with the failed disconnect status');
+    stored.clearAntigravityOAuthTokens = clear;
+    assert.equal(service.signOut().success, true);
+    assert.equal(stored.current(), null);
+    service.dispose();
+    service.initialize();
+    assert.equal(service.getStatus().signedIn, false, 'successful disconnect must survive restart');
+  } finally { stored.clearAntigravityOAuthTokens = clear; cleanupService(service, oldGetter); }
+});
 
 test('only OAuth invalid_grant clears credentials; transient refresh and invalid expiry preserve them', async () => {
   const mod = await loadService();
@@ -424,11 +450,11 @@ test('DNS resolution failures retry, other network and HTTP failures do not', as
   }
 });
 
-test('callback rejects mismatched state, denial, missing code, cancellation and browser failure with cleanup', async () => {
+test('callback handles denial, missing code, cancellation and browser failure with cleanup', async () => {
   const mod = await loadService();
   const oldFetch = globalThis.fetch;
   const oldOpen = fakeElectron.shell.openExternal;
-  for (const scenario of ['state', 'denied', 'missing-code', 'cancel', 'browser']) {
+  for (const scenario of ['denied', 'missing-code', 'cancel', 'browser']) {
     const stored = storageWith(null);
     const { service, oldGetter } = prepareService(mod, stored);
     const opened = {};
@@ -446,7 +472,7 @@ test('callback rejects mismatched state, denial, missing code, cancellation and 
       if (scenario === 'cancel') service.cancelLogin();
       else if (scenario !== 'browser') {
         assert.equal(await requestCallback('/oauth-callback', {}, 'POST'), 405);
-        const query = scenario === 'state' ? 'code=x&state=wrong' : scenario === 'denied' ? `error=access_denied&state=${state}` : `state=${state}`;
+        const query = scenario === 'denied' ? `error=access_denied&state=${state}` : `state=${state}`;
         await requestCallback(`/oauth-callback?${query}`);
       }
       await rejected;

--- a/electron/services/__tests__/AntigravityService.test.mjs
+++ b/electron/services/__tests__/AntigravityService.test.mjs
@@ -1,0 +1,518 @@
+import { test } from 'node:test';
+import { setTimeout as delay } from 'node:timers/promises';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import Module from 'node:module';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '../../..');
+
+const fakeElectron = { shell: { openExternal: async () => undefined } };
+const originalModuleLoad = Module._load;
+Module._load = function patchedModuleLoad(request, parent, isMain) {
+  if (request === 'electron') return fakeElectron;
+  return originalModuleLoad.call(this, request, parent, isMain);
+};
+
+async function loadService() {
+  const built = path.join(root, 'dist-electron/electron/services/AntigravityService.js');
+  assert.ok(fs.existsSync(built), `compiled AntigravityService is missing: ${built}`);
+  return import(pathToFileURL(built).href);
+}
+
+function jsonResponse(value, status = 200) {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+
+function requestCallback(pathname, headers = {}, method = 'GET') {
+  return new Promise((resolve, reject) => {
+    const request = http.request({
+      hostname: '127.0.0.1',
+      port: 51121,
+      path: pathname,
+      method,
+      headers,
+    }, response => {
+      response.resume();
+      response.once('end', () => resolve(response.statusCode));
+    });
+    request.once('error', reject);
+    request.end();
+  });
+}
+
+async function assertCallbackPortFree() {
+  const probe = http.createServer();
+  try {
+    await new Promise((resolve, reject) => { probe.once('error', reject); probe.listen(51121, '127.0.0.1', resolve); });
+  } finally { await new Promise(resolve => probe.close(resolve)); }
+}
+
+function storageWith(tokens, save = true) {
+  let current = tokens ? { ...tokens } : null;
+  return {
+    getAntigravityOAuthTokens: () => current && { ...current },
+    setAntigravityOAuthTokens: next => {
+      if (!save) return false;
+      current = { ...next };
+      return true;
+    },
+    clearAntigravityOAuthTokens: () => {
+      if (!save) return false;
+      current = null;
+      return true;
+    },
+    current: () => current && { ...current },
+  };
+}
+
+function prepareService(mod, stored) {
+  const service = mod.AntigravityService.getInstance();
+  const oldGetter = service.getCredentialsManager;
+  service.dispose();
+  service.getCredentialsManager = () => stored;
+  service.initialize();
+  return { service, oldGetter };
+}
+
+function cleanupService(service, oldGetter) {
+  try { service.signOut(); } catch { /* noop */ }
+  service.dispose();
+  service.getCredentialsManager = oldGetter;
+}
+
+async function waitForBrowserUrl(opened) {
+  for (let i = 0; i < 100 && !opened.value; i += 1) await delay(10);
+  assert.ok(opened.value, 'browser URL should be opened after the listener binds');
+  return new URL(opened.value);
+}
+
+test('Antigravity pins the Voice-app OAuth contract', async () => {
+  const mod = await loadService();
+  assert.equal(mod.ANTIGRAVITY_CLIENT_ID, '1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com');
+  assert.equal(mod.ANTIGRAVITY_REDIRECT_URI, 'http://localhost:51121/oauth-callback');
+  assert.equal(mod.ANTIGRAVITY_TOKEN_URL, 'https://oauth2.googleapis.com/token');
+  assert.deepEqual(mod.ANTIGRAVITY_SCOPES, [
+    'openid',
+    ...['cloud-platform', 'userinfo.email', 'userinfo.profile', 'cclog', 'experimentsandconfigs']
+      .map(scope => `https://www.googleapis.com/auth/${scope}`),
+  ]);
+});
+
+test('Antigravity PKCE uses a 32-byte base64url verifier and S256 challenge', async () => {
+  const mod = await loadService();
+  const pkce = mod.generateAntigravityPkce();
+  assert.equal(pkce.verifier.length, 43);
+  assert.match(pkce.verifier, /^[A-Za-z0-9_-]+$/);
+  assert.equal(
+    pkce.challenge,
+    crypto.createHash('sha256').update(pkce.verifier).digest('base64url'),
+  );
+  const url = new URL(mod.buildAntigravityAuthorizationUrl(pkce));
+  assert.equal(url.searchParams.get('redirect_uri'), 'http://localhost:51121/oauth-callback');
+  assert.equal(url.searchParams.get('scope'), mod.ANTIGRAVITY_SCOPES.join(' '));
+  assert.equal(url.searchParams.get('code_challenge_method'), 'S256');
+  assert.equal(url.searchParams.get('access_type'), 'offline');
+  assert.equal(url.searchParams.get('prompt'), 'consent');
+});
+
+test('Antigravity filters and orders only quota-bearing public models', async () => {
+  const mod = await loadService();
+  const models = mod.parseAntigravityModels({ models: {
+    'gemini-3.6-flash-low': { displayName: 'Flash low', quotaInfo: { remainingFraction: 0.4 } },
+    'gemini-3-flash': { displayName: 'Flash', quotaInfo: { remainingFraction: 0.4 } },
+    'zeta-flash': { displayName: 'Zeta', quotaInfo: { remainingFraction: 0.4 } },
+    'alpha-pro': { displayName: 'Alpha', quotaInfo: { remainingFraction: 0.4 } },
+    'internal': { displayName: 'Internal', quotaInfo: { remainingFraction: 0.4 }, isInternal: true },
+    'no-quota': { displayName: 'No quota', quotaInfo: { remainingFraction: 0 } },
+    'gemini-3.5-flash': { displayName: 'Old', quotaInfo: { remainingFraction: 1 } },
+    'foo-image': { displayName: 'Image', quotaInfo: { remainingFraction: 1 } },
+    'flash-lite': { displayName: 'Flash Lite', quotaInfo: { remainingFraction: 1 } },
+  } });
+  assert.deepEqual(models.map(model => model.id), [
+    'gemini-3.6-flash-low', 'gemini-3-flash', 'zeta-flash', 'alpha-pro',
+  ]);
+  assert.equal(mod.resolveAntigravityWireModel('models/Gemini-3.7-flash-low'), 'gemini-3.7-flash-tiered');
+  assert.equal(mod.resolveAntigravityWireModel('gemini-3.6-flash-low'), 'gemini-3.6-flash-tiered');
+  assert.equal(mod.resolveAntigravityWireModel('gemini-3.1-pro-high'), 'gemini-pro-agent');
+});
+
+test('Antigravity request payload and SSE parser match the Code Assist wire shape', async () => {
+  const mod = await loadService();
+  const payload = mod.buildAntigravityRequestPayload({
+    projectId: 'account-project',
+    model: 'gemini-3.7-flash-low',
+    systemPrompt: 'Use the existing Natively answer rules.',
+    userPrompt: 'Answer this.',
+    images: [{ mimeType: 'image/png', data: 'aGVsbG8=' }],
+    maxOutputTokens: 77,
+  });
+  assert.equal(payload.model, 'gemini-3.7-flash-tiered');
+  assert.equal(payload.project, 'account-project');
+  assert.match(payload.requestId, /^agent-[0-9a-f-]{36}$/);
+  assert.equal(payload.requestType, 'agent');
+  assert.equal(payload.request.contents[0].parts[0].text, 'System instruction: Use the existing Natively answer rules.');
+  assert.deepEqual(payload.request.contents[1].parts[1].inlineData, { mimeType: 'image/png', data: 'aGVsbG8=' });
+  assert.deepEqual(payload.request.generationConfig, {
+    candidateCount: 1,
+    maxOutputTokens: 77,
+    temperature: 0.45,
+    thinkingConfig: { thinkingLevel: 'low' },
+  });
+  assert.deepEqual(mod.parseAntigravityEvent(JSON.stringify({ response: {
+    candidates: [{ content: { parts: [
+      { text: 'Hello ' }, { thought: true, text: 'hidden' }, { text: 'world' },
+    ] }, finishReason: 'STOP' }],
+  } })), 'Hello world');
+  assert.throws(() => mod.parseAntigravityEvent('{bad-json}'), /malformed streaming data/i);
+});
+
+test('Antigravity refresh rotates tokens, deduplicates, and sends form headers', async () => {
+  const mod = await loadService();
+  const service = mod.AntigravityService.getInstance();
+  const oldGetter = service.getCredentialsManager;
+  const stored = storageWith({ accessToken: 'old-access', refreshToken: 'old-refresh', expiresAt: 0, projectId: 'p' });
+  service.getCredentialsManager = () => stored;
+  service.initialize();
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  let release;
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url, init });
+    await new Promise(resolve => { release = resolve; });
+    return jsonResponse({ access_token: 'new-access', refresh_token: 'rotated-refresh', expires_in: 3600 });
+  };
+  try {
+    const a = service.refreshTokens();
+    const b = service.refreshTokens();
+    await delay(5);
+    assert.equal(calls.length, 1);
+    release();
+    const [nextA, nextB] = await Promise.all([a, b]);
+    assert.equal(nextA.accessToken, 'new-access');
+    assert.equal(nextB.refreshToken, 'rotated-refresh');
+    assert.equal(stored.current().refreshToken, 'rotated-refresh');
+    assert.equal(calls[0].url, mod.ANTIGRAVITY_TOKEN_URL);
+    assert.equal(calls[0].init.headers['User-Agent'], mod.GOOGLE_API_USER_AGENT);
+    const form = new URLSearchParams(calls[0].init.body);
+    assert.equal(form.get('grant_type'), 'refresh_token');
+    assert.equal(form.get('refresh_token'), 'old-refresh');
+    assert.equal(form.get('client_id'), mod.ANTIGRAVITY_CLIENT_ID);
+  } finally {
+    globalThis.fetch = originalFetch;
+    service.dispose();
+    service.getCredentialsManager = oldGetter;
+  }
+});
+
+test('Antigravity failed persistence and logout races never adopt new tokens', async () => {
+  const mod = await loadService();
+  const service = mod.AntigravityService.getInstance();
+  const oldGetter = service.getCredentialsManager;
+  const originalFetch = globalThis.fetch;
+  const stored = storageWith({ accessToken: 'old', refreshToken: 'old-refresh', expiresAt: 0, projectId: 'p' }, false);
+  service.getCredentialsManager = () => stored;
+  service.initialize();
+  globalThis.fetch = async () => jsonResponse({ access_token: 'new', refresh_token: 'new-refresh', expires_in: 3600 });
+  await assert.rejects(service.refreshTokens(), error => error.code === 'storage');
+  assert.equal(stored.current().accessToken, 'old');
+
+  let release;
+  const raceStorage = storageWith({ accessToken: 'old', refreshToken: 'old-refresh', expiresAt: 0, projectId: 'p' });
+  service.getCredentialsManager = () => raceStorage;
+  service.initialize();
+  globalThis.fetch = async () => {
+    await new Promise(resolve => { release = resolve; });
+    return jsonResponse({ access_token: 'late', refresh_token: 'late-refresh', expires_in: 3600 });
+  };
+  const pending = service.refreshTokens();
+  await delay(5);
+  const signout = service.signOut();
+  assert.equal(signout.success, true);
+  release();
+  await assert.rejects(pending, error => error.code === 'cancelled');
+  assert.equal(service.getStatus().signedIn, false);
+  assert.equal(raceStorage.current(), null);
+  globalThis.fetch = originalFetch;
+  service.dispose();
+  service.getCredentialsManager = oldGetter;
+});
+
+test('Antigravity callback validates host/state and releases the fixed listener', async () => {
+  const mod = await loadService();
+  const electron = fakeElectron;
+  const service = mod.AntigravityService.getInstance();
+  const oldGetter = service.getCredentialsManager;
+  const oldOpen = electron.shell.openExternal;
+  const oldFetch = globalThis.fetch;
+  const stored = storageWith(null);
+  service.getCredentialsManager = () => stored;
+  service.initialize();
+  const opened = {};
+  electron.shell.openExternal = async url => { opened.value = url; };
+  globalThis.fetch = async (url) => {
+    if (url === mod.ANTIGRAVITY_TOKEN_URL) return jsonResponse({ access_token: 'access', refresh_token: 'refresh', expires_in: 3600 });
+    if (url.endsWith('/v1internal:loadCodeAssist')) return jsonResponse({ cloudaicompanionProject: 'project-from-google' });
+    throw new Error(`unexpected URL ${url}`);
+  };
+  try {
+    const login = service.startLogin();
+    const state = (await waitForBrowserUrl(opened)).searchParams.get('state');
+    assert.ok(state);
+    assert.equal(await requestCallback(`/oauth-callback?code=wrong&state=${state}`, { host: 'evil.test' }), 400);
+    assert.equal(await requestCallback(`http://evil.test/oauth-callback?code=wrong&state=${state}`, { host: 'localhost:51121' }), 400);
+    assert.equal(await requestCallback(`/oauth-callback?code=auth-code&state=${state}`, { host: 'localhost:51121' }), 200);
+    const tokens = await login;
+    assert.equal(tokens.projectId, 'project-from-google');
+    assert.equal(service.getStatus().signedIn, true);
+    assert.equal(stored.current().projectId, 'project-from-google');
+  } finally {
+    service.signOut();
+    service.dispose();
+    service.getCredentialsManager = oldGetter;
+    electron.shell.openExternal = oldOpen;
+    globalThis.fetch = oldFetch;
+  }
+});
+
+const validTokens = () => ({ accessToken: 'access', refreshToken: 'refresh', expiresAt: Date.now() + 3_600_000, projectId: 'p' });
+const catalog = { models: { 'gemini-3-flash': { displayName: 'Flash', quotaInfo: { remainingFraction: 1 } } } };
+const answer = JSON.stringify({ response: { candidates: [{ content: { parts: [{ text: 'answer' }] }, finishReason: 'STOP' }] } });
+const collect = async stream => { let text = ''; for await (const chunk of stream) text += chunk; return text; };
+
+test('only OAuth invalid_grant clears credentials; transient refresh and invalid expiry preserve them', async () => {
+  const mod = await loadService();
+  const oldFetch = globalThis.fetch;
+  for (const [status, body, revoked] of [
+    [503, { error: 'temporarily_unavailable', error_description: 'upstream session expired' }, false],
+    [400, { error: 'invalid_client' }, false],
+    [200, { access_token: 'new', expires_in: 0 }, false],
+    [400, { error: 'invalid_grant' }, true],
+  ]) {
+    const stored = storageWith(validTokens());
+    const { service, oldGetter } = prepareService(mod, stored);
+    globalThis.fetch = async () => jsonResponse(body, status);
+    try {
+      await assert.rejects(service.refreshTokens(), error => error.code === (revoked ? 'auth_revoked' : 'token_refresh'));
+      assert.equal(service.getStatus().signedIn, !revoked);
+      assert.equal(stored.current()?.accessToken ?? null, revoked ? null : 'access');
+    } finally { cleanupService(service, oldGetter); globalThis.fetch = oldFetch; }
+  }
+});
+
+test('models and inference replay a 401 once with refreshed access; 403 retains the session', async () => {
+  const mod = await loadService();
+  const oldFetch = globalThis.fetch;
+  for (const operation of ['models', 'stream']) {
+    for (const status of [401, 403]) {
+      const stored = storageWith(validTokens());
+      const { service, oldGetter } = prepareService(mod, stored);
+      let resourceCalls = 0;
+      let refreshCalls = 0;
+      globalThis.fetch = async (url, init) => {
+        if (url === mod.ANTIGRAVITY_TOKEN_URL) {
+          refreshCalls++;
+          return jsonResponse({ access_token: 'refreshed', expires_in: 3600 });
+        }
+        resourceCalls++;
+        assert.equal(init.headers.Authorization, `Bearer ${resourceCalls === 1 ? 'access' : 'refreshed'}`);
+        if (resourceCalls === 1) return jsonResponse({ error: 'rejected' }, status);
+        return operation === 'models' ? jsonResponse(catalog) : jsonResponse(JSON.parse(answer));
+      };
+      try {
+        const pending = operation === 'models' ? service.getModels(true) : collect(service.stream({ model: 'gemini-3-flash', userPrompt: 'Question' }));
+        if (status === 403) await assert.rejects(pending, error => error.status === 403);
+        else assert.deepEqual(await pending, operation === 'models' ? [{ id: 'gemini-3-flash', label: 'Flash' }] : 'answer');
+        assert.equal(resourceCalls, status === 401 ? 2 : 1);
+        assert.equal(refreshCalls, status === 401 ? 1 : 0);
+        assert.equal(stored.current().refreshToken, 'refresh', 'missing refresh token must retain the existing one');
+        assert.equal(service.getStatus().signedIn, true);
+      } finally { cleanupService(service, oldGetter); globalThis.fetch = oldFetch; }
+    }
+  }
+});
+
+test('disconnect blocks requests queued before token acquisition and discards late model discovery', async () => {
+  const mod = await loadService();
+  const oldFetch = globalThis.fetch;
+  for (const operation of ['models', 'stream', 'late-models']) {
+    const stored = storageWith(validTokens());
+    const { service, oldGetter } = prepareService(mod, stored);
+    let calls = 0;
+    let release;
+    globalThis.fetch = async () => {
+      calls++;
+      await new Promise(resolve => { release = resolve; });
+      return jsonResponse(catalog);
+    };
+    try {
+      const pending = operation === 'stream' ? collect(service.stream({ model: 'gemini-3-flash', userPrompt: 'Q' })) : service.getModels(true);
+      if (operation === 'late-models') await delay(5);
+      service.signOut();
+      release?.();
+      await assert.rejects(pending, error => error.code === 'cancelled');
+      assert.equal(calls, operation === 'late-models' ? 1 : 0);
+      assert.equal(service.cachedModels, null);
+      assert.equal(stored.current(), null);
+    } finally { cleanupService(service, oldGetter); globalThis.fetch = oldFetch; }
+  }
+});
+
+test('revocation during a 401 retry reports authentication failure instead of user cancellation', async () => {
+  const mod = await loadService();
+  const oldFetch = globalThis.fetch;
+  for (const operation of ['models', 'stream']) {
+    const { service, oldGetter } = prepareService(mod, storageWith(validTokens()));
+    globalThis.fetch = async url => url === mod.ANTIGRAVITY_TOKEN_URL
+      ? jsonResponse({ error: 'invalid_grant' }, 400) : jsonResponse({}, 401);
+    try {
+      const pending = operation === 'models' ? service.getModels(true) : collect(service.stream({ model: 'gemini-3-flash', userPrompt: 'Q' }));
+      await assert.rejects(pending, error => error.code === 'auth_revoked');
+      assert.equal(service.getStatus().signedIn, false);
+    } finally { cleanupService(service, oldGetter); globalThis.fetch = oldFetch; }
+  }
+});
+
+test('disconnect aborts a stream after headers and never returns buffered stale text', async () => {
+  const mod = await loadService();
+  const { service, oldGetter } = prepareService(mod, storageWith(validTokens()));
+  const oldFetch = globalThis.fetch;
+  let requestSignal;
+  globalThis.fetch = async (_url, init) => {
+    requestSignal = init.signal;
+    return new Response(new ReadableStream({ start(controller) {
+      controller.enqueue(new TextEncoder().encode(`data: ${answer}\n\n`));
+      init.signal.addEventListener('abort', () => controller.error(new DOMException('Aborted', 'AbortError')), { once: true });
+    } }));
+  };
+  try {
+    const stream = service.stream({ model: 'gemini-3-flash', userPrompt: 'Q' });
+    assert.equal((await stream.next()).value, 'answer');
+    const pending = stream.next();
+    service.signOut();
+    await assert.rejects(pending, error => error.code === 'cancelled');
+    assert.equal(requestSignal.aborted, true);
+  } finally { cleanupService(service, oldGetter); globalThis.fetch = oldFetch; }
+});
+
+test('DNS resolution failures retry, other network and HTTP failures do not', async () => {
+  const mod = await loadService();
+  const oldFetch = globalThis.fetch;
+  for (const failure of ['ENOTFOUND', 'ENETUNREACH', 'http']) {
+    const { service, oldGetter } = prepareService(mod, storageWith(validTokens()));
+    let calls = 0;
+    globalThis.fetch = async () => {
+      calls++;
+      if (calls > 1) return jsonResponse(catalog);
+      if (failure === 'http') return jsonResponse({}, 503);
+      throw new TypeError('fetch failed', { cause: { code: failure } });
+    };
+    try {
+      if (failure === 'ENOTFOUND') assert.equal((await service.getModels(true)).length, 1);
+      else await assert.rejects(service.getModels(true));
+      assert.equal(calls, failure === 'ENOTFOUND' ? 2 : 1);
+      assert.deepEqual([12, 4, 3, 2, 1].map(mod.dnsRetryDelayMillis), [250, 250, 500, 1000, 2000]);
+    } finally { cleanupService(service, oldGetter); globalThis.fetch = oldFetch; }
+  }
+});
+
+test('callback rejects mismatched state, denial, missing code, cancellation and browser failure with cleanup', async () => {
+  const mod = await loadService();
+  const oldFetch = globalThis.fetch;
+  const oldOpen = fakeElectron.shell.openExternal;
+  for (const scenario of ['state', 'denied', 'missing-code', 'cancel', 'browser']) {
+    const stored = storageWith(null);
+    const { service, oldGetter } = prepareService(mod, stored);
+    const opened = {};
+    let networkCalls = 0;
+    fakeElectron.shell.openExternal = async url => {
+      opened.value = url;
+      if (scenario === 'browser') throw new Error('browser unavailable');
+    };
+    globalThis.fetch = async () => { networkCalls++; throw new Error('unexpected exchange'); };
+    try {
+      const login = service.startLogin();
+      const rejected = assert.rejects(login, error => error.code === (scenario === 'cancel' ? 'cancelled' : scenario === 'browser' ? 'browser' : 'callback'));
+      const url = await waitForBrowserUrl(opened);
+      const state = url.searchParams.get('state');
+      if (scenario === 'cancel') service.cancelLogin();
+      else if (scenario !== 'browser') {
+        assert.equal(await requestCallback('/oauth-callback', {}, 'POST'), 405);
+        const query = scenario === 'state' ? 'code=x&state=wrong' : scenario === 'denied' ? `error=access_denied&state=${state}` : `state=${state}`;
+        await requestCallback(`/oauth-callback?${query}`);
+      }
+      await rejected;
+      assert.equal(networkCalls, 0);
+      assert.equal(stored.current(), null);
+      assert.equal(service.getStatus().inProgress, false);
+      await assertCallbackPortFree();
+    } finally { cleanupService(service, oldGetter); globalThis.fetch = oldFetch; fakeElectron.shell.openExternal = oldOpen; }
+  }
+});
+
+test('busy callback port fails before opening the browser', async () => {
+  const mod = await loadService();
+  const { service, oldGetter } = prepareService(mod, storageWith(null));
+  const blocker = http.createServer();
+  const oldOpen = fakeElectron.shell.openExternal;
+  let opened = false;
+  fakeElectron.shell.openExternal = async () => { opened = true; };
+  try {
+    await new Promise((resolve, reject) => { blocker.once('error', reject); blocker.listen(51121, '127.0.0.1', resolve); });
+    await assert.rejects(service.startLogin(), /port is busy/);
+    assert.equal(opened, false);
+  } finally {
+    await new Promise(resolve => blocker.close(resolve));
+    cleanupService(service, oldGetter);
+    fakeElectron.shell.openExternal = oldOpen;
+  }
+});
+
+test('OAuth exchange and onboarding use reference headers, PKCE verifier, selected tier and account project', async () => {
+  const mod = await loadService();
+  const stored = storageWith(null);
+  const { service, oldGetter } = prepareService(mod, stored);
+  const oldFetch = globalThis.fetch;
+  const oldOpen = fakeElectron.shell.openExternal;
+  const opened = {};
+  let polls = 0;
+  fakeElectron.shell.openExternal = async url => { opened.value = url; };
+  globalThis.fetch = async (url, init) => {
+    if (url === mod.ANTIGRAVITY_TOKEN_URL) {
+      const form = new URLSearchParams(init.body);
+      assert.equal(form.get('redirect_uri'), mod.ANTIGRAVITY_REDIRECT_URI);
+      assert.equal(form.get('code'), 'code');
+      assert.equal(form.get('client_secret'), mod.ANTIGRAVITY_CLIENT_SECRET);
+      assert.equal(crypto.createHash('sha256').update(form.get('code_verifier')).digest('base64url'), new URL(opened.value).searchParams.get('code_challenge'));
+      return jsonResponse({ access_token: 'access', refresh_token: 'refresh', expires_in: 3600 });
+    }
+    assert.equal(init.headers.Authorization, 'Bearer access');
+    assert.equal(init.headers['User-Agent'], mod.GOOGLE_API_USER_AGENT);
+    const body = JSON.parse(init.body);
+    assert.equal(body.metadata.ideType, 'ANTIGRAVITY');
+    if (url.endsWith(':loadCodeAssist')) return jsonResponse({ allowedTiers: [{ id: 'chosen-tier', isDefault: true }] });
+    assert.ok(url.endsWith(':onboardUser'));
+    assert.equal(body.tierId, 'chosen-tier');
+    polls++;
+    return jsonResponse(polls === 1 ? { done: false } : { done: true, response: { cloudaicompanionProject: { id: 'own-project' } } });
+  };
+  try {
+    const login = service.startLogin();
+    const url = await waitForBrowserUrl(opened);
+    await requestCallback(`/oauth-callback?code=code&state=${url.searchParams.get('state')}`);
+    assert.equal((await login).projectId, 'own-project');
+    assert.equal(polls, 2);
+    assert.equal(stored.current().projectId, 'own-project');
+    await assertCallbackPortFree();
+  } finally { cleanupService(service, oldGetter); globalThis.fetch = oldFetch; fakeElectron.shell.openExternal = oldOpen; }
+});
+
+test.after(() => { Module._load = originalModuleLoad; });

--- a/electron/services/__tests__/AntigravityWiring.test.mjs
+++ b/electron/services/__tests__/AntigravityWiring.test.mjs
@@ -1,0 +1,119 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const { LLMHelper } = require(path.join(root, 'dist-electron/electron/LLMHelper.js'));
+const { prepareDirectAssistPrompt } = require(path.join(root, 'dist-electron/electron/direct-assist/requestBuilder.js'));
+const { normalizeDirectAssistError } = require(path.join(root, 'dist-electron/electron/direct-assist/errors.js'));
+const collect = async (stream) => { let text = ''; for await (const chunk of stream) text += chunk; return text; };
+
+function helper(policy = {}) {
+  const h = Object.create(LLMHelper.prototype);
+  h.currentModelId = 'antigravity:gemini-3.6-flash-low';
+  h.isLocalOnlyMode = false;
+  h.useOllama = false;
+  h.isProviderDisabled = () => false;
+  h.getProviderScopePolicy = () => policy;
+  h.assertOutboundImagesAllowed = () => {};
+  h.processImage = async () => ({ mimeType: 'image/png', data: 'prepared-image' });
+  return h;
+}
+
+test('Antigravity model selection stays distinct from API-key Gemini and accepts Direct Assist', () => {
+  const h = helper();
+  assert.deepEqual(h.getDirectAssistSelection(), { provider: 'antigravity', model: h.currentModelId });
+  assert.equal(h.getCurrentProvider(), 'antigravity');
+  const prompt = prepareDirectAssistPrompt({
+    requestId: 'antigravity-check', source: 'typed', selection: h.getDirectAssistSelection(),
+    currentRequest: 'Explain queues', imagePaths: [],
+  });
+  assert.match(prompt.userPrompt, /Explain queues/);
+  assert.equal(h.directSelectionSupportsImages(h.getDirectAssistSelection(), null, null), true);
+});
+
+test('streaming preserves model, prompt, prepared images, budget and cancellation', async () => {
+  const previous = globalThis.__nativelyAntigravityServiceV1__;
+  const calls = [];
+  globalThis.__nativelyAntigravityServiceV1__ = {
+    async *stream(input) { calls.push(input); yield 'answer'; yield ' text'; },
+  };
+  try {
+    const h = helper();
+    const signal = new AbortController().signal;
+    assert.equal(await collect(h.streamWithAntigravity('question', 'system', ['screen.png'], signal)), 'answer text');
+    assert.equal(calls[0].model, 'gemini-3.6-flash-low');
+    assert.equal(calls[0].userPrompt, 'question');
+    assert.equal(calls[0].systemPrompt, 'system');
+    assert.deepEqual(calls[0].images, [{ mimeType: 'image/png', data: 'prepared-image' }]);
+    assert.equal(calls[0].signal, signal);
+    assert.ok(calls[0].maxOutputTokens > 192, 'Natively must retain its own answer budget');
+  } finally { globalThis.__nativelyAntigravityServiceV1__ = previous; }
+});
+
+test('disabled provider, local-only and denied scopes prevent outbound calls', async () => {
+  const previous = globalThis.__nativelyAntigravityServiceV1__;
+  let calls = 0;
+  globalThis.__nativelyAntigravityServiceV1__ = { async *stream() { calls++; yield 'unexpected'; } };
+  try {
+    const disabled = helper();
+    disabled.isProviderDisabled = (provider) => provider === 'antigravity';
+    await assert.rejects(collect(disabled.streamWithAntigravity('question')), /disabled/i);
+    const local = helper();
+    local.isLocalOnlyMode = true;
+    await assert.rejects(collect(local.streamWithAntigravity('question')), /local-only/i);
+    await assert.rejects(collect(helper({ screenshots: false }).streamWithAntigravity('question', '', ['screen.png'])), /scope/i);
+    await assert.rejects(collect(helper({ transcript: false }).streamWithAntigravity('question')), /scope/i);
+    assert.equal(calls, 0);
+  } finally { globalThis.__nativelyAntigravityServiceV1__ = previous; }
+});
+
+test('Direct Assist dispatch uses the selected Antigravity model exactly once', async () => {
+  const h = helper();
+  const calls = [];
+  h.streamWithAntigravity = async function* (...args) { calls.push(args); yield 'direct answer'; };
+  const selection = h.getDirectAssistSelection();
+  const result = await collect(h.streamDirectAssist({
+    requestId: 'direct-check', selection, systemPrompt: 'system', userPrompt: 'question', imagePaths: [],
+  }));
+  assert.equal(result, 'direct answer');
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0][4], selection.model);
+});
+
+test('switching to local or custom models clears Antigravity selection and capabilities', () => {
+  const h = helper();
+  h.useOllama = true;
+  h.ollamaModel = 'local-model';
+  assert.equal(h.getCurrentProvider(), 'ollama');
+  assert.equal(h.getDirectAssistSelection().provider, 'ollama');
+  assert.equal(h.getCurrentModelDisplayName(), 'local-model');
+  h.useOllama = false;
+  h.customProvider = { id: 'custom-model', name: 'Custom model', model: 'custom-model' };
+  assert.equal(h.getCurrentProvider(), 'custom');
+  assert.equal(h.getDirectAssistSelection().provider, 'custom');
+  assert.equal(h.getCurrentModelDisplayName(), 'Custom model');
+});
+
+test('Direct Assist can answer a typed question when meeting transcript sharing is disabled', async () => {
+  const previous = globalThis.__nativelyAntigravityServiceV1__;
+  globalThis.__nativelyAntigravityServiceV1__ = { async *stream() { yield 'answer'; } };
+  try {
+    const h = helper({ transcript: false });
+    assert.equal(await collect(h.streamDirectAssist({ requestId: 'private-check', selection: h.getDirectAssistSelection(),
+      userPrompt: 'CURRENT REQUEST:\nExplain queues', systemPrompt: 'Answer the question', imagePaths: [] })), 'answer');
+  } finally { globalThis.__nativelyAntigravityServiceV1__ = previous; }
+});
+
+test('Direct Assist auth errors give a safe recovery action without upstream text', () => {
+  for (const code of ['auth_required', 'auth_revoked']) {
+    const error = normalizeDirectAssistError({ name: 'AntigravityError', code, message: 'secret token' });
+    assert.equal(error.code, 'AUTH_FAILED');
+    assert.match(error.message, /Sign in.*Antigravity/);
+    assert.doesNotMatch(error.message, /secret/);
+  }
+  assert.equal(normalizeDirectAssistError({ name: 'AntigravityError', code: 'cancelled' }).code, 'CANCELLED');
+});

--- a/electron/services/__tests__/AntigravityWiring.test.mjs
+++ b/electron/services/__tests__/AntigravityWiring.test.mjs
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { createRequire } from 'node:module';
+import { EventEmitter } from 'node:events';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -10,6 +11,34 @@ const { LLMHelper } = require(path.join(root, 'dist-electron/electron/LLMHelper.
 const { prepareDirectAssistPrompt } = require(path.join(root, 'dist-electron/electron/direct-assist/requestBuilder.js'));
 const { normalizeDirectAssistError } = require(path.join(root, 'dist-electron/electron/direct-assist/errors.js'));
 const collect = async (stream) => { let text = ''; for await (const chunk of stream) text += chunk; return text; };
+
+test('reinitializing Antigravity IPC replaces owned lifecycle listeners and preserves other listeners', () => {
+  const { initializeAntigravityLifecycle } = require(path.join(root, 'dist-electron/electron/services/AntigravityService.js'));
+  const previous = globalThis.__nativelyAntigravityServiceV1__;
+  const app = new EventEmitter();
+  const service = new EventEmitter();
+  let disposed = 0, oldBroadcasts = 0, broadcasts = 0, models = 0, unrelatedQuit = 0;
+  service.initialize = () => service.emit('status-changed', {});
+  service.dispose = () => disposed++;
+  const unrelatedStatus = () => {};
+  service.on('status-changed', unrelatedStatus);
+  app.on('before-quit', () => unrelatedQuit++);
+  globalThis.__nativelyAntigravityServiceV1__ = service;
+  try {
+    initializeAntigravityLifecycle(app, () => oldBroadcasts++, () => oldBroadcasts++);
+    initializeAntigravityLifecycle(app, () => broadcasts++, () => models++);
+    service.emit('status-changed', {});
+    service.emit('models-changed', []);
+    assert.equal(oldBroadcasts, 0);
+    assert.equal(broadcasts, 1);
+    assert.equal(models, 1);
+    assert.equal(service.listenerCount('status-changed'), 2);
+    assert.ok(service.listeners('status-changed').includes(unrelatedStatus));
+    app.emit('before-quit');
+    assert.equal(disposed, 1);
+    assert.equal(unrelatedQuit, 1);
+  } finally { globalThis.__nativelyAntigravityServiceV1__ = previous; }
+});
 
 function helper(policy = {}) {
   const h = Object.create(LLMHelper.prototype);

--- a/electron/services/__tests__/ProviderVisibilityFilters.test.mjs
+++ b/electron/services/__tests__/ProviderVisibilityFilters.test.mjs
@@ -89,8 +89,9 @@ test('providerFamily() resolves custom-provider ids last, by identity', () => {
 
 test('reconciliation installs nothing when every candidate is filtered out', () => {
     const src = read(IPC);
-    const start = src.indexOf("      const next = modelAvailable('natively') ? 'natively'");
+    const start = src.indexOf('      const next =', src.indexOf('const refreshRuntimeDefaultIfUnavailable ='));
     assert.ok(start >= 0, 'the replacement chain should route through modelAvailable()');
+    assert.match(src.slice(src.indexOf('const antigravityFallback ='), start), /\.find\(modelAvailable\)/);
     const body = src.slice(start, src.indexOf('llmHelper.setModel(next, allProviders);', start));
 
     // Every candidate goes through modelAvailable(), so none of them can be a

--- a/src/components/ModelSelectorWindow.tsx
+++ b/src/components/ModelSelectorWindow.tsx
@@ -172,6 +172,13 @@ const ModelSelectorWindow = () => {
                     }
                 }
 
+                try {
+                    const result = await window.electronAPI.antigravityModels();
+                    for (const model of result.models) {
+                        models.push({ id: `antigravity:${model.id}`, name: `${model.label} (Antigravity)`, type: 'cloud', provider: 'antigravity' });
+                    }
+                } catch { /* Offline or signed out; other providers remain available. */ }
+
                 // Custom Providers
                 customProviders.forEach((p: any) => {
                     models.push({ id: p.id, name: p.name, type: 'custom' });

--- a/src/components/settings/AIProvidersSettings.tsx
+++ b/src/components/settings/AIProvidersSettings.tsx
@@ -2191,6 +2191,47 @@ export const AIProvidersSettings: React.FC<AIProvidersSettingsProps> = ({
     // without leaving Settings.
     const [codexOauthStatus, setCodexOauthStatus] = useState<{ signedIn: boolean; email?: string; expiresAt?: number }>({ signedIn: false });
     const [codexOauthInProgress, setCodexOauthInProgress] = useState(false);
+    const [antigravityStatus, setAntigravityStatus] = useState({ signedIn: false, inProgress: false, expiresAt: undefined as number | undefined });
+    const [antigravityModels, setAntigravityModels] = useState<{ id: string; label: string }[]>([]);
+    const [antigravityError, setAntigravityError] = useState('');
+    const [antigravityBusy, setAntigravityBusy] = useState(false);
+    const antigravityLoad = useRef(0);
+
+    useEffect(() => window.electronAPI.onAntigravityStatusChanged?.((status) => {
+        ++antigravityLoad.current;
+        setAntigravityStatus({ signedIn: status.signedIn, inProgress: status.inProgress, expiresAt: status.expiresAt });
+        if (!status.signedIn) setAntigravityModels([]);
+        setAntigravityError(status.error || '');
+    }), []);
+
+    const loadAntigravity = async (force = false) => {
+        const run = ++antigravityLoad.current;
+        if (!window.electronAPI.antigravityStatus) return;
+        try {
+            const status = await window.electronAPI.antigravityStatus();
+            const result = status.signedIn ? await window.electronAPI.antigravityModels(force) : null;
+            if (run !== antigravityLoad.current) return;
+            setAntigravityStatus({ signedIn: status.signedIn, inProgress: status.inProgress, expiresAt: status.expiresAt });
+            if (!status.signedIn || result?.success) setAntigravityModels(result?.models || []);
+            setAntigravityError(result?.error || status.error || '');
+        } catch {
+            if (run === antigravityLoad.current) setAntigravityError(t('Could not load Antigravity status. Try again.'));
+        }
+    };
+
+    const runAntigravityAction = async (action: 'login' | 'logout' | 'models') => {
+        setAntigravityBusy(true);
+        setAntigravityError('');
+        try {
+            if (action === 'models') { await loadAntigravity(true); return; }
+            const result = await (action === 'login' ? window.electronAPI.antigravityStartLogin()
+                : window.electronAPI.antigravitySignOut());
+            await loadAntigravity();
+            if (!result.success) setAntigravityError(result.error || t('Antigravity request failed. Try again.'));
+        } catch {
+            setAntigravityError(t('Could not reach Antigravity. Try again.'));
+        } finally { setAntigravityBusy(false); }
+    };
 
     // --- Default Model ---
     // UNION, not a pick. 3.8-flash is this branch's bump and main has no
@@ -2376,6 +2417,7 @@ export const AIProvidersSettings: React.FC<AIProvidersSettingsProps> = ({
                 }
 
                 const fastMode = await window.electronAPI?.getGroqFastTextMode();
+                await loadAntigravity();
                 if (fastMode) setFastResponseMode(fastMode.enabled);
 
                 // @ts-ignore
@@ -2513,6 +2555,12 @@ export const AIProvidersSettings: React.FC<AIProvidersSettingsProps> = ({
                 }
             });
         }
+        if (antigravityStatus.signedIn && isProviderEnabled('antigravity')) {
+            antigravityModels.forEach(({ id, label }) => {
+                const selectorId = `antigravity:${id}`;
+                if (isModelEnabled('antigravity', selectorId)) opts.push({ id: selectorId, name: `${label} (Antigravity)` });
+            });
+        }
         if (hasStoredKey.litellm && isProviderEnabled('litellm')) {
             // Same allow-list gate the cloud providers get above. Without it the proxy's
             // full catalogue reaches the picker while modelAvailable() filters it, and
@@ -2538,12 +2586,14 @@ export const AIProvidersSettings: React.FC<AIProvidersSettingsProps> = ({
     // changes instead of waiting for a failing request to discover stale state.
     useEffect(() => {
         if (!credentialsLoaded) return;
+        if (defaultModel.startsWith('antigravity:') && antigravityStatus.signedIn && antigravityError) return;
         const opts = buildAvailableModelOptions();
         if (!defaultModel || opts.some(o => o.id === defaultModel) || opts.length === 0) return;
-        const next = opts[0].id;
+        const next = (defaultModel.startsWith('antigravity:')
+            ? opts.find(option => option.id.startsWith('antigravity:'))?.id : undefined) || opts[0].id;
         setDefaultModel(next);
         window.electronAPI?.setDefaultModel?.(next).catch(console.error);
-    }, [credentialsLoaded, defaultModel, hasStoredKey, preferredModels, isCodexReady, codexCliConfig.model, customProviders, ollamaModels, litellmModels, disabledProviders, cloudEnabledModels]);
+    }, [credentialsLoaded, defaultModel, hasStoredKey, preferredModels, isCodexReady, codexCliConfig.model, customProviders, ollamaModels, litellmModels, disabledProviders, cloudEnabledModels, antigravityStatus.signedIn, antigravityModels, antigravityError]);
 
     // Load LiteLLM model IDs only when the proxy is configured. The active-model
     // selector should not expose stale `litellm/...` choices after the proxy is
@@ -3655,6 +3705,41 @@ export const AIProvidersSettings: React.FC<AIProvidersSettingsProps> = ({
                     })}
 
                 </div>
+            </div>
+
+            {/* Google Antigravity */}
+            <div className="aip-card p-5 space-y-4">
+                <div className="flex items-start justify-between gap-3">
+                    <div className="flex gap-3">
+                        <AipProviderMark provider="antigravity" name="Google Antigravity" className="mt-0.5" />
+                        <div>
+                            <h3 className="text-sm font-bold aip-hero mb-1">Google Antigravity</h3>
+                            <p className="text-xs aip-muted">{t('Sign in with Google to use your Antigravity models.')}</p>
+                        </div>
+                    </div>
+                    <button type="button" className="aip-btn" onClick={() => handleToggleProvider('antigravity', disabledProviders.includes('antigravity'))}>
+                        {disabledProviders.includes('antigravity') ? t('Enable provider') : t('Disable provider')}
+                    </button>
+                </div>
+                <p className="text-xs aip-muted" role="status">
+                    {antigravityStatus.inProgress ? t('Waiting for Google sign-in…')
+                        : antigravityStatus.signedIn ? t('Antigravity connected') : t('Not connected')}
+                    {antigravityStatus.signedIn && antigravityStatus.expiresAt && ` · ${t('Refreshes automatically before')} ${new Date(antigravityStatus.expiresAt).toLocaleTimeString()}`}
+                </p>
+                <div className="flex flex-wrap gap-2">
+                    {antigravityStatus.inProgress ? (
+                        <button type="button" className="aip-btn" onClick={() => window.electronAPI.antigravityCancelLogin().catch(() => setAntigravityError(t('Could not cancel sign-in. Try again.')))}>{t('Cancel sign-in')}</button>
+                    ) : !antigravityStatus.signedIn ? (
+                        <button type="button" className="aip-btn" disabled={antigravityBusy} onClick={() => void runAntigravityAction('login')}>{t('Sign in with Google')}</button>
+                    ) : <>
+                        <button type="button" className="aip-btn" disabled={antigravityBusy} onClick={() => void runAntigravityAction('models')}>{t('Reload models')}</button>
+                        <button type="button" className="aip-btn" onClick={() => void runAntigravityAction('logout')}>{t('Disconnect')}</button>
+                    </>}
+                </div>
+                {antigravityStatus.signedIn && <p className="text-xs aip-muted">{antigravityModels.length
+                    ? `${antigravityModels.length} ${t('models available in the model picker.')}`
+                    : t('No Antigravity models currently have quota. Reload models later.')}</p>}
+                {antigravityError && <p className="text-xs aip-warn-fg" role="alert">{antigravityError}</p>}
             </div>
 
             {/* Codex — ChatGPT subscription proxy */}

--- a/src/components/ui/ModelSelector.tsx
+++ b/src/components/ui/ModelSelector.tsx
@@ -86,6 +86,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({ currentModel, onSe
     };
 
     const getModelDisplayName = (model: string) => {
+        if (model.startsWith('antigravity:')) return `${model.slice('antigravity:'.length)} (Antigravity)`;
         const codexCliName = getCodexCliModelDisplayName(model);
         if (codexCliName) return codexCliName;
         if (model.startsWith('ollama-')) return model.replace('ollama-', '');

--- a/src/components/ui/aiProviderMarks.ts
+++ b/src/components/ui/aiProviderMarks.ts
@@ -46,6 +46,7 @@ import nativelyIcon from '../../../assets/icon-512.png';
  */
 export const AI_PROVIDER_BRANDS: Record<string, { mono: string; brand: string }> = {
     gemini:   { mono: 'GE', brand: '#7C9CF5' },
+    antigravity: { mono: 'AG', brand: '#7C9CF5' },
     groq:     { mono: 'GQ', brand: '#F2755C' },
     openai:   { mono: 'OA', brand: '#10A37F' },
     claude:   { mono: 'CL', brand: '#D97757' },
@@ -86,6 +87,7 @@ export const AI_PROVIDER_MARK_IMAGES: Record<string, string> = {
  */
 export const AI_PROVIDER_MARKS: Record<string, string> = {
     gemini: geminiMark,
+    antigravity: geminiMark,
     claude: claudeMark,
     anthropic: claudeMark,
     deepseek: deepseekMark,

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -183,7 +183,7 @@ export interface ElectronAPI {
   onOpenSettingsTab: (callback: (tab: string) => void) => () => void
 
   // LLM Model Management
-  getCurrentLlmConfig: () => Promise<{ provider: "ollama" | "gemini" | "custom" | "codex-cli"; /** @deprecated use `modelId` for selection, `displayName` for UI */ model: string; modelId: string; displayName: string; isOllama: boolean }>
+  getCurrentLlmConfig: () => Promise<{ provider: "ollama" | "gemini" | "custom" | "codex-cli" | "antigravity"; /** @deprecated use `modelId` for selection, `displayName` for UI */ model: string; modelId: string; displayName: string; isOllama: boolean }>
   getAvailableOllamaModels: () => Promise<string[]>
   /** Whether a denied data scope would actually be handled on-device. */
   getLocalFallbackStatus: () => Promise<{ text: boolean; vision: boolean }>
@@ -685,6 +685,12 @@ export interface ElectronAPI {
   codexCliDoctor: (config?: any) => Promise<{ success: boolean; action: string; output?: string; error?: string; resolvedPath?: string; config?: any }>;
   // ChatGPT OAuth (PKCE) — replaces the old `codex login` CLI subprocess.
   codexLoginStatus: () => Promise<{ success: boolean; signedIn: boolean; email?: string; expiresAt?: number; error?: string }>;
+  antigravityStatus: () => Promise<{ signedIn: boolean; inProgress: boolean; expiresAt?: number; projectId?: string; error?: string }>;
+  antigravityStartLogin: () => Promise<{ success: boolean; error?: string }>;
+  antigravityCancelLogin: () => Promise<void>;
+  antigravitySignOut: () => Promise<{ success: boolean; error?: string }>;
+  antigravityModels: (force?: boolean) => Promise<{ success: boolean; models: { id: string; label: string }[]; error?: string }>;
+  onAntigravityStatusChanged: (callback: (status: { signedIn: boolean; inProgress: boolean; expiresAt?: number; projectId?: string; error?: string }) => void) => () => void;
   codexStartLogin: () => Promise<{ success: boolean; email?: string; expiresAt?: number; error?: string }>;
   codexSignOut: () => Promise<{ success: boolean; error?: string }>;
   codexRefreshTokens: () => Promise<{ success: boolean; email?: string; expiresAt?: number; error?: string }>;


### PR DESCRIPTION
## Summary
Adds Google Antigravity OAuth support.

- Browser sign-in with PKCE and validated local callback.
- Encrypted credential storage, automatic token refresh, and disconnect.
- Authenticated model discovery and model picker integration.
- Streaming and non-streaming chat, Direct Assist, and screenshot support.
- Existing provider privacy controls and cancellation are preserved.
- Handles expired sessions, authentication failures, and disconnect races.

Validation: 24 automated tests passed, along with core Electron build and type checks. Live Google sign-in and inference have not been verified.

Fixes # N/A — new feature; no linked issue.

## Type of Change
- [ ] 🐛 Bug Fix
- [x] ✨ New Feature
- [ ] 🎨 Refactor / Style Update
- [ ] 📝 Documentation
- [ ] ⚡ Performance Improvement
- [ ] 🛠️ Chore / Tooling