### PR TITLE
feat(reranker-settings): candidate count as a sliding tab switcher, from feat/interaction-router

### DIFF
--- a/src/components/settings/RerankerSettings.tsx
+++ b/src/components/settings/RerankerSettings.tsx
@@ -314,7 +314,7 @@ const RerankerModelSelect: React.FC<FloatingSelectProps> = ({
     placeholder,
     disabled = false,
     className = '',
-    containerClassName = 'relative min-w-[200px] max-w-[320px] w-full sm:w-64',
+    containerClassName = 'relative min-w-[150px] max-w-[240px] w-full sm:w-48',
     ariaLabel,
     title,
     disabledHint,
@@ -358,7 +358,7 @@ const RerankerModelSelect: React.FC<FloatingSelectProps> = ({
             {isOpen && (
                 <div
                     role="listbox"
-                    className="aip-float aip-scroll-y aip-panel-fade absolute top-full right-0 mt-1.5 w-full min-w-[240px] z-50 max-h-64 p-1 custom-scrollbar shadow-2xl rounded-md border border-white/10 bg-[#161618]"
+                    className="aip-float aip-scroll-y aip-panel-fade absolute top-full right-0 mt-1.5 w-full min-w-[180px] z-50 max-h-64 p-1 custom-scrollbar shadow-2xl rounded-md border border-white/10 bg-[#161618]"
                 >
                     {options.map((option) => (
                         <button

--- a/src/components/settings/RerankerSettings.tsx
+++ b/src/components/settings/RerankerSettings.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { motion } from 'framer-motion';
 import { AlertCircle, Check, ChevronDown, Cloud, Download, ExternalLink, Filter, FolderOpen, HardDrive, KeyRound, Loader2, Monitor, Puzzle, RefreshCw, Search, ShieldAlert, Trash2, X } from 'lucide-react';
 import { useT } from '../../i18n';
 import { useResolvedTheme } from '../../hooks/useResolvedTheme';
@@ -384,6 +385,51 @@ const RerankerModelSelect: React.FC<FloatingSelectProps> = ({
                     )}
                 </div>
             )}
+        </div>
+    );
+};
+
+interface CandidatesSlidingTabsProps {
+    value: number;
+    choices: number[];
+    onChange: (choice: number) => void;
+}
+
+/**
+ * Tab switcher for candidate count using Framer Motion layoutId spring transition,
+ * matching MeetingDetails (Summary / Transcript / Usage) 1:1.
+ */
+const CandidatesSlidingTabs: React.FC<CandidatesSlidingTabsProps> = ({ value, choices, onChange }) => {
+    const layoutId = React.useId();
+    const theme = useResolvedTheme();
+    const isLight = theme === 'light';
+
+    return (
+        <div className={`p-1 rounded-xl inline-flex items-center gap-0.5 border shrink-0 ${isLight ? 'bg-[#E5E5EA] border-black/[0.04]' : 'bg-[#0D0D0F] border-white/[0.08]'}`}>
+            {choices.map((n) => {
+                const isSelected = value === n;
+                return (
+                    <button
+                        key={n}
+                        type="button"
+                        onClick={() => onChange(n)}
+                        className={`
+                            relative px-3 py-1 text-xs font-medium rounded-lg transition-colors duration-200 z-10 select-none
+                            ${isSelected ? (isLight ? 'text-black' : 'text-[#E9E9E9]') : (isLight ? 'text-black/60 hover:text-black' : 'text-white/40 hover:text-white/80')}
+                        `}
+                    >
+                        {isSelected && (
+                            <motion.div
+                                layoutId={`candidatesTabActive-${layoutId}`}
+                                className={`absolute inset-0 rounded-lg -z-10 shadow-sm ${isLight ? 'bg-white' : 'bg-[#3A3A3C]'}`}
+                                initial={false}
+                                transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+                            />
+                        )}
+                        {n}
+                    </button>
+                );
+            })}
         </div>
     );
 };
@@ -1799,27 +1845,35 @@ export const RerankerSettings: React.FC = () => {
                 </div>
             </div>
 
-            {/* Provider Card 5: Candidates. The hosted fallback used to share this
-                card; it now sits under Active Reranker, where it belongs. */}
-            <div className="aip-card p-5">
-                <div className="space-y-1.5">
-                    <label className="block text-xs font-medium uppercase tracking-wide aip-hero">{t('Candidates to rerank')}</label>
-                    <div className="flex gap-2 flex-wrap">
-                        {CANDIDATE_CHOICES.map(n => (
-                            <button
-                                key={n}
-                                type="button"
-                                className="aip-btn"
-                                data-active={status.candidateCount === n ? 'true' : undefined}
-                                onClick={() => void setConfig({ candidateCount: n })}
-                            >
-                                {n}
-                            </button>
-                        ))}
+            {/* Provider Card 5: Candidates Selector — High-End Segmented Control */}
+            <div className="aip-card p-5 space-y-3">
+                <div className="flex items-center justify-between gap-4 flex-wrap sm:flex-nowrap">
+                    <div>
+                        <label className="block text-xs font-medium uppercase tracking-wide aip-hero">
+                            {t('Candidates to rerank')}
+                        </label>
+                        <p className="text-[10px] aip-muted mt-0.5">
+                            {t('Number of initial retrieved passages scored by the reranker.')}
+                        </p>
                     </div>
-                    <p className="text-[10px] aip-muted">
-                        {t('More candidates can improve the answer but cost more and take longer. Leave this alone unless you have a reason.')}
-                    </p>
+
+                    <CandidatesSlidingTabs
+                        value={status.candidateCount ?? 15}
+                        choices={CANDIDATE_CHOICES}
+                        onChange={(n) => void setConfig({ candidateCount: n })}
+                    />
+                </div>
+
+                <div className="pt-2 border-t border-white/5 flex items-center justify-between text-[10.5px] aip-muted">
+                    <span>
+                        {(status.candidateCount ?? 15) <= 5 && t('Fast & low latency — best for quick queries.')}
+                        {(status.candidateCount ?? 15) === 10 && t('Balanced speed and recall.')}
+                        {(status.candidateCount ?? 15) === 15 && t('Recommended default — high accuracy with manageable cost.')}
+                        {(status.candidateCount ?? 15) >= 20 && t('Deep recall — evaluates maximum context passages.')}
+                    </span>
+                    <span className="font-mono text-white/50 text-[9.5px]">
+                        {status.candidateCount ?? 15} {t('passages')}
+                    </span>
                 </div>
             </div>
 

--- a/src/dev/rerankerSettingsHarness.tsx
+++ b/src/dev/rerankerSettingsHarness.tsx
@@ -43,7 +43,7 @@ const CATALOG_MODELS = [
     },
     {
         id: 'bge-reranker-large', name: 'BGE Reranker Large', runtime: 'onnx', repo: 'Xenova/bge-reranker-large',
-        params: '560M · int8', note: 'Highest quality of the local models measured — but the slowest to load.',
+        params: '560M · int8', note: 'High quality local model (560M parameters), but slower to load.',
         bytes: 580038433, recommended: false,
         license: { spdx: 'MIT', url: '#', commercialUseRestricted: false, requiresAcknowledgement: false },
         state: 'not-installed', bytesOnDisk: 0, selected: false,


### PR DESCRIPTION
## What

Lands the two commits from `feat/interaction-router` that were not on `main` by content, replayed on top of today's `main`:

- `539cd657` feat(ui): Reranker Settings candidate count becomes a sliding tab switcher (Framer Motion `layoutId` spring, same treatment as MeetingDetails)
- `456241df` style(ui): active reranker model selector trigger and dropdown 25% narrower

Only the `RerankerSettings.tsx` and harness parts of `539cd657` are taken. Two parts of that commit are deliberately left behind:

- Its `rerankerModelCatalog.ts` / `hostedRerankProviders.ts` hunk replaced the measured benchmark notes (MRR against the no-reranker baseline) with generic descriptions. `main` carries the measured notes and the tests that pin the recommendation to the benchmark, so that hunk is stale.
- Its `.aip-btn[data-active='true']` CSS was fixed on `main` separately in `3839ea26`.

The other six commits on `feat/interaction-router` are already on `main` by content (`git cherry`). After this merges the branch is closed.

## Verification

- `npm run typecheck:ts7` (root, renderer): 0 errors
- `vite build`: clean
- Playwright against `rerankerSettingsHarness.html` on this branch: the harness stub is static (it always reports 15, on `main` too), so with a stateful stub in the scratch worktree only: active `15 -> 5 -> 20` on click, pill x `805 -> 732` with intermediate frames (`792, 782, 731`), no page errors.
- Not physically verified inside the packaged app on either platform; renderer-only change with no platform branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BabueGV5FMBBN32xvoh4kS
