### PR TITLE
Fix Antigravity login when project discovery fails

### DIFF
--- a/electron/services/AntigravityService.ts
+++ b/electron/services/AntigravityService.ts
@@ -35,6 +35,8 @@ export const GOOGLE_API_USER_AGENT = 'google-api-nodejs-client/9.15.1';
 export const ANTIGRAVITY_SETUP_CLIENT = 'google-cloud-sdk vscode_cloudshelleditor/0.1';
 export const ANTIGRAVITY_PROD_ENDPOINT = 'https://cloudcode-pa.googleapis.com';
 export const ANTIGRAVITY_DAILY_ENDPOINT = 'https://daily-cloudcode-pa.googleapis.com';
+// Voice-app's configured project is usable independently of Code Assist onboarding.
+export const ANTIGRAVITY_DEFAULT_PROJECT_ID = 'rising-fact-p41fc';
 export const ANTIGRAVITY_REFRESH_LEAD_MS = 60_000;
 export const ANTIGRAVITY_STREAM_URL =
   `${ANTIGRAVITY_DAILY_ENDPOINT}/v1internal:streamGenerateContent?alt=sse`;
@@ -450,6 +452,15 @@ async function discoverProject(accessToken: string, signal: AbortSignal): Promis
     const project = onboarded?.done === true
       ? extractProjectId(onboarded?.response?.cloudaicompanionProject) : undefined;
     if (project) return project;
+    if (onboarded?.done === true) {
+      const reasons = Array.isArray(loaded?.ineligibleTiers)
+        ? loaded.ineligibleTiers
+          .filter((tier: any) => typeof tier?.reasonMessage === 'string' && tier.reasonMessage.trim())
+          .map((tier: any) => tier.reasonMessage.trim()) : [];
+      throw new AntigravityError('setup', reasons.length
+        ? `Google account setup failed: ${reasons.join(' ')}`
+        : 'Google completed account setup without providing a project ID. This account may require a Google Cloud project.');
+    }
     if (attempt < 5) await wait(1_500, undefined, { signal });
   }
   throw new AntigravityError('setup', 'Google account setup did not finish. Try signing in again.');
@@ -557,7 +568,24 @@ export class AntigravityService extends EventEmitter {
 
       const exchanged = await this.exchangeCode(callback.code, pkce.verifier, controller.signal);
       this.assertGeneration(generation);
-      const projectId = await discoverProject(exchanged.accessToken, controller.signal);
+      let projectId: string;
+      try {
+        projectId = await discoverProject(exchanged.accessToken, controller.signal);
+      } catch (error) {
+        this.assertGeneration(generation);
+        controller.signal.throwIfAborted();
+        if (!(error instanceof AntigravityError) || error.code !== 'setup') throw error;
+        // Voice-app keeps its configured project when optional discovery fails.
+        // Validate that project's model access before adopting the new session.
+        const response = await fetchWithDnsRetry(`${ANTIGRAVITY_DAILY_ENDPOINT}/v1internal:fetchAvailableModels`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${exchanged.accessToken}`, 'Content-Type': 'application/json', 'User-Agent': ANTIGRAVITY_USER_AGENT },
+          body: JSON.stringify({ project: ANTIGRAVITY_DEFAULT_PROJECT_ID }), signal: controller.signal,
+        }, 12);
+        const models = parseAntigravityModels(await responseJson(response, 'models'));
+        if (!models.length) throw new AntigravityError('models', 'The Voice-app project returned no available Antigravity models.');
+        projectId = ANTIGRAVITY_DEFAULT_PROJECT_ID;
+      }
       this.assertGeneration(generation);
       const tokens = { ...exchanged, projectId };
       if (!this.saveToStorage(tokens)) throw new AntigravityError('storage', 'Google sign-in could not be saved. Check credential storage and try again.');

--- a/electron/services/__tests__/AntigravityService.test.mjs
+++ b/electron/services/__tests__/AntigravityService.test.mjs
@@ -541,4 +541,53 @@ test('OAuth exchange and onboarding use reference headers, PKCE verifier, select
   } finally { cleanupService(service, oldGetter); globalThis.fetch = oldFetch; fakeElectron.shell.openExternal = oldOpen; }
 });
 
+test('Voice-app project fallback requires model access and preserves discovered projects', async () => {
+  const mod = await loadService();
+  const oldFetch = globalThis.fetch;
+  const oldOpen = fakeElectron.shell.openExternal;
+  const reason = 'This client is no longer supported for Gemini Code Assist for individuals.';
+  for (const [projectId, modelStatus, modelBody, expectedProject] of [
+    [null, 200, catalog, mod.ANTIGRAVITY_DEFAULT_PROJECT_ID],
+    [null, 403, {}, null],
+    [null, 200, { models: {} }, null],
+    ['paid-project', 200, catalog, 'paid-project'],
+  ]) {
+    const stored = storageWith(null);
+    const { service, oldGetter } = prepareService(mod, stored);
+    const opened = {};
+    let onboardCalls = 0;
+    let modelCalls = 0;
+    fakeElectron.shell.openExternal = async url => { opened.value = url; };
+    globalThis.fetch = async (url, init) => {
+      if (url === mod.ANTIGRAVITY_TOKEN_URL) return jsonResponse({ access_token: 'access', refresh_token: 'refresh', expires_in: 3600 });
+      if (url.endsWith(':loadCodeAssist')) return jsonResponse({
+        allowedTiers: [{ id: 'standard-tier', isDefault: true, userDefinedCloudaicompanionProject: true }],
+        ineligibleTiers: [{ reasonCode: 'UNSUPPORTED_CLIENT', reasonMessage: reason }],
+      });
+      if (url.endsWith(':fetchAvailableModels')) {
+        modelCalls++;
+        assert.equal(JSON.parse(init.body).project, 'rising-fact-p41fc');
+        assert.equal(init.headers.Authorization, 'Bearer access');
+        assert.match(init.headers['User-Agent'], /^antigravity\/1\.23\.2 /);
+        return jsonResponse(modelBody, modelStatus);
+      }
+      assert.ok(url.endsWith(':onboardUser'));
+      onboardCalls++;
+      return jsonResponse({ done: true, response: { cloudaicompanionProject: projectId ? { id: projectId } : {} } });
+    };
+    try {
+      const login = service.startLogin();
+      const outcome = expectedProject ? login : assert.rejects(login);
+      const url = await waitForBrowserUrl(opened);
+      await requestCallback(`/oauth-callback?code=code&state=${url.searchParams.get('state')}`);
+      await outcome;
+      assert.equal(onboardCalls, 1);
+      assert.equal(modelCalls, projectId ? 0 : 1);
+      assert.equal(stored.current()?.projectId ?? null, expectedProject);
+      assert.equal(service.getStatus().signedIn, Boolean(expectedProject));
+      await assertCallbackPortFree();
+    } finally { cleanupService(service, oldGetter); globalThis.fetch = oldFetch; fakeElectron.shell.openExternal = oldOpen; }
+  }
+});
+
 test.after(() => { Module._load = originalModuleLoad; });


### PR DESCRIPTION
Google can complete OAuth but return no project during Code Assist onboarding, leaving Natively disconnected even when Antigravity requests work with the project used by Voice-app.

Use the same project fallback when discovery fails, and verify model access before saving the connection. Keep successfully discovered projects, reject inaccessible or empty fallback catalogs, and stop retrying onboarding once Google reports it complete without a project ID.

Validation:
- All 27 Antigravity service, credential, and wiring tests pass, including fallback success and failure cases.
- Core Electron build passes.
- Live Google login, 12-model discovery, a Gemini response, and token refresh verified.
- Persistence after a live app restart was not verified; encrypted save/reload is covered by the credential test.
