### PR TITLE
fix(overlay): surface screenshot capture failures instead of failing silently

### DIFF
--- a/src/components/NativelyInterface.tsx
+++ b/src/components/NativelyInterface.tsx
@@ -1672,6 +1672,13 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
   // granted yet. Renders the inline permission banner so we never silently
   // fail — Cluely's onboarding is its UX moat; we mirror it.
   const [stealthPermissionMissing, setStealthPermissionMissing] = useState<boolean>(false);
+  // Set when a screenshot capture (full or selective) fails for a REAL reason
+  // (IPC rejection, or a resolved-but-empty result that wasn't a user
+  // cancel). Without this, takeScreenshot/takeSelectiveScreenshot failures
+  // were only console.error'd — the hotkey looked dead with no on-screen
+  // signal (issue #334). A user cancelling the selective-crop overlay
+  // (`data.cancelled === true`) is NOT an error and must stay silent.
+  const [screenshotAttachError, setScreenshotAttachError] = useState<string | null>(null);
   // Set when KeybindManager reports the stealth-typing global shortcut
   // failed to register (OS already owns it — common with Cmd+Shift+Space
   // if another app claimed it, or with the macOS input source switcher
@@ -4201,6 +4208,7 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
   }, []);
 
   const handleScreenshotAttach = (data: { path: string; preview: string }) => {
+    setScreenshotAttachError(null);
     setIsExpanded(true);
     setAttachedContext((prev) => {
       // Prevent duplicates and cap at 5
@@ -8431,9 +8439,14 @@ Provide only the answer, nothing else.`;
         const data = await window.electronAPI.takeScreenshot();
         if (data && data.path) {
           handleScreenshotAttach(data as { path: string; preview: string });
+        } else {
+          // Resolved with no path — a real capture failure (permission
+          // denial, empty source list, etc.), not a user cancel.
+          setScreenshotAttachError(t('Screenshot capture failed — no image was returned. Please try again.'));
         }
       } catch (err) {
         console.error('Error triggering screenshot:', err);
+        setScreenshotAttachError(t('Screenshot capture failed. Please try again.'));
       }
     },
     selectiveScreenshot: async () => {
@@ -8441,9 +8454,14 @@ Provide only the answer, nothing else.`;
         const data = await window.electronAPI.takeSelectiveScreenshot();
         if (data && !data.cancelled && data.path) {
           handleScreenshotAttach(data as { path: string; preview: string });
+        } else if (data && !data.cancelled) {
+          // Resolved but no path and not a user cancel (Esc / click-away) —
+          // a real capture failure. `cancelled` stays silent by design.
+          setScreenshotAttachError(t('Screenshot capture failed — no image was returned. Please try again.'));
         }
       } catch (err) {
         console.error('Error triggering selective screenshot:', err);
+        setScreenshotAttachError(t('Screenshot capture failed. Please try again.'));
       }
     },
   });
@@ -8472,9 +8490,14 @@ Provide only the answer, nothing else.`;
         const data = await window.electronAPI.takeScreenshot();
         if (data && data.path) {
           handleScreenshotAttach(data as { path: string; preview: string });
+        } else {
+          // Resolved with no path — a real capture failure (permission
+          // denial, empty source list, etc.), not a user cancel.
+          setScreenshotAttachError(t('Screenshot capture failed — no image was returned. Please try again.'));
         }
       } catch (err) {
         console.error('Error triggering screenshot:', err);
+        setScreenshotAttachError(t('Screenshot capture failed. Please try again.'));
       }
     },
     selectiveScreenshot: async () => {
@@ -8482,9 +8505,14 @@ Provide only the answer, nothing else.`;
         const data = await window.electronAPI.takeSelectiveScreenshot();
         if (data && !data.cancelled && data.path) {
           handleScreenshotAttach(data as { path: string; preview: string });
+        } else if (data && !data.cancelled) {
+          // Resolved but no path and not a user cancel (Esc / click-away) —
+          // a real capture failure. `cancelled` stays silent by design.
+          setScreenshotAttachError(t('Screenshot capture failed — no image was returned. Please try again.'));
         }
       } catch (err) {
         console.error('Error triggering selective screenshot:', err);
+        setScreenshotAttachError(t('Screenshot capture failed. Please try again.'));
       }
     },
   };
@@ -10163,6 +10191,21 @@ Provide only the answer, nothing else.`;
                         </OverlayBannerButton>
                       </>
                     }
+                  />
+                )}
+
+                {/* Screenshot capture failure — issue #334: the hotkey used to
+                                    look dead because a failed/empty capture only hit
+                                    console.error, with nothing on screen. A user cancel
+                                    (Esc / click-away on the selective-crop overlay) never
+                                    sets this and stays silent by design. */}
+                {screenshotAttachError && (
+                  <OverlayBanner
+                    className="mb-2"
+                    title={t('Screenshot Capture Failed')}
+                    message={screenshotAttachError}
+                    onDismiss={() => setScreenshotAttachError(null)}
+                    dismissLabel={t('Dismiss')}
                   />
                 )}
 


### PR DESCRIPTION
## Summary

`takeScreenshot`/`takeSelectiveScreenshot` failures (an IPC rejection, or a resolved result with no `path` that wasn't a user cancel) were only `console.error`'d in `src/components/NativelyInterface.tsx`. There was no on-screen signal, so a failed capture made the hotkey look dead — nothing attached to the chat input, no explanation (issue #334).

Per the investigation already posted on #334 by @bhargavap21: the actual capture bugs (multi-monitor local→global bounds, Retina crop math) are already fixed on `main` (PR #346, `e15c2fa`). What's left, and what this PR addresses, is the "renderer still quiet on IPC errors" gap they flagged — a follow-up PR (#398) attempted this but got bundled with unrelated changes (Process Disguise rename, paste/drop, calendar errors) and was closed unmerged. This PR is scoped to only the fail-loud notice.

## Fix

- Added a `screenshotAttachError` state.
- Both `takeScreenshot` and `takeSelectiveScreenshot` handlers (in `generalHandlersRef`, both the initial and the per-render "update ref" copies) now set it on a genuine failure — a caught exception, or a resolved-but-empty result that isn't `{cancelled: true}`.
- Cleared on the next successful attach, in `handleScreenshotAttach`.
- Surfaced through the existing `OverlayBanner` primitive (`src/components/ui/OverlayBanner.tsx`) — dismiss-only, no action buttons, the same surface already used for the system-audio and stealth-Accessibility banners just above it, so it matches their look/spacing exactly rather than introducing a fourth notice design.
- A user cancelling the selective-crop overlay (`data.cancelled === true`) is explicitly excluded and stays silent — that's existing, correct behavior, not an error.

## Test plan

- [x] Reviewed the diff by hand against the two existing `OverlayBanner` call sites (system-audio warning, stealth-Accessibility banner) it mirrors — same props shape, same conditional-render pattern.
- [x] Traced both call sites of each handler (the `useRef` initializer and the "Update ref" block a few lines below it) to confirm both were updated identically.
- [x] Could not run `npm run typecheck:ts5` / the full Electron build in this environment — the postinstall pulls in `patch-package` and several native-module rebuild steps that aren't available here. No test file exists yet for this specific code path (`src/components/__tests__/` has no screenshot-attach coverage), so this is code-review-only verification, not a run.