### PR TITLE
fix(stt): surface stopped system-audio streams, keep the Answer gate open for the STT tail, bound local-model start

### DIFF
--- a/electron/audio/LocalWhisperSTT.ts
+++ b/electron/audio/LocalWhisperSTT.ts
@@ -49,7 +49,34 @@ import { clearLoadSentinel, modelPreloader, writeLoadSentinel } from './whisper/
 import { buildWorkerInitMessage } from './whisper/inferenceConfig';
 import { resolveWhisperWorkerPath } from './whisper/workerPathResolver';
 import type { WorkerOutMessage } from './whisper/types';
-import { acquireOnnxSlot, hasEnoughMemoryForOnnxSession, getMinFreeGBForOnnxSession } from '../utils/onnxThreadConfig';
+import { acquireOnnxSlotWithin, hasEnoughMemoryForOnnxSession, getMinFreeGBForOnnxSession } from '../utils/onnxThreadConfig';
+
+/**
+ * Cold-start deadline for the local model worker's `ready`. Live-reproduced
+ * 2026-09-11: the second per-channel parakeet worker on a memory-constrained
+ * Mac logged "Loading …" and then nothing, for minutes — every VAD segment
+ * queued in pendingAudio, the channel transcribed nothing, and the only
+ * symptom was "No speech detected". Env-overridable so tests can shorten it.
+ */
+const WORKER_READY_TIMEOUT_MS = (() => {
+    const n = Number(process.env.NATIVELY_LOCAL_STT_READY_TIMEOUT_MS);
+    return Number.isFinite(n) && n > 0 ? n : 120_000;
+})();
+/** Log once at this point so a slow (but progressing) load is visible in the log. */
+const WORKER_SLOW_LOAD_WARN_MS = 30_000;
+
+/**
+ * Marker main.ts uses to classify a local-STT start failure as TERMINAL
+ * (state 'failed', message shown) instead of a retryable network blip that
+ * leaves the channel on "STT reconnecting" forever — nothing restarts a
+ * LocalWhisperSTT instance mid-meeting.
+ */
+export const LOCAL_STT_UNAVAILABLE_CODE = 'local_stt_unavailable';
+function markLocalSttUnavailable(err: unknown): Error {
+    const e = err instanceof Error ? err : new Error(String(err));
+    (e as any).code = LOCAL_STT_UNAVAILABLE_CODE;
+    return e;
+}
 import { resolveNemotronLangId } from './whisper/nemotron/languageTable';
 import { acquireSharedNemotronWorker } from './whisper/nemotron/sharedWorkerRegistry';
 // The engine's fixed audio window. Imported rather than duplicated as a local
@@ -99,6 +126,14 @@ export class LocalWhisperSTT extends EventEmitter {
     // when both LocalWhisperSTT instances run the same model.
     private channelLabel = '';
     private worker: Worker | null = null;
+    // Cold-start readiness deadline — see WORKER_READY_TIMEOUT_MS.
+    private workerReadyTimer: NodeJS.Timeout | null = null;
+    // Bumped by every spawn and every stop(): a slot wait that settles after
+    // stop() (or after a restart) must neither spawn an orphan worker nor
+    // tear down the NEXT session with its stale rejection.
+    private spawnGeneration = 0;
+    private workerSlowLoadTimer: NodeJS.Timeout | null = null;
+    private workerSpawnedAt = 0;
     private vad: VadProcessor | null = null;
     private isActive = false;
     // Cross-loader ONNX gate slot. Acquired in spawnWorker() before posting
@@ -198,6 +233,8 @@ export class LocalWhisperSTT extends EventEmitter {
     private readonly skipAgreement: boolean;
     private static readonly STREAMING_INTERVAL_MAX_MS = 12000;
     private static readonly MAX_SEGMENT_MS = 14000;       // soft-commit before VAD's 15s hard-flush
+    /** How long a cold start may wait for a shared ONNX session before failing loudly. */
+    private static readonly ONNX_SLOT_WAIT_MS = 20_000;
     // Backoff: count consecutive ticks where we couldn't dispatch (worker
     // busy or no open segment with enough audio). After 3 in a row, double
     // the next delay; reset to base on a successful dispatch.
@@ -448,6 +485,8 @@ export class LocalWhisperSTT extends EventEmitter {
     stop(): void {
         if (!this.isActive) return;
         this.isActive = false;
+        this.spawnGeneration++;
+        this.clearWorkerReadyDeadline();
 
         this.stopStreamingLoop();
         if (this.gapFlushTimer) {
@@ -547,10 +586,18 @@ export class LocalWhisperSTT extends EventEmitter {
         }, LocalWhisperSTT.GAP_FLUSH_MS);
     }
 
-    finalize(): void {
-        if (!this.isActive || !this.vad) return;
+    /**
+     * Flush the open VAD segment as a final. Returns true when a final is now
+     * IN FLIGHT (flushed here, or still queued behind a loading worker) — the
+     * Answer/Stop tail wait uses it to keep the recording gate open for the
+     * seconds a local model needs, instead of the short grace it gives a
+     * channel with nothing pending.
+     */
+    finalize(): boolean {
+        if (!this.isActive || !this.vad) return false;
         const segs = this.vad.flush();
         segs.forEach(s => this.dispatchFinal(s.samples));
+        return segs.length > 0 || this.pendingAudio.length > 0;
     }
 
     /* ──────────────── Streaming inference loop ──────────────── */
@@ -1081,7 +1128,34 @@ export class LocalWhisperSTT extends EventEmitter {
             );
         }
 
-        this.slotRelease = await acquireOnnxSlot('high', 1);
+        // Bounded: an unbounded wait here was a silent dead channel — the local
+        // embedding + reranker workers hold the whole default gate (cap 2) for
+        // the app lifetime, so this never resolved and nothing was logged.
+        // The rejection propagates to start()'s spawnWorker catch, which tears
+        // the instance down and emits 'error' so main shows an STT failure.
+        const generation = ++this.spawnGeneration;
+        let slotRelease: () => void;
+        try {
+            slotRelease = await acquireOnnxSlotWithin(
+                'high',
+                1,
+                LocalWhisperSTT.ONNX_SLOT_WAIT_MS,
+                `LocalWhisperSTT/${this.channelLabel}`,
+            );
+        } catch (err) {
+            // A rejection that lands after stop() / a restart belongs to a
+            // session that no longer exists — swallowing it is correct; the
+            // live session has its own wait.
+            if (generation !== this.spawnGeneration || !this.isActive) return;
+            throw markLocalSttUnavailable(err);
+        }
+        if (generation !== this.spawnGeneration || !this.isActive) {
+            // stop() ran while we waited: hand the slot straight back instead
+            // of spawning a worker nothing will ever stop.
+            slotRelease();
+            return;
+        }
+        this.slotRelease = slotRelease;
 
         console.log(`[LocalWhisperSTT] Cold-starting worker for ${this.modelId}`);
         const workerPath = resolveWhisperWorkerPath();
@@ -1089,6 +1163,65 @@ export class LocalWhisperSTT extends EventEmitter {
         this.worker = new Worker(workerPath);
         this.attachWorkerListeners();
         this.worker.postMessage(buildWorkerInitMessage(this.modelId));
+        this.armWorkerReadyDeadline();
+    }
+
+    private armWorkerReadyDeadline(): void {
+        this.workerSpawnedAt = Date.now();
+        this.scheduleWorkerReadyTimers();
+    }
+
+    /** (Re)schedules the deadline without touching workerSpawnedAt — a worker
+     *  'progress' message proves the load is alive, so the deadline restarts. */
+    private scheduleWorkerReadyTimers(): void {
+        this.clearWorkerReadyDeadline();
+        const label = this.channelLabel || 'stt';
+        this.workerSlowLoadTimer = setTimeout(() => {
+            this.workerSlowLoadTimer = null;
+            if (this.workerReady || !this.isActive) return;
+            console.warn(
+                `[LocalWhisperSTT/${label}] worker for ${this.modelId} still loading after ${WORKER_SLOW_LOAD_WARN_MS / 1000}s — ` +
+                `${this.pendingAudio.length} segment(s) queued, nothing transcribed yet on this channel`,
+            );
+        }, WORKER_SLOW_LOAD_WARN_MS);
+        (this.workerSlowLoadTimer as any).unref?.();
+        this.workerReadyTimer = setTimeout(() => {
+            this.workerReadyTimer = null;
+            if (this.workerReady || !this.isActive) return;
+            const waitedMs = Date.now() - this.workerSpawnedAt;
+            const queued = this.pendingAudio.length;
+            console.error(
+                `[LocalWhisperSTT/${label}] worker for ${this.modelId} not ready after ${waitedMs}ms — giving up on this channel ` +
+                `(${queued} queued segment(s) dropped)`,
+            );
+            // Same clean teardown as start()'s spawnWorker catch: no live VAD or
+            // streaming loop may outlive a worker that will never answer.
+            this.stopStreamingLoop();
+            if (this.gapFlushTimer) {
+                clearTimeout(this.gapFlushTimer);
+                this.gapFlushTimer = null;
+            }
+            this.vad = null;
+            this.isActive = false;
+            this.pendingAudio = [];
+            const w = this.worker;
+            if (w) this.beginWorkerTermination(w);
+            // A graceful give-up is not a native crash: leave the sentinel in
+            // place and the next launch would "recover" by silently resetting
+            // the user's model to the fallback.
+            clearLoadSentinel(this.modelId);
+            this.emit('error', markLocalSttUnavailable(new Error(
+                `Local STT model ${this.modelId} did not finish loading within ${Math.round(WORKER_READY_TIMEOUT_MS / 1000)}s ` +
+                `on the ${label} channel — nothing from this channel was transcribed. ` +
+                `Choose a smaller local model or a cloud STT provider.`,
+            )));
+        }, WORKER_READY_TIMEOUT_MS);
+        (this.workerReadyTimer as any).unref?.();
+    }
+
+    private clearWorkerReadyDeadline(): void {
+        if (this.workerReadyTimer) { clearTimeout(this.workerReadyTimer); this.workerReadyTimer = null; }
+        if (this.workerSlowLoadTimer) { clearTimeout(this.workerSlowLoadTimer); this.workerSlowLoadTimer = null; }
     }
 
     private attachWorkerListeners(): void {
@@ -1112,8 +1245,22 @@ export class LocalWhisperSTT extends EventEmitter {
                     return;
                 }
             }
+            if ((msg as any).type === 'progress') {
+                // The load is alive (per-file download / parse progress) —
+                // a slow but progressing init must not be killed by the deadline.
+                if (!this.workerReady && this.workerReadyTimer) this.scheduleWorkerReadyTimers();
+                return;
+            }
             if (msg.type === 'ready') {
                 clearLoadSentinel(this.modelId);
+                this.clearWorkerReadyDeadline();
+                if (this.workerSpawnedAt > 0) {
+                    console.log(
+                        `[LocalWhisperSTT/${this.channelLabel || 'stt'}] worker ready in ${Date.now() - this.workerSpawnedAt}ms ` +
+                        `(${this.pendingAudio.length} queued segment(s) flushing)`,
+                    );
+                    this.workerSpawnedAt = 0;
+                }
                 this.workerReady = true;
                 this.flushPending();
                 return;
@@ -1249,6 +1396,9 @@ export class LocalWhisperSTT extends EventEmitter {
         this.worker.on('message', messageHandler);
 
         const errorHandler = (err: Error) => {
+            // A worker that died during load must not also fire the ready
+            // deadline 120s later against a dead handle.
+            this.clearWorkerReadyDeadline();
             // Reset all in-flight streaming state so a dead worker can never
             // permanently pin streamingTaskInFlight=true (which would freeze
             // the loop — symptom: transcription stops after 3-4 questions).
@@ -1298,6 +1448,7 @@ export class LocalWhisperSTT extends EventEmitter {
         // streaming loop must be unblocked — otherwise streamingTaskInFlight
         // stays true and the next tick silently stalls forever.
         const exitHandler = (code: number) => {
+            this.clearWorkerReadyDeadline();
             if (code === 0) {
                 clearLoadSentinel(this.modelId);
                 return; // clean shutdown
@@ -1353,6 +1504,7 @@ export class LocalWhisperSTT extends EventEmitter {
     }
 
     private beginWorkerTermination(w: Worker): void {
+        this.clearWorkerReadyDeadline();
         this.worker = null;
         this.workerReady = false;
         this.isDrainingFinals = false;

--- a/electron/audio/SystemAudioCapture.ts
+++ b/electron/audio/SystemAudioCapture.ts
@@ -77,6 +77,23 @@ export class SystemAudioCapture extends EventEmitter {
     }
 
     /**
+     * Which native backend is actually capturing: 'sck' | 'coreaudio' |
+     * 'wasapi', or '' while the background init is still running (and after
+     * the monitor has been retired). main.ts compares it with the backend the
+     * user asked for to notice a silent fallback (see startSckReprobeWatcher).
+     */
+    public getActiveBackend(): string {
+        try {
+            if (this.monitor && typeof this.monitor.getActiveBackend === 'function') {
+                return String(this.monitor.getActiveBackend() ?? '');
+            }
+        } catch (e) {
+            console.warn('[SystemAudioCapture] getActiveBackend failed:', e);
+        }
+        return '';
+    }
+
+    /**
      * Start capturing audio
      */
     public start(): void {
@@ -117,6 +134,33 @@ export class SystemAudioCapture extends EventEmitter {
                 if (err) {
                     console.error('[SystemAudioCapture] Callback error:', err);
                     this.isRecording = false; // Allow recovery via restart
+                    // The Rust DSP thread has exited (a fatal init failure, or the
+                    // platform stopped the stream — see speaker/stop_signal.rs),
+                    // but its handle is still Some inside the monitor. A later
+                    // start() on this same instance would hit "Capture already
+                    // running". Retire the monitor now so the next start() takes
+                    // the lazy-init branch; stop() is deferred as in the failed-
+                    // start path below. isRecording is already false, so stop()
+                    // would otherwise skip the native teardown entirely.
+                    const dying = this.monitor;
+                    this.monitor = null;
+                    if (dying) {
+                        // Published as the teardown promise so the recovery
+                        // handler's `await destroy()` still means "native side
+                        // released" (F-104) even though stop() short-circuits.
+                        const retire = new Promise<void>((resolve) => {
+                            setImmediate(() => {
+                                try { dying.stop(); } catch (e) {
+                                    console.error('[SystemAudioCapture] Error retiring monitor after callback error:', e);
+                                }
+                                resolve();
+                            });
+                        });
+                        this._teardownPromise = retire;
+                        void retire.then(() => {
+                            if (this._teardownPromise === retire) this._teardownPromise = null;
+                        });
+                    }
                     this.emit('error', err);
                     return;
                 }

--- a/electron/audio/__tests__/LocalSttUnavailableTerminal2026_09_11.test.mjs
+++ b/electron/audio/__tests__/LocalSttUnavailableTerminal2026_09_11.test.mjs
@@ -1,0 +1,45 @@
+// electron/audio/__tests__/LocalSttUnavailableTerminal2026_09_11.test.mjs
+//
+// Review finding (2026-09-11): a local STT worker that cannot start (no ONNX
+// slot within 20s, or the model never reported ready) used to be classified by
+// main's stt.on('error') as a retryable blip — the overlay then showed "STT
+// reconnecting" for the rest of the meeting on a channel nothing restarts, and
+// the actionable message never surfaced. Also pinned: the mic provider's
+// finalize() result travels to the renderer so the Answer/Stop tail wait can
+// keep the gate open for a local model's multi-second final, and a capture
+// whose Rust thread exited retires its monitor so a later start() cannot hit
+// "Capture already running".
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const read = (rel) => fs.readFileSync(path.resolve(dirname, rel), 'utf8');
+const main = read('../../main.ts');
+const ipc = read('../../ipcHandlers.ts');
+const preload = read('../../preload.ts');
+const capture = read('../SystemAudioCapture.ts');
+const whisper = read('../LocalWhisperSTT.ts');
+
+test('main classifies local_stt_unavailable as terminal (failed), not reconnecting', () => {
+  assert.match(main, /const isLocalSttUnavailable = \(err as any\)\?\.code === 'local_stt_unavailable';/);
+  assert.match(main, /if \(isAuthError \|\| isLocalSttUnavailable\) \{/);
+  assert.match(whisper, /export const LOCAL_STT_UNAVAILABLE_CODE = 'local_stt_unavailable';/);
+});
+
+test("finalizeMicSTT's pending report reaches the renderer end to end", () => {
+  assert.match(main, /public finalizeMicSTT\(\): \{ pending: boolean \}/);
+  assert.match(main, /return \{ pending: r === true \};/);
+  assert.match(ipc, /safeHandle\('finalize-mic-stt', async \(\) => \{\n    return appState\.finalizeMicSTT\(\);/);
+  assert.match(preload, /finalizeMicSTT: \(\) => Promise<\{ pending: boolean \} \| void>;/);
+});
+
+test('a callback error retires the finished native monitor and publishes the teardown promise', () => {
+  const branch = capture.slice(capture.indexOf("console.error('[SystemAudioCapture] Callback error:', err);"), capture.indexOf("this.emit('error', err);"));
+  assert.match(branch, /this\.monitor = null;/, 'BUG: a later start() on the same instance would throw "Capture already running"');
+  assert.match(branch, /dying\.stop\(\)/);
+  assert.match(branch, /this\._teardownPromise = retire;/, 'destroy() must still await the native release (F-104)');
+});

--- a/electron/audio/__tests__/LocalWhisperReadyDeadline2026_09_11.test.mjs
+++ b/electron/audio/__tests__/LocalWhisperReadyDeadline2026_09_11.test.mjs
@@ -1,0 +1,91 @@
+// electron/audio/__tests__/LocalWhisperReadyDeadline2026_09_11.test.mjs
+//
+// Live-reproduced 2026-09-11 (isolated profile, per-channel local parakeet):
+// the channel that cold-started its worker logged "Loading …" and then
+// nothing for minutes. Every VAD segment sat in pendingAudio, the channel
+// transcribed nothing, and the user-visible symptom was "No speech detected"
+// — with no log line saying the model had not finished loading.
+//
+// Pinned here: the cold start arms a readiness deadline right after the init
+// post, `ready` clears it and logs the load time, and the deadline tears the
+// instance down and emits an actionable 'error' (the same clean teardown
+// start()'s spawnWorker catch performs) instead of queueing audio forever.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const source = fs.readFileSync(path.resolve(__dirname, '../LocalWhisperSTT.ts'), 'utf8');
+
+function method(name) {
+  const m = source.match(new RegExp(`private\\s+${name}\\s*\\([^)]*\\)\\s*:\\s*void\\s*\\{([\\s\\S]*?)\\n    \\}`));
+  assert.ok(m, `${name} must exist`);
+  return m[1];
+}
+
+test('the readiness deadline is a documented, env-overridable constant in a sane band', () => {
+  assert.match(source, /const WORKER_READY_TIMEOUT_MS = \(\(\) => \{/);
+  assert.match(source, /process\.env\.NATIVELY_LOCAL_STT_READY_TIMEOUT_MS/);
+  const def = source.match(/: 120_000;/);
+  assert.ok(def, 'default must stay 120s: model loads are legitimately slow on first run, but a meeting cannot wait forever');
+});
+
+test('the cold start arms the deadline immediately after posting init', () => {
+  const idx = source.indexOf('this.worker.postMessage(buildWorkerInitMessage(this.modelId));');
+  assert.ok(idx >= 0);
+  const after = source.slice(idx, idx + 200);
+  assert.match(after, /this\.armWorkerReadyDeadline\(\);/, 'BUG: a cold start with no deadline is a silent dead channel');
+});
+
+test('ready clears the deadline and logs how long the load took', () => {
+  const ready = source.slice(source.indexOf("if (msg.type === 'ready') {"), source.indexOf('this.flushPending();', source.indexOf("if (msg.type === 'ready') {")));
+  assert.match(ready, /this\.clearWorkerReadyDeadline\(\);/);
+  assert.match(ready, /worker ready in \$\{Date\.now\(\) - this\.workerSpawnedAt\}ms/);
+});
+
+test('the deadline tears the instance down and emits an actionable error', () => {
+  const body = method('scheduleWorkerReadyTimers');
+  assert.match(body, /this\.stopStreamingLoop\(\);/);
+  assert.match(body, /this\.vad = null;/);
+  assert.match(body, /this\.isActive = false;/);
+  assert.match(body, /this\.beginWorkerTermination\(w\);/, 'the slot must be released and the worker terminated');
+  assert.match(body, /this\.emit\('error', markLocalSttUnavailable\(new Error\(/, 'the error must carry the terminal marker main.ts classifies as failed');
+  assert.match(body, /did not finish loading within/);
+  assert.match(body, /cloud STT provider/);
+  // A graceful give-up is not a crash: the load sentinel must be cleared or
+  // the next launch "recovers" by resetting the user's model.
+  assert.match(body, /clearLoadSentinel\(this\.modelId\);/);
+  // Never fire on a worker that already answered, or on a stopped instance.
+  assert.match(body, /if \(this\.workerReady \|\| !this\.isActive\) return;/);
+  // Main-process timers never pin the event loop.
+  assert.equal((body.match(/\.unref\?\.\(\)/g) ?? []).length, 2);
+});
+
+test('a worker that dies during load clears the deadline; progress re-arms it', () => {
+  const err = source.slice(source.indexOf('const errorHandler = (err: Error) => {'), source.indexOf("this.worker.on('error', errorHandler);"));
+  assert.match(err.slice(0, 400), /this\.clearWorkerReadyDeadline\(\);/);
+  const exit = source.slice(source.indexOf('const exitHandler = (code: number) => {'), source.indexOf("this.worker.on('exit', exitHandler);"));
+  assert.match(exit.slice(0, 200), /this\.clearWorkerReadyDeadline\(\);/);
+  const progress = source.slice(source.indexOf("if ((msg as any).type === 'progress') {"), source.indexOf("if (msg.type === 'ready') {"));
+  assert.match(progress, /this\.scheduleWorkerReadyTimers\(\)/);
+  assert.match(source, /stop\(\): void \{\n        if \(!this\.isActive\) return;\n        this\.isActive = false;\n        this\.spawnGeneration\+\+;\n        this\.clearWorkerReadyDeadline\(\);/);
+});
+
+test('a slot wait that settles after stop() neither spawns an orphan nor tears down the next session', () => {
+  const cold = source.slice(source.indexOf('const generation = ++this.spawnGeneration;'), source.indexOf('console.log(`[LocalWhisperSTT] Cold-starting worker'));
+  assert.match(cold, /if \(generation !== this\.spawnGeneration \|\| !this\.isActive\) return;/, 'stale rejection must be swallowed');
+  assert.match(cold, /slotRelease\(\);\n            return;/, 'a slot arriving after stop() must be handed straight back');
+  assert.match(cold, /throw markLocalSttUnavailable\(err\);/);
+});
+
+test('finalize reports whether a final is now in flight', () => {
+  assert.match(source, /finalize\(\): boolean \{[\s\S]*?return segs\.length > 0 \|\| this\.pendingAudio\.length > 0;/);
+});
+
+test('termination always clears the deadline so a torn-down instance cannot fire it later', () => {
+  const body = method('beginWorkerTermination');
+  assert.match(body.slice(0, 120), /this\.clearWorkerReadyDeadline\(\);/);
+});

--- a/electron/audio/__tests__/SckReprobeAfterSystemStop2026_09_11.test.mjs
+++ b/electron/audio/__tests__/SckReprobeAfterSystemStop2026_09_11.test.mjs
@@ -1,0 +1,63 @@
+// electron/audio/__tests__/SckReprobeAfterSystemStop2026_09_11.test.mjs
+//
+// Live-reproduced 2026-09-11: after display sleep stopped the SCK stream, the
+// recovery rebuilt the capture while displays were still gone, SCK init
+// failed ("No displays found") and the Rust side fell back to the CoreAudio
+// tap — which then stayed for the rest of the meeting even after the display
+// woke. Users who chose SCK because the CoreAudio tap does not work with their
+// device (#540) silently lost the backend they picked.
+//
+// Pinned: the native module reports the active backend and whether SCK can
+// see a display; main polls both while the meeting runs on the 'sck' route
+// and rebuilds on SCK when displays return, bounded and mutex-disciplined.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const read = (rel) => fs.readFileSync(path.resolve(dirname, rel), 'utf8');
+const main = read('../../main.ts');
+const capture = read('../SystemAudioCapture.ts');
+const dts = read('../../../native-module/index.d.ts');
+const lib = read('../../../native-module/src/lib.rs');
+
+function method(name) {
+  let from = main.indexOf(`private ${name}(`);
+  if (from < 0) from = main.indexOf(`private async ${name}(`);
+  assert.ok(from >= 0, `${name} must exist`);
+  return main.slice(from, main.indexOf('\n  }\n', from));
+}
+
+test('the native module exposes the active backend and display availability', () => {
+  assert.match(dts, /getActiveBackend\(\): string/);
+  assert.match(dts, /export declare function screenCaptureDisplaysAvailable\(\): boolean/);
+  assert.match(lib, /speaker::active_display_count\(\) > 0/);
+  assert.match(capture, /public getActiveBackend\(\): string/);
+});
+
+test('the re-probe watcher is armed on the sck route only and stopped with the meeting', () => {
+  const w = method('startSckReprobeWatcher');
+  assert.match(w, /if \(process\.platform !== 'darwin'\) return;/);
+  assert.match(w, /if \(this\._lastRequestedOutputDeviceId !== 'sck'\) return;/);
+  assert.match(w, /capture\.getActiveBackend\(\)/);
+  assert.match(w, /NativeModule\.screenCaptureDisplaysAvailable\(\)/);
+  assert.match(w, /SCK_REPROBE_MAX_REBUILDS\) return;/, 'a flapping display must not rebuild forever');
+  // Respect the cross-flow mutexes shared with route-change and recovery.
+  assert.match(w, /if \(this\._defaultOutputSwitchInProgress \|\| this\._systemAudioRecoveryInProgress\) return;/);
+  const endMeeting = main.slice(main.indexOf('this.stopDefaultOutputWatcher();\n    this.stopSckReprobeWatcher();'));
+  assert.ok(endMeeting.length > 0, 'endMeeting must stop the re-probe watcher next to the route watcher');
+  assert.match(main, /this\.startDefaultOutputWatcher\(\);\n\s+this\.startSckReprobeWatcher\(\);/);
+});
+
+test('the SCK rebuild follows the destroy-await-revalidate discipline and requests sck explicitly', () => {
+  const r = method('rebuildSystemCaptureForSck');
+  assert.match(r, /this\._defaultOutputSwitchInProgress = true;/);
+  assert.match(r, /await oldCapture\?\.destroy\(\);/);
+  assert.match(r, /if \(this\.systemAudioCapture\) \{/, 'must re-validate ownership after the await (F-102)');
+  assert.match(r, /new SystemAudioCapture\('sck'\)/);
+  assert.match(r, /this\._systemAudioRecoveryAttempts = 0;/, 'a fresh backend gets a fresh recovery budget');
+  assert.match(r, /finally \{\n\s+this\._defaultOutputSwitchInProgress = false;/);
+});

--- a/electron/audio/whisper/nemotron/sharedWorkerRegistry.ts
+++ b/electron/audio/whisper/nemotron/sharedWorkerRegistry.ts
@@ -20,7 +20,7 @@
  */
 
 import { Worker } from 'worker_threads';
-import { acquireOnnxSlot } from '../../../utils/onnxThreadConfig';
+import { acquireOnnxSlotWithin } from '../../../utils/onnxThreadConfig';
 
 interface PendingReady {
   resolve: () => void;
@@ -195,7 +195,7 @@ export async function acquireSharedNemotronWorker(
       state.refCount++;
       console.log(`[sharedWorkerRegistry] channel "${channelId}" JOINED existing worker (refCount=${state.refCount})`);
     } else {
-      console.log(`[sharedWorkerRegistry] channel "${channelId}" COLD START — awaiting ONNX slot (weight 1, 15s deadline)...`);
+      console.log(`[sharedWorkerRegistry] channel "${channelId}" COLD START — awaiting ONNX slot (weight 1, 20s deadline)...`);
       const slotWaitStartedAt = Date.now();
       // Cold start — this registry owns the ONE ONNX slot acquisition for
       // Nemotron; LocalWhisperSTT no longer calls acquireOnnxSlot directly
@@ -226,7 +226,12 @@ export async function acquireSharedNemotronWorker(
       // reports the gate exists to prevent). Weight 1 restores the same
       // coexistence contract the pre-Nemotron catalog always had: local STT
       // plus one background ONNX consumer, capped at 2 workers.
-      const slotRelease = await acquireOnnxSlot('high', 1);
+      // Bounded (2026-09-11): the local embedding + reranker workers hold the
+      // whole default gate for the app lifetime, so an unbounded wait here was
+      // a silent dead channel with no log. The rejection propagates to
+      // LocalWhisperSTT.start()'s spawnWorker catch, which tears the instance
+      // down and emits 'error'.
+      const slotRelease = await acquireOnnxSlotWithin('high', 1, 20_000, 'sharedWorkerRegistry/nemotron');
       console.log(`[sharedWorkerRegistry] ONNX slot acquired after ${Date.now() - slotWaitStartedAt}ms — spawning worker for ${modelId}`);
       capturedWorker = new Worker(workerPath);
       state.worker = capturedWorker;

--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -1098,7 +1098,7 @@ export function initializeIpcHandlers(appState: AppState): void {
   });
 
   safeHandle('finalize-mic-stt', async () => {
-    appState.finalizeMicSTT();
+    return appState.finalizeMicSTT();
   });
 
   // IPC handler for analyzing image from file path

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1236,7 +1236,8 @@ import { DatabaseManager } from "./db/DatabaseManager"
 
 /** Unified type for all STT providers with optional extended capabilities */
 type STTProvider = (GoogleSTT | RestSTT | DeepgramStreamingSTT | SonioxStreamingSTT | ElevenLabsStreamingSTT | OpenAIStreamingSTT | NativelyProSTT | NvidiaNimStreamingSTT) & {
-  finalize?: () => void;
+  /** Local models return whether a trailing final is now in flight; cloud providers return void. */
+  finalize?: () => void | boolean;
   setAudioChannelCount?: (count: number) => void;
   notifySpeechEnded?: () => void;
 };
@@ -3634,7 +3635,14 @@ export class AppState {
       const isQuotaError = err.message.toLowerCase().includes('transcription_quota_exceeded')
         || err.message.toLowerCase().includes('quota');
 
-      if (isAuthError) {
+      // A local STT worker that could not start (no ONNX slot within 20s, or
+      // the model never reported ready) is terminal for this meeting: nothing
+      // restarts a LocalWhisperSTT instance, so "reconnecting" would be a lie
+      // the user stares at until they end the call. Surface the actionable
+      // message as a failure instead (LocalWhisperSTT.LOCAL_STT_UNAVAILABLE_CODE).
+      const isLocalSttUnavailable = (err as any)?.code === 'local_stt_unavailable';
+
+      if (isAuthError || isLocalSttUnavailable) {
         _consecutiveErrors = 0;
         _lastState = 'failed';
         this.sendSttStatus( {
@@ -5388,12 +5396,102 @@ export class AppState {
     this._lastObservedDefaultOutputId = null;
   }
 
+  // ── ScreenCaptureKit re-probe (macOS, 2026-09-11) ─────────────────────────
+  // When the user chose the SCK backend and a system-initiated stop (display
+  // sleep, a display reconfiguration during a screen share) made the recovery
+  // land on the CoreAudio fallback — SCK cannot enumerate a display while
+  // every display is asleep — nothing ever brought SCK back once displays
+  // returned: the user who picked SCK because the CoreAudio tap does not work
+  // with their Bluetooth/USB device (#540) stayed on it for the rest of the
+  // meeting. Poll while the meeting runs on the 'sck' route: if the live
+  // capture reports the CoreAudio backend and a display is available again,
+  // rebuild on SCK. Bounded so a display that flaps cannot rebuild forever.
+  private _sckReprobeInterval: NodeJS.Timeout | null = null;
+  private _sckReprobeRebuilds = 0;
+  private static readonly SCK_REPROBE_INTERVAL_MS = 10_000;
+  private static readonly SCK_REPROBE_MAX_REBUILDS = 3;
+
+  private startSckReprobeWatcher(): void {
+    if (process.platform !== 'darwin') return;
+    if (this._sckReprobeInterval) return;
+    if (this._lastRequestedOutputDeviceId !== 'sck') return;
+    const NativeModule: any = loadNativeModule();
+    if (!NativeModule || typeof NativeModule.screenCaptureDisplaysAvailable !== 'function') {
+      console.log('[SckReprobe] Native screenCaptureDisplaysAvailable unavailable — skipping re-probe watcher.');
+      return;
+    }
+    this._sckReprobeRebuilds = 0;
+    console.log('[SckReprobe] Started (SCK backend requested).');
+    this._sckReprobeInterval = setInterval(() => {
+      if (this._isQuitting || !this.isMeetingActive) return;
+      if (this._lastRequestedOutputDeviceId !== 'sck') return;
+      if (this._defaultOutputSwitchInProgress || this._systemAudioRecoveryInProgress) return;
+      const capture = this.systemAudioCapture;
+      if (!capture) return;
+      const backend = capture.getActiveBackend();
+      if (backend === 'sck') { this._sckReprobeRebuilds = 0; return; } // healthy
+      if (backend !== 'coreaudio') return;                               // still initialising
+      if (this._sckReprobeRebuilds >= AppState.SCK_REPROBE_MAX_REBUILDS) return;
+      let displays = false;
+      try { displays = !!NativeModule.screenCaptureDisplaysAvailable(); } catch { return; }
+      if (!displays) return;
+      this._sckReprobeRebuilds++;
+      console.log(`[SckReprobe] Displays are back and the capture is on the CoreAudio fallback — rebuilding on ScreenCaptureKit (attempt ${this._sckReprobeRebuilds}/${AppState.SCK_REPROBE_MAX_REBUILDS}).`);
+      this.rebuildSystemCaptureForSck().catch((err) => {
+        console.error('[SckReprobe] Rebuild failed:', err);
+      });
+    }, AppState.SCK_REPROBE_INTERVAL_MS);
+    this._sckReprobeInterval.unref?.();
+  }
+
+  private stopSckReprobeWatcher(): void {
+    if (this._sckReprobeInterval) {
+      clearInterval(this._sckReprobeInterval);
+      this._sckReprobeInterval = null;
+    }
+  }
+
+  /**
+   * Destroy + recreate the system capture on the SCK backend. Same ownership
+   * discipline as handleDefaultOutputChanged (F-102/F-103/F-104): the shared
+   * cross-flow mutex, an awaited destroy, and a re-validation after every await.
+   */
+  private async rebuildSystemCaptureForSck(): Promise<void> {
+    const meetingGeneration = this._meetingGeneration;
+    const isCurrentMeeting = () => this.isMeetingActive && this._meetingGeneration === meetingGeneration;
+    if (this._isQuitting || !isCurrentMeeting()) return;
+    if (this._defaultOutputSwitchInProgress || this._systemAudioRecoveryInProgress) return;
+    this._defaultOutputSwitchInProgress = true;
+    try {
+      const oldCapture = this.systemAudioCapture;
+      this.systemAudioCapture = null;
+      this._sysSttRateApplied = false;
+      await oldCapture?.destroy();
+      if (this._isQuitting || !isCurrentMeeting()) return;
+      if (this.systemAudioCapture) {
+        console.warn('[SckReprobe] Capture rebuilt by another flow mid-await — keeping theirs.');
+        return;
+      }
+      const fresh = new SystemAudioCapture('sck');
+      this.systemAudioCapture = fresh;
+      this.wireSystemCapture(fresh, '(SckReprobe)');
+      fresh.start();
+      // A fresh backend gets a fresh recovery budget.
+      this._systemAudioRecoveryAttempts = 0;
+      this._systemAudioConsecutiveFailures = 0;
+      console.log('[SckReprobe] Capture rebuilt on ScreenCaptureKit.');
+    } finally {
+      this._defaultOutputSwitchInProgress = false;
+    }
+  }
+
   // Public wrapper for the before-quit hook so shutdown can cancel the
   // interval without poking into a private method. Mirrors the meeting-end
   // path's stopDefaultOutputWatcher() call but is invoked from a context that
   // does not own a `this` reference inside the AppState class.
   public stopDefaultOutputWatcherForShutdown(): void {
     this.stopDefaultOutputWatcher();
+    this.stopSckReprobeWatcher();
   }
 
   private async handleDefaultOutputChanged(currentId?: string): Promise<void> {
@@ -5994,12 +6092,21 @@ export class AppState {
     }
   }
 
-  public finalizeMicSTT(): void {
+  /**
+   * Flush the user-mic provider so its trailing final is produced. Returns
+   * whether the provider reports a final now IN FLIGHT (local models can —
+   * they know a segment was just flushed to the worker); cloud providers
+   * return void and read as `pending: false`. The renderer's Answer/Stop tail
+   * wait uses this to decide between its short grace and its full window.
+   */
+  public finalizeMicSTT(): { pending: boolean } {
     // We only want to finalize the user microphone, because the context is Manual Answer
     if (this.googleSTT_User?.finalize) {
       console.log('[Main] Finalizing STT');
-      this.googleSTT_User.finalize();
+      const r: unknown = this.googleSTT_User.finalize();
+      return { pending: r === true };
     }
+    return { pending: false };
   }
 
   /**
@@ -6352,6 +6459,7 @@ export class AppState {
         // output or if the native binary lacks the getDefaultOutputDeviceId
         // export.
         this.startDefaultOutputWatcher();
+        this.startSckReprobeWatcher();
 
         if (this._verboseLogging) {
           const requestedInput = metadata?.audio?.inputDeviceId || 'default';
@@ -6544,6 +6652,7 @@ export class AppState {
     // Stop the default-output watcher — no point polling CoreAudio while
     // there's no active capture to rebind.
     this.stopDefaultOutputWatcher();
+    this.stopSckReprobeWatcher();
 
     // Tell STT to mark the audio stream as ended; trailing finals will arrive
     // over the next ~150ms while we're already returning to the renderer.

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -490,7 +490,8 @@ interface ElectronAPI {
    *  is unpackaged — the gate lives in the main-process handler. */
   debugInjectTranscript: (segments: Array<{ speaker?: string; text: string; timestamp?: number; confidence?: number }>)
     => Promise<{ success: boolean; injected?: number; error?: string }>;
-  finalizeMicSTT: () => Promise<void>;
+  /** Resolves with `{ pending }` — true when the mic provider reports a trailing final in flight. Older mains resolve void. */
+  finalizeMicSTT: () => Promise<{ pending: boolean } | void>;
   getRecentMeetings: () => Promise<
     Array<{ id: string; title: string; date: string; duration: string; summary: string }>
   >;

--- a/electron/utils/__tests__/OnnxSlotBoundedWait2026_09_11.test.mjs
+++ b/electron/utils/__tests__/OnnxSlotBoundedWait2026_09_11.test.mjs
@@ -1,0 +1,92 @@
+// electron/utils/__tests__/OnnxSlotBoundedWait2026_09_11.test.mjs
+//
+// Live-reproduced 2026-09-11 (isolated profile, per-channel local parakeet STT,
+// local embedding + reranker loaded): the interviewer channel never logged
+// "Cold-starting worker" and transcribed nothing for a 10-minute meeting.
+// Cause: LocalWhisperSTT.spawnWorker awaited acquireOnnxSlot('high') with no
+// deadline while the embedding and reranker workers held both slots of the
+// default cap for the app lifetime. Nothing logged, nothing surfaced.
+//
+// acquireOnnxSlotWithin turns that into a rejection with an actionable message,
+// and a slot arriving after the deadline is released at once so the abandoned
+// waiter can never leak the gate.
+//
+// Run: ELECTRON_RUN_AS_NODE=1 electron --test (after npm run build:electron).
+
+import { test, describe, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MODULE_URL = pathToFileURL(
+  path.resolve(__dirname, '../../../dist-electron/electron/utils/onnxThreadConfig.js')
+).href;
+const { acquireOnnxSlot, acquireOnnxSlotWithin, describeOnnxGate, __resetOnnxGateForTests } = await import(MODULE_URL);
+
+process.env.NATIVELY_ONNX_MAX_CONCURRENT_SESSIONS = '1';
+// STT channels draw on their own budget; make it 1 so ONE high-priority holder
+// fills it and the next high-priority request has to wait.
+process.env.NATIVELY_ONNX_HIGH_PRIORITY_SESSIONS = '1';
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+describe('bounded ONNX slot acquisition', () => {
+  beforeEach(() => { __resetOnnxGateForTests(); });
+
+  test('rejects with an actionable message when the STT budget is already held', async () => {
+    const releaseHolder = await acquireOnnxSlot('high', 1); // the other STT channel, in effect
+    await assert.rejects(
+      acquireOnnxSlotWithin('high', 1, 120, 'LocalWhisperSTT/system'),
+      (err) => {
+        assert.match(err.message, /LocalWhisperSTT\/system: no ONNX session slot became free within 120ms/);
+        assert.match(err.message, /1\/1 high-priority \(STT\) sessions in use/);
+        assert.match(err.message, /cloud STT provider/);
+        return true;
+      },
+    );
+    releaseHolder();
+  });
+
+  test('a slot freed after the deadline is released immediately — the abandoned waiter never leaks the gate', async () => {
+    const releaseHolder = await acquireOnnxSlot('high', 1);
+    await assert.rejects(acquireOnnxSlotWithin('high', 1, 80, 'late'));
+    releaseHolder(); // the abandoned waiter would now be handed the slot
+    await sleep(20);
+    // If the late slot had been kept, this fresh request would hang past its deadline.
+    const release = await acquireOnnxSlotWithin('high', 1, 300, 'fresh');
+    assert.equal(typeof release, 'function');
+    assert.match(describeOnnxGate(), /1\/1 high-priority \(STT\) sessions in use/);
+    release();
+    assert.match(describeOnnxGate(), /0\/1 high-priority \(STT\) sessions in use/);
+  });
+
+  test('a background holder does NOT block an STT channel: the pools are disjoint', async () => {
+    const releaseEmbedder = await acquireOnnxSlot('normal', 1); // fills the background cap of 1
+    const t0 = Date.now();
+    const releaseStt = await acquireOnnxSlotWithin('high', 1, 1000, 'LocalWhisperSTT/mic');
+    assert.ok(Date.now() - t0 < 200, 'the STT channel must be admitted immediately despite the full background cap');
+    assert.match(describeOnnxGate(), /1\/1 background ONNX sessions and 1\/1 high-priority/);
+    releaseStt();
+    releaseEmbedder();
+  });
+
+  test('resolves promptly when a slot is free', async () => {
+    const t0 = Date.now();
+    const release = await acquireOnnxSlotWithin('high', 1, 1000, 'free');
+    assert.ok(Date.now() - t0 < 200);
+    release();
+  });
+
+  test('source: LocalWhisperSTT cold start uses the bounded acquire, never the unbounded one', () => {
+    const src = fs.readFileSync(path.resolve(__dirname, '../../audio/LocalWhisperSTT.ts'), 'utf8');
+    assert.match(src, /acquireOnnxSlotWithin\(\s*'high',\s*1,\s*LocalWhisperSTT\.ONNX_SLOT_WAIT_MS/);
+    assert.doesNotMatch(src, /\bacquireOnnxSlot\(/, 'an unbounded acquire would silently dead-end a channel again');
+  });
+
+  test('source: the Nemotron shared-worker cold start is bounded too', () => {
+    const src = fs.readFileSync(path.resolve(__dirname, '../../audio/whisper/nemotron/sharedWorkerRegistry.ts'), 'utf8');
+    assert.match(src, /acquireOnnxSlotWithin\('high', 1, 20_000, 'sharedWorkerRegistry\/nemotron'\)/);
+    assert.doesNotMatch(src, /await acquireOnnxSlot\(/, 'the bare unbounded await must be gone (prose mentions in comments are fine)');
+  });
+});

--- a/electron/utils/onnxThreadConfig.ts
+++ b/electron/utils/onnxThreadConfig.ts
@@ -169,19 +169,40 @@ export type OnnxSlotPriority = 'normal' | 'high';
 interface OnnxSemaphore {
     inFlightNormal: number;
     inFlightHigh: number;
+    /** Weight-exceeds-cap holders currently running (they must run alone). */
+    exclusiveInFlight: number;
     waitersNormal: Array<() => void>;
     waitersHigh: Array<() => void>;
 }
 const _sem: OnnxSemaphore = (() => {
     const g = globalThis as unknown as Record<string, OnnxSemaphore | undefined>;
     if (!g.__nativelyOnnxSemaphoreV1__) {
-        g.__nativelyOnnxSemaphoreV1__ = { inFlightNormal: 0, inFlightHigh: 0, waitersNormal: [], waitersHigh: [] };
+        g.__nativelyOnnxSemaphoreV1__ = { inFlightNormal: 0, inFlightHigh: 0, exclusiveInFlight: 0, waitersNormal: [], waitersHigh: [] };
     }
     return g.__nativelyOnnxSemaphoreV1__;
 })();
 
 function readMaxConcurrent(): number {
     return readIntEnv('NATIVELY_ONNX_MAX_CONCURRENT_SESSIONS', 2);
+}
+
+/**
+ * Budget for latency-critical (`'high'`) sessions — the local STT channels —
+ * SEPARATE from the background cap above. Default 2: one worker per audio
+ * channel (mic + system).
+ *
+ * Why separate (2026-09-11, live-reproduced): the local embedding and
+ * reranker workers each hold a background slot for the app lifetime, which
+ * is the whole default cap. Counting STT against the same pool meant a
+ * per-channel local STT worker could NEVER be admitted while local RAG was
+ * on — the channel waited forever (now: fails after 20s). STT is the
+ * feature the user is looking at during a meeting; the RAG workers already
+ * run with the CPU arena disabled and every session passes the
+ * available-memory gate, so the worst case is cap + budget = 4 workers,
+ * only when the user explicitly enabled per-channel local models.
+ */
+function readHighPriorityBudget(): number {
+    return readIntEnv('NATIVELY_ONNX_HIGH_PRIORITY_SESSIONS', 2);
 }
 
 function readMinFreeGB(): number {
@@ -211,20 +232,27 @@ function readExclusiveTimeoutMs(): number {
 function canAcquireNow(priority: OnnxSlotPriority, weight: number): boolean {
     const cap = readMaxConcurrent();
     const current = _sem.inFlightNormal + _sem.inFlightHigh;
+    // An exclusive holder (weight > cap) runs alone: nobody else is admitted
+    // — from either pool — until it releases.
+    if ((_sem.exclusiveInFlight ?? 0) > 0) return false;
     // A request whose own weight exceeds the cap (Nemotron's 3 sessions
     // against the default cap of 2) can never satisfy "current + weight <=
     // cap" — that would deadlock forever. Treat it as exclusive: admit only
     // when nothing else is in flight, then let it run alone even though it
     // temporarily exceeds the nominal cap.
     if (weight > cap) {
-        if (current > 0) return false;
-    } else if (current + weight > cap) {
-        return false;
+        return current === 0;
     }
-    if (priority === 'high') return true;
-    // Normal priority: only acquire when there are no high-priority waiters
-    // queued (so Whisper can grab the next slot promptly).
-    return _sem.waitersHigh.length === 0;
+    if (priority === 'high') {
+        // Latency-critical STT channels draw on their OWN budget — see
+        // readHighPriorityBudget for why they must not queue behind the
+        // lifetime-held background slots.
+        return _sem.inFlightHigh + weight <= readHighPriorityBudget();
+    }
+    // Background consumers: their own cap. High-priority waiters no longer
+    // block them — the pools are disjoint, so a queued STT channel is waiting
+    // on ITS budget, not on this slot.
+    return _sem.inFlightNormal + weight <= cap;
 }
 
 function removeFromQueue(queue: Array<() => void>, resolver: () => void): void {
@@ -302,6 +330,7 @@ export async function acquireOnnxSlot(priority: OnnxSlotPriority = 'normal', wei
 
     if (priority === 'high') _sem.inFlightHigh += weight;
     else _sem.inFlightNormal += weight;
+    if (exclusive) _sem.exclusiveInFlight = (_sem.exclusiveInFlight ?? 0) + 1;
 
     let released = false;
     return () => {
@@ -309,6 +338,7 @@ export async function acquireOnnxSlot(priority: OnnxSlotPriority = 'normal', wei
         released = true;
         if (priority === 'high') _sem.inFlightHigh -= weight;
         else _sem.inFlightNormal -= weight;
+        if (exclusive) _sem.exclusiveInFlight = Math.max(0, (_sem.exclusiveInFlight ?? 0) - 1);
         // Wake EVERY waiter, not just one: a multi-unit release (weight > 1)
         // can free capacity for more than one queued weight-1 waiter, and a
         // single-wake design (correct when every release always freed
@@ -375,6 +405,71 @@ function readLinuxAvailableGB(): number | null {
     return (kb * 1024) / 1024 ** 3;
 }
 
+/** One-line picture of who holds the gate, for logs and actionable errors. */
+export function describeOnnxGate(): string {
+    const cap = readMaxConcurrent();
+    const budget = readHighPriorityBudget();
+    return `${_sem.inFlightNormal}/${cap} background ONNX sessions and ${_sem.inFlightHigh}/${budget} ` +
+        `high-priority (STT) sessions in use` +
+        `${(_sem.exclusiveInFlight ?? 0) > 0 ? ', an exclusive holder is running' : ''}; ` +
+        `${_sem.waitersHigh.length} high-priority + ${_sem.waitersNormal.length} normal-priority waiting`;
+}
+
+/**
+ * `acquireOnnxSlot` with a deadline. Rejects with an actionable message when
+ * no slot frees within `timeoutMs`; a slot that arrives after the deadline is
+ * released immediately so the abandoned waiter can never hold the gate.
+ *
+ * Why this exists (2026-09-11, live-reproduced): the local embedding and
+ * reranker workers each hold a slot for the app lifetime. With the default cap
+ * of 2 that is the whole gate, so a per-channel local STT worker's plain
+ * `acquireOnnxSlot('high')` waited FOREVER — no log, no error — and that
+ * channel transcribed nothing for the entire meeting (the interviewer channel
+ * never even logged "Cold-starting worker"). A bounded wait turns a silent
+ * dead channel into a visible STT failure the user can act on.
+ */
+export function acquireOnnxSlotWithin(
+    priority: OnnxSlotPriority,
+    weight: number,
+    timeoutMs: number,
+    label: string = 'onnx',
+): Promise<() => void> {
+    return new Promise((resolve, reject) => {
+        let settled = false;
+        const slowLog = setTimeout(() => {
+            if (!settled) console.warn(`[OnnxGate] ${label} has waited ${Math.min(3000, timeoutMs)}ms for an ONNX session — ${describeOnnxGate()}`);
+        }, Math.min(3000, timeoutMs));
+        (slowLog as any).unref?.();
+        const timer = setTimeout(() => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(slowLog);
+            reject(new Error(
+                `${label}: no ONNX session slot became free within ${timeoutMs}ms — ${describeOnnxGate()}. ` +
+                `Raise NATIVELY_ONNX_HIGH_PRIORITY_SESSIONS (STT channels) or NATIVELY_ONNX_MAX_CONCURRENT_SESSIONS ` +
+                `(background models), or use a cloud STT provider.`,
+            ));
+        }, timeoutMs);
+        (timer as any).unref?.();
+        acquireOnnxSlot(priority, weight).then(
+            (release) => {
+                if (settled) { release(); return; } // too late — never hold the gate from an abandoned wait
+                settled = true;
+                clearTimeout(timer);
+                clearTimeout(slowLog);
+                resolve(release);
+            },
+            (err) => {
+                if (settled) return;
+                settled = true;
+                clearTimeout(timer);
+                clearTimeout(slowLog);
+                reject(err);
+            },
+        );
+    });
+}
+
 /**
  * Best-effort AVAILABLE (not merely free) system memory in GB. Falls back to
  * `os.freemem()` when the platform-specific probe is unavailable or throws.
@@ -437,6 +532,10 @@ export function getMinFreeGBForOnnxSession(): number {
 }
 
 /** Returns the current max-concurrent cap (live, env-aware). */
+export function getHighPriorityOnnxBudget(): number {
+    return readHighPriorityBudget();
+}
+
 export function getMaxConcurrentOnnxSessions(): number {
     return readMaxConcurrent();
 }
@@ -449,6 +548,7 @@ export function getMaxConcurrentOnnxSessions(): number {
 export function __resetOnnxGateForTests(): void {
     _sem.inFlightNormal = 0;
     _sem.inFlightHigh = 0;
+    _sem.exclusiveInFlight = 0;
     _sem.waitersNormal.length = 0;
     _sem.waitersHigh.length = 0;
 }

--- a/native-module/index.d.ts
+++ b/native-module/index.d.ts
@@ -59,6 +59,8 @@ export declare class StealthKeyboardTap {
 
 export declare class SystemAudioCapture {
   constructor(deviceId?: string | undefined | null)
+  /** "sck" | "coreaudio" | "wasapi", or "" until the background init finished. */
+  getActiveBackend(): string
   /**
    * EMITTED sample rate — the rate of the PCM handed to STT (16000 when the
    * resampler is active). This is what callers must declare to STT providers.
@@ -194,6 +196,14 @@ export interface OverlayBoundsInput {
   width: number
   height: number
 }
+
+/**
+ * macOS: whether ScreenCaptureKit can currently enumerate a display (false
+ * while every display is asleep — the state in which an SCK stream stops
+ * with -3815 and a rebuild would fail "No displays found"). Always true on
+ * other platforms, whose backends are not display-bound.
+ */
+export declare function screenCaptureDisplaysAvailable(): boolean
 
 /**
  * One joint-state transition from the dual-channel tracker

--- a/native-module/index.js
+++ b/native-module/index.js
@@ -586,6 +586,7 @@ module.exports.getHardwareId = nativeBinding.getHardwareId
 module.exports.getInputDevices = nativeBinding.getInputDevices
 module.exports.getOutputDevices = nativeBinding.getOutputDevices
 module.exports.isAccessibilityGranted = nativeBinding.isAccessibilityGranted
+module.exports.screenCaptureDisplaysAvailable = nativeBinding.screenCaptureDisplaysAvailable
 module.exports.validateDodoKey = nativeBinding.validateDodoKey
 module.exports.verifyDodoKey = nativeBinding.verifyDodoKey
 module.exports.verifyGumroadKey = nativeBinding.verifyGumroadKey

--- a/native-module/src/lib.rs
+++ b/native-module/src/lib.rs
@@ -4,7 +4,7 @@
 extern crate napi_derive;
 
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
@@ -195,6 +195,10 @@ pub struct SystemAudioCapture {
     /// HFP/Bluetooth-degradation detection — distinct from the emitted rate above.
     native_sample_rate: Arc<AtomicU32>,
     device_id: Option<String>,
+    /// Which backend the background thread actually ended up on ("sck",
+    /// "coreaudio", "wasapi"); empty until init completes. main.ts compares
+    /// it with the requested backend to notice a silent fallback.
+    active_backend: Arc<Mutex<String>>,
 }
 
 #[napi]
@@ -212,7 +216,17 @@ impl SystemAudioCapture {
             // background thread reports the real hardware rate.
             native_sample_rate: Arc::new(AtomicU32::new(48000)),
             device_id,
+            active_backend: Arc::new(Mutex::new(String::new())),
         })
+    }
+
+    /// "sck" | "coreaudio" | "wasapi", or "" until the background init finished.
+    #[napi]
+    pub fn get_active_backend(&self) -> String {
+        match self.active_backend.lock() {
+            Ok(s) => s.clone(),
+            Err(poisoned) => poisoned.into_inner().clone(),
+        }
     }
 
     /// EMITTED sample rate — the rate of the PCM handed to STT (16000 when the
@@ -251,6 +265,7 @@ impl SystemAudioCapture {
         let stop_signal = self.stop_signal.clone();
         let sample_rate_shared = self.sample_rate.clone();
         let native_rate_shared = self.native_sample_rate.clone();
+        let active_backend_shared = self.active_backend.clone();
         let device_id = self.device_id.clone();
 
         // ALL init + DSP runs in background thread — start() returns INSTANTLY
@@ -295,6 +310,11 @@ impl SystemAudioCapture {
                     return;
                 }
             };
+            if let Ok(mut b) = active_backend_shared.lock() {
+                *b = stream.backend_name().to_string();
+            }
+            println!("[SystemAudioCapture] Active backend: {}", stream.backend_name());
+
             let mut consumer = match stream.take_consumer() {
                 Some(c) => c,
                 None => {
@@ -355,6 +375,26 @@ impl SystemAudioCapture {
 
             loop {
                 if stop_signal.load(Ordering::Relaxed) {
+                    break;
+                }
+
+                // The platform stopped the stream underneath us (SCK delegate on
+                // macOS, WASAPI read failures on Windows; the CoreAudio tap has
+                // no stop callback and relies on main.ts's route watcher). A
+                // quiet ring buffer is exactly what a silent meeting looks like,
+                // so for those backends this is the only signal that tells the
+                // two apart. Flush what we have, hand
+                // the reason to JS as a capture error (the SystemAudioCapture
+                // wrapper emits 'error' → main.ts rebuilds the capture), and
+                // end this thread.
+                if let Some(reason) = stream.take_stop_error() {
+                    let msg = format!("[SystemAudioCapture] Capture stream stopped by the system: {}", reason);
+                    eprintln!("{}", msg);
+                    emitter.flush(&tsfn);
+                    tsfn.call(
+                        Err(napi::Error::from_reason(msg)),
+                        ThreadsafeFunctionCallMode::NonBlocking,
+                    );
                     break;
                 }
 
@@ -761,6 +801,22 @@ pub fn get_output_devices() -> Vec<AudioDeviceInfo> {
             eprintln!("[get_output_devices] Error: {}", e);
             Vec::new()
         }
+    }
+}
+
+/// macOS: whether ScreenCaptureKit can currently enumerate a display (false
+/// while every display is asleep — the state in which an SCK stream stops
+/// with -3815 and a rebuild would fail "No displays found"). Always true on
+/// other platforms, whose backends are not display-bound.
+#[napi]
+pub fn screen_capture_displays_available() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        speaker::active_display_count() > 0
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        true
     }
 }
 

--- a/native-module/src/speaker/core_audio.rs
+++ b/native-module/src/speaker/core_audio.rs
@@ -267,6 +267,10 @@ impl SpeakerStream {
         self.consumer.take()
     }
 
+    pub fn backend_name(&self) -> &'static str {
+        "coreaudio"
+    }
+
     /// Pause the aggregate device without destroying it.
     /// Allows fast restart without the 1-second audio mute.
     /// NOTE: This is a one-way operation for CoreAudio — resume() is not supported.

--- a/native-module/src/speaker/macos.rs
+++ b/native-module/src/speaker/macos.rs
@@ -3,6 +3,7 @@ use super::sck;
 use anyhow::Result;
 use ringbuf::HeapCons;
 
+pub use super::sck::active_display_count;
 pub use super::sck::list_output_devices;
 
 pub struct SpeakerInput {
@@ -82,6 +83,25 @@ impl SpeakerStream {
         match &mut self.backend {
             BackendStream::CoreAudio(s) => s.take_consumer(),
             BackendStream::Sck(s) => s.take_consumer(),
+        }
+    }
+
+    /// The reason the platform stopped the stream underneath us, once.
+    /// `None` while healthy. CoreAudio taps have no stop callback of their own;
+    /// their route changes are handled by main.ts's default-output watcher.
+    pub fn take_stop_error(&self) -> Option<String> {
+        match &self.backend {
+            BackendStream::CoreAudio(_) => None,
+            BackendStream::Sck(s) => s.take_stop_error(),
+        }
+    }
+
+    /// Which backend actually ended up capturing — the JS side compares this
+    /// with what the user requested ("sck") to notice a silent fallback.
+    pub fn backend_name(&self) -> &'static str {
+        match &self.backend {
+            BackendStream::CoreAudio(s) => s.backend_name(),
+            BackendStream::Sck(s) => s.backend_name(),
         }
     }
 

--- a/native-module/src/speaker/mod.rs
+++ b/native-module/src/speaker/mod.rs
@@ -1,5 +1,9 @@
 // removed unused anyhow::Result
 
+/// Shared by every backend — see stop_signal.rs for why a stopped stream must
+/// be surfaced instead of read as silence.
+pub mod stop_signal;
+
 #[cfg(target_os = "macos")]
 mod core_audio;
 #[cfg(target_os = "macos")]
@@ -14,6 +18,8 @@ pub use macos::SpeakerInput;
 pub use macos::SpeakerStream;
 #[cfg(target_os = "macos")]
 pub use sck::default_output_device_uid;
+#[cfg(target_os = "macos")]
+pub use sck::active_display_count;
 
 #[cfg(target_os = "windows")]
 pub mod windows;
@@ -60,6 +66,12 @@ pub mod fallback {
             unreachable!("SpeakerStream is never constructed on this platform")
         }
         pub fn take_consumer(&mut self) -> Option<HeapCons<f32>> {
+            unreachable!("SpeakerStream is never constructed on this platform")
+        }
+        pub fn take_stop_error(&self) -> Option<String> {
+            unreachable!("SpeakerStream is never constructed on this platform")
+        }
+        pub fn backend_name(&self) -> &'static str {
             unreachable!("SpeakerStream is never constructed on this platform")
         }
         pub fn pause(&mut self) {

--- a/native-module/src/speaker/sck.rs
+++ b/native-module/src/speaker/sck.rs
@@ -1,16 +1,35 @@
 // ScreenCaptureKit-based system audio capture
 // Uses cidre 0.11.10 API with correct class registration and inner state
 
+use super::stop_signal::StopSignal;
 use anyhow::Result;
 use cidre::sc::StreamOutput;
+// Brings the optional-method selector helpers (sel_*) into scope for add_methods.
+use cidre::sc::stream::Delegate as _;
 use cidre::{api, arc, cm, define_obj_type, dispatch, ns, objc, sc};
 use ringbuf::{
     traits::{Producer, Split},
     HeapCons, HeapProd, HeapRb,
 };
+use std::sync::Arc;
 
 // keep for compatibility
 use cidre::core_audio as ca;
+
+#[link(name = "CoreGraphics", kind = "framework")]
+extern "C" {
+    fn CGGetActiveDisplayList(max_displays: u32, active_displays: *mut u32, display_count: *mut u32) -> i32;
+}
+
+/// Number of active displays. ScreenCaptureKit enumerates NO displays while
+/// they are asleep (SCShareableContent comes back empty and a running stream
+/// stops with -3815), so main.ts polls this to know when an SCK rebuild can
+/// succeed again after a system-initiated stop. 0 on error.
+pub fn active_display_count() -> u32 {
+    let mut count: u32 = 0;
+    let err = unsafe { CGGetActiveDisplayList(0, std::ptr::null_mut(), &mut count) };
+    if err != 0 { 0 } else { count }
+}
 
 pub fn list_output_devices() -> Result<Vec<(String, String)>> {
     let all_devices = ca::System::devices()?;
@@ -97,6 +116,54 @@ impl sc::stream::OutputImpl for AudioHandler {
                 println!("[SystemAudio-SCK] Failed to get audio buffer: {:?}", e);
             }
         }
+    }
+}
+
+/// SCStreamDelegate. Until 2026-09-11 the stream was created with NO delegate,
+/// so a stream the system stopped underneath us was indistinguishable from a
+/// silent meeting: the ring buffer just went quiet, JS saw 0 chunks, no error,
+/// no recovery. Live-reproduced on macOS 26: display sleep stops the stream
+/// with SCStreamErrorDomain -3815 ("Failed to find any displays or windows to
+/// capture") and it never resumes — even after the display wakes and audio
+/// plays. The same class covers a display unplugged mid-meeting and the user
+/// (or macOS) stopping the capture from the screen-sharing menu-bar item.
+/// The delegate raises the reason on a shared StopSignal; the DSP loop in
+/// lib.rs takes it and surfaces a capture error so main.ts rebuilds the capture.
+pub struct StopDelegateInner {
+    signal: Arc<StopSignal>,
+}
+
+define_obj_type!(
+    StopDelegate + sc::stream::DelegateImpl,
+    StopDelegateInner,
+    STOP_DELEGATE_CLS
+);
+
+impl sc::stream::Delegate for StopDelegate {}
+
+#[objc::add_methods]
+impl sc::stream::DelegateImpl for StopDelegate {
+    extern "C" fn impl_stream_did_stop_with_err(
+        &mut self,
+        _cmd: Option<&objc::Sel>,
+        _stream: &sc::Stream,
+        error: &ns::Error,
+    ) {
+        let domain: &ns::String = &error.domain();
+        let reason = format!(
+            "ScreenCaptureKit stopped the system-audio stream ({} code {}): {}",
+            domain,
+            error.code(),
+            error.localized_desc()
+        );
+        println!("[SystemAudio-SCK] {}", reason);
+        self.inner_mut().signal.raise(reason);
+    }
+
+    extern "C" fn impl_user_did_stop_stream(&mut self, _cmd: Option<&objc::Sel>, _stream: &sc::Stream) {
+        let reason = "ScreenCaptureKit system-audio stream was stopped from the macOS screen-sharing menu".to_string();
+        println!("[SystemAudio-SCK] {}", reason);
+        self.inner_mut().signal.raise(reason);
     }
 }
 
@@ -227,7 +294,11 @@ impl SpeakerInput {
         let rb = HeapRb::<f32>::new(buffer_size);
         let (producer, consumer) = rb.split();
 
-        let stream = sc::Stream::new(&self.filter, &self.cfg);
+        let stop_signal = Arc::new(StopSignal::new());
+        let delegate = StopDelegate::with(StopDelegateInner {
+            signal: stop_signal.clone(),
+        });
+        let stream = sc::Stream::with_delegate(&self.filter, &self.cfg, delegate.as_ref());
 
         // Initialize handler
         let inner = AudioHandlerInner { producer };
@@ -290,6 +361,8 @@ impl SpeakerInput {
         Ok(SpeakerStream {
             consumer: Some(consumer),
             stream,
+            stop_signal,
+            _delegate: delegate,
             _handler: handler,
             _filter: self.filter,
             _cfg: self.cfg,
@@ -300,6 +373,9 @@ impl SpeakerInput {
 pub struct SpeakerStream {
     consumer: Option<HeapCons<f32>>,
     stream: arc::R<sc::Stream>,
+    stop_signal: Arc<StopSignal>,
+    // The delegate is only weakly referenced by SCStream; we own it.
+    _delegate: arc::R<StopDelegate>,
     _handler: arc::R<AudioHandler>,
     _filter: arc::R<sc::ContentFilter>,
     _cfg: arc::R<sc::StreamCfg>,
@@ -313,11 +389,29 @@ impl SpeakerStream {
     pub fn take_consumer(&mut self) -> Option<HeapCons<f32>> {
         self.consumer.take()
     }
+
+    /// The reason the system stopped this stream, once. `None` while healthy.
+    pub fn take_stop_error(&self) -> Option<String> {
+        self.stop_signal.take()
+    }
+
+    pub fn backend_name(&self) -> &'static str {
+        "sck"
+    }
 }
 
 impl Drop for SpeakerStream {
     fn drop(&mut self) {
         use std::sync::{Arc, Condvar, Mutex};
+
+        if self.stop_signal.was_ever_raised() {
+            // Already stopped by the system (the DSP loop has usually taken
+            // the reason by now, hence the sticky flag); stopCapture on a dead
+            // stream only errors back (or never calls back), and the JS
+            // recovery path is awaiting this drop before it rebuilds.
+            println!("[SpeakerStream] ScreenCaptureKit stream already stopped by the system — skipping stopCapture.");
+            return;
+        }
 
         println!("[SpeakerStream] Stopping ScreenCaptureKit stream...");
 

--- a/native-module/src/speaker/stop_signal.rs
+++ b/native-module/src/speaker/stop_signal.rs
@@ -1,0 +1,121 @@
+//! One-shot "the platform stopped our capture stream" signal.
+//!
+//! Every system-audio backend runs its own capture thread (ScreenCaptureKit
+//! delegate callbacks on macOS, the WASAPI loopback loop on Windows) while the
+//! DSP loop in lib.rs drains a lock-free ring buffer. When the platform ends the
+//! stream underneath us the ring buffer simply goes quiet — and a quiet ring
+//! buffer is exactly what a silent meeting looks like, so nothing downstream can
+//! tell the difference. Live-reproduced 2026-09-11 on macOS 26: display sleep
+//! stops an SCStream with SCStreamErrorDomain -3815 ("Failed to find any
+//! displays or windows to capture") and it never resumes, even after the display
+//! wakes and audio plays. Without a delegate the app saw 0 chunks, no error, no
+//! recovery — for the rest of the meeting.
+//!
+//! The backend raises the FIRST reason it observes; the DSP loop takes it once,
+//! flushes, and surfaces it to JS as a capture error so the existing recovery
+//! handler (main.ts setupAudioRecoveryHandler) can rebuild the capture.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+
+#[derive(Default, Debug)]
+pub struct StopSignal {
+    slot: Mutex<Option<String>>,
+    /// Sticky: set by the first `raise` and never cleared. `take` hands the
+    /// reason to the DSP loop once; the backend's `Drop` still needs to know
+    /// the platform already ended the stream so it does not issue a redundant
+    /// stop and wait on a callback that never comes.
+    ever_raised: AtomicBool,
+}
+
+impl StopSignal {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Records `reason` unless one is already pending. Returns `true` when this
+    /// call recorded it. The first reason is the root cause; a later one (for
+    /// example our own stop after the platform already stopped us) must not
+    /// overwrite it.
+    pub fn raise(&self, reason: impl Into<String>) -> bool {
+        let mut slot = match self.slot.lock() {
+            Ok(s) => s,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if slot.is_some() {
+            return false;
+        }
+        *slot = Some(reason.into());
+        self.ever_raised.store(true, Ordering::Release);
+        true
+    }
+
+    /// Takes the pending reason, if any. One-shot: a second call returns `None`
+    /// until something raises again.
+    pub fn take(&self) -> Option<String> {
+        let mut slot = match self.slot.lock() {
+            Ok(s) => s,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        slot.take()
+    }
+
+    /// Whether a reason is pending (raised and not yet taken).
+    pub fn is_raised(&self) -> bool {
+        match self.slot.lock() {
+            Ok(s) => s.is_some(),
+            Err(poisoned) => poisoned.into_inner().is_some(),
+        }
+    }
+
+    /// Whether the platform has EVER stopped this stream — survives `take`.
+    pub fn was_ever_raised(&self) -> bool {
+        self.ever_raised.load(Ordering::Acquire)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn take_is_one_shot() {
+        let s = StopSignal::new();
+        assert_eq!(s.take(), None);
+        assert!(s.raise("display went away"));
+        assert!(s.is_raised());
+        assert_eq!(s.take().as_deref(), Some("display went away"));
+        assert!(!s.is_raised());
+        assert!(s.was_ever_raised(), "the sticky flag must survive take()");
+        assert_eq!(s.take(), None);
+    }
+
+    #[test]
+    fn never_raised_reads_false_on_both_flags() {
+        let s = StopSignal::new();
+        assert!(!s.is_raised());
+        assert!(!s.was_ever_raised());
+    }
+
+    #[test]
+    fn first_reason_wins_until_taken() {
+        let s = StopSignal::new();
+        assert!(s.raise("root cause"));
+        assert!(!s.raise("later symptom"));
+        assert_eq!(s.take().as_deref(), Some("root cause"));
+        assert!(s.raise("a fresh stop after the first was handled"));
+    }
+
+    #[test]
+    fn shared_across_threads() {
+        use std::sync::Arc;
+        let s = Arc::new(StopSignal::new());
+        let s2 = s.clone();
+        std::thread::spawn(move || {
+            s2.raise("from the capture thread");
+        })
+        .join()
+        .unwrap();
+        assert_eq!(s.take().as_deref(), Some("from the capture thread"));
+    }
+}

--- a/native-module/src/speaker/windows.rs
+++ b/native-module/src/speaker/windows.rs
@@ -1,4 +1,5 @@
 // Ported logic
+use super::stop_signal::StopSignal;
 use crate::audio_config::RING_BUFFER_SAMPLES;
 use anyhow::Result;
 use ringbuf::{
@@ -6,11 +7,15 @@ use ringbuf::{
     HeapCons, HeapProd, HeapRb,
 };
 use std::collections::VecDeque;
+use std::rc::Rc;
 use std::sync::{mpsc, Arc, Condvar, Mutex};
 use std::thread;
 use std::time::Duration;
 use tracing::error;
-use wasapi::{get_default_device, DeviceCollection, Direction, SampleType, ShareMode, WaveFormat};
+use wasapi::{
+    get_default_device, DeviceCollection, Direction, DisconnectReason, EventCallbacks, SampleType,
+    ShareMode, WaveFormat,
+};
 
 struct WakerState {
     shutdown: bool,
@@ -20,12 +25,21 @@ pub struct SpeakerInput {
     device_id: Option<String>,
 }
 
+/// Consecutive `IAudioCaptureClient` read failures before the loop gives up
+/// and surfaces the stream as stopped. A single failure can be transient; a
+/// run of them is the signature of AUDCLNT_E_DEVICE_INVALIDATED (headset
+/// unplugged, driver reset, Windows switching the endpoint) — which until
+/// 2026-09-11 was logged and then `continue`d forever, so JS saw a quiet
+/// ring buffer indistinguishable from a silent meeting.
+const MAX_CONSECUTIVE_READ_FAILURES: u32 = 5;
+
 pub struct SpeakerStream {
     consumer: Option<HeapCons<f32>>,
     waker_state: Arc<Mutex<WakerState>>,
     capture_thread: Option<thread::JoinHandle<()>>,
     actual_sample_rate: u32,
     data_ready: Arc<(Mutex<bool>, Condvar)>,
+    stop_signal: Arc<StopSignal>,
 }
 
 impl SpeakerStream {
@@ -35,6 +49,16 @@ impl SpeakerStream {
 
     pub fn take_consumer(&mut self) -> Option<HeapCons<f32>> {
         self.consumer.take()
+    }
+
+    /// The reason the capture loop stopped on its own (device invalidated),
+    /// once. `None` while healthy.
+    pub fn take_stop_error(&self) -> Option<String> {
+        self.stop_signal.take()
+    }
+
+    pub fn backend_name(&self) -> &'static str {
+        "wasapi"
     }
 
     pub fn data_ready_signal(&self) -> Arc<(Mutex<bool>, Condvar)> {
@@ -133,10 +157,12 @@ impl SpeakerInput {
 
         let waker_state = Arc::new(Mutex::new(WakerState { shutdown: false }));
         let data_ready = Arc::new((Mutex::new(false), Condvar::new()));
+        let stop_signal = Arc::new(StopSignal::new());
         let (init_tx, init_rx) = mpsc::channel();
 
         let waker_clone = waker_state.clone();
         let data_ready_clone = data_ready.clone();
+        let stop_signal_clone = stop_signal.clone();
         let device_id = self.device_id;
 
         let capture_thread = thread::spawn(move || {
@@ -144,6 +170,7 @@ impl SpeakerInput {
                 producer,
                 waker_clone,
                 data_ready_clone,
+                stop_signal_clone,
                 init_tx,
                 device_id,
             ) {
@@ -180,6 +207,7 @@ impl SpeakerInput {
             capture_thread: Some(capture_thread),
             actual_sample_rate,
             data_ready,
+            stop_signal,
         })
     }
 
@@ -187,6 +215,7 @@ impl SpeakerInput {
         mut producer: HeapProd<f32>,
         waker_state: Arc<Mutex<WakerState>>,
         data_ready: Arc<(Mutex<bool>, Condvar)>,
+        stop_signal: Arc<StopSignal>,
         init_tx: mpsc::Sender<Result<u32>>,
         device_id: Option<String>,
     ) -> Result<()> {
@@ -241,13 +270,55 @@ impl SpeakerInput {
                 .start_stream()
                 .map_err(|e| anyhow::anyhow!("{}", e))?;
 
-            Ok((h_event, render_client, actual_rate, audio_client))
+            // Session-disconnect notification (IAudioSessionEvents::
+            // OnSessionDisconnected). This is the signal that fires when the
+            // endpoint is removed or the format changes REGARDLESS of buffer
+            // activity — an invalidated endpoint that simply stops pulsing
+            // its event never reaches the read-failure counter below, because
+            // the 3s wait timeout is also what silence looks like. Both the
+            // control and the callbacks must stay alive for the loop's
+            // lifetime (the registration holds only a Weak). Registration
+            // failure is non-fatal: the read-failure counter still applies.
+            let session_notification = (|| -> Result<(wasapi::AudioSessionControl, Rc<EventCallbacks>)> {
+                let control = audio_client
+                    .get_audiosessioncontrol()
+                    .map_err(|e| anyhow::anyhow!("{}", e))?;
+                let mut callbacks = EventCallbacks::new();
+                let signal = stop_signal.clone();
+                callbacks.set_disconnected_callback(move |reason: DisconnectReason| {
+                    let msg = format!("WASAPI audio session disconnected ({:?})", reason);
+                    eprintln!("[SystemAudio-WASAPI] {}", msg);
+                    signal.raise(msg);
+                });
+                let callbacks = Rc::new(callbacks);
+                control
+                    .register_session_notification(Rc::downgrade(&callbacks))
+                    .map_err(|e| anyhow::anyhow!("{}", e))?;
+                Ok((control, callbacks))
+            })();
+            let session_notification = match session_notification {
+                Ok(v) => Some(v),
+                Err(e) => {
+                    error!("[SystemAudio-WASAPI] session notification unavailable ({}); relying on read failures only", e);
+                    None
+                }
+            };
+
+            Ok((h_event, render_client, actual_rate, audio_client, session_notification))
         })();
 
         match init_result {
-            Ok((h_event, render_client, sample_rate, audio_client)) => {
+            Ok((h_event, render_client, sample_rate, audio_client, session_notification)) => {
                 let _ = init_tx.send(Ok(sample_rate));
+                let mut consecutive_read_failures: u32 = 0;
                 loop {
+                    // The session-disconnect callback (above) raised the signal
+                    // from the COM notification thread; leave promptly so the
+                    // DSP loop surfaces it instead of waiting on a dead event.
+                    if stop_signal.is_raised() {
+                        let _ = audio_client.stop_stream();
+                        break;
+                    }
                     {
                         let state = waker_state.lock().unwrap();
                         if state.shutdown {
@@ -269,8 +340,20 @@ impl SpeakerInput {
                         render_client.read_from_device_to_deque(bytes_per_frame, &mut temp_queue)
                     {
                         error!("Failed to read audio data: {}", e);
+                        consecutive_read_failures += 1;
+                        if consecutive_read_failures >= MAX_CONSECUTIVE_READ_FAILURES {
+                            let reason = format!(
+                                "WASAPI loopback read failed {} times in a row (device invalidated or endpoint changed): {}",
+                                consecutive_read_failures, e
+                            );
+                            eprintln!("[SystemAudio-WASAPI] {}", reason);
+                            stop_signal.raise(reason);
+                            let _ = audio_client.stop_stream();
+                            break;
+                        }
                         continue;
                     }
+                    consecutive_read_failures = 0;
 
                     if temp_queue.is_empty() {
                         continue;
@@ -298,6 +381,8 @@ impl SpeakerInput {
                         cvar.notify_all();
                     }
                 }
+                // Keep the registration alive for the whole loop; dropped here.
+                drop(session_notification);
             }
             Err(e) => {
                 let _ = init_tx.send(Err(e));

--- a/src/components/NativelyInterface.tsx
+++ b/src/components/NativelyInterface.tsx
@@ -243,6 +243,7 @@ import {
 import { shouldDedupeManualSubmit } from '../lib/overlaySubmitDedup.mjs';
 import { decideScrollInterrupt } from '../lib/scrollInterruptDecision.mjs';
 import { mergeTranscriptChunks } from '../lib/transcriptMerge.mjs';
+import { createTranscriptTailWaiter } from '../lib/answerTailWait.mjs';
 import {
   applyWhatToAnswerNullFeedbackMessages,
   finalizeStreamingByIntentMessages,
@@ -1254,6 +1255,13 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
   const [conversationContext, setConversationContext] = useState<string>('');
   const [isManualRecording, setIsManualRecording] = useState(false);
   const isRecordingRef = useRef(false); // Ref to track recording state (avoids stale closure)
+  // Answer/Stop tail collection — see answerTailWait.mjs. The recording ref
+  // stays open after the Stop press until the STT final lands (or a bounded
+  // window elapses); answerStopInFlightRef blocks a new Start meanwhile so it
+  // cannot reset the buffers mid-snapshot.
+  const answerTailWaiterRef = useRef<ReturnType<typeof createTranscriptTailWaiter> | null>(null);
+  if (answerTailWaiterRef.current === null) answerTailWaiterRef.current = createTranscriptTailWaiter();
+  const answerStopInFlightRef = useRef(false);
   const [manualTranscript, setManualTranscript] = useState('');
   const manualTranscriptRef = useRef<string>('');
   const [showTranscript, setShowTranscript] = useState(() => {
@@ -4349,6 +4357,14 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
       setAttachedContext([]);
       setManualTranscript('');
       setVoiceInput('');
+      // The refs are the dictation source of truth (the final-transcript
+      // merge reads voiceInputRef, not React state); a meeting ended mid-
+      // recording must not prepend its words to the next meeting's question.
+      manualTranscriptRef.current = '';
+      voiceInputRef.current = '';
+      isRecordingRef.current = false;
+      answerStopInFlightRef.current = false;
+      setIsManualRecording(false);
       setIsProcessing(false);
       if (rollingPartialDebounceRef.current !== null) {
         clearTimeout(rollingPartialDebounceRef.current);
@@ -6083,13 +6099,21 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
             // Accumulate final transcripts, collapsing STT overlap/re-transcription
             // races (RC5, docs/context-rebuild/03_LIVE_REPRO_FINDINGS.md item 4)
             // instead of blindly concatenating.
-            setVoiceInput((prev) => {
-              const updated = mergeTranscriptChunks(prev, transcript.text);
-              voiceInputRef.current = updated;
-              return updated;
-            });
+            //
+            // The ref is the source of truth and is written SYNCHRONOUSLY, with
+            // the state set from the same value. It used to be written inside
+            // the setVoiceInput updater, which React runs lazily on the next
+            // render — so a Stop press woken by notifyFinal() below snapshotted
+            // the ref before React had applied the merge and still saw ''
+            // (live-reproduced 2026-09-11 with an injected final: the waiter
+            // resolved 'final' with voice "").
+            const updated = mergeTranscriptChunks(voiceInputRef.current, transcript.text);
+            voiceInputRef.current = updated;
+            setVoiceInput(updated);
             setManualTranscript(''); // Clear partial preview
             manualTranscriptRef.current = '';
+            // A Stop press may be waiting for exactly this chunk.
+            answerTailWaiterRef.current!.notifyFinal();
           } else {
             // Show live partial transcript
             setManualTranscript(transcript.text);
@@ -7502,23 +7526,47 @@ const NativelyInterface: React.FC<NativelyInterfaceProps> = ({
     if (isManualRecording) {
       if (!tryBeginOverlayAction('answer_now')) return;
       try {
-        // Stop recording - send accumulated voice input to Gemini
-        isRecordingRef.current = false;
-        setIsManualRecording(false);
-        setManualTranscript('');
+        // Stop recording - send accumulated voice input to Gemini.
+        //
+        // The button flips to "Answer" immediately, but the recording gate
+        // (isRecordingRef) stays OPEN until the STT tail has landed: the
+        // transcript for the last second or two of speech arrives AFTER the
+        // Stop press (cloud finals 0.5–2s later, local models 1.5–7s), and the
+        // onNativeAudioTranscript handler drops every user chunk while the gate
+        // is closed. Closing it first — as this code did until 2026-09-11 —
+        // threw away exactly the chunk being waited for, so a short question
+        // came back as "No speech detected" (live-reproduced; see
+        // src/lib/__tests__/AnswerNowTranscriptTail2026_09_11.test.mjs).
+        // The button keeps reading "Stop" until the tail has landed: the state
+        // is truthful (the gate IS still open) and a second press in that window
+        // is absorbed by tryBeginOverlayAction instead of silently ignored.
+        answerStopInFlightRef.current = true;
 
-        // Wait for the final STT flush acknowledgement before snapshotting refs.
-        // Older preloads may never acknowledge, so cap the wait and allow one
-        // short renderer turn for the final transcript IPC to land.
+        // Ask main to flush the provider (a no-op for providers that finalize
+        // server-side). Local models report whether a final is now in flight.
+        // Older preloads may never acknowledge, so cap the wait.
+        let providerReportsPending = false;
         try {
-          await Promise.race([
+          const finalizeResult: unknown = await Promise.race([
             window.electronAPI.finalizeMicSTT(),
             new Promise<void>((resolve) => setTimeout(resolve, 750)),
           ]);
-          await new Promise<void>((resolve) => setTimeout(resolve, 50));
+          providerReportsPending = typeof finalizeResult === 'object' && finalizeResult !== null
+            && (finalizeResult as { pending?: boolean }).pending === true;
         } catch (err) {
           console.error('[NativelyInterface] Failed to finalize mic STT:', err);
         }
+
+        // Event-driven: resolves the moment a FINAL user chunk is merged, and
+        // is bounded so an empty recording still returns promptly.
+        await answerTailWaiterRef.current!.wait({
+          hasCapturedFinal: voiceInputRef.current.trim().length > 0,
+          hasPendingInterim: manualTranscriptRef.current.trim().length > 0 || providerReportsPending,
+        });
+        isRecordingRef.current = false;
+        answerStopInFlightRef.current = false;
+        setIsManualRecording(false);
+        setManualTranscript('');
 
         const currentAttachments = attachedContext;
         setAttachedContext([]);
@@ -7708,10 +7756,14 @@ Provide only the answer, nothing else.`;
           });
         }
       } finally {
+        answerStopInFlightRef.current = false;
         endOverlayAction('answer_now');
       }
     } else {
-      // Start recording - reset voice input state
+      // Start recording - reset voice input state.
+      // A previous Stop may still be collecting its transcript tail; starting
+      // now would wipe voiceInput while that snapshot is being taken.
+      if (answerStopInFlightRef.current) return;
       setVoiceInput('');
       voiceInputRef.current = '';
       setManualTranscript('');

--- a/src/lib/__tests__/AnswerNowTranscriptTail2026_09_11.test.mjs
+++ b/src/lib/__tests__/AnswerNowTranscriptTail2026_09_11.test.mjs
@@ -1,0 +1,170 @@
+// src/lib/__tests__/AnswerNowTranscriptTail2026_09_11.test.mjs
+//
+// Live-reproduced 2026-09-11 (isolated profile, local parakeet STT, spoken
+// audio through the speakers): pressing Answer → speaking a 1.8s question →
+// pressing Stop the moment the speech ended produced
+//   "⚠️ No speech detected. Try speaking closer to your microphone."
+// while the main log showed the user's FINAL transcript ("what is a linked
+// list", 21 chars) landing one line AFTER "[Main] Finalizing STT". Pressing
+// Stop 4s after the speech captured and answered the same question.
+//
+// Root cause (src/components/NativelyInterface.tsx, handleAnswerNow):
+//   1. `isRecordingRef.current = false` ran BEFORE the finalize wait, and the
+//      onNativeAudioTranscript handler drops every user chunk while that ref is
+//      false — so any transcript that arrived during the wait was discarded.
+//   2. The wait itself was a fixed 750ms cap on an IPC that resolves
+//      immediately (finalizeMicSTT is synchronous in main), not a wait for the
+//      transcript. Cloud finals land 0.5–2s after speech ends; local models
+//      1.5–7s (issue #540's log: moonshine p50 7160ms). Both lose the tail.
+//
+// Fix: a small event-driven waiter (answerTailWait.mjs) — the recording ref
+// stays open until a FINAL user chunk lands or a bounded window elapses.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createTranscriptTailWaiter, TAIL_WAIT_MS, TAIL_GRACE_MS } from '../answerTailWait.mjs';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const interfaceSource = fs.readFileSync(
+  path.resolve(dirname, '../../components/NativelyInterface.tsx'),
+  'utf8',
+);
+
+function section(startMarker, endMarker) {
+  const start = interfaceSource.indexOf(startMarker);
+  assert.ok(start >= 0, `missing start marker: ${startMarker}`);
+  const end = interfaceSource.indexOf(endMarker, start + startMarker.length);
+  assert.ok(end > start, `missing end marker: ${endMarker}`);
+  return interfaceSource.slice(start, end);
+}
+
+function fakeTimers() {
+  let now = 0;
+  let nextId = 1;
+  const pending = new Map();
+  return {
+    setTimeout(fn, ms) { const id = nextId++; pending.set(id, { at: now + ms, fn }); return id; },
+    clearTimeout(id) { pending.delete(id); },
+    async advance(ms) {
+      now += ms;
+      for (const [id, t] of [...pending.entries()].sort((a, b) => a[1].at - b[1].at)) {
+        if (t.at <= now) { pending.delete(id); t.fn(); }
+      }
+      await Promise.resolve();
+    },
+    pendingCount: () => pending.size,
+  };
+}
+
+test('nothing captured yet: waits the full tail window and resolves early on a final', async () => {
+  const timers = fakeTimers();
+  const waiter = createTranscriptTailWaiter(timers);
+  let outcome = null;
+  const p = waiter.wait({ hasCapturedFinal: false, hasPendingInterim: false }).then((r) => { outcome = r; });
+  await timers.advance(TAIL_WAIT_MS - 1);
+  assert.equal(outcome, null, 'must still be waiting inside the window');
+  waiter.notifyFinal();
+  await p;
+  assert.equal(outcome, 'final');
+  assert.equal(timers.pendingCount(), 0, 'the timeout must be cleared once a final lands');
+});
+
+test('nothing captured and nothing arrives: resolves timeout at the window edge', async () => {
+  const timers = fakeTimers();
+  const waiter = createTranscriptTailWaiter(timers);
+  const p = waiter.wait({ hasCapturedFinal: false, hasPendingInterim: false });
+  await timers.advance(TAIL_WAIT_MS);
+  assert.equal(await p, 'timeout');
+});
+
+test('a final already captured with no interim pending: only a short grace, not the full window', async () => {
+  const timers = fakeTimers();
+  const waiter = createTranscriptTailWaiter(timers);
+  const p = waiter.wait({ hasCapturedFinal: true, hasPendingInterim: false });
+  await timers.advance(TAIL_GRACE_MS);
+  assert.equal(await p, 'timeout');
+  assert.ok(TAIL_GRACE_MS < TAIL_WAIT_MS);
+});
+
+test('an interim pending means speech is still in flight: full window even though a final exists', async () => {
+  const timers = fakeTimers();
+  const waiter = createTranscriptTailWaiter(timers);
+  let outcome = null;
+  waiter.wait({ hasCapturedFinal: true, hasPendingInterim: true }).then((r) => { outcome = r; });
+  await timers.advance(TAIL_GRACE_MS + 1);
+  assert.equal(outcome, null, 'grace alone must not end the wait while an interim is pending');
+  await timers.advance(TAIL_WAIT_MS);
+  assert.equal(outcome, 'timeout');
+});
+
+test('a final arriving after the window closed is a no-op for the stale waiter', async () => {
+  const timers = fakeTimers();
+  const waiter = createTranscriptTailWaiter(timers);
+  const p = waiter.wait({ hasCapturedFinal: false, hasPendingInterim: false });
+  await timers.advance(TAIL_WAIT_MS);
+  assert.equal(await p, 'timeout');
+  assert.doesNotThrow(() => waiter.notifyFinal());
+});
+
+test('source: handleAnswerNow keeps the recording ref open until the tail wait resolves', () => {
+  const body = section('const handleAnswerNow = async () => {', 'const selectSkill = useCallback');
+  const clearRef = body.indexOf('isRecordingRef.current = false');
+  const tailWait = body.indexOf('answerTailWaiterRef.current!.wait(');
+  assert.ok(tailWait >= 0, 'BUG: handleAnswerNow does not wait for the transcript tail');
+  assert.ok(
+    clearRef > tailWait,
+    'BUG: the recording ref is cleared before the tail wait, so a user FINAL that lands after the Stop press is dropped → "No speech detected"',
+  );
+  // The snapshot of the captured text must happen after the ref is cleared, never before the wait.
+  const snapshot = body.indexOf('const question = mergeTranscriptChunks(');
+  assert.ok(snapshot > clearRef, 'the question snapshot must follow the tail wait');
+  // The fixed 750ms cap on the IPC is fine; it must not be the ONLY wait.
+  assert.match(body, /window\.electronAPI\.finalizeMicSTT\(\)/);
+  // The button must keep reading "Stop" while the gate is open — flipping it
+  // early created a window where a press was silently ignored.
+  const flip = body.indexOf('setIsManualRecording(false)');
+  assert.ok(flip > tailWait, 'setIsManualRecording(false) must follow the tail wait');
+  // A local model's multi-second tail is selected by main's `pending` report,
+  // not guessed from the interim preview alone.
+  assert.match(body, /providerReportsPending/);
+  assert.match(body, /hasPendingInterim: manualTranscriptRef\.current\.trim\(\)\.length > 0 \|\| providerReportsPending/);
+});
+
+test('source: a session reset clears the dictation refs, not only the React state', () => {
+  const reset = section("window.electronAPI.onSessionReset(() => {", 'analytics.trackConversationStarted();');
+  assert.match(reset, /voiceInputRef\.current = ''/, 'BUG: the merge reads voiceInputRef, so a stale ref prepends the previous meeting to the next question');
+  assert.match(reset, /isRecordingRef\.current = false/);
+  assert.match(reset, /answerStopInFlightRef\.current = false/);
+});
+
+test('source: the transcript handler wakes the tail waiter on a FINAL user chunk', () => {
+  const handler = section(
+    'window.electronAPI.onNativeAudioTranscript((transcript) => {',
+    '// Ignore user mic transcripts when not recording',
+  );
+  const finalBranch = handler.indexOf('if (transcript.final) {');
+  const wake = handler.indexOf('answerTailWaiterRef.current!.notifyFinal()');
+  const partialBranch = handler.indexOf('} else {', finalBranch);
+  assert.ok(finalBranch >= 0 && wake > finalBranch && wake < partialBranch,
+    'BUG: notifyFinal must be called inside the final-transcript branch (never for partials)');
+  // The ref must be written synchronously BEFORE the wake — a write inside the
+  // setVoiceInput updater runs lazily on React's next render, after the woken
+  // Stop press has already snapshotted the ref (live-reproduced: waiter resolved
+  // 'final' with voice "").
+  const finalBody = handler.slice(finalBranch, wake);
+  const refWrite = finalBody.indexOf('voiceInputRef.current = updated');
+  assert.ok(refWrite >= 0, 'BUG: the final branch must assign voiceInputRef.current');
+  assert.doesNotMatch(finalBody, /setVoiceInput\(\(prev\)\s*=>/,
+    'BUG: the merge must not live inside a lazy state updater');
+  assert.match(finalBody, /const updated = mergeTranscriptChunks\(voiceInputRef\.current, transcript\.text\)/);
+});
+
+test('source: a new recording cannot start while the previous Stop is still collecting its tail', () => {
+  const body = section('const handleAnswerNow = async () => {', 'const selectSkill = useCallback');
+  const startBranch = body.slice(body.lastIndexOf('} else {'));
+  assert.match(startBranch, /answerStopInFlightRef\.current/,
+    'BUG: a second Answer press during the tail wait would reset voiceInput mid-snapshot');
+});

--- a/src/lib/answerTailWait.d.mts
+++ b/src/lib/answerTailWait.d.mts
@@ -1,0 +1,10 @@
+export const TAIL_WAIT_MS: number;
+export const TAIL_GRACE_MS: number;
+export interface TranscriptTailWaiter {
+  notifyFinal(): void;
+  wait(state: { hasCapturedFinal: boolean; hasPendingInterim: boolean }): Promise<'final' | 'timeout'>;
+}
+export function createTranscriptTailWaiter(timers?: {
+  setTimeout: (fn: () => void, ms: number) => unknown;
+  clearTimeout: (id: unknown) => void;
+}): TranscriptTailWaiter;

--- a/src/lib/answerTailWait.mjs
+++ b/src/lib/answerTailWait.mjs
@@ -1,0 +1,54 @@
+/**
+ * Event-driven wait for the STT "tail" after the user presses Stop on the
+ * voice-dictation Answer flow (src/components/NativelyInterface.tsx,
+ * handleAnswerNow). Pure helper, unit-tested — see
+ * src/lib/__tests__/AnswerNowTranscriptTail2026_09_11.test.mjs.
+ *
+ * Why this exists: the transcript for the last second or two of speech lands
+ * AFTER the Stop press — cloud finals 0.5–2s after speech ends, local models
+ * 1.5–7s. The previous code capped the wait at a fixed 750ms and, worse, had
+ * already closed the recording gate, so whatever arrived was thrown away and a
+ * short question became "No speech detected". The waiter resolves the moment a
+ * FINAL user chunk lands, and is bounded so a genuinely empty recording still
+ * returns promptly.
+ */
+
+/** Nothing captured yet, or an interim is still pending: speech is in flight. */
+export const TAIL_WAIT_MS = 3000;
+/**
+ * A final already landed and nothing is reported pending: a short grace for a
+ * straggler. Long enough for a cloud provider's finalize round-trip (300–800 ms
+ * for Deepgram/Soniox) — a local model's multi-second tail is covered instead by
+ * main reporting `pending` from finalizeMicSTT, which selects the full window.
+ */
+export const TAIL_GRACE_MS = 1000;
+
+export function createTranscriptTailWaiter(timers = globalThis) {
+  let wake = null;
+  return {
+    /** Call whenever a FINAL user chunk has been merged into the captured text. */
+    notifyFinal() {
+      const w = wake;
+      wake = null;
+      if (w) w('final');
+    },
+    /**
+     * Resolves 'final' as soon as notifyFinal() fires, else 'timeout' at the
+     * bound. One wait at a time — a new wait supersedes an unresolved one.
+     */
+    wait({ hasCapturedFinal, hasPendingInterim }) {
+      const ms = (!hasCapturedFinal || hasPendingInterim) ? TAIL_WAIT_MS : TAIL_GRACE_MS;
+      return new Promise((resolve) => {
+        const timer = timers.setTimeout(() => {
+          if (wake === settle) wake = null;
+          resolve('timeout');
+        }, ms);
+        const settle = (why) => {
+          timers.clearTimeout(timer);
+          resolve(why);
+        };
+        wake = settle;
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Why

Users on macOS and Windows report "No speech detected", and on the ScreenCaptureKit (SCK) backend the system audio sometimes goes silent mid-meeting. Every cause below was live-reproduced in a spawned Natively session (isolated profile, real native module, real local STT, spoken audio).

## Root causes and fixes

**1. A system-stopped SCK stream was invisible.** `sck.rs` created the SCStream with no delegate. Display sleep (and display reconfiguration during a screen share) stops the stream with `SCStreamErrorDomain -3815`; the ring buffer just went quiet, which is exactly what a silent meeting looks like: zero chunks, no error, no recovery, for the rest of the meeting.
- New `speaker/stop_signal.rs`; an `SCStreamDelegate` raises the reason; the DSP loop surfaces it as a capture error and main's existing recovery rebuilds the capture.
- Native now reports the active backend and display availability; main re-probes SCK once displays return instead of staying on the CoreAudio fallback.
- Windows: the WASAPI loop raises the same signal on repeated read failures and on `IAudioSessionEvents` disconnect.

**2. Answer/Stop threw away the transcript tail.** The recording gate closed before a fixed 750 ms wait; every provider's final for the last second of speech lands after the press (cloud 0.2–2 s, local 1–7 s). `src/lib/answerTailWait.mjs` waits, bounded and event-driven, for the next final; the ref is written synchronously (it lived inside a lazy React updater); main reports whether the provider has a final in flight; session reset clears the dictation refs.

**3. Local STT could wait forever for an ONNX slot.** The embedding and reranker workers hold the whole default cap for the app lifetime. STT channels now draw on their own budget (`NATIVELY_ONNX_HIGH_PRIORITY_SESSIONS`), the cold-start wait is bounded, and the failure is classified terminal so the overlay does not say "reconnecting" forever.

**4. Local STT had no readiness deadline or ready log.** Progress-aware 120 s deadline, 30 s "still loading" warning, load-time logging; a retired native monitor no longer throws "Capture already running".

## Validation

- Tested physically on macOS: SCK stop → recovery → CoreAudio fallback → re-probe back onto SCK after wake; Answer race with an injected final and with real speech on the local model.
- Automated: 734 electron audio/whisper/utils tests, 521 renderer-lib tests, 40 Rust tests; electron and renderer type checks pass. Eight new test files.
- Reviewed but not executed on Windows: the loopback change type-checks for `x86_64-pc-windows-msvc` (scratch crate with `wasapi` + `windows`); the full crate cannot cross-compile from macOS. Requires physical Windows verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016o2cb7XWWksfzahHWBpaAw
