### PR TITLE
fix(wta): show the provider's reason when it permanently rejects a request (#543)

### DIFF
--- a/electron/llm/WhatToAnswerLLM.ts
+++ b/electron/llm/WhatToAnswerLLM.ts
@@ -14,6 +14,7 @@ import { assemblePromptV2 } from "../intelligence/PromptAssemblerV2";
 import { beginTrace, commitTrace } from "../intelligence/IntelligenceTrace";
 import { DOM_CONTEXT_MAX_CHARS } from "../config/constants";
 import { checkAnswerForCodeBugs } from "./CodeSanityCheck";
+import { providerRejectionUserMessage } from "./providerErrorClassifier";
 import { formatAnswerPlanForPrompt, isCodingAnswerType } from "./AnswerPlanner";
 import { resolveCodingPromptSignals, isDeicticAsk, isPromotedScreenCodingTurn } from "./codingPromptSignals";
 import type { AnswerPlan, AnswerType } from "./AnswerPlanner";
@@ -1264,7 +1265,14 @@ The user triggered this action with a coding problem on screen and NO new questi
             // support. Surface an actionable message for provider failures.
             const msg = String(error?.message ?? error ?? '').toLowerCase();
             const isProviderFailure = /\b(401|403|429)\b|api key|unauthor|forbidden|quota|rate.?limit|billing|exhausted|permission/.test(msg);
-            if (isProviderFailure) {
+            // A permanent rejection ("The '<model>' model is not supported when
+            // using Codex with a ChatGPT account", issue #543) is not retryable:
+            // the engine's regeneration would replay the same refused call and
+            // then say "press again". The provider's explanation is the answer.
+            const rejection = isProviderFailure ? null : providerRejectionUserMessage(error);
+            if (rejection) {
+                yield rejection;
+            } else if (isProviderFailure) {
                 yield "I couldn't reach the AI provider — this looks like an API key or rate-limit issue. Check your API keys / plan in Settings and try again.";
             } else {
                 // ALWAYS ANSWER (2026-09-07): yield NOTHING. The engine treats an

--- a/electron/llm/__tests__/WtaCodexModelRejectedIssue543_2026_09_11.test.mjs
+++ b/electron/llm/__tests__/WtaCodexModelRejectedIssue543_2026_09_11.test.mjs
@@ -1,0 +1,172 @@
+// Issue #543 — "What to answer" on a Codex (ChatGPT sign-in) model returned
+// "Just to make sure I get this right — could you ask that once more?" while
+// the same account answered screenshots.
+//
+// The chain, end to end on the shipped code:
+//   Codex backend rejects the request with a PERMANENT 400 ("The '<model>'
+//   model is not supported when using Codex with a ChatGPT account.") →
+//   CodexCliService throws that message → WhatToAnswerLLM's catch tested it
+//   against a 401/403/429/key/quota regex, it matched nothing, and the catch
+//   yielded buildGracefulRetry (v2.8.8: "could you ask that once more?"; main
+//   since 2026-09-08: yields nothing, the engine regenerates the same rejected
+//   call, then "Press again and I'll retry"). Either way the provider's own
+//   explanation never reached the user, and pressing again can never work.
+//   Screenshots "worked" because the vision chain has spare rungs: Codex
+//   failed there too and another provider answered.
+//
+// Driven through the REAL WhatToAnswerLLM → LLMHelper → CodexCliService; only
+// the HTTPS call is stubbed.
+//
+// Run via: npm run build:electron && ELECTRON_RUN_AS_NODE=1 npx electron --test electron/llm/__tests__/WtaCodexModelRejectedIssue543_2026_09_11.test.mjs
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import os from 'node:os';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const dist = (p) => path.join(__dirname, '../../../dist-electron/electron', p);
+
+const electronPath = require.resolve('electron');
+require.cache[electronPath] = {
+  id: electronPath, filename: electronPath, loaded: true,
+  exports: {
+    app: { isReady: () => true, getPath: () => os.tmpdir(), getVersion: () => '0.0.0-test' },
+    safeStorage: { isEncryptionAvailable: () => false },
+  },
+};
+
+const { LLMHelper } = require(dist('LLMHelper.js'));
+const { WhatToAnswerLLM } = require(dist('llm/WhatToAnswerLLM.js'));
+const {
+  providerFailureUserMessage,
+  providerRejectionUserMessage,
+  isClarificationStall,
+} = require(dist('llm/providerErrorClassifier.js'));
+const { isProviderTransportError } = require(dist('llm/answerPolish.js'));
+
+// Same seam CodexVisionPayload2026_08_05 uses: the CodexOAuthService copy
+// inlined into the LLMHelper bundle reads tokens through this global slot.
+const CRED_SLOT = '__nativelyCredentialsManagerV1__';
+// Every other credential getter the answer path touches (Antigravity tokens,
+// provider keys, …) reads as "not configured".
+const seedSignedIn = () => {
+  const known = {
+    getCodexOAuthTokens: () => ({
+      accessToken: 'test-access-token',
+      refreshToken: 'test-refresh-token',
+      accountId: 'acct_test',
+      expiresAt: Date.now() + 3_600_000,
+    }),
+    getDisabledProviders: () => [],
+    anyVisionProviderConfigured: () => true,
+    anyLocalVisionProviderConfigured: () => false,
+  };
+  globalThis[CRED_SLOT] = new Proxy(known, {
+    get: (target, prop) => (prop in target ? target[prop] : () => null),
+  });
+};
+
+// The Codex backend answers an unentitled model with a FastAPI-style envelope.
+const REJECTION = "The 'gpt-5.5' model is not supported when using Codex with a ChatGPT account.";
+
+const modesManager = {
+  getActiveModeSystemPromptSuffix: () => '',
+  buildRetrievedActiveModeContextBlockHybrid: async () => '',
+  buildRetrievedActiveModeContextBlock: () => '',
+  buildActiveModeContextBlock: () => '',
+};
+
+async function pressWhatToAnswer(responseFactory) {
+  seedSignedIn();
+  const helper = new LLMHelper(undefined, false);
+  helper.setCodexCliConfig({ enabled: true, model: 'gpt-5.5', timeoutMs: 30_000 });
+  helper.setModel('codex-cli:gpt-5.5');
+  const realFetch = globalThis.fetch;
+  let fetches = 0;
+  globalThis.fetch = async (url) => {
+    if (String(url).includes('chatgpt.com/backend-api/codex')) { fetches++; return responseFactory(); }
+    throw new Error(`unexpected fetch in test: ${url}`);
+  };
+  try {
+    const answerer = new WhatToAnswerLLM(helper, modesManager);
+    const snap = Object.freeze({
+      activeModeInfo: null, modeId: 'general', requestId: 'r543',
+      surface: 'what_to_answer', generationId: 1,
+    });
+    const chunks = [];
+    for await (const c of answerer.generateStream(
+      '[INTERVIEWER]: How would you design a rate limiter for a public API?',
+      undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined, undefined, snap,
+    )) chunks.push(c);
+    return { out: chunks.join(''), fetches };
+  } finally {
+    globalThis.fetch = realFetch;
+    delete globalThis[CRED_SLOT];
+  }
+}
+
+describe('#543 — a Codex model the account cannot use is named on the WTA surface', () => {
+  test('the provider\'s rejection reaches the user instead of an empty/"ask again" answer', async () => {
+    const { out, fetches } = await pressWhatToAnswer(() => new Response(
+      JSON.stringify({ detail: REJECTION }),
+      { status: 400, headers: { 'content-type': 'application/json' } },
+    ));
+    assert.equal(fetches, 1, 'a 400 is not retried');
+    assert.ok(out.trim().length > 0, 'WTA yielded nothing — the engine would regenerate the same rejected call, then say "press again"');
+    assert.match(out, /not supported when using Codex with a ChatGPT account/, out);
+    assert.doesNotMatch(out, /\{"detail"/, 'the JSON envelope is unwrapped, not shown raw');
+    assert.doesNotMatch(out, /repeat|rephrase|once more|press again/i, out);
+    assert.equal(isClarificationStall(out), false, out);
+    assert.equal(isProviderTransportError(out), true,
+      'the engine must recognise the line as a provider error so it is shown but never stored as session history');
+  });
+
+  test('a transient failure still leaves the answer empty so the engine regenerates', async () => {
+    const { out } = await pressWhatToAnswer(() => { throw new Error('socket closed unexpectedly'); });
+    assert.equal(out, '', 'only PERMANENT rejections short-circuit the regeneration');
+  });
+});
+
+describe('providerRejectionUserMessage', () => {
+  const rejected = [
+    new Error(REJECTION),
+    new Error("Unsupported value: 'none' is not supported with the 'gpt-5.5' model."),
+    new Error('The model `gpt-9` does not exist or you do not have access to it.'),
+    new Error('models/gemini-9-flash is not found for API version v1beta, or is not supported for generateContent.'),
+    Object.assign(new Error('model_not_found'), { status: 404 }),
+  ];
+  for (const err of rejected) {
+    test(`names the rejection: ${err.message.slice(0, 50)}`, () => {
+      const m = providerRejectionUserMessage(err);
+      assert.ok(m, 'null');
+      assert.ok(m.includes(err.message.replace(/\s+/g, ' ').trim().slice(0, 40)), m);
+      assert.equal(isProviderTransportError(m), true);
+      assert.equal(providerFailureUserMessage(err), m, 'both catches (WTA stream + engine) agree');
+    });
+  }
+
+  const notRejections = [
+    new Error('Codex request aborted.'),
+    new Error('Cannot read properties of undefined (reading \'length\')'),
+    new Error("ENOENT: no such file or directory, open '/tmp/shot.png'"),
+    new Error('Codex upstream 503 after 3 retries: overloaded'),
+    Object.assign(new Error('Invalid API key'), { status: 401 }),
+    Object.assign(new Error('RESOURCE_EXHAUSTED: quota'), { status: 429 }),
+  ];
+  for (const err of notRejections) {
+    test(`leaves other failures to their own handling: ${err.message.slice(0, 40)}`, () => {
+      assert.equal(providerRejectionUserMessage(err), null);
+    });
+  }
+
+  test('a long provider message is capped and kept on one line', () => {
+    const m = providerRejectionUserMessage(new Error(`The model 'x' is not supported.\n${'detail '.repeat(200)}`));
+    assert.ok(m && m.length < 400, String(m?.length));
+    assert.doesNotMatch(m, /\n/);
+  });
+});

--- a/electron/llm/answerPolish.ts
+++ b/electron/llm/answerPolish.ts
@@ -17,6 +17,8 @@
 //
 // Pure logic, no I/O, no LLM — callers own any regeneration.
 
+import { isProviderRejectionLine } from './providerErrorClassifier';
+
 // ── Artifact cleanup ─────────────────────────────────────────────────────────
 
 const CODE_FENCE_RE = /```[\s\S]*?```/g;
@@ -284,7 +286,9 @@ const PROVIDER_TRANSPORT_ERROR_TEXT =
   "I couldn't reach the AI provider — this looks like an API key or rate-limit issue. Check your API keys / plan in Settings and try again.";
 export function isProviderTransportError(text: string): boolean {
   if (!text) return false;
-  return text.trim() === PROVIDER_TRANSPORT_ERROR_TEXT;
+  // The permanent-rejection line (issue #543) carries the provider's own
+  // explanation, so it is matched by its fixed app-authored prefix.
+  return text.trim() === PROVIDER_TRANSPORT_ERROR_TEXT || isProviderRejectionLine(text);
 }
 
 /** A leading META-COMMENTARY preamble the model sometimes emits before the real

--- a/electron/llm/providerErrorClassifier.ts
+++ b/electron/llm/providerErrorClassifier.ts
@@ -9,6 +9,8 @@
 //
 // No I/O, no LLM. Inspects an error object and/or the produced text.
 
+import { redactSecretsOnly } from '../utils/redactForLog';
+
 export type ProviderErrorKind =
   | 'rate_limit'        // 429 / RESOURCE_EXHAUSTED / "rate limit"
   | 'auth'              // 401 / 403 / API_KEY / permission
@@ -147,6 +149,8 @@ export function classifyProviderError(err: any, text?: string): ProviderErrorCla
  */
 export function providerFailureUserMessage(err: unknown): string | null {
   if (!err) return null;
+  const rejection = providerRejectionUserMessage(err);
+  if (rejection) return rejection;
   const c = classifyProviderError(err);
   const msg = String((err as { message?: unknown })?.message ?? err ?? '').toLowerCase();
   const status = statusOf(err);
@@ -170,4 +174,42 @@ export function providerFailureUserMessage(err: unknown): string | null {
     default:
       return null;
   }
+}
+
+// A request the provider refuses PERMANENTLY for this account/model: a model the
+// plan does not include, a model id that does not exist, a parameter value the
+// model rejects. Retrying cannot succeed, so the provider's own explanation is
+// the answer (issue #543: a ChatGPT-plan Codex user pressed "What to answer"
+// and saw "could you ask that once more?" while the backend was saying
+// "The '<model>' model is not supported when using Codex with a ChatGPT account").
+const PROVIDER_REJECTION_RE = /\bmodels?\b[^\n]{0,120}?\b(?:is not supported|not supported|is not available|not available|is not found|not found|does not exist|is not enabled|unsupported)\b|\bunsupported (?:value|parameter|model)\b|\bmodel_not_found\b|\binvalid[_ ]model\b/i;
+
+/** Fixed start of the rejection line, so downstream guards can recognise it
+ *  as a provider error (shown, never stored as session history). */
+export const PROVIDER_REJECTION_PREFIX = 'The AI provider rejected this request: ';
+
+const PROVIDER_REJECTION_DETAIL_MAX = 240;
+
+/**
+ * The user-facing line for a permanent provider rejection, or null. Auth and
+ * rate-limit failures keep their own lines (providerFailureUserMessage).
+ */
+export function providerRejectionUserMessage(err: unknown): string | null {
+  if (!err) return null;
+  const raw = String((err as { message?: unknown })?.message ?? err ?? '');
+  if (!PROVIDER_REJECTION_RE.test(raw)) return null;
+  const kind = classifyProviderError(err).kind;
+  if (kind === 'auth' || kind === 'rate_limit') return null;
+  let detail = String(redactSecretsOnly(raw.replace(/\s+/g, ' ').trim()));
+  if (detail.length > PROVIDER_REJECTION_DETAIL_MAX) {
+    detail = `${detail.slice(0, PROVIDER_REJECTION_DETAIL_MAX).trimEnd()}…`;
+  } else if (!/[.!?]$/.test(detail)) {
+    detail += '.';
+  }
+  return `${PROVIDER_REJECTION_PREFIX}${detail} Choose a different model in Settings → AI Providers.`;
+}
+
+/** Is `text` a line produced by providerRejectionUserMessage? */
+export function isProviderRejectionLine(text: string | null | undefined): boolean {
+  return (text || '').trim().startsWith(PROVIDER_REJECTION_PREFIX);
 }

--- a/electron/services/CodexCliService.ts
+++ b/electron/services/CodexCliService.ts
@@ -1122,6 +1122,9 @@ function extractResponsesErrorMessage(text: string): string {
     const json = JSON.parse(text);
     if (json?.error?.message) return String(json.error.message);
     if (typeof json?.message === 'string') return json.message;
+    // The ChatGPT backend's own envelope, e.g. an unentitled model:
+    // {"detail":"The '<model>' model is not supported when using Codex with a ChatGPT account."}
+    if (typeof json?.detail === 'string') return json.detail;
   } catch { /* not JSON */ }
   return text;
 }


### PR DESCRIPTION
Refs #543

## Problem
Pressing **What to answer** with a Codex (ChatGPT sign-in) model returned *"Just to make sure I get this right — could you ask that once more?"*, while screenshots answered normally.

The app heard the question. ChatGPT **refused the request**: "The '&lt;model&gt;' model is not supported when using Codex with a ChatGPT account". This was live-verified for `gpt-5.4` (our default), `gpt-5.3-codex` (our default fast model) and Spark.
- The What-to-answer error handler only recognised key / 401 / 403 / 429 / quota / billing errors, so the refusal was swallowed.
- **v2.8.8 (latest release):** it turned into the "ask that once more" line.
- **main since 7a3cc494 (unreleased):** the wording is gone, but the engine retries the same refused call and then says "press again", which can never succeed.

Screenshots only *looked* fine: the vision path has backup providers, so Codex failed there too and another provider (the user's Gemini key) answered.

## Fix
- `providerRejectionUserMessage` (providerErrorClassifier) recognises refusals that won't go away on retry: model not supported / not found / does not exist, unsupported value or parameter, `model_not_found`. It turns them into:
  > The AI provider rejected this request: The 'gpt-5.5' model is not supported when using Codex with a ChatGPT account. Choose a different model in Settings → AI Providers.
  
  Auth and rate-limit errors keep their existing lines. Provider text is scrubbed of credentials and capped at 240 chars.
- `WhatToAnswerLLM` yields it from the stream catch, and the engine's outer catch (`providerFailureUserMessage`) checks it first.
- `isProviderTransportError` recognises it by its fixed prefix. The line is shown but **never stored as session history**, and a repair pass that outputs it is rejected.
- `CodexCliService` unwraps a `{"detail": "..."}` error body, so users see the sentence instead of raw JSON (manual chat too). That envelope shape is inferred; if it's absent, the raw text is used.

Temporary failures (network, 5xx, abort) still leave the answer empty so the engine regenerates once, same as before.

## Verification
- New `WtaCodexModelRejectedIssue543_2026_09_11.test.mjs` drives the real `WhatToAnswerLLM` → `LLMHelper` → `CodexCliService` with only the HTTPS call stubbed. It was **red before** (empty answer) and is **green after** (14/14).
- The new line is not flagged by the canned-opener/tail strippers, `detectAssistantVoiceMisfire`, `isAssistantRefusal` or `isClarificationStall`.
- `typecheck:electron` is clean.
- llm 4427/0; auto-answer + utils + context-intelligence 1561/0.
- services: 28 failures, **identical test names on unmodified origin/main** (pre-existing).

## Cross-platform
Shared TypeScript with no `process.platform` branch and no paths, processes or native code.
- Covered by automated macOS branch tests
- Reviewed but not executed on Windows
- Requires physical Windows verification (the reporter is on Windows): pick a Codex model the plan doesn't include, press What to answer, and expect the rejection line.

## Related
- #558's patch (not yet merged) replaces the default Codex models that ChatGPT sign-in rejects, which removes the most common cause. The two patches apply cleanly together.
- Not addressed here: Codex's inactivity timer resets only on text output, so a long reasoning phase can abort a healthy request (the What-to-answer 30s deadline binds first).
- The reporter's `gpt-5.5` failure is unconfirmed (gpt-5.5 works on a free account). A comment asking for their log line is drafted, not posted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
